### PR TITLE
Instead of "todo" show "unedited"

### DIFF
--- a/src/config/2019.json
+++ b/src/config/2019.json
@@ -21,8 +21,7 @@
         {
           "part": "I",
           "chapter": "4",
-          "title": "Media",
-          "todo": true
+          "title": "Media"
         },
         {
           "part": "I",
@@ -32,8 +31,7 @@
         {
           "part": "I",
           "chapter": "6",
-          "title": "Fonts",
-          "todo": true
+          "title": "Fonts"
         }
       ]
     },

--- a/src/content/en/2019/fonts.md
+++ b/src/content/en/2019/fonts.md
@@ -1,4 +1,5 @@
 ---
+unedited: true
 part_number: I
 chapter_number: 6
 title: Fonts

--- a/src/content/en/2019/media.md
+++ b/src/content/en/2019/media.md
@@ -1,4 +1,5 @@
 ---
+unedited: true
 part_number: I
 chapter_number: 4
 title: Media

--- a/src/content/en/2019/pwa.md
+++ b/src/content/en/2019/pwa.md
@@ -1,4 +1,5 @@
 ---
+unedited: true
 part_number: II
 chapter_number: 11
 title: PWA

--- a/src/content/en/2019/seo.md
+++ b/src/content/en/2019/seo.md
@@ -1,4 +1,5 @@
 ---
+unedited: true
 part_number: I
 chapter_number: 10
 title: SEO

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -133,6 +133,14 @@
   margin-left: -1em
 }
 
