### PR TITLE
Generate last_updated

### DIFF
--- a/src/content/en/2019/accessibility.md
+++ b/src/content/en/2019/accessibility.md
@@ -6,7 +6,7 @@ description: Accessibility chapter of the 2019 Web Almanac covering ease of read
 authors: [nektarios-paisios, obto, kleinab]
 reviewers: [ljme]
 published: 2019-11-04T12:00:00+00:00:00
-last_updated: 2019-11-04T12:00:00+00:00:00 
+last_updated: 2019-11-04T18:46:53.000Z 
 ---
 
 # Introduction

--- a/src/content/en/2019/caching.md
+++ b/src/content/en/2019/caching.md
@@ -6,7 +6,7 @@ description: Caching chapter of the 2019 Web Almanac covering cache-control, exp
 authors: [paulcalvano]
 reviewers: [obto, bkardell]
 published: 2019-11-04T12:00:00+00:00:00
-last_updated: 2019-11-04T12:00:00+00:00:00 
+last_updated: 2019-11-04T22:37:21.000Z 
 ---
 
 # Intro

--- a/src/content/en/2019/compression.md
+++ b/src/content/en/2019/compression.md
@@ -6,7 +6,7 @@ description: Compression chapter of the 2019 Web Almanac covering HTTP compressi
 authors: [paulcalvano]
 reviewers: [obto, yoavweiss]
 published: 2019-11-04T12:00:00+00:00:00
-last_updated: 2019-11-04T12:00:00+00:00:00 
+last_updated: 2019-11-04T22:37:21.000Z 
 ---
 
 # Intro

--- a/src/content/en/2019/ecommerce.md
+++ b/src/content/en/2019/ecommerce.md
@@ -6,7 +6,7 @@ description: Ecommerce chapter of the 2019 Web Almanac covering ecommerce platfo
 authors: [samdutton, alankent]
 reviewers: [voltek62]
 published: 2019-11-04T12:00:00+00:00:00
-last_updated: 2019-11-04T12:00:00+00:00:00 
+last_updated: 2019-11-05T01:25:08.000Z 
 ---
 
 ## Introduction

--- a/src/content/en/2019/fonts.md
+++ b/src/content/en/2019/fonts.md
@@ -6,7 +6,7 @@ description: Fonts chapter of the 2019 Web Almanac covering ecommerce platforms,
 authors: [zachleat]
 reviewers: [hyperpress, AymenLoukil]
 published: 2019-11-04T12:00:00+00:00:00
-last_updated: 2019-11-04T12:00:00+00:00:00 
+last_updated: 2019-11-04T22:37:21.000Z 
 ---
 
 ## Introduction

--- a/src/content/en/2019/http2.md
+++ b/src/content/en/2019/http2.md
@@ -6,7 +6,7 @@ description: HTTP/2 chapter of the 2019 Web Almanac covering adoption and impact
 authors: [bazzadp]
 reviewers: [bagder, rmarx, dotjs]
 published: 2019-11-04T12:00:00+00:00:00
-last_updated: 2019-11-04T12:00:00+00:00:00 
+last_updated: 2019-11-04T18:46:53.000Z 
 ---
 
 ## Introduction

--- a/src/content/en/2019/markup.md
+++ b/src/content/en/2019/markup.md
@@ -6,7 +6,7 @@ description: Markup chapter of the 2019 Web Almanac covering elements used, cust
 authors: [bkardell]
 reviewers: [zcorpan, tomhodgins, matthewp]
 published: 2019-11-04T12:00:00+00:00:00
-last_updated: 2019-11-04T12:00:00+00:00:00 
+last_updated: 2019-11-06T20:17:09.000Z 
 ---
 
 ## Introduction

--- a/src/content/en/2019/media.md
+++ b/src/content/en/2019/media.md
@@ -6,7 +6,7 @@ description: Media chapter of the 2019 Web Almanac covering images, animations, 
 authors: [colinbendell, dougsillars]
 reviewers: [ahmadawais, kornelski, eeeps]
 published: 2019-11-04T12:00:00+00:00:00
