### PR TITLE
Horizontal scrollbar

### DIFF
--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -197,6 +197,7 @@
   padding:50px 36px;
   border:1px solid #1A2B490A;
   margin: 20px 0;
+  overflow: hidden;
 }
 
 #chapter-navigation>a{

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -197,7 +197,6 @@
   padding:50px 36px;
   border:1px solid #1A2B490A;
   margin: 20px 0;
-  overflow: auto;
 }
 
 #chapter-navigation>a{


### PR DESCRIPTION
This closes #352.

Removed the `overflow:auto`  because it was causing a horizontal scrollbar on chrome on a mac.