### PR TITLE
SEO fixes for canonical and meta info (inc Meta Descriptions, OG, Twitter and Article Structured Data)

### DIFF
--- a/src/content/en/2019/http2.md
+++ b/src/content/en/2019/http2.md
@@ -5,6 +5,8 @@ title: HTTP/2
 description: HTTP/2 Chapter of the 2019 Web Almanac covering adoption and impact of HTTP/2, HTTP/2 Push, Issues and HTTP/3
 authors: [bazzadp]
 reviewers: [bagder, rmarx, dotjs]
+published: 2019-11-01T12:00:00+00:00:00
+last_updated: 2019-11-02T12:00:00+00:00:00 
 ---
 
 ## Introduction

--- a/src/content/en/2019/http2.md
+++ b/src/content/en/2019/http2.md
@@ -2,6 +2,7 @@
 part_number: IV
 chapter_number: 20
 title: HTTP/2
+description: HTTP/2 Chapter of the 2019 Web Almanac covering adoption and impact of HTTP/2, HTTP/2 Push, Issues and HTTP/3
 authors: [bazzadp]
 reviewers: [bagder, rmarx, dotjs]
 ---

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -24,6 +24,9 @@
     {% endblock %}
     {% for l in supported_languages %}
     <link rel="alternate" href="{{ url_for(request.endpoint, **get_view_args(lang=l.lang_code)) }}" hreflang="{{ l.lang_code}}" />
+    {% if l==language %}
+    <link rel="canonical" href="{{ url_for(request.endpoint, **get_view_args(lang=l.lang_code)) }}" />
+    {% endif %}
     {% endfor %}
   </head>
 

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -22,11 +22,9 @@
       <link rel="stylesheet" href="/static/css/normalize.css">
       {% block styles %}{% endblock %}
     {% endblock %}
+    <link rel="canonical" href="{{ url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}" />
     {% for l in supported_languages %}
     <link rel="alternate" href="{{ url_for(request.endpoint, **get_view_args(lang=l.lang_code)) }}" hreflang="{{ l.lang_code}}" />
-    {% if l==language %}
-    <link rel="canonical" href="{{ url_for(request.endpoint, **get_view_args(lang=l.lang_code)) }}" />
-    {% endif %}
     {% endfor %}
   </head>
 

--- a/src/templates/en/2019/base_chapter.html
+++ b/src/templates/en/2019/base_chapter.html
@@ -1,8 +1,6 @@
 {% extends "en/2019/base.html" %}
 
-{% block title %}
-{{ metadata.get('title') }} | 2019 | The Web Almanac by HTTP Archive
-{% endblock %}
+{% block title %}{{ metadata.get('title') }} | 2019 | The Web Almanac by HTTP Archive{% endblock %}
 
 {% block styles %}
 {{ super() }}

--- a/src/templates/en/2019/chapter.html
+++ b/src/templates/en/2019/chapter.html
@@ -16,6 +16,7 @@
 <meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}">
 
 <meta property="og:title" content="{{ self.title() }}">
+<meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}">
 <meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg">
 <meta property="og:type" content="article">
 <meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}">

--- a/src/templates/en/2019/chapter.html
+++ b/src/templates/en/2019/chapter.html
@@ -26,6 +26,51 @@
 <meta name="twitter:title" content="{{ self.title() }}">
 <meta name="twitter:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg">
 <meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}">
+
+<script type="application/ld+json">
+	{
+	  "@context": "http://schema.org",
+	  "@type": "Article",
+	  "mainEntityOfPage": {
+	  	  "@type": "WebPage",
+	  	  "@id": "https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}"
+	  },
+	  "headline": "{{ metadata.get('title') }}",
+	  "image": {
+	  	  "@type": "ImageObject",
+	  	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+	  },
+	  "publisher": {
+	  	  "@type": "Organization",
+	  	  "name": "HTTPArchive",
+	  	  "logo": {
+	  	      "@type": "ImageObject",
+	  	      "url": "https://almanac.httparchive.org/static/images/ha.png",
+	  	      "height": 160,
+	  	      "width": 320
+	  	  }
+      },
+	  "author": [
+      {% for author in metadata.get('authors') %}
+      {% set authordata = config.contributors[author] if author in config.contributors else None %}
+      {% if authordata %}
+	  {
+	  	  "@type": "Person",
+          "sameas": [
+            "https://almanac.httparchive.org{{ url_for('contributors', year=year, lang=lang, _anchor=author) }}"
+            {% if authordata.twitter %},"https://twitter.com/{{ authordata.twitter }}"{% endif %}
+            {% if authordata.github %},"https://github.com/{{ authordata.github }}"{% endif %}
+            ],
+	  	  "name": "{{ authordata.name if authordata.name else author }}"
+      }{% if loop.index < loop.length %},{% endif %}
+      {% endif %}
+      {% endfor %}
+      ],
+      "description": "{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}",
+      "datePublished": "2019-11-08T12:00:00+00:00:00",
+      "dateModified": "2019-11-08T12:00:00+00:00:00"
+	}
+	</script>
 {% endblock %}
 
 {% block main %}

--- a/src/templates/en/2019/chapter.html
+++ b/src/templates/en/2019/chapter.html
@@ -67,8 +67,8 @@
       {% endfor %}
       ],
       "description": "{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}",
