### PR TITLE
Remainder of A11Y queries

### DIFF
--- a/sql/2019/09_Accessibility/9_25.sql
+++ b/sql/2019/09_Accessibility/9_25.sql
@@ -1,0 +1,12 @@
+#standardSQL
+# 09_25 Sites that lock display orientation (using ScreenOrientation.lock)
+SELECT
+  num_urls AS freq,
+  total_urls AS total,
+  ROUND(pct_urls * 100, 2) AS pct
+FROM
+  `httparchive.blink_features.usage`
+WHERE
+  client = 'mobile' AND
+  yyyymmdd = '20190701' AND
+  feature = 'ScreenOrientationLock'


### PR DESCRIPTION
9.25 is a copy of 12.07

I don't think we can reliably implement 9.23. Without a custom metric we're forced to use regex here, and regex cannot reliably test if an element is WITHIN another, like in the example below:

```html
<div role="radiogroup">
  <input type="radio" name="grouped" value="1" checked>
  <input type="radio" name="grouped" value="2">
  <input type="radio" name="grouped" value="3">
</div>

<!--
  Will still match the inputs below with regex like <[^>]+\brole=['"]radiogroup
  And we can't find out where this group ends
-->
<input type="radio" name="not-grouped" value="1" checked>
<input type="radio" name="not-grouped" value="2">
```

Should we mark this one as non-implementable?