### PR TITLE
add lang specifics to the lang's own base template

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -1,11 +1,11 @@
 <!doctype html>
-<html lang="en">
+<html lang="{% block lang %}{% endblock %}">
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {% block meta %}
     <meta property="og:title" content="{{ self.title() }}">
-    <meta property="og:image" content="/static/img/ha.png">
+    <meta property="og:image" content="/static/images/ha.png">
     {% endblock %}
     {% block head %}
     <title>{% block title %}The Web Almanac{% endblock %}</title>

--- a/src/templates/en-US/base.html
+++ b/src/templates/en-US/base.html
@@ -1,0 +1,3 @@
+{% extends "base.html" %}
+
+{% block lang %}en-US{% endblock %}

--- a/src/templates/en-US/index.html
+++ b/src/templates/en-US/index.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "en-US/base.html" %}
 
 {% block title %}
 The Web Almanac by HTTP Archive


### PR DESCRIPTION
All en-US templates should extend the en-US/base.html template, which specifies the value for the document's lang attribute. Other locale-specific overrides could be places in this template, like custom fonts or styles.