### PR TITLE
add toc with desktop resolution footer

### DIFF
--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -230,6 +230,12 @@ footer .nav-items *:last-child {
   font-size: 12px;
   color: #F2F2F2;
 }
+.misc > div {
+  display: flex;
+}
+.misc > div a.navigation-logo {
+  margin-right: 24px;
+}
 
 .social-media {
   display: flex;
@@ -362,6 +368,7 @@ footer .nav-items *:last-child {
     display: block;
   }
 
+  footer .misc > div a.navigation-logo,
   footer .misc .social-media {
     display: none;
   }

--- a/src/templates/en/2019/base.html
+++ b/src/templates/en/2019/base.html
@@ -56,9 +56,7 @@
       <section class="nav">
         <a class="navigation-logo" href="{{ url_for('home', year=year, lang=lang) }}"><img src="/static/images/logo.png" alt="web almanac by http archive"/></a>
         <nav class="nav-items">
-          <a class="navigation-logo" href="https://httparchive.org">
-            <img src="/static/images/ha-home.png" alt="HTTP Archive home" />
-          </a>
+          <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}">Table of Contents</a>
           <a href="{{ url_for('contributors', year=year, lang=lang) }}">Contributors</a>
           <a href="{{ url_for('methodology', year=year, lang=lang) }}">Methodology</a>
         </nav>
@@ -87,6 +85,9 @@
       <div class="misc">
         <p>Copyright © 2019 Web Almanac. All rights reserved.</p>
         <div>
+          <a class="navigation-logo" href="https://httparchive.org">
+            <img src="/static/images/ha-home.png" alt="HTTP Archive home" />
+          </a>
           <div class="social-media">
             <a href="https://twitter.com/HTTPArchive" class="twitter">
               <img src="/static/images/twitter.png" alt="Twitter" />


### PR DESCRIPTION
Fixes #216 

- Added table of contents
- Moved HTTP Archive home logo image to second line

![スクリーンショット 2019-10-25 15 07 20](https://user-images.githubusercontent.com/2183053/67547289-a54d1680-f739-11e9-903c-5d11eb479a95.png)
