### PR TITLE
Take Effective Connection Type into account when upgrading to interactive visuals

### DIFF
--- a/src/static/js/chapter.js
+++ b/src/static/js/chapter.js
@@ -28,7 +28,7 @@ function dataSaverEnabled() {
   return dataSaver;
 }
 
-//Check if networh API states this is a high bandwidth connection
+//Check if network API states this is a high bandwidth connection
 //Assume it is for those browsers who do not support this (e.g. Safari and IE)
 function highBandwidthConnection() {
   var highBandwidth = true;
@@ -217,4 +217,3 @@ function setDiscussionCount() {
 
 upgradeInteractiveFigures();
 //setDiscussionCount();
-

--- a/src/static/js/chapter.js
+++ b/src/static/js/chapter.js
@@ -21,9 +21,31 @@ function dataSaverEnabled() {
     } else {
       gtag('event', 'data-saver', { 'event_category': 'user', 'event_label': 'not-enabled', 'value': 0 });
     }
+  } else {
+    gtag('event', 'data-saver', { 'event_category': 'user', 'event_label': 'not-reported', 'value': 0 });
   }
 
   return dataSaver;
+}
+
+//Check if networh API states this is a high bandwidth connection
+//Assume it is for those browsers who do not support this (e.g. Safari and IE)
+function highBandwidthConnection() {
+  var highBandwidth = true;
+  if ('connection' in navigator) {
+    const effectiveType = navigator.connection.effectiveType;
+    if (effectiveType == 'slow-2g' || effectiveType == '2g' || effectiveType == '3g') {
+      highBandwidth = false;
+      console.log('effectiveType ' + effectiveType + ' is low BandWidth');
+      gtag('event', 'connection-type', { 'event_category': 'user', 'event_label': effectiveType, 'value': 0 });
+    } else {
+      gtag('event', 'connection-type', { 'event_category': 'user', 'event_label': effectiveType, 'value': 1 });
+    }
+  } else {
+    gtag('event', 'connection-type', { 'event_category': 'user', 'event_label': 'note-reported', 'value': 1 });
+  }
+
+  return highBandwidth;
 }
 
 //iOS causes Google Sheets to create a 6000 by 3700 canvas, which annoyingly isn't supported by iOS!
@@ -98,7 +120,7 @@ function googleSheetsPixelNotLoaded() {
 function upgradeInteractiveFigures() {
 
   try {
-    if (bigEnoughForInteractiveFigures() && !dataSaverEnabled() && highResolutionCanvasSupported()) {
+    if (bigEnoughForInteractiveFigures() && !dataSaverEnabled() && highBandwidthConnection() && highResolutionCanvasSupported()) {
 
       console.log('Upgrading to interactive figures');
 

--- a/src/static/js/chapter.js
+++ b/src/static/js/chapter.js
@@ -42,7 +42,7 @@ function highBandwidthConnection() {
       gtag('event', 'connection-type', { 'event_category': 'user', 'event_label': effectiveType, 'value': 1 });
     }
   } else {
-    gtag('event', 'connection-type', { 'event_category': 'user', 'event_label': 'note-reported', 'value': 1 });
+    gtag('event', 'connection-type', { 'event_category': 'user', 'event_label': 'not-reported', 'value': 1 });
   }
 
   return highBandwidth;

--- a/src/templates/en/2019/base_chapter.html
+++ b/src/templates/en/2019/base_chapter.html
@@ -18,7 +18,7 @@ indexBoxTitle.addEventListener('click', function(e) {
   indexBox.classList.toggle('show');
 });
 
-fetch(`https://discuss.httparchive.org/t/{{ metadata.get('discuss') }}.json`)
+fetch("https://discuss.httparchive.org/t/{{ metadata.get('discuss') }}.json")
     .then(function(r) { return r.json(); })
     .then(function(r) {
   if (!r) {


### PR DESCRIPTION
Look at [Effective Connection Type](https://developer.mozilla.org/en-US/docs/Glossary/Effective_connection_type) and use that as part of the decision making as to whether to upgrade to Sheets interactive visuals or stay on images.

At the moment I say `slow-2g`, `2g` or `3g` is low bandwidth and everything else (including when ECT is not reported) is high bandwidth. That seem about right or should we include `3g` as high bandwidth too?

Also includes a small bug fix for IE11 that currently bails on the fetch call (even though fetch is not supported) and so fails to upgrade to Sheets visuals. This won't be needed once https://github.com/HTTPArchive/almanac.httparchive.org/pull/511 is merged but putting it in there for now anyway.