-last_updated: 2019-11-04T12:00:00+00:00:00 
+last_updated: 2019-11-06T20:26:01.000Z 
 ---
 
 ## Introduction

--- a/src/content/en/2019/mobile-web.md
+++ b/src/content/en/2019/mobile-web.md
@@ -6,7 +6,7 @@ description: Mobile Web chapter of the 2019 Web Almanac covering page loading, t
 authors: [obto]
 reviewers: [AymenLoukil, hyperpress]
 published: 2019-11-04T12:00:00+00:00:00
-last_updated: 2019-11-04T12:00:00+00:00:00 
+last_updated: 2019-11-05T18:43:57.000Z 
 ---
 
 ## Introduction

--- a/src/content/en/2019/page-weight.md
+++ b/src/content/en/2019/page-weight.md
@@ -6,7 +6,7 @@ description: Page Weight chapter of the 2019 Web Almanac covering why page weigh
 authors: [tammyeverts, khempenius]
 reviewers: [paulcalvano]
 published: 2019-11-04T12:00:00+00:00:00
-last_updated: 2019-11-04T12:00:00+00:00:00
+last_updated: 2019-11-06T18:14:24.000Z
 ---
 
 ## Introduction

--- a/src/content/en/2019/performance.md
+++ b/src/content/en/2019/performance.md
@@ -6,7 +6,7 @@ description: Performance chapter of the 2019 Web Almanac covering First Contentf
 authors: [rviscomi]
 reviewers: [JMPerez,obto,sergeychernyshev,zeman]
 published: 2019-11-04T12:00:00+00:00:00
-last_updated: 2019-11-04T12:00:00+00:00:00 
+last_updated: 2019-11-06T06:33:38.000Z 
 ---
 
 ## Introduction

--- a/src/content/en/2019/pwa.md
+++ b/src/content/en/2019/pwa.md
@@ -6,7 +6,7 @@ description: PWA chapter of the 2019 Web Almanac covering Service Workers, Web A
 authors: [tomayac, jeffposnick]
 reviewers: [hyperpress, ahmadawais]
 published: 2019-11-04T12:00:00+00:00:00
-last_updated: 2019-11-04T12:00:00+00:00:00 
+last_updated: 2019-11-05T01:25:08.000Z 
 ---
 
 ## Introduction

--- a/src/content/en/2019/resource-hints.md
+++ b/src/content/en/2019/resource-hints.md
@@ -6,7 +6,7 @@ description: Resource Hints chapter of the 2019 Web Almanac covering usage of dn
 authors: [khempenius]
 reviewers: [andydavies, bazzadp, yoavweiss]
 published: 2019-11-04T12:00:00+00:00:00
-last_updated: 2019-11-04T12:00:00+00:00:00 
+last_updated: 2019-11-04T18:45:53.000Z 
 ---
 
 ## Introduction

--- a/src/content/en/2019/seo.md
+++ b/src/content/en/2019/seo.md
@@ -6,7 +6,7 @@ description: SEO chapter of the 2019 Web Almanac covering content, meta tags, in
 authors: [ymschaap, rachellcostello, AVGP]
 reviewers: [clarkeclark, andylimn, AymenLoukil, catalinred, mattludwig]
 published: 2019-11-04T12:00:00+00:00:00
-last_updated: 2019-11-04T12:00:00+00:00:00 
+last_updated: 2019-11-04T18:46:53.000Z 
 ---
 
 ## Introduction

--- a/src/content/en/2019/third-parties.md
+++ b/src/content/en/2019/third-parties.md
@@ -6,7 +6,7 @@ description: Third Parties chapter of the 2019 Web Almanac covering data of what
 authors: [patrickhulce]
 reviewers: [zcorpan, obto, jasti]
 published: 2019-11-04T12:00:00+00:00:00
-last_updated: 2019-11-04T12:00:00+00:00:00
+last_updated: 2019-11-05T15:45:32.000Z
 ---
 
 ## Introduction