-      "datePublished": "2019-11-08T12:00:00+00:00:00",
-      "dateModified": "2019-11-08T12:00:00+00:00:00"
+      "datePublished": "{{ metadata.get('published','2019-11-08T12:00:00+00:00:00') }}",
+      "dateModified": "{{ metadata.get('last_updated','2019-11-08T12:00:00+00:00:00') }}"
 	}
 	</script>
 {% endblock %}

--- a/src/templates/en/2019/chapter.html
+++ b/src/templates/en/2019/chapter.html
@@ -16,14 +16,14 @@
 <meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}">
 
 <meta property="og:title" content="{{ self.title() }}">
-<meta property="og:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg">
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg">
 <meta property="og:type" content="article">
 <meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}">
 
 <meta name="twitter:card" content="summary">
 <meta name="twitter:site" content="@HTTPArchive">
 <meta name="twitter:title" content="{{ self.title() }}">
-<meta name="twitter:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg">
+<meta name="twitter:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg">
 <meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}">
 {% endblock %}
 

--- a/src/templates/en/2019/chapter.html
+++ b/src/templates/en/2019/chapter.html
@@ -12,6 +12,21 @@
 
 {% set metadata = <%- JSON.stringify(metadata) %> %}
 
+{% block meta %}
+<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}">
+
+<meta property="og:title" content="{{ self.title() }}">
+<meta property="og:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg">
+<meta property="og:type" content="article">
+<meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}">
+
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@HTTPArchive">
+<meta name="twitter:title" content="{{ self.title() }}">
+<meta name="twitter:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg">
+<meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}">
+{% endblock %}
+
 {% block main %}
 <article id="chapter" class="main">
     <nav class="index">

--- a/src/templates/en/2019/chapters/accessibility.html
+++ b/src/templates/en/2019/chapters/accessibility.html
@@ -65,8 +65,8 @@
        {% endfor %}
        ],
        "description": "{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}",
-       "datePublished": "2019-11-08T12:00:00+00:00:00",
-       "dateModified": "2019-11-08T12:00:00+00:00:00"
+       "datePublished": "{{ metadata.get('published','2019-11-08T12:00:00+00:00:00') }}",
+       "dateModified": "{{ metadata.get('last_updated','2019-11-08T12:00:00+00:00:00') }}"
   }
 </script>
 {% endblock %} {% block main %}

--- a/src/templates/en/2019/chapters/accessibility.html
+++ b/src/templates/en/2019/chapters/accessibility.html
@@ -14,14 +14,14 @@
 <meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
-<meta property="og:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@HTTPArchive" />
 <meta name="twitter:title" content="{{ self.title() }}" />
-<meta name="twitter:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta name="twitter:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 {% endblock %} {% block main %}
 <article id="chapter" class="main">

--- a/src/templates/en/2019/chapters/accessibility.html
+++ b/src/templates/en/2019/chapters/accessibility.html
@@ -10,7 +10,20 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"II","chapter_number":9,"title":"Accessibility","authors":["nektarios-paisios","obto","kleinab"],"reviewers":["ljme"]} %} {% block main %}
+{% set metadata = {"part_number":"II","chapter_number":9,"title":"Accessibility","authors":["nektarios-paisios","obto","kleinab"],"reviewers":["ljme"]} %} {% block meta %}
+<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<meta property="og:title" content="{{ self.title() }}" />
+<meta property="og:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:type" content="article" />
+<meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:site" content="@HTTPArchive" />
+<meta name="twitter:title" content="{{ self.title() }}" />
+<meta name="twitter:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+{% endblock %} {% block main %}
 <article id="chapter" class="main">
   <nav class="index">
     <div class="index-box floating-card">

--- a/src/templates/en/2019/chapters/accessibility.html
+++ b/src/templates/en/2019/chapters/accessibility.html
@@ -24,6 +24,51 @@
 <meta name="twitter:title" content="{{ self.title() }}" />
 <meta name="twitter:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<script type="application/ld+json">
+  {
+    "@context": "http://schema.org",
+    "@type": "Article",
+    "mainEntityOfPage": {
+    	  "@type": "WebPage",
+    	  "@id": "https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}"
+    },
+    "headline": "{{ metadata.get('title') }}",
+    "image": {
+    	  "@type": "ImageObject",
+    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+    },
+    "publisher": {
+    	  "@type": "Organization",
+    	  "name": "HTTPArchive",
+    	  "logo": {
+    	      "@type": "ImageObject",
+    	      "url": "https://almanac.httparchive.org/static/images/ha.png",
+    	      "height": 160,
+    	      "width": 320
+    	  }
+       },
+    "author": [
+       {% for author in metadata.get('authors') %}
+       {% set authordata = config.contributors[author] if author in config.contributors else None %}
+       {% if authordata %}
+    {
+    	  "@type": "Person",
+           "sameas": [
+             "https://almanac.httparchive.org{{ url_for('contributors', year=year, lang=lang, _anchor=author) }}"
+             {% if authordata.twitter %},"https://twitter.com/{{ authordata.twitter }}"{% endif %}
+             {% if authordata.github %},"https://github.com/{{ authordata.github }}"{% endif %}
+             ],
+    	  "name": "{{ authordata.name if authordata.name else author }}"
+       }{% if loop.index < loop.length %},{% endif %}
+       {% endif %}
+       {% endfor %}
+       ],
+       "description": "{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}",
+       "datePublished": "2019-11-08T12:00:00+00:00:00",
+       "dateModified": "2019-11-08T12:00:00+00:00:00"
+  }
+</script>
 {% endblock %} {% block main %}
 <article id="chapter" class="main">
   <nav class="index">

