### PR TITLE
Table of Contents Translation

### DIFF
--- a/src/templates/es/2019/table_of_contents.html
+++ b/src/templates/es/2019/table_of_contents.html
@@ -1,0 +1,228 @@
+{% extends "es/2019/base.html" %}
+
+{% block title %}Tabla de Contenidos | Web Almanac 2019{% endblock %}
+
+{% block description %}Tabla de contenido para el Web Almanac 2019 de HTTP Archive, que enumera cada sección: contenido de la página, experiencia del usuario, publicación de contenido, distribución de contenido{% endblock %}
+
+{% block meta %}
+<meta name="description" content="{{ self.description() }}">
+
+<meta property="og:title" content="{{ self.title() }}">
+<meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, year=year, lang=lang) }}">
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/methodology-characters-bg.png">
+<meta property="og:image:height" content="354">
+<meta property="og:image:width" content="984">
+<meta property="og:type" content="article">
+<meta property="og:description" content="{{ self.description() }}">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@HTTPArchive">
+<meta name="twitter:title" content="{{ self.title() }}">
+<meta name="twitter:image" content="https://almanac.httparchive.org/static/images/methodology-characters-bg.png">
+<meta name="twitter:image:alt" content="{{ year }} Web Almanac methodology" />
+<meta name="twitter:description" content="{{ self.description() }}">
+
+<script type="application/ld+json">
+	{
+	  "@context": "http://schema.org",
+	  "@type": "Article",
+	  "mainEntityOfPage": {
+	  	  "@type": "WebPage",
+	  	  "@id": "https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}"
+	  },
+	  "headline": "{{ self.title() }}",
+	  "image": {
+	  	  "@type": "ImageObject",
+        "url": "https://almanac.httparchive.org/static/images/methodology-characters-bg.png",
+        "height": 354,
+	  	  "width": 984
+	  },
+	  "publisher": {
+	  	  "@type": "Organization",
+	  	  "name": "HTTP Archive",
+	  	  "logo": {
+	  	      "@type": "ImageObject",
+	  	      "url": "https://almanac.httparchive.org/static/images/ha.png",
+	  	      "height": 160,
+	  	      "width": 320
+	  	  }
+      },
+    "author":
+      {
+	  	  "@type": "Person",
+          "sameas": [
+            "https://almanac.httparchive.org{{ url_for('contributors', year=year, lang=lang, _anchor='rviscomi') }}",
+            "https://twitter.com/rick_viscomi",
+            "https://github.com/rviscomi"
+            ],
+	  	  "name": "Rick Viscomi"
+      },
+      "description": "{{ self.description() }}",
+      "datePublished": "2019-11-04T12:00:00+00:00:00",
+      "dateModified": "2019-11-04T12:00:00+00:00:00"
+	}
+	</script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [{
+        "@type": "ListItem",
+        "position": 1,
+        "name": "{{ year }} Home ({{ language }})",
+        "item": "https://almanac.httparchive.org{{  url_for('home', year=year, lang=lang) }}"
+      },{
+        "@type": "ListItem",
+        "position": 2,
+        "name": "{{ year }} Table of Contents",
+        "item": "https://almanac.httparchive.org{{  url_for(request.endpoint, year=year, lang=lang) }}"
+      }]
+    }
+    </script>
+{% endblock %}
+
+{% block styles %}
+{{ super() }}
+<style>
+.main {
+  margin-bottom: 100px;
+}
+.title::before {
+  display: block;
+  content: '';
+  margin-bottom: 18px;
+  border-bottom: solid 1px #c6dcd2;
+  width: 70px;
+}
+.contents-wrapper {
+  display: grid;
+  grid-template-areas: 'parts characters';
+}
+.parts {
+  grid-area: parts;
+  max-width: 600px;
+}
+.characters {
+  grid-area: characters;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+}
+.character {
+  max-width: 150px;
+  height: auto;
+}
+.part,
+.part-name,
+.chapter {
+  border-bottom: 1px solid #eee;
+  margin: 0;
+}
+.chapter:last-child {
+  border-bottom: none;
+}
+
+.part-name,
+.chapter {
+  padding: 20px 0;
+}
+
+.chapters {
+  padding-left: 20px;
+}
+
+.chapter .todo {
+  opacity: 0.3;
+}
+.chapter a {
+  text-decoration: none;
+  color: #1A2B49;
+}
+.chapter a:hover,
+.chapter a:focus {
+  text-decoration: underline;
+}
+@media (max-width: 600px) {
+  .contents-wrapper {
+    display: block;
+  }
+  .parts {
+    max-width: 100%;
+  }
+  .characters {
+    display: none;
+  }
+}
+</style>
+{% endblock %}
+
+{% block main %}
+<section class="main">
+  <h1 class="title">Tabla de Contenidos</h1>
+
+  <section>
+    <h2>Prefacio</h2>
+
+    <p>
+      La web abierta es una red de tecnologías increíblemente compleja y en evolución. Industrias y carreras enteras se crean en la web y dependen de su vibrante ecosistema para tener éxito. Tan importante como es la web, comprender cómo está funcionando ha sido sorprendentemente difícil de alcanzar. Desde 2010, la misión del proyecto HTTP Archive ha sido rastrear cómo se construye la web, y ha estado haciendo un trabajo increíble. Sin embargo, ha habido una brecha que ha sido especialmente difícil de cerrar: dar sentido a los datos que el proyecto de HTTP Archive ha estado recopilando y permitir a la comunidad comprender fácilmente el rendimiento de la web. Ahí es donde entra el Web Almanac.
+    </p>
+
+    <p>
+      La misión de Web Almanac es tomar el tesoro de ideas que de otro modo serían accesibles solo para intrépidos mineros de datos, y empaquetarlo de una manera que sea fácil de entender. Esto es posible con la ayuda de expertos de la industria que pueden dar sentido a los datos y decirnos lo que significan. Cada uno de los 20 capítulos en Web Almanac se enfoca en un aspecto específico de la web, y cada uno ha sido escrito y revisado por expertos en su campo. La fuerza del Web Almanac fluye directamente de la experiencia de las personas que lo escriben.
+    </p>
+
+    <p>
+      Muchos de los hallazgos en Web Almanac son dignos de celebración, pero también es un recordatorio importante del trabajo que aún se requiere para brindar experiencias de usuario de alta calidad. Los análisis basados en datos en cada capítulo son una forma de responsabilidad que todos compartimos para desarrollar una mejor web. No se trata de avergonzar a los que se están equivocando, sino de iluminar el camino de las mejores prácticas para que haya una manera clara y correcta de hacer las cosas. Con la ayuda continua de la comunidad web, esperamos hacer de esto una tradición anual, para que cada año podamos seguir nuestro progreso y hacer correcciones de cursos según sea necesario.
+    </p>
+
+    <p>
+      Hay mucho que aprender en este informe, así que comience a explorar y comparta sus conclusiones con la comunidad para que podamos avanzar colectivamente en nuestra comprensión del estado de la web.
+    </p>
+
+    <p>— <em><a href="{{ url_for('contributors', year=year, lang=lang, _anchor='rviscomi') }}">Rick Viscomi</a>, creador del Web Almanac</em></p>
+
+  </section>
+
+  <div class="contents-wrapper">
+    <div class="parts">
+      {% for part_config in config.outline %}
+        <section class="part">
+          <h2 class="part-name">Parte {{ part_config.part }}</h2>
+          <div class="chapters">
+            {% for chapter_config in part_config.chapters %}
+              <div class="chapter">
+                {% if chapter_config.todo %}
+                <span class="todo">Capítulo {{ chapter_config.chapter }}: {{ chapter_config.title }}</span>
+                {% else %}
+                <a href="{{ url_for('chapter', year=year, lang=lang, chapter=get_chapter_slug(chapter_config)) }}">
+                  Capítulo {{ chapter_config.chapter }}: {{ chapter_config.title }}
+                </a>
+                {% endif %}
+              </div>
+            {% endfor %}
+          </div>
+        </section>
+      {% endfor %}
+      <section class="part">
+        <h2 class="part-name">Apéndice</h2>
+        <div class="chapters">
+          <div class="chapter">
+            <a href="{{ url_for('methodology', year=year, lang=lang) }}">Metodología</a>
+          </div>
+          <div class="chapter">
+            <a href="{{ url_for('contributors', year=year, lang=lang) }}">Contribuidores</a>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <section class="characters">
+      <img class="character" src="/static/images/character-painter.png" alt=""/>
+      <img class="character" src="/static/images/character-file.png" alt=""/>
+      <img class="character" src="/static/images/character-star.png" alt=""/>
+      <img class="character" src="/static/images/character-hat.png" alt=""/>
+    </section>
+  </div>
+</section>
+{% endblock %}

--- a/src/templates/es/2019/table_of_contents.html
+++ b/src/templates/es/2019/table_of_contents.html
@@ -2,7 +2,7 @@
 
 {% block title %}Tabla de Contenidos | Web Almanac 2019{% endblock %}
 
-{% block description %}Tabla de contenido para el Web Almanac 2019 de HTTP Archive, que enumera cada sección: contenido de la página, experiencia del usuario, publicación de contenido, distribución de contenido{% endblock %}
+{% block description %}Tabla de contenidos del Web Almanac 2019 de HTTP Archive, que enumera cada sección: contenido de la página, experiencia del usuario, publicación de contenido, distribución de contenido{% endblock %}
 
 {% block meta %}
 <meta name="description" content="{{ self.description() }}">


### PR DESCRIPTION
- Adding the table_of_contents.html file with the content translated into Spanish.

Please notice that because the outline information comes directly from the config/2019.json file it is not possible to translate the actual chapter's names. The current version only translates the Chapter and Part keywords from the table of contents.

I am OK with keeping the table of content this way as would say many chapters are _universal_ keywords used to build the web, but would like to hear from @JMPerez, @taytus, and @rviscomi.