### PR TITLE
Prevent generating ids for Table Headers to fix #310

### DIFF
--- a/src/templates/en/2019/chapters/http2.html
+++ b/src/templates/en/2019/chapters/http2.html
@@ -149,10 +149,10 @@
       <table>
         <thead>
           <tr>
-            <th id="protocol">Protocol</th>
-            <th id="desktop">Desktop</th>
-            <th id="mobile">Mobile</th>
-            <th id="both">Both</th>
+            <th>Protocol</th>
+            <th>Desktop</th>
+            <th>Mobile</th>
+            <th>Both</th>
           </tr>
         </thead>
         <tbody>
@@ -196,10 +196,10 @@
       <table>
         <thead>
           <tr>
-            <th id="protocol">Protocol</th>
-            <th id="desktop">Desktop</th>
-            <th id="mobile">Mobile</th>
-            <th id="both">Both</th>
+            <th>Protocol</th>
+            <th>Desktop</th>
+            <th>Mobile</th>
+            <th>Both</th>
           </tr>
         </thead>
         <tbody>
@@ -234,10 +234,10 @@
       <table>
         <thead>
           <tr>
-            <th id="protocol">Protocol</th>
-            <th id="desktop">Desktop</th>
-            <th id="mobile">Mobile</th>
-            <th id="both">Both</th>
+            <th>Protocol</th>
+            <th>Desktop</th>
+            <th>Mobile</th>
+            <th>Both</th>
           </tr>
         </thead>
         <tbody>
@@ -272,10 +272,10 @@
       <table>
         <thead>
           <tr>
-            <th id="server">Server</th>
-            <th id="desktop">Desktop</th>
-            <th id="mobile">Mobile</th>
-            <th id="both">Both</th>
+            <th>Server</th>
+            <th>Desktop</th>
+            <th>Mobile</th>
+            <th>Both</th>
           </tr>
         </thead>
         <tbody>
@@ -341,10 +341,10 @@
       <table>
         <thead>
           <tr>
-            <th id="server">Server</th>
-            <th id="desktop">Desktop</th>
-            <th id="mobile">Mobile</th>
-            <th id="both">Both</th>
+            <th>Server</th>
+            <th>Desktop</th>
+            <th>Mobile</th>
+            <th>Both</th>
           </tr>
         </thead>
         <tbody>
@@ -409,9 +409,9 @@
       <table>
         <thead>
           <tr>
-            <th id="server">Server</th>
-            <th id="desktop">Desktop</th>
-            <th id="mobile">Mobile</th>
+            <th>Server</th>
+            <th>Desktop</th>
+            <th>Mobile</th>
           </tr>
         </thead>
         <tbody>
@@ -485,9 +485,9 @@
       <table>
         <thead>
           <tr>
-            <th id="client">Client</th>
-            <th id="sites_using_http/2_push">Sites Using HTTP/2 Push</th>
-            <th id="sites_using_http/2_push_(%)">Sites Using HTTP/2 Push (%)</th>
+            <th>Client</th>
+            <th>Sites Using HTTP/2 Push</th>
+            <th>Sites Using HTTP/2 Push (%)</th>
           </tr>
         </thead>
         <tbody>
@@ -508,9 +508,9 @@
       <table>
         <thead>
           <tr>
-            <th id="client">Client</th>
-            <th id="avg_pushed_requests">Avg Pushed Requests</th>
-            <th id="avg_kb_pushed">Avg KB Pushed</th>
+            <th>Client</th>
+            <th>Avg Pushed Requests</th>
+            <th>Avg KB Pushed</th>
           </tr>
         </thead>
         <tbody>
@@ -541,11 +541,11 @@
       <table>
         <thead>
           <tr>
-            <th id="cdn">CDN</th>
-            <th id="prioritizes_correctly?">Prioritizes Correctly?</th>
-            <th id="desktop">Desktop</th>
-            <th id="mobile">Mobile</th>
-            <th id="both">Both</th>
+            <th>CDN</th>
+            <th>Prioritizes Correctly?</th>
+            <th>Desktop</th>
+            <th>Mobile</th>
+            <th>Both</th>
           </tr>
         </thead>
         <tbody>

--- a/src/templates/en/2019/chapters/markup.html
+++ b/src/templates/en/2019/chapters/markup.html
@@ -148,9 +148,9 @@
         <table>
           <thead>
             <tr>
-              <th id="2005_(per_site)">2005 (per site)</th>
-              <th id="2019_(per_site)">2019 (per site)</th>
-              <th id="2019_(frequency)">2019 (frequency)</th>
+              <th>2005 (per site)</th>
+              <th>2019 (per site)</th>
+              <th>2019 (frequency)</th>
             </tr>
           </thead>
           <tbody>

--- a/src/tools/generate/generate_chapters.js
+++ b/src/tools/generate/generate_chapters.js
@@ -10,6 +10,7 @@ const { generate_figure_ids } = require('./generate_figure_ids');
 const converter = new showdown.Converter({ tables: true, metadata: true });
 converter.setFlavor('github');
 converter.setOption('simpleLineBreaks', false);
+converter.setOption('tablesHeaderId', false);
 
 const generate_chapters = async () => {
   for (const file of await find_files()) {


### PR DESCRIPTION
Fixes https://github.com/HTTPArchive/almanac.httparchive.org/issues/310

This turned out to be easier to fix than I thought as there's an [option to turn this off](https://github.com/showdownjs/showdown/wiki/Showdown-Options#tablesheaderid). Weirdly it says it's off by default and can't see where we turned this on. Unless documentation is misleading and once tables is on, this is automatically enabled. Any ideas @mikegeyser?

Either way this fixes our issue by explicitly turning it off.