--- a/src/templates/en/2019/chapters/accessibility.html
+++ b/src/templates/en/2019/chapters/accessibility.html
@@ -14,6 +14,7 @@
 <meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
+<meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}" />
 <meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />

--- a/src/templates/en/2019/chapters/ecommerce.html
+++ b/src/templates/en/2019/chapters/ecommerce.html
@@ -65,8 +65,8 @@
        {% endfor %}
        ],
        "description": "{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}",
-       "datePublished": "2019-11-08T12:00:00+00:00:00",
-       "dateModified": "2019-11-08T12:00:00+00:00:00"
+       "datePublished": "{{ metadata.get('published','2019-11-08T12:00:00+00:00:00') }}",
+       "dateModified": "{{ metadata.get('last_updated','2019-11-08T12:00:00+00:00:00') }}"
   }
 </script>
 {% endblock %} {% block main %}

--- a/src/templates/en/2019/chapters/ecommerce.html
+++ b/src/templates/en/2019/chapters/ecommerce.html
@@ -14,14 +14,14 @@
 <meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
-<meta property="og:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@HTTPArchive" />
 <meta name="twitter:title" content="{{ self.title() }}" />
-<meta name="twitter:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta name="twitter:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 {% endblock %} {% block main %}
 <article id="chapter" class="main">

--- a/src/templates/en/2019/chapters/ecommerce.html
+++ b/src/templates/en/2019/chapters/ecommerce.html
@@ -24,6 +24,51 @@
 <meta name="twitter:title" content="{{ self.title() }}" />
 <meta name="twitter:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<script type="application/ld+json">
+  {
+    "@context": "http://schema.org",
+    "@type": "Article",
+    "mainEntityOfPage": {
+    	  "@type": "WebPage",
+    	  "@id": "https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}"
+    },
+    "headline": "{{ metadata.get('title') }}",
+    "image": {
+    	  "@type": "ImageObject",
+    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+    },
+    "publisher": {
+    	  "@type": "Organization",
+    	  "name": "HTTPArchive",
+    	  "logo": {
+    	      "@type": "ImageObject",
+    	      "url": "https://almanac.httparchive.org/static/images/ha.png",
+    	      "height": 160,
+    	      "width": 320
+    	  }
+       },
+    "author": [
+       {% for author in metadata.get('authors') %}
+       {% set authordata = config.contributors[author] if author in config.contributors else None %}
+       {% if authordata %}
+    {
+    	  "@type": "Person",
+           "sameas": [
+             "https://almanac.httparchive.org{{ url_for('contributors', year=year, lang=lang, _anchor=author) }}"
+             {% if authordata.twitter %},"https://twitter.com/{{ authordata.twitter }}"{% endif %}
+             {% if authordata.github %},"https://github.com/{{ authordata.github }}"{% endif %}
+             ],
+    	  "name": "{{ authordata.name if authordata.name else author }}"
+       }{% if loop.index < loop.length %},{% endif %}
+       {% endif %}
+       {% endfor %}
+       ],
+       "description": "{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}",
+       "datePublished": "2019-11-08T12:00:00+00:00:00",
+       "dateModified": "2019-11-08T12:00:00+00:00:00"
+  }
+</script>
 {% endblock %} {% block main %}
 <article id="chapter" class="main">
   <nav class="index">

--- a/src/templates/en/2019/chapters/ecommerce.html
+++ b/src/templates/en/2019/chapters/ecommerce.html
@@ -10,7 +10,20 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"III","chapter_number":13,"title":"Ecommerce platforms","authors":["samdutton","alankent"],"reviewers":["voltek62"]} %} {% block main %}
+{% set metadata = {"part_number":"III","chapter_number":13,"title":"Ecommerce platforms","authors":["samdutton","alankent"],"reviewers":["voltek62"]} %} {% block meta %}
+<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<meta property="og:title" content="{{ self.title() }}" />
+<meta property="og:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:type" content="article" />
+<meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:site" content="@HTTPArchive" />
+<meta name="twitter:title" content="{{ self.title() }}" />
+<meta name="twitter:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+{% endblock %} {% block main %}
 <article id="chapter" class="main">
   <nav class="index">
     <div class="index-box floating-card">

--- a/src/templates/en/2019/chapters/ecommerce.html
+++ b/src/templates/en/2019/chapters/ecommerce.html
@@ -14,6 +14,7 @@
 <meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
+<meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}" />
 <meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />

