### PR TITLE
JS query fixes

### DIFF
--- a/sql/2019/01_JavaScript/01_14.sql
+++ b/sql/2019/01_JavaScript/01_14.sql
@@ -13,7 +13,11 @@ RETURNS BOOLEAN LANGUAGE js AS '''
 ''';
 
 SELECT
+  _TABLE_SUFFIX AS client,
   COUNTIF(hasScriptPreload(payload)) AS num_pages,
+  COUNT(0) AS total,
   ROUND(COUNTIF(hasScriptPreload(payload)) * 100 / COUNT(0), 2) AS pct_script_preload
 FROM
   `httparchive.pages.2019_07_01_*`
+GROUP BY
+  client

--- a/sql/2019/01_JavaScript/01_15.sql
+++ b/sql/2019/01_JavaScript/01_15.sql
@@ -13,7 +13,11 @@ RETURNS BOOLEAN LANGUAGE js AS '''
 ''';
 
 SELECT
+  _TABLE_SUFFIX AS client,
   COUNTIF(hasModulePreload(payload)) AS num_pages,
+  COUNT(0) AS total,
   ROUND(COUNTIF(hasModulePreload(payload)) * 100 / COUNT(0), 2) AS pct_modulepreload
 FROM
   `httparchive.pages.2019_07_01_*`
+GROUP BY
+  client

--- a/sql/2019/01_JavaScript/01_16.sql
+++ b/sql/2019/01_JavaScript/01_16.sql
@@ -13,7 +13,11 @@ RETURNS BOOLEAN LANGUAGE js AS '''
 ''';
 
 SELECT
+  _TABLE_SUFFIX AS client,
   COUNTIF(hasScriptPrefetch(payload)) AS num_pages,
+  COUNT(0) AS total,
   ROUND(COUNTIF(hasScriptPrefetch(payload)) * 100 / COUNT(0), 2) AS pct_script_prefetch
 FROM
   `httparchive.pages.2019_07_01_*`
+GROUP BY
+  client

--- a/sql/2019/01_JavaScript/01_24.sql
+++ b/sql/2019/01_JavaScript/01_24.sql
@@ -1,11 +1,20 @@
 #standardSQL
 # 01_24: % of sites that use dynamic imports.
 SELECT
+  client,
   COUNT(DISTINCT page) AS freq,
-  ROUND(COUNT(DISTINCT page) * 100 / (SELECT COUNT(DISTINCT page) FROM `httparchive.almanac.summary_response_bodies`), 2) AS pct
+  total,
+  ROUND(COUNT(DISTINCT page) * 100 / total, 2) AS pct
 FROM
   `httparchive.almanac.summary_response_bodies`
+JOIN
+  (SELECT _TABLE_SUFFIX AS client, COUNT(0) AS total FROM `httparchive.summary_pages.2019_07_01_*` GROUP BY _TABLE_SUFFIX)
+USING
+  (client)
 WHERE
   type = 'script' AND
   body LIKE '%import(%' AND
   NET.REG_DOMAIN(page) = NET.REG_DOMAIN(url)
+GROUP BY
+  client,
+  total

--- a/sql/2019/01_JavaScript/01_25.sql
+++ b/sql/2019/01_JavaScript/01_25.sql
@@ -1,12 +1,20 @@
 #standardSQL
 # 01_25: % of sites that ship sourcemaps.
 SELECT
+  client,
   COUNT(DISTINCT page) AS freq,
-  ROUND(COUNT(DISTINCT page) * 100 /
-    (SELECT COUNT(DISTINCT page) FROM `httparchive.almanac.summary_response_bodies`), 2) AS pct
+  total,
+  ROUND(COUNT(DISTINCT page) * 100 / total, 2) AS pct
 FROM
   `httparchive.almanac.summary_response_bodies`
+JOIN
+  (SELECT _TABLE_SUFFIX AS client, COUNT(0) AS total FROM `httparchive.summary_pages.2019_07_01_*` GROUP BY _TABLE_SUFFIX)
+USING
+  (client)
 WHERE
   type = 'script' AND
   body LIKE '%sourceMappingURL%' AND
   NET.REG_DOMAIN(page) = NET.REG_DOMAIN(url)
+GROUP BY
+  client,
+  total


### PR DESCRIPTION
Follow up to #82 

- always group by client
- prefer explicit percentiles over array of quantiles