### PR TITLE
Add XML declaration to sitemap and fix whitespace issue

### DIFF
--- a/src/templates/en/2019/chapters/cdn.html
+++ b/src/templates/en/2019/chapters/cdn.html
@@ -10,7 +10,7 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"IV","chapter_number":17,"title":"CDN","description":"CDN chapter of the 2019 Web Almanac covering CDN adoption and usage","authors":["andydavies","colinbendell"],"reviewers":["yoavweiss","paulcalvano","pmeenan","enygren"],"discuss":"1772","published":"2019-11-11T00:00:00.000Z","last_updated":"2019-11-11T00:00:00.000Z"} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac probing into the use of ' + metadata.get('description',metadata.get('title')) + ' on the web.') }}{% endblock %} {% block meta %}
+{% set metadata = {"part_number":"IV","chapter_number":17,"title":"CDN","description":"CDN chapter of the 2019 Web Almanac covering CDN adoption and usage, RTT &amp; TLS management, HTTP/2 adoption, caching and common library and content CDNs.","authors":["andydavies","colinbendell"],"reviewers":["yoavweiss","paulcalvano","pmeenan","enygren"],"discuss":"1772","published":"2019-11-11T00:00:00.000Z","last_updated":"2019-11-11T00:00:00.000Z"} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac probing into the use of ' + metadata.get('description',metadata.get('title')) + ' on the web.') }}{% endblock %} {% block meta %}
 <meta name="description" content="{{ self.description() }}" />
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />

--- a/src/templates/sitemap.ejs.xml
+++ b/src/templates/sitemap.ejs.xml
@@ -3,8 +3,7 @@
 <% for (let url of urls ) { %>
     <url>
         <loc>https://almanac.httparchive.org/<%= url.url %></loc>
-        <% if (url.lastmod) { %><lastmod><%= url.lastmod %></lastmod>
-        <% } %>
+        <% if (url.lastmod) { %><lastmod><%= url.lastmod %></lastmod><% } %>
     </url>
 <% } %>   
 </urlset>

--- a/src/templates/sitemap.ejs.xml
+++ b/src/templates/sitemap.ejs.xml
@@ -1,13 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 <% for (let url of urls ) { %>
     <url>
-        <loc>
-            https://almanac.httparchive.org/<%= url.url %>
-        </loc>
-        <% if (url.lastmod) { %>
-        <lastmod>
-            <%= url.lastmod %>
-        </lastmod>
+        <loc>https://almanac.httparchive.org/<%= url.url %></loc>
+        <% if (url.lastmod) { %><lastmod><%= url.lastmod %></lastmod>
         <% } %>
     </url>
 <% } %>   

--- a/src/templates/sitemap.xml
+++ b/src/templates/sitemap.xml
@@ -4,145 +4,121 @@
     <url>
         <loc>https://almanac.httparchive.org/en/2019/</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
 
     <url>
         <loc>https://almanac.httparchive.org/en/2019/accessibility</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
 
     <url>
         <loc>https://almanac.httparchive.org/en/2019/caching</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
 
     <url>
         <loc>https://almanac.httparchive.org/en/2019/cdn</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
 
     <url>
         <loc>https://almanac.httparchive.org/en/2019/cms</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
 
     <url>
         <loc>https://almanac.httparchive.org/en/2019/compression</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
 
     <url>
         <loc>https://almanac.httparchive.org/en/2019/contributors</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
 
     <url>
         <loc>https://almanac.httparchive.org/en/2019/css</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
 
     <url>
         <loc>https://almanac.httparchive.org/en/2019/ecommerce</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
 
     <url>
         <loc>https://almanac.httparchive.org/en/2019/fonts</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
 
     <url>
         <loc>https://almanac.httparchive.org/en/2019/http2</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
 
     <url>
         <loc>https://almanac.httparchive.org/en/2019/javascript</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
 
     <url>
         <loc>https://almanac.httparchive.org/en/2019/markup</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
 
     <url>
         <loc>https://almanac.httparchive.org/en/2019/media</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
 
     <url>
         <loc>https://almanac.httparchive.org/en/2019/methodology</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
 
     <url>
         <loc>https://almanac.httparchive.org/en/2019/mobile-web</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
 
     <url>
         <loc>https://almanac.httparchive.org/en/2019/page-weight</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
 
     <url>
         <loc>https://almanac.httparchive.org/en/2019/performance</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
 
     <url>
         <loc>https://almanac.httparchive.org/en/2019/pwa</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
 
     <url>
         <loc>https://almanac.httparchive.org/en/2019/resource-hints</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
 
     <url>
         <loc>https://almanac.httparchive.org/en/2019/security</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
 
     <url>
         <loc>https://almanac.httparchive.org/en/2019/seo</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
 
     <url>
         <loc>https://almanac.httparchive.org/en/2019/table_of_contents</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
 
     <url>
         <loc>https://almanac.httparchive.org/en/2019/third-parties</loc>
         <lastmod>2019-11-11</lastmod>
-        
     </url>
    
 </urlset>

--- a/src/templates/sitemap.xml
+++ b/src/templates/sitemap.xml
@@ -1,266 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/accessibility
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/accessibility</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/caching
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/caching</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/cdn
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/cdn</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/cms
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/cms</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/compression
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/compression</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/contributors
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/contributors</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/css
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/css</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/ecommerce
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/ecommerce</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/fonts
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/fonts</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/http2
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/http2</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/javascript
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/javascript</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/markup
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/markup</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/media
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/media</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/methodology
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/methodology</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/mobile-web
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/mobile-web</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/page-weight
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/page-weight</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/performance
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/performance</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/pwa
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/pwa</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/resource-hints
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/resource-hints</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/security
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/security</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/seo
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/seo</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/table_of_contents
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/table_of_contents</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
 
     <url>
-        <loc>
-            https://almanac.httparchive.org/en/2019/third-parties
-        </loc>
-        
-        <lastmod>
-            2019-11-11
-        </lastmod>
+        <loc>https://almanac.httparchive.org/en/2019/third-parties</loc>
+        <lastmod>2019-11-11</lastmod>
         
     </url>
    


### PR DESCRIPTION
Adds a missing XML declaration at the top of the sitemap.xml document.

I'm also a little concerned with the whitespace in the tags so have removed that.

Oh and you missed my CDN meta update last time you were generating that chapter so included that.

At least [one tool](https://www.websiteplanet.com/webtools/sitemap-validator/?page=https://almanac.httparchive.org/sitemap.xml) was complaining about both these issues.