--- a/src/templates/en/2019/chapters/http2.html
+++ b/src/templates/en/2019/chapters/http2.html
@@ -10,7 +10,7 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"IV","chapter_number":20,"title":"HTTP/2","description":"HTTP/2 Chapter of the 2019 Web Almanac covering adoption and impact of HTTP/2, HTTP/2 Push, Issues and HTTP/3","authors":["bazzadp"],"reviewers":["bagder","rmarx","dotjs"]} %} {% block meta %}
+{% set metadata = {"part_number":"IV","chapter_number":20,"title":"HTTP/2","description":"HTTP/2 Chapter of the 2019 Web Almanac covering adoption and impact of HTTP/2, HTTP/2 Push, Issues and HTTP/3","authors":["bazzadp"],"reviewers":["bagder","rmarx","dotjs"],"published":"2019-11-01T12:00:00+00:00:00","last_updated":"2019-11-02T12:00:00+00:00:00 "} %} {% block meta %}
 <meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
@@ -65,8 +65,8 @@
        {% endfor %}
        ],
        "description": "{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}",
-       "datePublished": "2019-11-08T12:00:00+00:00:00",
-       "dateModified": "2019-11-08T12:00:00+00:00:00"
+       "datePublished": "{{ metadata.get('published','2019-11-08T12:00:00+00:00:00') }}",
+       "dateModified": "{{ metadata.get('last_updated','2019-11-08T12:00:00+00:00:00') }}"
   }
 </script>
 {% endblock %} {% block main %}

--- a/src/templates/en/2019/chapters/http2.html
+++ b/src/templates/en/2019/chapters/http2.html
@@ -10,7 +10,20 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"IV","chapter_number":20,"title":"HTTP/2","authors":["bazzadp"],"reviewers":["bagder","rmarx","dotjs"]} %} {% block main %}
+{% set metadata = {"part_number":"IV","chapter_number":20,"title":"HTTP/2","description":"HTTP/2 Chapter of the 2019 Web Almanac covering adoption and impact of HTTP/2, HTTP/2 Push, Issues and HTTP/3","authors":["bazzadp"],"reviewers":["bagder","rmarx","dotjs"]} %} {% block meta %}
+<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<meta property="og:title" content="{{ self.title() }}" />
+<meta property="og:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:type" content="article" />
+<meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:site" content="@HTTPArchive" />
+<meta name="twitter:title" content="{{ self.title() }}" />
+<meta name="twitter:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+{% endblock %} {% block main %}
 <article id="chapter" class="main">
   <nav class="index">
     <div class="index-box floating-card">

--- a/src/templates/en/2019/chapters/http2.html
+++ b/src/templates/en/2019/chapters/http2.html
@@ -14,14 +14,14 @@
 <meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
-<meta property="og:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@HTTPArchive" />
 <meta name="twitter:title" content="{{ self.title() }}" />
-<meta name="twitter:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta name="twitter:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 {% endblock %} {% block main %}
 <article id="chapter" class="main">

--- a/src/templates/en/2019/chapters/http2.html
+++ b/src/templates/en/2019/chapters/http2.html
@@ -24,6 +24,51 @@
 <meta name="twitter:title" content="{{ self.title() }}" />
 <meta name="twitter:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<script type="application/ld+json">
+  {
+    "@context": "http://schema.org",
+    "@type": "Article",
+    "mainEntityOfPage": {
+    	  "@type": "WebPage",
+    	  "@id": "https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}"
+    },
+    "headline": "{{ metadata.get('title') }}",
+    "image": {
+    	  "@type": "ImageObject",
+    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+    },
+    "publisher": {
+    	  "@type": "Organization",
+    	  "name": "HTTPArchive",
+    	  "logo": {
+    	      "@type": "ImageObject",
+    	      "url": "https://almanac.httparchive.org/static/images/ha.png",
+    	      "height": 160,
+    	      "width": 320
+    	  }
+       },
+    "author": [
+       {% for author in metadata.get('authors') %}
+       {% set authordata = config.contributors[author] if author in config.contributors else None %}
+       {% if authordata %}
+    {
+    	  "@type": "Person",
+           "sameas": [
+             "https://almanac.httparchive.org{{ url_for('contributors', year=year, lang=lang, _anchor=author) }}"
+             {% if authordata.twitter %},"https://twitter.com/{{ authordata.twitter }}"{% endif %}
+             {% if authordata.github %},"https://github.com/{{ authordata.github }}"{% endif %}
+             ],
+    	  "name": "{{ authordata.name if authordata.name else author }}"
+       }{% if loop.index < loop.length %},{% endif %}
+       {% endif %}
+       {% endfor %}
+       ],
+       "description": "{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}",
+       "datePublished": "2019-11-08T12:00:00+00:00:00",
+       "dateModified": "2019-11-08T12:00:00+00:00:00"
+  }
+</script>
 {% endblock %} {% block main %}
 <article id="chapter" class="main">
   <nav class="index">

--- a/src/templates/en/2019/chapters/http2.html
+++ b/src/templates/en/2019/chapters/http2.html
@@ -14,6 +14,7 @@
 <meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
+<meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}" />
 <meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />

--- a/src/templates/en/2019/chapters/markup.html
+++ b/src/templates/en/2019/chapters/markup.html
@@ -65,8 +65,8 @@
        {% endfor %}
        ],
        "description": "{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}",
-       "datePublished": "2019-11-08T12:00:00+00:00:00",
-       "dateModified": "2019-11-08T12:00:00+00:00:00"
+       "datePublished": "{{ metadata.get('published','2019-11-08T12:00:00+00:00:00') }}",
+       "dateModified": "{{ metadata.get('last_updated','2019-11-08T12:00:00+00:00:00') }}"
   }
 </script>
 {% endblock %} {% block main %}

