### PR TITLE
Additional logging for 404s

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -141,7 +141,9 @@ def bad_request(e):
 
 @app.errorhandler(404)
 def page_not_found(e):
-    logging.exception('An error occurred during a request due to page not found.')
+    message = ('An error occurred during a request due to page not found. (Requested url: %s)' % (request.url))
+    logging.exception(message)
+
     return render_template('error/404.html', error=e), 404
 
 


### PR DESCRIPTION
This is related to #452.

Logging the url as a part of the 404 error message. We can expand upon this, but it seems like a start.

Please check this? It does seem to work on my machine, and it's how [flask docs indicate](https://flask.palletsprojects.com/en/1.1.x/reqcontext/) you should work with the current http request context.