### PR TITLE
Sitemap date fix

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -22,9 +22,9 @@
       <link rel="stylesheet" href="/static/css/normalize.css">
       {% block styles %}{% endblock %}
     {% endblock %}
-    <link rel="canonical" href="{{ url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}" />
+    <link rel="canonical" href="https://almanac.httparchive.org{{ url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}" />
     {% for l in supported_languages %}
-    <link rel="alternate" href="{{ url_for(request.endpoint, **get_view_args(lang=l.lang_code)) }}" hreflang="{{ l.lang_code}}" />
+    <link rel="alternate" href="https://almanac.httparchive.org{{ url_for(request.endpoint, **get_view_args(lang=l.lang_code)) }}" hreflang="{{ l.lang_code}}" />
     {% endfor %}
   </head>
 

--- a/src/templates/sitemap.xml
+++ b/src/templates/sitemap.xml
@@ -108,6 +108,17 @@
 
     <url>
         <loc>
+            https://almanac.httparchive.org/en/2019/fonts
+        </loc>
+        
+        <lastmod>
+            2019-11-11
+        </lastmod>
+        
+    </url>
+
+    <url>
+        <loc>
             https://almanac.httparchive.org/en/2019/http2
         </loc>
         
@@ -148,17 +159,6 @@
 
     <url>
         <loc>
-            https://almanac.httparchive.org/en/2019/fonts
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
-        
-    </url>
-
-    <url>
-        <loc>
             https://almanac.httparchive.org/en/2019/mobile-web
         </loc>
         
@@ -181,7 +181,7 @@
 
     <url>
         <loc>
-            https://almanac.httparchive.org/en/2019/performance
+            https://almanac.httparchive.org/en/2019/resource-hints
         </loc>
         
         <lastmod>
@@ -203,7 +203,18 @@
 
     <url>
         <loc>
-            https://almanac.httparchive.org/en/2019/resource-hints
+            https://almanac.httparchive.org/en/2019/performance
+        </loc>
+        
+        <lastmod>
+            2019-11-11
+        </lastmod>
+        
+    </url>
+
+    <url>
+        <loc>
+            https://almanac.httparchive.org/en/2019/seo
         </loc>
         
         <lastmod>
@@ -216,17 +227,6 @@
         <loc>
             https://almanac.httparchive.org/en/2019/security
         </loc>
-        
-    </url>
-
-    <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/seo
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
         
     </url>
 

--- a/src/templates/sitemap.xml
+++ b/src/templates/sitemap.xml
@@ -2,28 +2,6 @@
 
     <url>
         <loc>
-            https://almanac.httparchive.org/es/2019/
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
-        
-    </url>
-
-    <url>
-        <loc>
-            https://almanac.httparchive.org/es/2019/table_of_contents
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
-        
-    </url>
-
-    <url>
-        <loc>
             https://almanac.httparchive.org/en/2019/
         </loc>
         
@@ -68,17 +46,6 @@
 
     <url>
         <loc>
-            https://almanac.httparchive.org/es/2019/performance
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
-        
-    </url>
-
-    <url>
-        <loc>
             https://almanac.httparchive.org/en/2019/accessibility
         </loc>
         
@@ -90,7 +57,7 @@
 
     <url>
         <loc>
-            https://almanac.httparchive.org/en/2019/caching
+            https://almanac.httparchive.org/en/2019/cms
         </loc>
         
         <lastmod>
@@ -101,7 +68,7 @@
 
     <url>
         <loc>
-            https://almanac.httparchive.org/en/2019/cms
+            https://almanac.httparchive.org/en/2019/caching
         </loc>
         
         <lastmod>
@@ -131,17 +98,6 @@
     <url>
         <loc>
             https://almanac.httparchive.org/en/2019/ecommerce
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
-        
-    </url>
-
-    <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/fonts
         </loc>
         
         <lastmod>