--- a/src/templates/en/2019/chapters/markup.html
+++ b/src/templates/en/2019/chapters/markup.html
@@ -14,14 +14,14 @@
 <meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
-<meta property="og:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@HTTPArchive" />
 <meta name="twitter:title" content="{{ self.title() }}" />
-<meta name="twitter:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta name="twitter:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 {% endblock %} {% block main %}
 <article id="chapter" class="main">

--- a/src/templates/en/2019/chapters/markup.html
+++ b/src/templates/en/2019/chapters/markup.html
@@ -24,6 +24,51 @@
 <meta name="twitter:title" content="{{ self.title() }}" />
 <meta name="twitter:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<script type="application/ld+json">
+  {
+    "@context": "http://schema.org",
+    "@type": "Article",
+    "mainEntityOfPage": {
+    	  "@type": "WebPage",
+    	  "@id": "https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}"
+    },
+    "headline": "{{ metadata.get('title') }}",
+    "image": {
+    	  "@type": "ImageObject",
+    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+    },
+    "publisher": {
+    	  "@type": "Organization",
+    	  "name": "HTTPArchive",
+    	  "logo": {
+    	      "@type": "ImageObject",
+    	      "url": "https://almanac.httparchive.org/static/images/ha.png",
+    	      "height": 160,
+    	      "width": 320
+    	  }
+       },
+    "author": [
+       {% for author in metadata.get('authors') %}
+       {% set authordata = config.contributors[author] if author in config.contributors else None %}
+       {% if authordata %}
+    {
+    	  "@type": "Person",
+           "sameas": [
+             "https://almanac.httparchive.org{{ url_for('contributors', year=year, lang=lang, _anchor=author) }}"
+             {% if authordata.twitter %},"https://twitter.com/{{ authordata.twitter }}"{% endif %}
+             {% if authordata.github %},"https://github.com/{{ authordata.github }}"{% endif %}
+             ],
+    	  "name": "{{ authordata.name if authordata.name else author }}"
+       }{% if loop.index < loop.length %},{% endif %}
+       {% endif %}
+       {% endfor %}
+       ],
+       "description": "{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}",
+       "datePublished": "2019-11-08T12:00:00+00:00:00",
+       "dateModified": "2019-11-08T12:00:00+00:00:00"
+  }
+</script>
 {% endblock %} {% block main %}
 <article id="chapter" class="main">
   <nav class="index">

--- a/src/templates/en/2019/chapters/markup.html
+++ b/src/templates/en/2019/chapters/markup.html
@@ -10,7 +10,20 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"I","chapter_number":3,"title":"Markup","authors":["bkardell"],"reviewers":["zcorpan","tomhodgins","matthewp"]} %} {% block main %}
+{% set metadata = {"part_number":"I","chapter_number":3,"title":"Markup","authors":["bkardell"],"reviewers":["zcorpan","tomhodgins","matthewp"]} %} {% block meta %}
+<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<meta property="og:title" content="{{ self.title() }}" />
+<meta property="og:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:type" content="article" />
+<meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:site" content="@HTTPArchive" />
+<meta name="twitter:title" content="{{ self.title() }}" />
+<meta name="twitter:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+{% endblock %} {% block main %}
 <article id="chapter" class="main">
   <nav class="index">
     <div class="index-box floating-card">

--- a/src/templates/en/2019/chapters/markup.html
+++ b/src/templates/en/2019/chapters/markup.html
@@ -14,6 +14,7 @@
 <meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
+<meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}" />
 <meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />

--- a/src/templates/en/2019/chapters/performance.html
+++ b/src/templates/en/2019/chapters/performance.html
@@ -65,8 +65,8 @@
        {% endfor %}
        ],
        "description": "{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}",
-       "datePublished": "2019-11-08T12:00:00+00:00:00",
-       "dateModified": "2019-11-08T12:00:00+00:00:00"
+       "datePublished": "{{ metadata.get('published','2019-11-08T12:00:00+00:00:00') }}",
+       "dateModified": "{{ metadata.get('last_updated','2019-11-08T12:00:00+00:00:00') }}"
   }
 </script>
 {% endblock %} {% block main %}

--- a/src/templates/en/2019/chapters/performance.html
+++ b/src/templates/en/2019/chapters/performance.html
@@ -14,14 +14,14 @@
 <meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
-<meta property="og:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@HTTPArchive" />
 <meta name="twitter:title" content="{{ self.title() }}" />
-<meta name="twitter:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta name="twitter:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 {% endblock %} {% block main %}
 <article id="chapter" class="main">

--- a/src/templates/en/2019/chapters/performance.html
+++ b/src/templates/en/2019/chapters/performance.html
@@ -24,6 +24,51 @@
 <meta name="twitter:title" content="{{ self.title() }}" />
 <meta name="twitter:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<script type="application/ld+json">