+.chapter-unedited {
+  font-family: monospace;
+  text-transform: uppercase;
+  color: red;
+  vertical-align: super;
+  font-size: 0.5em;
+}
+
 .content-banner {
   max-width: 100%;
   border-radius: 8px;

--- a/src/templates/en/2019/chapter.html
+++ b/src/templates/en/2019/chapter.html
@@ -111,6 +111,9 @@
             </div>
             <h1 class="title">
                 {{ metadata.get('title') }}
+                {% if metadata.get('unedited', false) %}
+                <span class="chapter-unedited">[Unedited]</span>
+                {% endif %}
             </h1>
             <img src="/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" class="content-banner" alt="">
             {{ render_byline() }}

--- a/src/templates/en/2019/chapters/accessibility.html
+++ b/src/templates/en/2019/chapters/accessibility.html
@@ -239,7 +239,9 @@
         Part {{ metadata.get('part_number') }} Chapter {{ metadata.get('chapter_number') }}
       </div>
       <h1 class="title">
-        {{ metadata.get('title') }}
+        {{ metadata.get('title') }} {% if metadata.get('unedited', false) %}
+        <span class="chapter-unedited">[Unedited]</span>
+        {% endif %}
       </h1>
       <img src="/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" class="content-banner" alt="" />
       {{ render_byline() }}

--- a/src/templates/en/2019/chapters/caching.html
+++ b/src/templates/en/2019/chapters/caching.html
@@ -163,7 +163,9 @@
         Part {{ metadata.get('part_number') }} Chapter {{ metadata.get('chapter_number') }}
       </div>
       <h1 class="title">
-        {{ metadata.get('title') }}
+        {{ metadata.get('title') }} {% if metadata.get('unedited', false) %}
+        <span class="chapter-unedited">[Unedited]</span>
+        {% endif %}
       </h1>
       <img src="/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" class="content-banner" alt="" />
       {{ render_byline() }}

--- a/src/templates/en/2019/chapters/cdn.html
+++ b/src/templates/en/2019/chapters/cdn.html
@@ -167,7 +167,9 @@
         Part {{ metadata.get('part_number') }} Chapter {{ metadata.get('chapter_number') }}
       </div>
       <h1 class="title">
-        {{ metadata.get('title') }}
+        {{ metadata.get('title') }} {% if metadata.get('unedited', false) %}
+        <span class="chapter-unedited">[Unedited]</span>
+        {% endif %}
       </h1>
       <img src="/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" class="content-banner" alt="" />
       {{ render_byline() }}

--- a/src/templates/en/2019/chapters/cms.html
+++ b/src/templates/en/2019/chapters/cms.html
@@ -185,7 +185,9 @@
         Part {{ metadata.get('part_number') }} Chapter {{ metadata.get('chapter_number') }}
       </div>
       <h1 class="title">
-        {{ metadata.get('title') }}
+        {{ metadata.get('title') }} {% if metadata.get('unedited', false) %}
+        <span class="chapter-unedited">[Unedited]</span>
+        {% endif %}
       </h1>
       <img src="/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" class="content-banner" alt="" />
       {{ render_byline() }}

--- a/src/templates/en/2019/chapters/compression.html
+++ b/src/templates/en/2019/chapters/compression.html
@@ -135,7 +135,9 @@
         Part {{ metadata.get('part_number') }} Chapter {{ metadata.get('chapter_number') }}
       </div>
       <h1 class="title">
-        {{ metadata.get('title') }}
+        {{ metadata.get('title') }} {% if metadata.get('unedited', false) %}
+        <span class="chapter-unedited">[Unedited]</span>
+        {% endif %}
       </h1>
       <img src="/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" class="content-banner" alt="" />
       {{ render_byline() }}

--- a/src/templates/en/2019/chapters/css.html
+++ b/src/templates/en/2019/chapters/css.html
@@ -315,7 +315,9 @@
         Part {{ metadata.get('part_number') }} Chapter {{ metadata.get('chapter_number') }}
       </div>
       <h1 class="title">
-        {{ metadata.get('title') }}
+        {{ metadata.get('title') }} {% if metadata.get('unedited', false) %}
+        <span class="chapter-unedited">[Unedited]</span>
+        {% endif %}
       </h1>
       <img src="/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" class="content-banner" alt="" />
       {{ render_byline() }}

--- a/src/templates/en/2019/chapters/ecommerce.html
+++ b/src/templates/en/2019/chapters/ecommerce.html
@@ -183,7 +183,9 @@
         Part {{ metadata.get('part_number') }} Chapter {{ metadata.get('chapter_number') }}
       </div>
       <h1 class="title">
-        {{ metadata.get('title') }}
+        {{ metadata.get('title') }} {% if metadata.get('unedited', false) %}
+        <span class="chapter-unedited">[Unedited]</span>
+        {% endif %}
       </h1>
       <img src="/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" class="content-banner" alt="" />
       {{ render_byline() }}

--- a/src/templates/en/2019/chapters/fonts.html
+++ b/src/templates/en/2019/chapters/fonts.html
@@ -10,7 +10,7 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"I","chapter_number":6,"title":"Fonts","description":"Fonts chapter of the 2019 Web Almanac covering where fonts are loaded from, font formats, font loading performance, variable fonts and color fonts.","authors":["zachleat"],"reviewers":["hyperpress","AymenLoukil"],"discuss":"1761","published":"2019-11-11T00:00:00.000Z","last_updated":"2019-11-11T00:00:00.000Z"} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac probing into the use of ' + metadata.get('description',metadata.get('title')) + ' on the web.') }}{% endblock %} {% block meta %}
+{% set metadata = {"unedited":"true","part_number":"I","chapter_number":6,"title":"Fonts","description":"Fonts chapter of the 2019 Web Almanac covering where fonts are loaded from, font formats, font loading performance, variable fonts and color fonts.","authors":["zachleat"],"reviewers":["hyperpress","AymenLoukil"],"discuss":"1761","published":"2019-11-11T00:00:00.000Z","last_updated":"2019-11-11T00:00:00.000Z"} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac probing into the use of ' + metadata.get('description',metadata.get('title')) + ' on the web.') }}{% endblock %} {% block meta %}
 <meta name="description" content="{{ self.description() }}" />
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />
@@ -189,7 +189,9 @@
         Part {{ metadata.get('part_number') }} Chapter {{ metadata.get('chapter_number') }}
       </div>
       <h1 class="title">
-        {{ metadata.get('title') }}
+        {{ metadata.get('title') }} {% if metadata.get('unedited', false) %}
+        <span class="chapter-unedited">[Unedited]</span>
+        {% endif %}
       </h1>
       <img src="/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" class="content-banner" alt="" />
       {{ render_byline() }}

--- a/src/templates/en/2019/chapters/http2.html
+++ b/src/templates/en/2019/chapters/http2.html
@@ -139,7 +139,9 @@
         Part {{ metadata.get('part_number') }} Chapter {{ metadata.get('chapter_number') }}
       </div>
       <h1 class="title">
-        {{ metadata.get('title') }}
+        {{ metadata.get('title') }} {% if metadata.get('unedited', false) %}
+        <span class="chapter-unedited">[Unedited]</span>
+        {% endif %}
       </h1>
       <img src="/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" class="content-banner" alt="" />
       {{ render_byline() }}

--- a/src/templates/en/2019/chapters/javascript.html
+++ b/src/templates/en/2019/chapters/javascript.html
@@ -163,7 +163,9 @@
         Part {{ metadata.get('part_number') }} Chapter {{ metadata.get('chapter_number') }}
       </div>
       <h1 class="title">
-        {{ metadata.get('title') }}
+        {{ metadata.get('title') }} {% if metadata.get('unedited', false) %}
+        <span class="chapter-unedited">[Unedited]</span>
+        {% endif %}
       </h1>
       <img src="/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" class="content-banner" alt="" />
       {{ render_byline() }}

--- a/src/templates/en/2019/chapters/markup.html
+++ b/src/templates/en/2019/chapters/markup.html
@@ -151,7 +151,9 @@
         Part {{ metadata.get('part_number') }} Chapter {{ metadata.get('chapter_number') }}
       </div>
       <h1 class="title">
-        {{ metadata.get('title') }}
+        {{ metadata.get('title') }} {% if metadata.get('unedited', false) %}
+        <span class="chapter-unedited">[Unedited]</span>
+        {% endif %}
       </h1>
       <img src="/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" class="content-banner" alt="" />
       {{ render_byline() }}

--- a/src/templates/en/2019/chapters/media.html
+++ b/src/templates/en/2019/chapters/media.html
@@ -10,7 +10,7 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"I","chapter_number":4,"title":"Media","description":"Media chapter of the 2019 Web Almanac covering image file sizes and formats, responsive images, client hints, lazy loading, accessibility and video.","authors":["colinbendell","dougsillars"],"discuss":"1759","reviewers":["ahmadawais","kornelski","eeeps"],"published":"2019-11-11T00:00:00.000Z","last_updated":"2019-11-07T21:46:11.000Z "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac probing into the use of ' + metadata.get('description',metadata.get('title')) + ' on the web.') }}{% endblock %} {% block meta %}
+{% set metadata = {"unedited":"true","part_number":"I","chapter_number":4,"title":"Media","description":"Media chapter of the 2019 Web Almanac covering image file sizes and formats, responsive images, client hints, lazy loading, accessibility and video.","authors":["colinbendell","dougsillars"],"discuss":"1759","reviewers":["ahmadawais","kornelski","eeeps"],"published":"2019-11-11T00:00:00.000Z","last_updated":"2019-11-07T21:46:11.000Z "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac probing into the use of ' + metadata.get('description',metadata.get('title')) + ' on the web.') }}{% endblock %} {% block meta %}
 <meta name="description" content="{{ self.description() }}" />
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />
@@ -111,7 +111,9 @@
         Part {{ metadata.get('part_number') }} Chapter {{ metadata.get('chapter_number') }}
       </div>
       <h1 class="title">
-        {{ metadata.get('title') }}
+        {{ metadata.get('title') }} {% if metadata.get('unedited', false) %}
+        <span class="chapter-unedited">[Unedited]</span>
+        {% endif %}
       </h1>
       <img src="/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" class="content-banner" alt="" />
       {{ render_byline() }}

--- a/src/templates/en/2019/chapters/mobile-web.html
+++ b/src/templates/en/2019/chapters/mobile-web.html
@@ -197,7 +197,9 @@
         Part {{ metadata.get('part_number') }} Chapter {{ metadata.get('chapter_number') }}
       </div>
       <h1 class="title">
-        {{ metadata.get('title') }}
+        {{ metadata.get('title') }} {% if metadata.get('unedited', false) %}
+        <span class="chapter-unedited">[Unedited]</span>
+        {% endif %}
       </h1>
       <img src="/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" class="content-banner" alt="" />
       {{ render_byline() }}

--- a/src/templates/en/2019/chapters/page-weight.html
+++ b/src/templates/en/2019/chapters/page-weight.html
@@ -213,7 +213,9 @@
         Part {{ metadata.get('part_number') }} Chapter {{ metadata.get('chapter_number') }}
       </div>
       <h1 class="title">
-        {{ metadata.get('title') }}
+        {{ metadata.get('title') }} {% if metadata.get('unedited', false) %}
+        <span class="chapter-unedited">[Unedited]</span>
+        {% endif %}
       </h1>
       <img src="/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" class="content-banner" alt="" />
       {{ render_byline() }}

--- a/src/templates/en/2019/chapters/performance.html
+++ b/src/templates/en/2019/chapters/performance.html
@@ -167,7 +167,9 @@
         Part {{ metadata.get('part_number') }} Chapter {{ metadata.get('chapter_number') }}
       </div>
       <h1 class="title">
-        {{ metadata.get('title') }}
+        {{ metadata.get('title') }} {% if metadata.get('unedited', false) %}
+        <span class="chapter-unedited">[Unedited]</span>
+        {% endif %}
       </h1>
       <img src="/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" class="content-banner" alt="" />
       {{ render_byline() }}

--- a/src/templates/en/2019/chapters/pwa.html
+++ b/src/templates/en/2019/chapters/pwa.html
@@ -10,7 +10,7 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"II","chapter_number":11,"title":"PWA","description":"PWA chapter of the 2019 Web Almanac covering service workers (registations, installability, events and filesizes), Web App Manifests properties, and Workbox.","authors":["tomayac","jeffposnick"],"reviewers":["hyperpress","ahmadawais"],"discuss":"1766","published":"2019-11-11T00:00:00.000Z","last_updated":"2019-11-07T21:46:11.000Z "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac probing into the use of ' + metadata.get('description',metadata.get('title')) + ' on the web.') }}{% endblock %} {% block meta %}
+{% set metadata = {"unedited":"true","part_number":"II","chapter_number":11,"title":"PWA","description":"PWA chapter of the 2019 Web Almanac covering service workers (registations, installability, events and filesizes), Web App Manifests properties, and Workbox.","authors":["tomayac","jeffposnick"],"reviewers":["hyperpress","ahmadawais"],"discuss":"1766","published":"2019-11-11T00:00:00.000Z","last_updated":"2019-11-07T21:46:11.000Z "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac probing into the use of ' + metadata.get('description',metadata.get('title')) + ' on the web.') }}{% endblock %} {% block meta %}
 <meta name="description" content="{{ self.description() }}" />
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />
@@ -163,7 +163,9 @@
         Part {{ metadata.get('part_number') }} Chapter {{ metadata.get('chapter_number') }}
       </div>
       <h1 class="title">
-        {{ metadata.get('title') }}
+        {{ metadata.get('title') }} {% if metadata.get('unedited', false) %}
+        <span class="chapter-unedited">[Unedited]</span>
+        {% endif %}
       </h1>
       <img src="/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" class="content-banner" alt="" />
       {{ render_byline() }}

--- a/src/templates/en/2019/chapters/resource-hints.html
+++ b/src/templates/en/2019/chapters/resource-hints.html
@@ -163,7 +163,9 @@
         Part {{ metadata.get('part_number') }} Chapter {{ metadata.get('chapter_number') }}
       </div>
       <h1 class="title">
-        {{ metadata.get('title') }}
+        {{ metadata.get('title') }} {% if metadata.get('unedited', false) %}
+        <span class="chapter-unedited">[Unedited]</span>
+        {% endif %}
       </h1>
       <img src="/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" class="content-banner" alt="" />
       {{ render_byline() }}

--- a/src/templates/en/2019/chapters/security.html
+++ b/src/templates/en/2019/chapters/security.html
@@ -267,7 +267,9 @@
         Part {{ metadata.get('part_number') }} Chapter {{ metadata.get('chapter_number') }}
       </div>
       <h1 class="title">
-        {{ metadata.get('title') }}
+        {{ metadata.get('title') }} {% if metadata.get('unedited', false) %}
+        <span class="chapter-unedited">[Unedited]</span>
+        {% endif %}
       </h1>
       <img src="/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" class="content-banner" alt="" />
       {{ render_byline() }}

--- a/src/templates/en/2019/chapters/seo.html
+++ b/src/templates/en/2019/chapters/seo.html
@@ -10,7 +10,7 @@
   - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
 #}-->
 
-{% set metadata = {"part_number":"I","chapter_number":10,"title":"SEO","description":"SEO chapter of the 2019 Web Almanac covering content, meta tags, indexability, linking, speed, structured data, internationalization, SPAs, AMP and security.","authors":["ymschaap","rachellcostello","AVGP"],"reviewers":["clarkeclark","andylimn","AymenLoukil","catalinred","mattludwig"],"discuss":"1765","published":"2019-11-11T00:00:00.000Z","last_updated":"2019-11-07T21:46:11.000Z "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac probing into the use of ' + metadata.get('description',metadata.get('title')) + ' on the web.') }}{% endblock %} {% block meta %}
+{% set metadata = {"unedited":"true","part_number":"I","chapter_number":10,"title":"SEO","description":"SEO chapter of the 2019 Web Almanac covering content, meta tags, indexability, linking, speed, structured data, internationalization, SPAs, AMP and security.","authors":["ymschaap","rachellcostello","AVGP"],"reviewers":["clarkeclark","andylimn","AymenLoukil","catalinred","mattludwig"],"discuss":"1765","published":"2019-11-11T00:00:00.000Z","last_updated":"2019-11-07T21:46:11.000Z "} %} {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac probing into the use of ' + metadata.get('description',metadata.get('title')) + ' on the web.') }}{% endblock %} {% block meta %}
 <meta name="description" content="{{ self.description() }}" />
 <meta property="og:title" content="{{ self.title() }}" />
 <meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />
@@ -209,7 +209,9 @@
         Part {{ metadata.get('part_number') }} Chapter {{ metadata.get('chapter_number') }}
       </div>
       <h1 class="title">
-        {{ metadata.get('title') }}
+        {{ metadata.get('title') }} {% if metadata.get('unedited', false) %}
+        <span class="chapter-unedited">[Unedited]</span>
+        {% endif %}
       </h1>
       <img src="/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" class="content-banner" alt="" />
       {{ render_byline() }}

--- a/src/templates/en/2019/chapters/third-parties.html
+++ b/src/templates/en/2019/chapters/third-parties.html
@@ -199,7 +199,9 @@
         Part {{ metadata.get('part_number') }} Chapter {{ metadata.get('chapter_number') }}
       </div>
       <h1 class="title">
-        {{ metadata.get('title') }}
+        {{ metadata.get('title') }} {% if metadata.get('unedited', false) %}
+        <span class="chapter-unedited">[Unedited]</span>
+        {% endif %}
       </h1>
       <img src="/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" class="content-banner" alt="" />
       {{ render_byline() }}


### PR DESCRIPTION
All chapters should be readable on the website in their current state.

For the remaining chapters that either haven't finished editing or embedding data viz, show an "unedited" label so readers know it's still in progress.

We're working to make sure all chapters are fully complete ASAP but didn't want to hold anyone back from launch day.

![image](https://user-images.githubusercontent.com/1120896/68562449-8e2b4b80-03fe-11ea-97a7-edbea5026c71.png)