--- a/src/templates/en/2019/chapters/accessibility.html
+++ b/src/templates/en/2019/chapters/accessibility.html
@@ -10,7 +10,7 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"II","chapter_number":9,"title":"Accessibility","description":"Accessibility chapter of the 2019 Web Almanac covering ease of reading, media, ease of navigation, and compatibility with assistive technologies","authors":["nektarios-paisios","obto","kleinab"],"reviewers":["ljme"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
+{% set metadata = {"part_number":"II","chapter_number":9,"title":"Accessibility","description":"Accessibility chapter of the 2019 Web Almanac covering ease of reading, media, ease of navigation, and compatibility with assistive technologies","authors":["nektarios-paisios","obto","kleinab"],"reviewers":["ljme"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T18:46:53.000Z "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
 <meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
@@ -39,9 +39,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
-    	  "height": 163,
-    	  "width": 326
+    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg",
+    	  "height": 433,
+    	  "width": 866
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/caching.html
+++ b/src/templates/en/2019/chapters/caching.html
@@ -10,7 +10,7 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"IV","chapter_number":16,"title":"Caching","description":"Caching chapter of the 2019 Web Almanac covering cache-control, expires, TTLs, validitaty, vary, set-cookies, AppCache, Service Workers and opportunities","authors":["paulcalvano"],"reviewers":["obto","bkardell"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
+{% set metadata = {"part_number":"IV","chapter_number":16,"title":"Caching","description":"Caching chapter of the 2019 Web Almanac covering cache-control, expires, TTLs, validitaty, vary, set-cookies, AppCache, Service Workers and opportunities","authors":["paulcalvano"],"reviewers":["obto","bkardell"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T22:37:21.000Z "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
 <meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
@@ -39,9 +39,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
-    	  "height": 163,
-    	  "width": 326
+    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg",
+    	  "height": 433,
+    	  "width": 866
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/compression.html
+++ b/src/templates/en/2019/chapters/compression.html
@@ -10,7 +10,7 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"IV","chapter_number":15,"title":"Compression","description":"Compression chapter of the 2019 Web Almanac covering HTTP compression, algorithms, content types, 1st party and 3rd party compression and opportunities","authors":["paulcalvano"],"reviewers":["obto","yoavweiss"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
+{% set metadata = {"part_number":"IV","chapter_number":15,"title":"Compression","description":"Compression chapter of the 2019 Web Almanac covering HTTP compression, algorithms, content types, 1st party and 3rd party compression and opportunities","authors":["paulcalvano"],"reviewers":["obto","yoavweiss"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T22:37:21.000Z "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
 <meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
@@ -39,9 +39,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
-    	  "height": 163,
-    	  "width": 326
+    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg",
+    	  "height": 433,
+    	  "width": 866
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/css.html
+++ b/src/templates/en/2019/chapters/css.html
@@ -39,9 +39,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
-    	  "height": 163,
-    	  "width": 326
+    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg",
+    	  "height": 433,
+    	  "width": 866
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/ecommerce.html
+++ b/src/templates/en/2019/chapters/ecommerce.html
@@ -10,7 +10,7 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"III","chapter_number":13,"title":"Ecommerce","description":"Ecommerce chapter of the 2019 Web Almanac covering ecommerce platforms, payloads, images, third parties, performance, seo, and PWAs","authors":["samdutton","alankent"],"reviewers":["voltek62"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
+{% set metadata = {"part_number":"III","chapter_number":13,"title":"Ecommerce","description":"Ecommerce chapter of the 2019 Web Almanac covering ecommerce platforms, payloads, images, third parties, performance, seo, and PWAs","authors":["samdutton","alankent"],"reviewers":["voltek62"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-05T01:25:08.000Z "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
 <meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
@@ -39,9 +39,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
-    	  "height": 163,
-    	  "width": 326
+    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg",
+    	  "height": 433,
+    	  "width": 866
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/fonts.html
+++ b/src/templates/en/2019/chapters/fonts.html
@@ -10,7 +10,7 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"I","chapter_number":6,"title":"Fonts","description":"Fonts chapter of the 2019 Web Almanac covering ecommerce platforms, payloads, images, third parties, performance, seo, and PWAs","authors":["zachleat"],"reviewers":["hyperpress","AymenLoukil"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
+{% set metadata = {"part_number":"I","chapter_number":6,"title":"Fonts","description":"Fonts chapter of the 2019 Web Almanac covering ecommerce platforms, payloads, images, third parties, performance, seo, and PWAs","authors":["zachleat"],"reviewers":["hyperpress","AymenLoukil"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T22:37:21.000Z "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
 <meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
@@ -39,9 +39,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
-    	  "height": 163,
-    	  "width": 326
+    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg",
+    	  "height": 433,
+    	  "width": 866
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/http2.html
+++ b/src/templates/en/2019/chapters/http2.html
@@ -10,7 +10,7 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"IV","chapter_number":20,"title":"HTTP/2","description":"HTTP/2 chapter of the 2019 Web Almanac covering adoption and impact of HTTP/2, HTTP/2 Push, HTTP/2 Issues, and HTTP/3","authors":["bazzadp"],"reviewers":["bagder","rmarx","dotjs"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
+{% set metadata = {"part_number":"IV","chapter_number":20,"title":"HTTP/2","description":"HTTP/2 chapter of the 2019 Web Almanac covering adoption and impact of HTTP/2, HTTP/2 Push, HTTP/2 Issues, and HTTP/3","authors":["bazzadp"],"reviewers":["bagder","rmarx","dotjs"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T18:46:53.000Z "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
 <meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
@@ -39,9 +39,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
-    	  "height": 163,
-    	  "width": 326
+    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg",
+    	  "height": 433,
+    	  "width": 866
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/javascript.html
+++ b/src/templates/en/2019/chapters/javascript.html
@@ -39,9 +39,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
-    	  "height": 163,
-    	  "width": 326
+    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg",
+    	  "height": 433,
+    	  "width": 866
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/markup.html
+++ b/src/templates/en/2019/chapters/markup.html
@@ -10,7 +10,7 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"I","chapter_number":3,"title":"Markup","description":"Markup chapter of the 2019 Web Almanac covering elements used, custom elements, value, products, and common use cases","authors":["bkardell"],"reviewers":["zcorpan","tomhodgins","matthewp"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
+{% set metadata = {"part_number":"I","chapter_number":3,"title":"Markup","description":"Markup chapter of the 2019 Web Almanac covering elements used, custom elements, value, products, and common use cases","authors":["bkardell"],"reviewers":["zcorpan","tomhodgins","matthewp"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-06T20:17:09.000Z "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
 <meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
@@ -39,9 +39,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
-    	  "height": 163,
-    	  "width": 326
+    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg",
+    	  "height": 433,
+    	  "width": 866
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/media.html
+++ b/src/templates/en/2019/chapters/media.html
@@ -10,7 +10,7 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"I","chapter_number":4,"title":"Media","description":"Media chapter of the 2019 Web Almanac covering images, animations, and videos","authors":["colinbendell","dougsillars"],"reviewers":["ahmadawais","kornelski","eeeps"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
+{% set metadata = {"part_number":"I","chapter_number":4,"title":"Media","description":"Media chapter of the 2019 Web Almanac covering images, animations, and videos","authors":["colinbendell","dougsillars"],"reviewers":["ahmadawais","kornelski","eeeps"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-06T20:26:01.000Z "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
 <meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
@@ -39,9 +39,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
-    	  "height": 163,
-    	  "width": 326
+    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg",
+    	  "height": 433,
+    	  "width": 866
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/mobile-web.html
+++ b/src/templates/en/2019/chapters/mobile-web.html
@@ -10,7 +10,7 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"II","chapter_number":12,"title":"Mobile Web","description":"Mobile Web chapter of the 2019 Web Almanac covering page loading, textual content, zooming and scaling, buttons and links, and ease of filling out forms","authors":["obto"],"reviewers":["AymenLoukil","hyperpress"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
+{% set metadata = {"part_number":"II","chapter_number":12,"title":"Mobile Web","description":"Mobile Web chapter of the 2019 Web Almanac covering page loading, textual content, zooming and scaling, buttons and links, and ease of filling out forms","authors":["obto"],"reviewers":["AymenLoukil","hyperpress"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-05T18:43:57.000Z "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
 <meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
@@ -39,9 +39,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
-    	  "height": 163,
-    	  "width": 326
+    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg",
+    	  "height": 433,
+    	  "width": 866
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/page-weight.html
+++ b/src/templates/en/2019/chapters/page-weight.html
@@ -10,7 +10,7 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"IV","chapter_number":18,"title":"Page Weight","description":"Page Weight chapter of the 2019 Web Almanac covering why page weight matters, bandwidth, complex pages, page weight over time, page requests, and file formats","authors":["tammyeverts","khempenius"],"reviewers":["paulcalvano"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00"} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
+{% set metadata = {"part_number":"IV","chapter_number":18,"title":"Page Weight","description":"Page Weight chapter of the 2019 Web Almanac covering why page weight matters, bandwidth, complex pages, page weight over time, page requests, and file formats","authors":["tammyeverts","khempenius"],"reviewers":["paulcalvano"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-06T18:14:24.000Z"} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
 <meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
@@ -39,9 +39,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
-    	  "height": 163,
-    	  "width": 326
+    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg",
+    	  "height": 433,
+    	  "width": 866
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/performance.html
+++ b/src/templates/en/2019/chapters/performance.html
@@ -10,7 +10,7 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"II","chapter_number":7,"title":"Performance","description":"Performance chapter of the 2019 Web Almanac covering First Contentful Paint (FCP), Time to First Byte (TTFB), and First Input Delay (FID) ","authors":["rviscomi"],"reviewers":["JMPerez","obto","sergeychernyshev","zeman"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
+{% set metadata = {"part_number":"II","chapter_number":7,"title":"Performance","description":"Performance chapter of the 2019 Web Almanac covering First Contentful Paint (FCP), Time to First Byte (TTFB), and First Input Delay (FID) ","authors":["rviscomi"],"reviewers":["JMPerez","obto","sergeychernyshev","zeman"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-06T06:33:38.000Z "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
 <meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
@@ -39,9 +39,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
-    	  "height": 163,
-    	  "width": 326
+    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg",
+    	  "height": 433,
+    	  "width": 866
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/pwa.html
+++ b/src/templates/en/2019/chapters/pwa.html
@@ -10,7 +10,7 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"II","chapter_number":11,"title":"PWA","description":"PWA chapter of the 2019 Web Almanac covering Service Workers, Web App Manifests, and Workbox","authors":["tomayac","jeffposnick"],"reviewers":["hyperpress","ahmadawais"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
+{% set metadata = {"part_number":"II","chapter_number":11,"title":"PWA","description":"PWA chapter of the 2019 Web Almanac covering Service Workers, Web App Manifests, and Workbox","authors":["tomayac","jeffposnick"],"reviewers":["hyperpress","ahmadawais"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-05T01:25:08.000Z "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
 <meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
@@ -39,9 +39,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
-    	  "height": 163,
-    	  "width": 326
+    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg",
+    	  "height": 433,
+    	  "width": 866
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/resource-hints.html
+++ b/src/templates/en/2019/chapters/resource-hints.html
@@ -10,7 +10,7 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"IV","chapter_number":19,"title":"Resource Hints","description":"Resource Hints chapter of the 2019 Web Almanac covering usage of dns-prefetch, preconnect, preload, and prefetch as well as priority hints and native lazy loading","authors":["khempenius"],"reviewers":["andydavies","bazzadp","yoavweiss"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
+{% set metadata = {"part_number":"IV","chapter_number":19,"title":"Resource Hints","description":"Resource Hints chapter of the 2019 Web Almanac covering usage of dns-prefetch, preconnect, preload, and prefetch as well as priority hints and native lazy loading","authors":["khempenius"],"reviewers":["andydavies","bazzadp","yoavweiss"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T18:45:53.000Z "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
 <meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
@@ -39,9 +39,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
-    	  "height": 163,
-    	  "width": 326
+    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg",
+    	  "height": 433,
+    	  "width": 866
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/seo.html
+++ b/src/templates/en/2019/chapters/seo.html
@@ -10,7 +10,7 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"I","chapter_number":10,"title":"SEO","description":"SEO chapter of the 2019 Web Almanac covering content, meta tags, indexability, linking, speed, structured data, internationalization, SPAs, AMP and security","authors":["ymschaap","rachellcostello","AVGP"],"reviewers":["clarkeclark","andylimn","AymenLoukil","catalinred","mattludwig"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00 "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
+{% set metadata = {"part_number":"I","chapter_number":10,"title":"SEO","description":"SEO chapter of the 2019 Web Almanac covering content, meta tags, indexability, linking, speed, structured data, internationalization, SPAs, AMP and security","authors":["ymschaap","rachellcostello","AVGP"],"reviewers":["clarkeclark","andylimn","AymenLoukil","catalinred","mattludwig"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T18:46:53.000Z "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
 <meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
@@ -39,9 +39,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
-    	  "height": 163,
-    	  "width": 326
+    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg",
+    	  "height": 433,
+    	  "width": 866
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/templates/en/2019/chapters/third-parties.html
+++ b/src/templates/en/2019/chapters/third-parties.html
@@ -10,7 +10,7 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"II","chapter_number":5,"title":"Third Parties","description":"Third Parties chapter of the 2019 Web Almanac covering data of what third parties are used, what they are used for, performance impacts and privacy impacts","authors":["patrickhulce"],"reviewers":["zcorpan","obto","jasti"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-04T12:00:00+00:00:00"} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
+{% set metadata = {"part_number":"II","chapter_number":5,"title":"Third Parties","description":"Third Parties chapter of the 2019 Web Almanac covering data of what third parties are used, what they are used for, performance impacts and privacy impacts","authors":["patrickhulce"],"reviewers":["zcorpan","obto","jasti"],"published":"2019-11-04T12:00:00+00:00:00","last_updated":"2019-11-05T15:45:32.000Z"} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac') }}{% endblock %} {% block meta %}
 <meta name="description" content="{{ self.description() }}" />
 
 <meta property="og:title" content="{{ self.title() }}" />
@@ -39,9 +39,9 @@
     "headline": "{{ metadata.get('title') }}",
     "image": {
     	  "@type": "ImageObject",
-    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg",
-    	  "height": 163,
-    	  "width": 326
+    	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg",
+    	  "height": 433,
+    	  "width": 866
     },
     "publisher": {
     	  "@type": "Organization",

--- a/src/tools/generate/generate_chapters.js
+++ b/src/tools/generate/generate_chapters.js
@@ -2,8 +2,8 @@ const fs = require('fs-extra');
 const showdown = require('showdown');
 const ejs = require('ejs');
 const prettier = require('prettier');
-const recursive = require('recursive-readdir');
 
+const { find_files, size_of, parse_array } = require('./shared');
 const { generate_table_of_contents } = require('./generate_table_of_contents');
 const { generate_figure_ids } = require('./generate_figure_ids');
 const { wrap_tables } = require('./wrap_tables');
@@ -29,17 +29,6 @@ const generate_chapters = async () => {
       console.error('  Failed to generate chapter, moving onto the next one. ');
     }
   }
-};
-
-const find_files = async () => {
-  const filter = (file, stats) => {
-    const isMd = file && file.endsWith('.md');
-    const isDirectory = stats && stats.isDirectory();
-
-    return !isMd && !isDirectory;
-  };
-
-  return await recursive('content', [filter]);
 };
 
 const parse_file = async (markdown) => {
@@ -79,27 +68,6 @@ const write_template = async (language, year, chapter, metadata, body, toc) => {
 
   await size_of(path);
 };
-
-const parse_array = (s) => s.substring(1, s.length - 1)
-                            .split(',')
-                            .map((value) => value.trim());
-
-const size_of = async (path) => {
-  let b = (await fs.stat(path)).size;
-
-  let u = 0,
-    s = 1024;
-  while (b >= s || -b >= s) {
-    b /= s;
-    u++;
-  }
-  let size = (u ? b.toFixed(1) + ' ' : b) + ' KMGTPEZY'[u] + 'B';
-
-  console.log(` - Output file size: ${size}`);
-};
-
-const ignorelist = ['.DS_Store'];
-const ignore = (file) => ignorelist.find((f) => f === file);
 
 module.exports = {
   generate_chapters

--- a/src/tools/generate/generate_last_updated.js
+++ b/src/tools/generate/generate_last_updated.js
@@ -1,0 +1,37 @@
+const fs = require('fs-extra');
+const { execSync } = require('child_process');
+const { find_files } = require('./shared');
+
+const generate_last_updated = async () => {
+  for (const file of await find_files()) {
+    console.log(`\n Setting the last_updated field on ${file}`);
+
+    // Fetch the last modified date, according to the git log.
+    const date = get_last_updated_date(file);
+    console.log(`  last_updated: ${date}`);
+
+    // Read the content of the file
+    let content = await fs.readFile(file, 'utf-8');
+
+    // Replace the frontmatter last_updated field. This is not
+    // greedy, so it will match the first instance (which must be
+    // in the frontmatter).
+    content = content.replace(/last_updated:\s*(\S*)/, `last_updated: ${date}`);
+
+    // Overwrite the file with the updated date.
+    await fs.outputFile(file, content, 'utf8');
+  }
+};
+
+const get_last_updated_date = (path) => {
+  const command = `git log -1 --date=iso-strict-local ${path} | cat`;
+  const stdout = execSync(command).toString();
+  const date_string = /Date:\s+(\S*)/g.exec(stdout)[1];
+  const date = new Date(date_string);
+
+  return date.toISOString();
+};
+
+module.exports = {
+  generate_last_updated
+};

--- a/src/tools/generate/index.js
+++ b/src/tools/generate/index.js
@@ -1,5 +1,9 @@
+let { generate_last_updated } = require('./generate_last_updated');
 let { generate_chapters } = require('./generate_chapters');
 
-// TODO: Generate visualisations 
-generate_chapters();
+(async () => {
+  await generate_last_updated();
 
+  // TODO: Generate visualisations
+  await generate_chapters();
+})();

--- a/src/tools/generate/shared.js
+++ b/src/tools/generate/shared.js
@@ -1,0 +1,40 @@
+const fs = require('fs-extra');
+const recursive = require('recursive-readdir');
+
+const find_files = async () => {
+  const filter = (file, stats) => {
+    const isMd = file && file.endsWith('.md');
+    const isDirectory = stats && stats.isDirectory();
+
+    return !isMd && !isDirectory;
+  };
+
+  return await recursive('content', [filter]);
+};
+
+const size_of = async (path) => {
+  let b = (await fs.stat(path)).size;
+
+  let u = 0,
+    s = 1024;
+  while (b >= s || -b >= s) {
+    b /= s;
+    u++;
+  }
+  let size = (u ? b.toFixed(1) + ' ' : b) + ' KMGTPEZY'[u] + 'B';
+
+  console.log(` - Output file size: ${size}`);
+};
+
+const parse_array = (array_as_string) => {
+  return array_as_string
+    .substring(1, array_as_string.length - 1)
+    .split(',')
+    .map((value) => value.trim());
+};
+
+module.exports = {
+  find_files,
+  size_of,
+  parse_array
+};


### PR DESCRIPTION
This closes #317.

This PR adds a generate script for the `last_updated` timestamp on every content file. It is not tightly coupled to the `generate_chapters` functionality, because we might want it to be a pre-commit hook instead. At the moment it will run first and uses the date of the latest commit on the file to generate the `last_modified`.

I'm a little nervous of the updating of source files, but I do think it's better than having to do it by hand.