@@ -182,6 +138,17 @@
     <url>
         <loc>
             https://almanac.httparchive.org/en/2019/media
+        </loc>
+        
+        <lastmod>
+            2019-11-11
+        </lastmod>
+        
+    </url>
+
+    <url>
+        <loc>
+            https://almanac.httparchive.org/en/2019/fonts
         </loc>
         
         <lastmod>

--- a/src/templates/sitemap.xml
+++ b/src/templates/sitemap.xml
@@ -2,11 +2,33 @@
 
     <url>
         <loc>
+            https://almanac.httparchive.org/es/2019/
+        </loc>
+        
+        <lastmod>
+            2019-11-11
+        </lastmod>
+        
+    </url>
+
+    <url>
+        <loc>
+            https://almanac.httparchive.org/es/2019/table_of_contents
+        </loc>
+        
+        <lastmod>
+            2019-11-11
+        </lastmod>
+        
+    </url>
+
+    <url>
+        <loc>
             https://almanac.httparchive.org/en/2019/
         </loc>
         
         <lastmod>
-            2019-11-05
+            2019-11-11
         </lastmod>
         
     </url>
@@ -17,7 +39,7 @@
         </loc>
         
         <lastmod>
-            2019-11-05
+            2019-11-11
         </lastmod>
         
     </url>
@@ -28,7 +50,7 @@
         </loc>
         
         <lastmod>
-            2019-11-05
+            2019-11-11
         </lastmod>
         
     </url>
@@ -39,73 +61,18 @@
         </loc>
         
         <lastmod>
-            2019-11-05
+            2019-11-11
         </lastmod>
         
     </url>
 
     <url>
         <loc>
-            https://almanac.httparchive.org/en/2019/caching
+            https://almanac.httparchive.org/es/2019/performance
         </loc>
         
         <lastmod>
-            Thu Nov 07 2019 21:46:00 GMT+0000 (Greenwich Mean Time)
-        </lastmod>
-        
-    </url>
-
-    <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/compression
-        </loc>
-        
-        <lastmod>
-            Thu Nov 07 2019 21:46:00 GMT+0000 (Greenwich Mean Time)
-        </lastmod>
-        
-    </url>
-
-    <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/cms
-        </loc>
-        
-        <lastmod>
-            Thu Nov 07 2019 22:02:00 GMT-0800 (Pacific Standard Time)
-        </lastmod>
-        
-    </url>
-
-    <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/compression
-        </loc>
-        
-        <lastmod>
-            Thu Nov 07 2019 21:46:00 GMT-0800 (Pacific Standard Time)
-        </lastmod>
-        
-    </url>
-
-    <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/fonts
-        </loc>
-        
-        <lastmod>
-            Thu Nov 07 2019 21:46:00 GMT+0000 (Greenwich Mean Time)
-        </lastmod>
-        
-    </url>
-
-    <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/cms
-        </loc>
-        
-        <lastmod>
-            Thu Nov 07 2019 22:02:00 GMT+0000 (Greenwich Mean Time)
+            2019-11-11
         </lastmod>
         
     </url>
@@ -116,7 +83,69 @@
         </loc>
         
         <lastmod>
-            2019-11-05
+            2019-11-11
+        </lastmod>
+        
+    </url>
+
+    <url>
+        <loc>
+            https://almanac.httparchive.org/en/2019/caching
+        </loc>
+        
+        <lastmod>
+            2019-11-11
+        </lastmod>
+        
+    </url>
+
+    <url>
+        <loc>
+            https://almanac.httparchive.org/en/2019/cms
+        </loc>
+        
+        <lastmod>
+            2019-11-11
+        </lastmod>
+        
+    </url>
+
+    <url>
+        <loc>
+            https://almanac.httparchive.org/en/2019/compression
+        </loc>
+        
+        <lastmod>
+            2019-11-11
+        </lastmod>
+        
+    </url>
+
+    <url>
+        <loc>
+            https://almanac.httparchive.org/en/2019/css
+        </loc>
+        
+    </url>
+
+    <url>
+        <loc>
+            https://almanac.httparchive.org/en/2019/ecommerce
+        </loc>
+        
+        <lastmod>
+            2019-11-11
+        </lastmod>
+        
+    </url>
+
+    <url>
+        <loc>
+            https://almanac.httparchive.org/en/2019/fonts
+        </loc>
+        
+        <lastmod>
+            2019-11-11
         </lastmod>
         
     </url>
