### PR TITLE
Use larger image for OG meta data, add image dimensions

### DIFF
--- a/src/templates/en/2019/chapter.html
+++ b/src/templates/en/2019/chapter.html
@@ -15,19 +15,21 @@
 {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %}
 
 {% block meta %}
-<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}">
+<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
 
-<meta property="og:title" content="{{ self.title() }}">
-<meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}">
-<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg">
-<meta property="og:type" content="article">
-<meta property="og:description" content="{{ self.description() }}">
+<meta property="og:title" content="{{ self.title() }}" />
+<meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" />
+<meta property="og:image:height" content="433" />
+<meta property="og:image:width" content="866" />
+<meta property="og:type" content="article" />
+<meta property="og:description" content="{{ self.description() }}" />
 
-<meta name="twitter:card" content="summary">
-<meta name="twitter:site" content="@HTTPArchive">
-<meta name="twitter:title" content="{{ self.title() }}">
-<meta name="twitter:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg">
-<meta name="twitter:description" content="{{ self.description() }}">
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:site" content="@HTTPArchive" />
+<meta name="twitter:title" content="{{ self.title() }}" />
+<meta name="twitter:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta name="twitter:description" content="{{ self.description() }}" />
 
 <script type="application/ld+json">
 	{
@@ -40,7 +42,9 @@
 	  "headline": "{{ metadata.get('title') }}",
 	  "image": {
 	  	  "@type": "ImageObject",
-	  	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+	  	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
+	  	  "height": 163,
+	  	  "width": 326
 	  },
 	  "publisher": {
 	  	  "@type": "Organization",

--- a/src/templates/en/2019/chapter.html
+++ b/src/templates/en/2019/chapter.html
@@ -15,7 +15,7 @@
 {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %}
 
 {% block meta %}
-<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+<meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />

--- a/src/templates/en/2019/chapters/accessibility.html
+++ b/src/templates/en/2019/chapters/accessibility.html
@@ -11,7 +11,7 @@
 #}-->
 
 {% set metadata = {"part_number":"II","chapter_number":9,"title":"Accessibility","description":"Accessibility chapter of the 2019 Web Almanac covering ease of reading, media, ease of navigation, and compatibility with assistive technologies","authors":["nektarios-paisios","obto","kleinab"],"reviewers":["ljme"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
-<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+<meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />

--- a/src/templates/en/2019/chapters/accessibility.html
+++ b/src/templates/en/2019/chapters/accessibility.html
@@ -15,7 +15,9 @@
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />
-<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" />
+<meta property="og:image:height" content="433" />
+<meta property="og:image:width" content="866" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ self.description() }}" />
 
@@ -36,7 +38,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
+    	  "height": 163,
+    	  "width": 326
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/caching.html
+++ b/src/templates/en/2019/chapters/caching.html
@@ -15,7 +15,9 @@
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />
-<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" />
+<meta property="og:image:height" content="433" />
+<meta property="og:image:width" content="866" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ self.description() }}" />
 
@@ -36,7 +38,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
+    	  "height": 163,
+    	  "width": 326
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/caching.html
+++ b/src/templates/en/2019/chapters/caching.html
@@ -11,7 +11,7 @@
 #}-->
 
 {% set metadata = {"part_number":"IV","chapter_number":16,"title":"Caching","description":"Caching chapter of the 2019 Web Almanac covering cache-control, expires, TTLs, validitaty, vary, set-cookies, AppCache, Service Workers and opportunities","authors":["paulcalvano"],"reviewers":["obto","bkardell"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
-<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+<meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />

--- a/src/templates/en/2019/chapters/compression.html
+++ b/src/templates/en/2019/chapters/compression.html
@@ -15,7 +15,9 @@
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />
-<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" />
+<meta property="og:image:height" content="433" />
+<meta property="og:image:width" content="866" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ self.description() }}" />
 
@@ -36,7 +38,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
+    	  "height": 163,
+    	  "width": 326
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/compression.html
+++ b/src/templates/en/2019/chapters/compression.html
@@ -11,7 +11,7 @@
 #}-->
 
 {% set metadata = {"part_number":"IV","chapter_number":15,"title":"Compression","description":"Compression chapter of the 2019 Web Almanac covering HTTP compression, algorithms, content types, 1st party and 3rd party compression and opportunities","authors":["paulcalvano"],"reviewers":["obto","yoavweiss"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
-<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+<meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />

--- a/src/templates/en/2019/chapters/ecommerce.html
+++ b/src/templates/en/2019/chapters/ecommerce.html
@@ -15,7 +15,9 @@
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />
-<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" />
+<meta property="og:image:height" content="433" />
+<meta property="og:image:width" content="866" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ self.description() }}" />
 
@@ -36,7 +38,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
+    	  "height": 163,
+    	  "width": 326
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/ecommerce.html
+++ b/src/templates/en/2019/chapters/ecommerce.html
@@ -11,7 +11,7 @@
 #}-->
 
 {% set metadata = {"part_number":"III","chapter_number":13,"title":"Ecommerce","description":"Ecommerce chapter of the 2019 Web Almanac covering ecommerce platforms, payloads, images, third parties, performance, seo, and PWAs","authors":["samdutton","alankent"],"reviewers":["voltek62"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
-<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+<meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />

--- a/src/templates/en/2019/chapters/fonts.html
+++ b/src/templates/en/2019/chapters/fonts.html
@@ -15,7 +15,9 @@
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />
-<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" />
+<meta property="og:image:height" content="433" />
+<meta property="og:image:width" content="866" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ self.description() }}" />
 
@@ -36,7 +38,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
+    	  "height": 163,
+    	  "width": 326
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/fonts.html
+++ b/src/templates/en/2019/chapters/fonts.html
@@ -11,7 +11,7 @@
 #}-->
 
 {% set metadata = {"part_number":"I","chapter_number":6,"title":"Fonts","description":"Fonts chapter of the 2019 Web Almanac covering ecommerce platforms, payloads, images, third parties, performance, seo, and PWAs","authors":["zachleat"],"reviewers":["hyperpress","AymenLoukil"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
-<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+<meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />

--- a/src/templates/en/2019/chapters/http2.html
+++ b/src/templates/en/2019/chapters/http2.html
@@ -15,7 +15,9 @@
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />
-<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" />
+<meta property="og:image:height" content="433" />
+<meta property="og:image:width" content="866" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ self.description() }}" />
 
@@ -36,7 +38,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
+    	  "height": 163,
+    	  "width": 326
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/http2.html
+++ b/src/templates/en/2019/chapters/http2.html
@@ -11,7 +11,7 @@
 #}-->
 
 {% set metadata = {"part_number":"IV","chapter_number":20,"title":"HTTP/2","description":"HTTP/2 chapter of the 2019 Web Almanac covering adoption and impact of HTTP/2, HTTP/2 Push, HTTP/2 Issues, and HTTP/3","authors":["bazzadp"],"reviewers":["bagder","rmarx","dotjs"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
-<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+<meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />

--- a/src/templates/en/2019/chapters/markup.html
+++ b/src/templates/en/2019/chapters/markup.html
@@ -15,7 +15,9 @@
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />
-<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" />
+<meta property="og:image:height" content="433" />
+<meta property="og:image:width" content="866" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ self.description() }}" />
 
@@ -36,7 +38,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
+    	  "height": 163,
+    	  "width": 326
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/markup.html
+++ b/src/templates/en/2019/chapters/markup.html
@@ -11,7 +11,7 @@
 #}-->
 
 {% set metadata = {"part_number":"I","chapter_number":3,"title":"Markup","description":"Markup chapter of the 2019 Web Almanac covering elements used, custom elements, value, products, and common use cases","authors":["bkardell"],"reviewers":["zcorpan","tomhodgins","matthewp"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
-<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+<meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />

--- a/src/templates/en/2019/chapters/mobile-web.html
+++ b/src/templates/en/2019/chapters/mobile-web.html
@@ -15,7 +15,9 @@
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />
-<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" />
+<meta property="og:image:height" content="433" />
+<meta property="og:image:width" content="866" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ self.description() }}" />
 
@@ -36,7 +38,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
+    	  "height": 163,
+    	  "width": 326
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/mobile-web.html
+++ b/src/templates/en/2019/chapters/mobile-web.html
@@ -11,7 +11,7 @@
 #}-->
 
 {% set metadata = {"part_number":"II","chapter_number":12,"title":"Mobile Web","description":"Mobile Web chapter of the 2019 Web Almanac covering page loading, textual content, zooming and scaling, buttons and links, and ease of filling out forms","authors":["obto"],"reviewers":["aymenloukil","hyperpress"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
-<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+<meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />

--- a/src/templates/en/2019/chapters/page-weight.html
+++ b/src/templates/en/2019/chapters/page-weight.html
@@ -15,7 +15,9 @@
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />
-<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" />
+<meta property="og:image:height" content="433" />
+<meta property="og:image:width" content="866" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ self.description() }}" />
 
@@ -36,7 +38,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
+    	  "height": 163,
+    	  "width": 326
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/page-weight.html
+++ b/src/templates/en/2019/chapters/page-weight.html
@@ -11,7 +11,7 @@
 #}-->
 
 {% set metadata = {"part_number":"IV","chapter_number":18,"title":"Page Weight","description":"Page Weight chapter of the 2019 Web Almanac covering why page weight matters, bandwidth, complex pages, page weight over time, page requests, and file formats","authors":["tammyeverts","khempenius"],"reviewers":["paulcalvano"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
-<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+<meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />

--- a/src/templates/en/2019/chapters/performance.html
+++ b/src/templates/en/2019/chapters/performance.html
@@ -15,7 +15,9 @@
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />
-<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" />
+<meta property="og:image:height" content="433" />
+<meta property="og:image:width" content="866" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ self.description() }}" />
 
@@ -36,7 +38,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
+    	  "height": 163,
+    	  "width": 326
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/performance.html
+++ b/src/templates/en/2019/chapters/performance.html
@@ -11,7 +11,7 @@
 #}-->
 
 {% set metadata = {"part_number":"II","chapter_number":7,"title":"Performance","description":"Performance chapter of the 2019 Web Almanac covering First Contentful Paint (FCP), Time to First Byte (TTFB), and First Input Delay (FID) ","authors":["rviscomi"],"reviewers":["JMPerez","obto","sergeychernyshev","zeman"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
-<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+<meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />

--- a/src/templates/en/2019/chapters/pwa.html
+++ b/src/templates/en/2019/chapters/pwa.html
@@ -15,7 +15,9 @@
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />
-<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" />
+<meta property="og:image:height" content="433" />
+<meta property="og:image:width" content="866" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ self.description() }}" />
 
@@ -36,7 +38,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
+    	  "height": 163,
+    	  "width": 326
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/pwa.html
+++ b/src/templates/en/2019/chapters/pwa.html
@@ -11,7 +11,7 @@
 #}-->
 
 {% set metadata = {"part_number":"II","chapter_number":11,"title":"PWA","description":"PWA chapter of the 2019 Web Almanac covering Service Workers, Web App Manifests, and Workbox","authors":["tomayac","jeffposnick"],"reviewers":["hyperpress","ahmadawais"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
-<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+<meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />

--- a/src/templates/en/2019/chapters/resource-hints.html
+++ b/src/templates/en/2019/chapters/resource-hints.html
@@ -15,7 +15,9 @@
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />
-<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" />
+<meta property="og:image:height" content="433" />
+<meta property="og:image:width" content="866" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ self.description() }}" />
 
@@ -36,7 +38,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
+    	  "height": 163,
+    	  "width": 326
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/resource-hints.html
+++ b/src/templates/en/2019/chapters/resource-hints.html
@@ -11,7 +11,7 @@
 #}-->
 
 {% set metadata = {"part_number":"IV","chapter_number":19,"title":"Resource Hints","description":"Resource Hints chapter of the 2019 Web Almanac covering usage of dns-prefetch, preconnect, preload, and prefetch as well as priority hints and native lazy loading","authors":["khempenius"],"reviewers":["andydavies","bazzadp","yoavweiss"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
-<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+<meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />

--- a/src/templates/en/2019/chapters/seo.html
+++ b/src/templates/en/2019/chapters/seo.html
@@ -15,7 +15,9 @@
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />
-<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" />
+<meta property="og:image:height" content="433" />
+<meta property="og:image:width" content="866" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ self.description() }}" />
 
@@ -36,7 +38,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
+    	  "height": 163,
+    	  "width": 326
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/seo.html
+++ b/src/templates/en/2019/chapters/seo.html
@@ -11,7 +11,7 @@
 #}-->
 
 {% set metadata = {"part_number":"I","chapter_number":10,"title":"SEO","description":"SEO chapter of the 2019 Web Almanac covering content, meta tags, indexability, linking, speed, structured data, internationalization, SPAs, AMP and security","authors":["ymschaap","rachellcostello","AVGP"],"reviewers":["clarkeclark","andylimn","AymenLoukil","catalinred","mattludwig"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
-<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+<meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />

--- a/src/templates/en/2019/chapters/third-parties.html
+++ b/src/templates/en/2019/chapters/third-parties.html
@@ -15,7 +15,9 @@
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />
-<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" />
+<meta property="og:image:height" content="433" />
+<meta property="og:image:width" content="866" />
 <meta property="og:type" content="article" />
 <meta property="og:description" content="{{ self.description() }}" />
 
@@ -36,7 +38,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg"
+    	  "url": "https://almanac.httparchive.org/static/images/2019/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
+    	  "height": 163,
+    	  "width": 326
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/third-parties.html
+++ b/src/templates/en/2019/chapters/third-parties.html
@@ -11,7 +11,7 @@
 #}-->
 
 {% set metadata = {"part_number":"II","chapter_number":5,"title":"Third Parties","description":"Third Parties chapter of the 2019 Web Almanac covering data of what third parties are used, what they are used for, performance impacts and privacy impacts","authors":["patrickhulce"],"reviewers":["zcorpan","obto","jasti"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
-<meta name="description" content="{{ metadata.get('description',metadata.get('title') + ' chapter of the 2019 Web Almanac') }}" />
+<meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />

--- a/src/templates/en/2019/contributors.html
+++ b/src/templates/en/2019/contributors.html
@@ -10,6 +10,8 @@
 <meta property="og:title" content="{{ self.title() }}">
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, year=year, lang=lang) }}">
 <meta property="og:image" content="https://almanac.httparchive.org/static/images/methodology-characters.png">
+<meta property="og:image:height" content="354">
+<meta property="og:image:width" content="984">
 <meta property="og:type" content="article">
 <meta property="og:description" content="{{ self.description() }}">
 
@@ -30,7 +32,9 @@
 	  "headline": "{{ self.title() }}",
 	  "image": {
 	  	  "@type": "ImageObject",
-	  	  "url": "https://almanac.httparchive.org/static/images/methodology-characters.png"
+	  	  "url": "https://almanac.httparchive.org/static/images/methodology-characters.png",
+	  	  "height": 354,
+	  	  "width": 984
 	  },
 	  "publisher": {
 	  	  "@type": "Organization",

--- a/src/templates/en/2019/index.html
+++ b/src/templates/en/2019/index.html
@@ -10,6 +10,8 @@
 <meta property="og:title" content="{{ self.title() }}">
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint , year=year, lang=lang) }}">
 <meta property="og:image" content="https://almanac.httparchive.org/static/images/methodology-characters.png">
+<meta property="og:image:height" content="354">
+<meta property="og:image:width" content="984">
 <meta property="og:type" content="article">
 <meta property="og:description" content="{{ self.description() }}">
 
@@ -38,7 +40,9 @@
 	  "headline": "{{ self.title() }}",
 	  "image": {
 	  	  "@type": "ImageObject",
-	  	  "url": "https://almanac.httparchive.org/static/images/methodology-characters.png"
+	  	  "url": "https://almanac.httparchive.org/static/images/methodology-characters.png",
+	  	  "height": 354,
+	  	  "width": 984
 	  },
 	  "publisher": {
 	  	  "@type": "Organization",

--- a/src/templates/en/2019/methodology.html
+++ b/src/templates/en/2019/methodology.html
@@ -10,6 +10,8 @@
 <meta property="og:title" content="{{ self.title() }}">
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}">
 <meta property="og:image" content="https://almanac.httparchive.org/static/images/methodology-characters.png">
+<meta property="og:image:height" content="354">
+<meta property="og:image:width" content="984">
 <meta property="og:type" content="article">
 <meta property="og:description" content="{{ self.description() }}">
 
@@ -30,7 +32,9 @@
 	  "headline": "{{ self.title() }}",
 	  "image": {
 	  	  "@type": "ImageObject",
-	  	  "url": "https://almanac.httparchive.org/static/images/methodology-characters.png"
+	  	  "url": "https://almanac.httparchive.org/static/images/methodology-characters.png",
+	  	  "height": 354,
+	  	  "width": 984
 	  },
 	  "publisher": {
 	  	  "@type": "Organization",


### PR DESCRIPTION
Change to use larger images for OG meta data as Facebook is complaining about the OG data using [their testing tool on the example chapters just published](https://developers.facebook.com/tools/debug/sharing/?q=https%3A%2F%2Falmanac.httparchive.org%2Fen%2F2019%2Fmarkup).

Additionally added Dimensions as recommended by Facebook. Luckily all our chapter images are the same size or this might have been quite tricky! 😀