+  {
+    "@context": "http://schema.org",
+    "@type": "Article",
+    "mainEntityOfPage": {
+    	  "@type": "WebPage",
+    	  "@id": "https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}"
+    },
+    "headline": "{{ metadata.get('title') }}",
+    "image": {
+    	  "@type": "ImageObject",
+    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+    },
+    "publisher": {
+    	  "@type": "Organization",
+    	  "name": "HTTPArchive",
+    	  "logo": {
+    	      "@type": "ImageObject",
+    	      "url": "https://almanac.httparchive.org/static/images/ha.png",
+    	      "height": 160,
+    	      "width": 320
+    	  }
+       },
+    "author": [
+       {% for author in metadata.get('authors') %}
+       {% set authordata = config.contributors[author] if author in config.contributors else None %}
+       {% if authordata %}
+    {
+    	  "@type": "Person",
+           "sameas": [
+             "https://almanac.httparchive.org{{ url_for('contributors', year=year, lang=lang, _anchor=author) }}"
+             {% if authordata.twitter %},"https://twitter.com/{{ authordata.twitter }}"{% endif %}
+             {% if authordata.github %},"https://github.com/{{ authordata.github }}"{% endif %}
+             ],
+    	  "name": "{{ authordata.name if authordata.name else author }}"
+       }{% if loop.index < loop.length %},{% endif %}
+       {% endif %}
+       {% endfor %}
+       ],
+       "description": "{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}",
+       "datePublished": "2019-11-08T12:00:00+00:00:00",
+       "dateModified": "2019-11-08T12:00:00+00:00:00"
+  }
+</script>
 {% endblock %} {% block main %}
 <article id="chapter" class="main">
   <nav class="index">

--- a/src/templates/en/2019/chapters/performance.html
+++ b/src/templates/en/2019/chapters/performance.html
@@ -10,7 +10,20 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"II","chapter_number":7,"title":"Performance","authors":["rviscomi"],"reviewers":["JMPerez","obto","sergeychernyshev","zeman"]} %} {% block main %}
+{% set metadata = {"part_number":"II","chapter_number":7,"title":"Performance","authors":["rviscomi"],"reviewers":["JMPerez","obto","sergeychernyshev","zeman"]} %} {% block meta %}
+<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<meta property="og:title" content="{{ self.title() }}" />
+<meta property="og:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:type" content="article" />
+<meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:site" content="@HTTPArchive" />
+<meta name="twitter:title" content="{{ self.title() }}" />
+<meta name="twitter:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+{% endblock %} {% block main %}
 <article id="chapter" class="main">
   <nav class="index">
     <div class="index-box floating-card">

--- a/src/templates/en/2019/chapters/performance.html
+++ b/src/templates/en/2019/chapters/performance.html
@@ -14,6 +14,7 @@
 <meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
+<meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}" />
 <meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />

--- a/src/templates/en/2019/chapters/pwa.html
+++ b/src/templates/en/2019/chapters/pwa.html
@@ -65,8 +65,8 @@
        {% endfor %}
        ],
        "description": "{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}",
-       "datePublished": "2019-11-08T12:00:00+00:00:00",
-       "dateModified": "2019-11-08T12:00:00+00:00:00"
+       "datePublished": "{{ metadata.get('published','2019-11-08T12:00:00+00:00:00') }}",
+       "dateModified": "{{ metadata.get('last_updated','2019-11-08T12:00:00+00:00:00') }}"
   }
 </script>
 {% endblock %} {% block main %}

--- a/src/templates/en/2019/chapters/pwa.html
+++ b/src/templates/en/2019/chapters/pwa.html
@@ -14,14 +14,14 @@
 <meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
-<meta property="og:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@HTTPArchive" />
 <meta name="twitter:title" content="{{ self.title() }}" />
-<meta name="twitter:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta name="twitter:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 {% endblock %} {% block main %}
 <article id="chapter" class="main">

--- a/src/templates/en/2019/chapters/pwa.html
+++ b/src/templates/en/2019/chapters/pwa.html
@@ -10,7 +10,20 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"II","chapter_number":11,"title":"PWA","authors":["tomayac","jeffposnick"],"reviewers":["hyperpress","ahmadawais"]} %} {% block main %}
+{% set metadata = {"part_number":"II","chapter_number":11,"title":"PWA","authors":["tomayac","jeffposnick"],"reviewers":["hyperpress","ahmadawais"]} %} {% block meta %}
+<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<meta property="og:title" content="{{ self.title() }}" />
+<meta property="og:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:type" content="article" />
+<meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:site" content="@HTTPArchive" />
+<meta name="twitter:title" content="{{ self.title() }}" />
+<meta name="twitter:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+{% endblock %} {% block main %}
 <article id="chapter" class="main">
   <nav class="index">
     <div class="index-box floating-card">

--- a/src/templates/en/2019/chapters/pwa.html
+++ b/src/templates/en/2019/chapters/pwa.html
@@ -24,6 +24,51 @@
 <meta name="twitter:title" content="{{ self.title() }}" />
 <meta name="twitter:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<script type="application/ld+json">