@@ -127,7 +156,7 @@
         </loc>
         
         <lastmod>
-            Thu Nov 07 2019 21:46:00 GMT+0000 (Greenwich Mean Time)
+            2019-11-11
         </lastmod>
         
     </url>
@@ -145,7 +174,7 @@
         </loc>
         
         <lastmod>
-            Thu Nov 07 2019 21:46:00 GMT+0000 (Greenwich Mean Time)
+            2019-11-11
         </lastmod>
         
     </url>
@@ -156,7 +185,7 @@
         </loc>
         
         <lastmod>
-            Thu Nov 07 2019 21:46:00 GMT+0000 (Greenwich Mean Time)
+            2019-11-11
         </lastmod>
         
     </url>
@@ -167,7 +196,7 @@
         </loc>
         
         <lastmod>
-            Thu Nov 07 2019 21:46:00 GMT+0000 (Greenwich Mean Time)
+            2019-11-11
         </lastmod>
         
     </url>
@@ -178,7 +207,7 @@
         </loc>
         
         <lastmod>
-            Thu Nov 07 2019 21:46:00 GMT+0000 (Greenwich Mean Time)
+            2019-11-11
         </lastmod>
         
     </url>
@@ -189,7 +218,7 @@
         </loc>
         
         <lastmod>
-            Thu Nov 07 2019 21:46:00 GMT+0000 (Greenwich Mean Time)
+            2019-11-11
         </lastmod>
         
     </url>
@@ -200,7 +229,7 @@
         </loc>
         
         <lastmod>
-            Thu Nov 07 2019 21:46:00 GMT+0000 (Greenwich Mean Time)
+            2019-11-11
         </lastmod>
         
     </url>
@@ -211,7 +240,7 @@
         </loc>
         
         <lastmod>
-            Thu Nov 07 2019 21:46:00 GMT+0000 (Greenwich Mean Time)
+            2019-11-11
         </lastmod>
         
     </url>
@@ -229,7 +258,7 @@
         </loc>
         
         <lastmod>
-            Thu Nov 07 2019 21:46:00 GMT+0000 (Greenwich Mean Time)
+            2019-11-11
         </lastmod>
         
     </url>
@@ -240,7 +269,7 @@
         </loc>
         
         <lastmod>
-            Thu Nov 07 2019 21:46:00 GMT+0000 (Greenwich Mean Time)
+            2019-11-11
         </lastmod>
         
     </url>

