### PR TITLE
Script to generate JSON from SQL

### DIFF
--- a/sql/run_queries.sh
+++ b/sql/run_queries.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Converts BigQuery SQL to JSON.
+#
+# Usage: `sql/run_queries.sh <sql-directory>`
+#
+# For example:
+#
+#     sql/run_queries.sh sql/2019
+#
+# This will run all 2019 queries.
+# You could provide the path to a specific sql file to run only that query.
+
+set -o pipefail
+
+DIRECTORY=$1
+BQ_CMD="bq --format prettyjson --project_id httparchive query --max_rows 1000000"
+
+for sql in $(find $DIRECTORY | grep \.sql); do
+  echo "Querying $sql"
+  metric=$(echo $sql | cut -d"." -f1)
+  cat $sql | $BQ_CMD | sed '/^$/d' > $metric.json
+  # Make sure the query succeeded.
+  if [ $? -ne 0 ]; then
+    echo "Error querying $sql"
+    exit 1
+  fi
+done
+
+echo "Done!"


### PR DESCRIPTION
Progress on #111

This script will write a JSON file adjacent to every SQL file under in the input directory. Note that [generate_visualizations.py](https://github.com/HTTPArchive/almanac.httparchive.org/blob/master/src/generate_visualisations.py) looks for the JSON data in the `src/data/2019/<metric>.json` directory but the JSON files are with the SQL in `sql/2019/<chapter>/<metric>.json`. I like keeping the query and results close together. Things under `src` are also intended to be part of the website itself, whereas this is more related to the development environment. I'll also be updating the data viz script before closing #111.

Optional additional features:

1. dry run mode where you see which queries were found
2. batch mode to queue up all queries and write their output as they finish
3. noclobber by default, where rerunning a query that already has output will be skipped, with an option to force overwriting results
4. better error handling, for example a log of broken queries
5. mode to output results to CSV
6. for efficiency, maybe just look at the metrics included in the written chapters and query only what's needed instead of literally everything