+  {
+    "@context": "http://schema.org",
+    "@type": "Article",
+    "mainEntityOfPage": {
+    	  "@type": "WebPage",
+    	  "@id": "https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}"
+    },
+    "headline": "{{ metadata.get('title') }}",
+    "image": {
+    	  "@type": "ImageObject",
+    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+    },
+    "publisher": {
+    	  "@type": "Organization",
+    	  "name": "HTTPArchive",
+    	  "logo": {
+    	      "@type": "ImageObject",
+    	      "url": "https://almanac.httparchive.org/static/images/ha.png",
+    	      "height": 160,
+    	      "width": 320
+    	  }
+       },
+    "author": [
+       {% for author in metadata.get('authors') %}
+       {% set authordata = config.contributors[author] if author in config.contributors else None %}
+       {% if authordata %}
+    {
+    	  "@type": "Person",
+           "sameas": [
+             "https://almanac.httparchive.org{{ url_for('contributors', year=year, lang=lang, _anchor=author) }}"
+             {% if authordata.twitter %},"https://twitter.com/{{ authordata.twitter }}"{% endif %}
+             {% if authordata.github %},"https://github.com/{{ authordata.github }}"{% endif %}
+             ],
+    	  "name": "{{ authordata.name if authordata.name else author }}"
+       }{% if loop.index < loop.length %},{% endif %}
+       {% endif %}
+       {% endfor %}
+       ],
+       "description": "{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}",
+       "datePublished": "2019-11-08T12:00:00+00:00:00",
+       "dateModified": "2019-11-08T12:00:00+00:00:00"
+  }
+</script>
 {% endblock %} {% block main %}
 <article id="chapter" class="main">
   <nav class="index">

--- a/src/templates/en/2019/chapters/pwa.html
+++ b/src/templates/en/2019/chapters/pwa.html
@@ -14,6 +14,7 @@
 <meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
+<meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}" />
 <meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />

--- a/src/templates/en/2019/chapters/seo.html
+++ b/src/templates/en/2019/chapters/seo.html
@@ -65,8 +65,8 @@
        {% endfor %}
        ],
        "description": "{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}",
-       "datePublished": "2019-11-08T12:00:00+00:00:00",
-       "dateModified": "2019-11-08T12:00:00+00:00:00"
+       "datePublished": "{{ metadata.get('published','2019-11-08T12:00:00+00:00:00') }}",
+       "dateModified": "{{ metadata.get('last_updated','2019-11-08T12:00:00+00:00:00') }}"
   }
 </script>
 {% endblock %} {% block main %}

--- a/src/templates/en/2019/chapters/seo.html
+++ b/src/templates/en/2019/chapters/seo.html
@@ -14,14 +14,14 @@
 <meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
-<meta property="og:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@HTTPArchive" />
 <meta name="twitter:title" content="{{ self.title() }}" />
-<meta name="twitter:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta name="twitter:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 {% endblock %} {% block main %}
 <article id="chapter" class="main">

--- a/src/templates/en/2019/chapters/seo.html
+++ b/src/templates/en/2019/chapters/seo.html
@@ -24,6 +24,51 @@
 <meta name="twitter:title" content="{{ self.title() }}" />
 <meta name="twitter:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<script type="application/ld+json">
+  {
+    "@context": "http://schema.org",
+    "@type": "Article",
+    "mainEntityOfPage": {
+    	  "@type": "WebPage",
+    	  "@id": "https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}"
+    },
+    "headline": "{{ metadata.get('title') }}",
+    "image": {
+    	  "@type": "ImageObject",
+    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+    },
+    "publisher": {
+    	  "@type": "Organization",
+    	  "name": "HTTPArchive",
+    	  "logo": {
+    	      "@type": "ImageObject",
+    	      "url": "https://almanac.httparchive.org/static/images/ha.png",
+    	      "height": 160,
+    	      "width": 320
+    	  }
+       },
+    "author": [
+       {% for author in metadata.get('authors') %}
+       {% set authordata = config.contributors[author] if author in config.contributors else None %}
+       {% if authordata %}
+    {
+    	  "@type": "Person",
+           "sameas": [
+             "https://almanac.httparchive.org{{ url_for('contributors', year=year, lang=lang, _anchor=author) }}"
+             {% if authordata.twitter %},"https://twitter.com/{{ authordata.twitter }}"{% endif %}
+             {% if authordata.github %},"https://github.com/{{ authordata.github }}"{% endif %}
+             ],
+    	  "name": "{{ authordata.name if authordata.name else author }}"
+       }{% if loop.index < loop.length %},{% endif %}
+       {% endif %}
+       {% endfor %}
+       ],
+       "description": "{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}",
+       "datePublished": "2019-11-08T12:00:00+00:00:00",
+       "dateModified": "2019-11-08T12:00:00+00:00:00"
+  }
+</script>
 {% endblock %} {% block main %}
 <article id="chapter" class="main">
   <nav class="index">

--- a/src/templates/en/2019/chapters/seo.html
+++ b/src/templates/en/2019/chapters/seo.html
@@ -10,7 +10,20 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"I","chapter_number":10,"title":"SEO","authors":["ymschaap","rachellcostello","AVGP"],"reviewers":["clarkeclark","andylimn","AymenLoukil","catalinred","mattludwig"]} %} {% block main %}
+{% set metadata = {"part_number":"I","chapter_number":10,"title":"SEO","authors":["ymschaap","rachellcostello","AVGP"],"reviewers":["clarkeclark","andylimn","AymenLoukil","catalinred","mattludwig"]} %} {% block meta %}
+<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<meta property="og:title" content="{{ self.title() }}" />
+<meta property="og:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:type" content="article" />
+<meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:site" content="@HTTPArchive" />
+<meta name="twitter:title" content="{{ self.title() }}" />
+<meta name="twitter:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+{% endblock %} {% block main %}
 <article id="chapter" class="main">
   <nav class="index">
     <div class="index-box floating-card">

