### PR TITLE
Lazy loading the background image

### DIFF
--- a/src/static/css/index.css
+++ b/src/static/css/index.css
@@ -1,8 +1,14 @@
 body {
-  background-image: url(/static/images/intro-background-fit.png);
   background-repeat: no-repeat;
   background-size: 100% 910px;
 }
+
+body.lazy {
+  /* This is a 1px solid #677486 image. */
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNML2n7DwAFDQJi8nQACgAAAABJRU5ErkJggg==);
+  background-size: 100% 700px;
+}
+
 header.alt-bg {
   background-color: initial;
 }

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -32,7 +32,7 @@
     {% endif %}
   </head>
 
-  <body>
+  <body class="lazy">
     {% block content %}{% endblock %}
   </body>
 </html>

--- a/src/templates/en/2019/index.html
+++ b/src/templates/en/2019/index.html
@@ -97,7 +97,7 @@
       reader.onload = function() {
         var body = document.getElementsByTagName('body')[0];
         body.setAttribute('style', 'background-image: url(' + reader.result + ');');
-        body.removeAttribute('class');
+        body.classList.remove('lazy');
       };
 
       reader.readAsDataURL(blob);

--- a/src/templates/en/2019/index.html
+++ b/src/templates/en/2019/index.html
@@ -107,13 +107,6 @@
       fetch(url)
         .then(function(response) { return response.blob(); })
         .then(function(blob) { setImage(blob); });
-    } else {
-      // Internet explorer.. :(
-      var request = new XMLHttpRequest();
-      request.open('GET', url);
-      request.responseType = 'blob';
-      request.onload = function () { setImage(request.response); };
-      request.send();
     }
   </script>
 {% endblock %}

--- a/src/templates/en/2019/index.html
+++ b/src/templates/en/2019/index.html
@@ -89,6 +89,35 @@
   <link rel="stylesheet" href="/static/css/index.css">
 {% endblock %}
 
+{% block scripts %}
+  <script defer="defer" nonce="{{ csp_nonce() }}">
+    var url = '/static/images/intro-background-fit.png';
+    var setImage = function(blob) {
+      var reader = new FileReader;
+      reader.onload = function() {
+        var body = document.getElementsByTagName('body')[0];
+        body.setAttribute('style', 'background-image: url(' + reader.result + ');');
+        body.removeAttribute('class');
+      };
+
+      reader.readAsDataURL(blob);
+    };
+
+    if (window.fetch) {
+      fetch(url)
+        .then(function(response) { return response.blob(); })
+        .then(function(blob) { setImage(blob); });
+    } else {
+      // Internet explorer.. :(
+      var request = new XMLHttpRequest();
+      request.open('GET', url);
+      request.responseType = 'blob';
+      request.onload = function () { setImage(request.response); };
+      request.send();
+    }
+  </script>
+{% endblock %}
+
 {% block main %}
 <div id="home">
   <section class="intro-container">


### PR DESCRIPTION
This is a part of #413 

Setting the background header of the home page to a solid colour, and then lazily loading the background image using javascript and swapping it out. This was the only way I could find to do this reliably, given the background image being set on the body of the page and falling across the first two sections. The next step would be to remake the background using SVG, so that it's also lighter across the wire.

What do you think? If we don't want to do it this way, I don't mind. I did test it on 'slow 3g' and it works ok.