--- a/src/tools/generate/generate_chapters.js
+++ b/src/tools/generate/generate_chapters.js
@@ -66,14 +66,16 @@ const write_template = async (language, year, chapter, metadata, body, toc) => {
   const template = `templates/${language}/${year}/chapter.html`;
   const path = `templates/${language}/${year}/chapters/${chapter}.html`;
 
-  let html = await ejs.renderFile(template, { metadata, body, toc });
-  let fomatted_html = prettier.format(html, {
-    parser: 'html',
-    printWidth: Number.MAX_SAFE_INTEGER
-  });
+  if (fs.existsSync(template)) {
+    let html = await ejs.renderFile(template, { metadata, body, toc });
+    let fomatted_html = prettier.format(html, {
+      parser: 'html',
+      printWidth: Number.MAX_SAFE_INTEGER
+    });
 
-  await fs.outputFile(path, fomatted_html, 'utf8');
-  await size_of(path);
+    await fs.outputFile(path, fomatted_html, 'utf8');
+    await size_of(path);
+  }
 };
 
 module.exports = {

--- a/src/tools/generate/generate_chapters.js
+++ b/src/tools/generate/generate_chapters.js
@@ -3,6 +3,9 @@ const showdown = require('showdown');
 const ejs = require('ejs');
 const prettier = require('prettier');
 
+//Chapters may exist but not be ready to be launched so do not include in sitemap
+const sitemap_languages = ['en'];
+
 const { find_files, size_of, parse_array } = require('./shared');
 const { generate_table_of_contents } = require('./generate_table_of_contents');
 const { generate_figure_ids } = require('./generate_figure_ids');
@@ -25,9 +28,9 @@ const generate_chapters = async () => {
 
       const markdown = await fs.readFile(file, 'utf-8');
       const { metadata, body, toc } = await parse_file(markdown);
-
-      sitemap.push({ language, year, chapter, metadata });
-
+      if ( sitemap_languages.includes(language) ) {
+        sitemap.push({ language, year, chapter, metadata });
+      }
       await write_template(language, year, chapter, metadata, body, toc);
     } catch (error) {
       console.error(error);

--- a/src/tools/generate/generate_sitemap.js
+++ b/src/tools/generate/generate_sitemap.js
@@ -1,7 +1,7 @@
 const fs = require('fs-extra');
 const ejs = require('ejs');
 
-const min_publish_date = new Date('2019-11-05T12:00');
+const min_publish_date = new Date('2019-11-11T00:00');
 const sitemap_template = `templates/sitemap.ejs.xml`;
 const sitemap_path = `templates/sitemap.xml`;
 const static_pages = [
@@ -12,6 +12,7 @@ const static_pages = [
 ];
 
 const generate_sitemap = async (sitemap_chapters) => {
+
   const urls = await get_static_pages(sitemap_chapters);
 
   for (let sitemap_chapter of sitemap_chapters) {
@@ -47,12 +48,14 @@ const get_static_pages = async (sitemap_chapters) => {
   let urls = [];
 
   for (const loc of await files) {
-    const file = await fs.readFile(`templates/${loc}`, 'utf-8');
-    const match = file.match(/"datePublished": "([0-9\-\+\:T]*)"/);
-    const lastmod = set_min_date(match[1]);
-    const url = strip_html_extension(loc);
+    if (fs.existsSync(`templates/${loc}`)) {
+      const file = await fs.readFile(`templates/${loc}`, 'utf-8');
+      const match = file.match(/"datePublished": "([0-9\-\+\:T]*)"/);
+      const lastmod = set_min_date(match[1]);
+      const url = strip_html_extension(loc);
 
-    urls.push({ url, lastmod });
+      urls.push({ url, lastmod });
+    }
   }
 
   return urls;
@@ -78,7 +81,7 @@ const set_min_date = (date) => {
     if (date < min_publish_date) {
       return min_publish_date.toISOString().substr(0, 10);
     } else {
-      return date;
+      return date.toISOString().substr(0, 10);
     }
   } else {
     return new Date().toISOString().substr(0, 10);


### PR DESCRIPTION
Closes https://github.com/HTTPArchive/almanac.httparchive.org/issues/418
Also solves https://github.com/HTTPArchive/almanac.httparchive.org/issues/286#issuecomment-552181436

Changes:
- Fixes date format for sitemap for one missed case (https://github.com/HTTPArchive/almanac.httparchive.org/issues/286#issuecomment-552181436)
- Makes `rel="alternative"` and `rel="canonical"` absolute (https://github.com/HTTPArchive/almanac.httparchive.org/issues/286#issuecomment-552181436)
- Handles when templates are missing, like they currently are for Spanish chapters (https://github.com/HTTPArchive/almanac.httparchive.org/issues/418)
- Add a `sitemap_languages` array in case a chapter exists but is not ready to be launched to Google
- Sets min publish date to launch date (2019-11-11)