--- a/src/templates/en/2019/chapters/seo.html
+++ b/src/templates/en/2019/chapters/seo.html
@@ -14,6 +14,7 @@
 <meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
+<meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}" />
 <meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />

--- a/src/templates/en/2019/chapters/third-parties.html
+++ b/src/templates/en/2019/chapters/third-parties.html
@@ -65,8 +65,8 @@
        {% endfor %}
        ],
        "description": "{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}",
-       "datePublished": "2019-11-08T12:00:00+00:00:00",
-       "dateModified": "2019-11-08T12:00:00+00:00:00"
+       "datePublished": "{{ metadata.get('published','2019-11-08T12:00:00+00:00:00') }}",
+       "dateModified": "{{ metadata.get('last_updated','2019-11-08T12:00:00+00:00:00') }}"
   }
 </script>
 {% endblock %} {% block main %}

--- a/src/templates/en/2019/chapters/third-parties.html
+++ b/src/templates/en/2019/chapters/third-parties.html
@@ -14,14 +14,14 @@
 <meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
-<meta property="og:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@HTTPArchive" />
 <meta name="twitter:title" content="{{ self.title() }}" />
-<meta name="twitter:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta name="twitter:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 {% endblock %} {% block main %}
 <article id="chapter" class="main">

--- a/src/templates/en/2019/chapters/third-parties.html
+++ b/src/templates/en/2019/chapters/third-parties.html
@@ -24,6 +24,51 @@
 <meta name="twitter:title" content="{{ self.title() }}" />
 <meta name="twitter:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<script type="application/ld+json">
+  {
+    "@context": "http://schema.org",
+    "@type": "Article",
+    "mainEntityOfPage": {
+    	  "@type": "WebPage",
+    	  "@id": "https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}"
+    },
+    "headline": "{{ metadata.get('title') }}",
+    "image": {
+    	  "@type": "ImageObject",
+    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+    },
+    "publisher": {
+    	  "@type": "Organization",
+    	  "name": "HTTPArchive",
+    	  "logo": {
+    	      "@type": "ImageObject",
+    	      "url": "https://almanac.httparchive.org/static/images/ha.png",
+    	      "height": 160,
+    	      "width": 320
+    	  }
+       },
+    "author": [
+       {% for author in metadata.get('authors') %}
+       {% set authordata = config.contributors[author] if author in config.contributors else None %}
+       {% if authordata %}
+    {
+    	  "@type": "Person",
+           "sameas": [
+             "https://almanac.httparchive.org{{ url_for('contributors', year=year, lang=lang, _anchor=author) }}"
+             {% if authordata.twitter %},"https://twitter.com/{{ authordata.twitter }}"{% endif %}
+             {% if authordata.github %},"https://github.com/{{ authordata.github }}"{% endif %}
+             ],
+    	  "name": "{{ authordata.name if authordata.name else author }}"
+       }{% if loop.index < loop.length %},{% endif %}
+       {% endif %}
+       {% endfor %}
+       ],
+       "description": "{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}",
+       "datePublished": "2019-11-08T12:00:00+00:00:00",
+       "dateModified": "2019-11-08T12:00:00+00:00:00"
+  }
+</script>
 {% endblock %} {% block main %}
 <article id="chapter" class="main">
   <nav class="index">

--- a/src/templates/en/2019/chapters/third-parties.html
+++ b/src/templates/en/2019/chapters/third-parties.html
@@ -14,6 +14,7 @@
 <meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
+<meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}" />
 <meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />

--- a/src/templates/en/2019/chapters/third-parties.html
+++ b/src/templates/en/2019/chapters/third-parties.html
@@ -10,7 +10,20 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"II","chapter_number":5,"title":"Third Parties","authors":["patrickhulce"],"reviewers":["zcorpan","obto","jasti"]} %} {% block main %}
+{% set metadata = {"part_number":"II","chapter_number":5,"title":"Third Parties","authors":["patrickhulce"],"reviewers":["zcorpan","obto","jasti"]} %} {% block meta %}
+<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<meta property="og:title" content="{{ self.title() }}" />
+<meta property="og:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:type" content="article" />
+<meta property="og:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:site" content="@HTTPArchive" />
+<meta name="twitter:title" content="{{ self.title() }}" />
+<meta name="twitter:image" content="/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta name="twitter:description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+{% endblock %} {% block main %}
 <article id="chapter" class="main">
   <nav class="index">
     <div class="index-box floating-card">


### PR DESCRIPTION
Fixes some of https://github.com/HTTPArchive/almanac.httparchive.org/issues/286, sets up basis for https://github.com/HTTPArchive/almanac.httparchive.org/issues/292 and fixes https://github.com/HTTPArchive/almanac.httparchive.org/issues/294.

Still to do:

- Add descriptions to each Chapter (only HTTP/2 done here as an example).
- Get descriptions reviewed by SEO experts
- Add Published Date and Last Updated timestamps to each Chapter meta data
- Do similar for non-chapter pages (Methodology, ToC...etc.)