### PR TITLE
Foreword

### DIFF
--- a/src/.gcloudignore
+++ b/src/.gcloudignore
@@ -1,0 +1,19 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Python pycache:
+__pycache__/
+# Ignored by the build system
+/setup.cfg

--- a/src/templates/en/2019/table_of_contents.html
+++ b/src/templates/en/2019/table_of_contents.html
@@ -156,6 +156,29 @@
 <section class="main">
   <h1 class="title">Table of Contents</h1>
 
+  <section>
+    <h2>Foreword</h2>
+
+    <p>
+      The open web is an amazingly complex, evolving network of technologies. Entire industries and careers are built on the web and depend on its vibrant ecosystem to succeed. As critical as the web is, understanding how it's doing has been surprisingly elusive. Since 2010, the mission of the <a href="https://httparchive.org/">HTTP Archive</a> project has been to track how the web is built. And it's been doing an amazing job of it. But there has been one gap that has been especially challenging to close: bringing meaning to the data and enabling the web community to easily understand how it's performing. That's where the Web Almanac comes in.
+    </p>
+
+    <p>
+      The mission of the Web Almanac is to take the treasure trove of insights that would otherwise be accessible only to intrepid data miners and package it up in a way that's easy to understand. This is made possible with the help of industry experts who can make sense of the data and tell us what it means. Each of the 20 chapters in the Web Almanac focuses on a specific aspect of the web and it's authored and peer reviewed by experts in their field. The strength of the Web Almanac flows directly from the expertise of the people who write it.
+    </p>
+
+    <p>
+      Many of the findings in the Web Almanac are are worthy of celebration, but it's also an important reminder of the work still required to deliver high quality user experiences. The data-driven analyses in each chapter are a form of accountability we all share for developing a better web. It's not about shaming those that are getting it wrong, but about shining a guiding light on the path of best practices so there is a clear right way to do things. And with the continued help of the web community, we hope to make this an annual tradition, so each year we can track our progress and make course corrections as needed.
+    </p>
+
+    <p>
+      There is so much to learn in this report, so start exploring and share your takeaways with the community so we can collectively advance our understanding of the state of the web.
+    </p>
+
+    <p>— <em><a href="{{ url_for('contributors', year=year, lang=lang, _anchor='rviscomi') }}">Rick Viscomi</a>, creator of the Web Almanac</em></p>
+
+  </section>
+
   <div class="contents-wrapper">
     <div class="parts">
       {% for part_config in config.outline %}
@@ -176,6 +199,12 @@
           </div>
         </section>
       {% endfor %}
+      <section class="part">
+        <h2 class="part-name">Appendix</h2>
+        <div class="chapters"><div class="chapter">
+          <a href="{{ url_for('methodology', year=year, lang=lang) }}">Methodology</a>
+        </div></div>
+      </section>
     </div>
 
     <section class="characters">

--- a/src/templates/en/2019/table_of_contents.html
+++ b/src/templates/en/2019/table_of_contents.html
@@ -164,7 +164,7 @@
     </p>
 
     <p>
-      The mission of the Web Almanac is to take the treasure trove of insights that would otherwise be accessible only to intrepid data miners and package it up in a way that's easy to understand. This is made possible with the help of industry experts who can make sense of the data and tell us what it means. Each of the 20 chapters in the Web Almanac focuses on a specific aspect of the web and it's authored and peer reviewed by experts in their field. The strength of the Web Almanac flows directly from the expertise of the people who write it.
+      The mission of the Web Almanac is to take the treasure trove of insights that would otherwise be accessible only to intrepid data miners and package it up in a way that's easy to understand. This is made possible with the help of industry experts who can make sense of the data and tell us what it means. Each of the 20 chapters in the Web Almanac focuses on a specific aspect of the web and is authored and peer reviewed by experts in their field. The strength of the Web Almanac flows directly from the expertise of the people who write it.
     </p>
 
     <p>
@@ -201,9 +201,14 @@
       {% endfor %}
       <section class="part">
         <h2 class="part-name">Appendix</h2>
-        <div class="chapters"><div class="chapter">
-          <a href="{{ url_for('methodology', year=year, lang=lang) }}">Methodology</a>
-        </div></div>
+        <div class="chapters">
+          <div class="chapter">
+            <a href="{{ url_for('methodology', year=year, lang=lang) }}">Methodology</a>
+          </div>
+          <div class="chapter">
+            <a href="{{ url_for('contributors', year=year, lang=lang) }}">Contributors</a>
+          </div>
+        </div>
       </section>
     </div>
 


### PR DESCRIPTION
Here are the full contents of the section:

> The open web is an amazingly complex, evolving network of technologies. Entire industries and careers are built on the web and depend on its vibrant ecosystem to succeed. As critical as the web is, understanding how it's doing has been surprisingly elusive. Since 2010, the mission of the HTTP Archive project has been to track how the web is built. And it's been doing an amazing job of it. But there has been one gap that has been especially challenging to close: bringing meaning to the data and enabling the web community to easily understand how it's performing. That's where the Web Almanac comes in.
>
> The mission of the Web Almanac is to take the treasure trove of insights that would otherwise be accessible only to intrepid data miners and package it up in a way that's easy to understand. This is made possible with the help of industry experts who can make sense of the data and tell us what it means. Each of the 20 chapters in the Web Almanac focuses on a specific aspect of the web and it's authored and peer reviewed by experts in their field. The strength of the Web Almanac flows directly from the expertise of the people who write it.
> 
> Many of the findings in the Web Almanac are are worthy of celebration, but it's also an important reminder of the work still required to deliver high quality user experiences. The data-driven analyses in each chapter are a form of accountability we all share for developing a better web. It's not about shaming those that are getting it wrong, but about shining a guiding light on the path of best practices so there is a clear right way to do things. And with the continued help of the web community, we hope to make this an annual tradition, so each year we can track our progress and make course corrections as needed.
>
> There is so much to learn in this report, so start exploring and share your takeaways with the community so we can collectively advance our understanding of the state of the web.

I've added this to the Table of Contents page as a "Foreword" section before the parts/chapters. After those I also added the Methodology page as part of a new "Appendix" section.