### PR TITLE
Mobile web query changes to add more context to results

### DIFF
--- a/sql/2019/12_Mobile_Web/12_08.sql
+++ b/sql/2019/12_Mobile_Web/12_08.sql
@@ -3,8 +3,15 @@
 # password-inputs-can-be-pasted-into
 
 SELECT
-    COUNT(url) AS total,
-    COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.password-inputs-can-be-pasted-into.score') as NUMERIC) = 1) AS score_sum,
-    ROUND(COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.password-inputs-can-be-pasted-into.score') as NUMERIC) = 1) * 100 / COUNT(url), 2) as score_percentage
-FROM
-    `httparchive.lighthouse.2019_07_01_mobile`
+    COUNT(0) AS total_pages,
+    COUNTIF(password_score IS NOT NULL) AS applicable_pages,
+
+    COUNTIF(CAST(password_score as NUMERIC) = 1) AS total_allowing,
+    ROUND(COUNTIF(CAST(password_score as NUMERIC) = 1) * 100 / COUNTIF(password_score IS NOT NULL), 2) as perc_allowing
+FROM (
+    SELECT
+        url,
+        JSON_EXTRACT_SCALAR(report, '$.audits.password-inputs-can-be-pasted-into.score') AS password_score
+    FROM
+        `httparchive.lighthouse.2019_07_01_mobile`
+)

--- a/sql/2019/12_Mobile_Web/12_13.sql
+++ b/sql/2019/12_Mobile_Web/12_13.sql
@@ -2,25 +2,38 @@
 
 # input types occurence prefined set %
 
-CREATE TEMPORARY FUNCTION hasNewInputType(payload STRING)
-RETURNS BOOL LANGUAGE js AS '''
+CREATE TEMPORARY FUNCTION getInputStats(payload STRING)
+RETURNS STRUCT<found_advanced_types BOOLEAN, total_inputs INT64> LANGUAGE js AS '''
   try {
     var $ = JSON.parse(payload);
     var almanac = JSON.parse($._almanac);
-    var found = almanac['input-elements'].findIndex(node => {
+    var found_index = almanac['input-elements'].findIndex(node => {
         if(node.type && node.type.match(/(color|date|datetime-local|email|month|number|range|reset|search|tel|time|url|week|datalist)/i)) {
             return true;
         }
     });
-    return found >= 0 ? true : false;
+
+    return {
+      found_advanced_types: found_index >= 0 ? true : false,
+      total_inputs: almanac['input-elements'].length
+    };
   } catch (e) {
-    return false;
+    return {
+      found_advanced_types: false,
+      total_inputs: 0
+    };
   }
 ''';
 
 SELECT
     COUNT(0) as count,
-    COUNTIF(hasNewInputType(payload)) AS occurence,
-    ROUND(COUNTIF(hasNewInputType(payload)) * 100 / SUM(COUNT(0)) OVER (), 2) AS occurence_perc
-FROM
+    COUNTIF(input_stats.total_inputs > 0) AS total_applicable,
+
+    COUNTIF(input_stats.found_advanced_types) AS total_pages_using,
+    ROUND(COUNTIF(input_stats.found_advanced_types) * 100 / COUNTIF(input_stats.total_inputs > 0), 2) AS occurence_perc
+FROM (
+  SELECT
+    getInputStats(payload) as input_stats
+  FROM
     `httparchive.pages.2019_07_01_mobile`
+)

--- a/sql/2019/12_Mobile_Web/12_15.sql
+++ b/sql/2019/12_Mobile_Web/12_15.sql
@@ -2,12 +2,12 @@
 
 # input attributes occurence defined set % (minus placeholder and required)
 
-CREATE TEMPORARY FUNCTION hasInputAttributes(payload STRING)
-RETURNS BOOL LANGUAGE js AS '''
+CREATE TEMPORARY FUNCTION getInputStats(payload STRING)
+RETURNS STRUCT<has_advanced_attributes BOOLEAN, total_inputs INT64> LANGUAGE js AS '''
   try {
     var $ = JSON.parse(payload);
     var almanac = JSON.parse($._almanac);
-    var found = almanac['input-elements'].findIndex(node => {
+    var found_index = almanac['input-elements'].findIndex(node => {
         var search = Object.keys(node).findIndex(attr => {
             if(attr.match(/(autocomplete|min|max|pattern|step)/i)) {
                 return true;
@@ -16,15 +16,28 @@ RETURNS BOOL LANGUAGE js AS '''
 
         return search >= 0 ? true : false;
     });
-    return found >= 0 ? true : false;
+
+    return {
+      has_advanced_attributes: found_index >= 0 ? true : false,
+      total_inputs: almanac['input-elements'].length
+    };
   } catch (e) {
-    return false;
+    return {
+      has_advanced_attributes: false,
+      total_inputs: 0
+    };
   }
 ''';
 
 SELECT
     COUNT(0) as count,
-    COUNTIF(hasInputAttributes(payload)) AS occurence,
-    ROUND(COUNTIF(hasInputAttributes(payload)) * 100 / SUM(COUNT(0)) OVER (), 2) AS occurence_perc
-FROM
+    COUNTIF(input_stats.total_inputs > 0) AS total_applicable,
+
+    COUNTIF(input_stats.has_advanced_attributes) AS total_pages_using,
+    ROUND(COUNTIF(input_stats.has_advanced_attributes) * 100 / COUNTIF(input_stats.total_inputs > 0), 2) AS occurence_perc
+FROM (
+  SELECT
+    getInputStats(payload) as input_stats
+  FROM
     `httparchive.pages.2019_07_01_mobile`
+)


### PR DESCRIPTION
These are some fixes to the queries so the data we look is more impactful and relevant to readers.

For example, instead of seeing how many type=email inputs are used across the web... lets find out how often thats used just on pages which have inputs.

I've appended this new data to the datasheet already if you'd like to take a look :)