### PR TITLE
FR - Language-specific templates part I

### DIFF
--- a/src/config/2019.json
+++ b/src/config/2019.json
@@ -314,6 +314,7 @@
     "borisschapira": {
       "name": "Boris Schapira",
       "teams": [
+        "developers",
         "translators"
       ],
       "avatar_url": "https:\/\/avatars1.githubusercontent.com\/u\/284742?v=4&s=200",

--- a/src/config/2019.json
+++ b/src/config/2019.json
@@ -311,6 +311,17 @@
       "github": "bkardell",
       "twitter": "briankardell"
     },
+    "borisschapira": {
+      "name": "Boris Schapira",
+      "bio": "Boris is Customer Success Manager at <a href=\"https://dareboost.com/en/\">Dareboost</a>. He's a WebPerf & Web Quality aficionado, a web professional, a developer, a teacher and loves standars, microtypography and chocolatines.",
+      "teams": [
+        "translators"
+      ],
+      "avatar_url": "https:\/\/avatars1.githubusercontent.com\/u\/284742?v=4&s=200",
+      "website": "https:\/\/boris.schapira.dev",
+      "github": "borisschapira",
+      "twitter": "boostmarks"
+    },
     "caraya": {
       "name": "Carlos Araya",
       "teams": [

--- a/src/config/2019.json
+++ b/src/config/2019.json
@@ -313,7 +313,6 @@
     },
     "borisschapira": {
       "name": "Boris Schapira",
-      "bio": "Boris is Customer Success Manager at <a href=\"https://dareboost.com/en/\">Dareboost</a>. He's a WebPerf & Web Quality aficionado, a web professional, a developer, a teacher and loves standars, microtypography and chocolatines.",
       "teams": [
         "translators"
       ],

--- a/src/language.py
+++ b/src/language.py
@@ -30,6 +30,7 @@ class Language(object):
   JAPANESE = _Language('日本語', 'ja', 'JP')
   ENGLISH = _Language('English', 'en', 'US')
   SPANISH = _Language('Español', 'es', 'ES')
+  FRENCH = _Language('Français', 'fr', 'FR')
 
 DEFAULT_LANGUAGE = Language.ENGLISH
 

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -154,6 +154,9 @@
 #num_comments {
   line-height: 24px;
 }
+[data-translation] {
+  display: none;
+}
 
 .authors h4{
   padding: 16px 0;

--- a/src/static/js/chapter.js
+++ b/src/static/js/chapter.js
@@ -185,15 +185,6 @@ function upgradeInteractiveFigures() {
   }
 }
 
-function getElementContent(selector, fallback){
-  var element = document.querySelector(selector);
-  if (element) {
-    return element.innerText;
-  } else {
-    return fallback;
-  }
-}
-
 function setDiscussionCount() {
   try {
     if (window.discussion_url) {
@@ -208,10 +199,11 @@ function setDiscussionCount() {
           if (isNaN(comments)) {
             return;
           }
-          var commentSingular = getElementContent('#comment-singular', 'comment');
-          var commentPlural = getElementContent('#comment-plural', 'comments');
           var el = document.getElementById('num_comments');
-          el.innerText = comments + ' ' + (comments == 1 ? commentSingular : commentPlural);
+          el.innerText = comments;
+          
+          document.getElementById(comments <= 1 ? 'comment-singular' : 'comment-plural').removeAttribute('data-translation');
+          
           gtag('event', 'discussion-count', { 'event_category': 'user', 'event_label': 'enabled', 'value': 1 });
         })
         .catch(function (err) {

--- a/src/static/js/chapter.js
+++ b/src/static/js/chapter.js
@@ -185,6 +185,15 @@ function upgradeInteractiveFigures() {
   }
 }
 
+function getElementContent(selector, fallback){
+  var element = document.querySelector(selector);
+  if (element) {
+    return element.innerText;
+  } else {
+    return fallback;
+  }
+}
+
 function setDiscussionCount() {
   try {
     if (window.discussion_url) {
@@ -199,8 +208,10 @@ function setDiscussionCount() {
           if (isNaN(comments)) {
             return;
           }
+          var commentSingular = getElementContent('#comment-singular', 'comment');
+          var commentPlural = getElementContent('#comment-plural', 'comments');
           var el = document.getElementById('num_comments');
-          el.innerText = comments + ' ' + (comments == 1 ? 'comment' : 'comments');
+          el.innerText = comments + ' ' + (comments == 1 ? commentSingular : commentPlural);
           gtag('event', 'discussion-count', { 'event_category': 'user', 'event_label': 'enabled', 'value': 1 });
         })
         .catch(function (err) {

--- a/src/templates/en/2019/base_chapter.html
+++ b/src/templates/en/2019/base_chapter.html
@@ -44,7 +44,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
 {% macro render_actions() %}
   <div class="discuss">
     <a class="alt btn" href="https://discuss.httparchive.org/t/{{ metadata.get('discuss') }}">
-      <img src="/static/images/discuss.png" alt="Discuss this chapter" height="24" width="24" loading="lazy" /><span id="num_comments"></span><span data-translation id="comment-singular">commentaire</span><span data-translation id="comment-plural">commentaires</span>
+      <img src="/static/images/discuss.png" alt="Discuss this chapter" height="24" width="24" loading="lazy" /><span id="num_comments"></span> <span data-translation id="comment-singular">comment</span><span data-translation id="comment-plural">comments</span>
     </a>
   </div>
 {% endmacro %}

--- a/src/templates/en/2019/base_chapter.html
+++ b/src/templates/en/2019/base_chapter.html
@@ -44,7 +44,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
 {% macro render_actions() %}
   <div class="discuss">
     <a class="alt btn" href="https://discuss.httparchive.org/t/{{ metadata.get('discuss') }}">
-      <img src="/static/images/discuss.png" alt="Discuss this chapter" height="24" width="24" loading="lazy" /><span id="num_comments"></span><span data-translation id="comment-singular" style="display:none;">commentaire</span><span data-translation id="comment-plural">commentaires</span>
+      <img src="/static/images/discuss.png" alt="Discuss this chapter" height="24" width="24" loading="lazy" /><span id="num_comments"></span><span data-translation id="comment-singular">commentaire</span><span data-translation id="comment-plural">commentaires</span>
     </a>
   </div>
 {% endmacro %}

--- a/src/templates/en/2019/base_chapter.html
+++ b/src/templates/en/2019/base_chapter.html
@@ -44,7 +44,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
 {% macro render_actions() %}
   <div class="discuss">
     <a class="alt btn" href="https://discuss.httparchive.org/t/{{ metadata.get('discuss') }}">
-      <img src="/static/images/discuss.png" alt="Discuss this chapter" height="24" width="24" loading="lazy" /><span id="num_comments"></span>
+      <img src="/static/images/discuss.png" alt="Discuss this chapter" height="24" width="24" loading="lazy" /><span id="num_comments"></span><span data-translation id="comment-singular" style="display:none;">commentaire</span><span data-translation id="comment-plural">commentaires</span>
     </a>
   </div>
 {% endmacro %}

--- a/src/templates/fr/2019/base.html
+++ b/src/templates/fr/2019/base.html
@@ -67,8 +67,8 @@
           Commencer l'exploration
         </a>
       </div>
-      <img class="intro-image-2019" src="/static/images/home-hero-2019.png" alt="The Web Almanac 2019 edition" />
-      <img class="intro-image" src="/static/images/home-hero.png" alt="The Web Almanac 2019 edition" />
+      <img class="intro-image-2019" src="/static/images/home-hero-2019.png" alt="Édition 2019 du Web Almanac" />
+      <img class="intro-image" src="/static/images/home-hero.png" alt="Web Almanac" />
     </div>
     {% endif %}
   </header>
@@ -78,9 +78,9 @@
 
   {% block footer %}
     <footer class="alt-bg">
-      <a class="navigation-logo home-logo" href="{{ url_for('home', year=year, lang=lang) }}"><img src="/static/images/logo.svg" alt="Web Almanac by HTTP Archive"></a>
+      <a class="navigation-logo home-logo" href="{{ url_for('home', year=year, lang=lang) }}"><img src="/static/images/logo.svg" alt="Web Almanac par HTTP Archive"></a>
       <a class="navigation-logo ha-logo" href="https://httparchive.org">
-        <img src="/static/images/ha-home.svg" alt="HTTP Archive home" height="35" width="70">
+        <img src="/static/images/ha-home.svg" alt="Page d'accueil HTTP Archive" height="35" width="70">
       </a>
       <nav class="nav-items">
         <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}">Table des matières</a>
@@ -145,7 +145,7 @@
       </option>
     {% endfor %}
   </select>
-  <img class="dropdown-arrow" src="/static/images/dropdown-arrow.png" alt="open" height="20" width="20" loading="lazy" />
+  <img class="dropdown-arrow" src="/static/images/dropdown-arrow.png" alt="ouvrir" height="20" width="20" loading="lazy" />
 </div>
 {% endif %}
 {% endmacro %}
@@ -161,6 +161,6 @@
         </option>
       {% endfor %}
   </select>
-  <img class="dropdown-arrow" src="/static/images/dropdown-arrow.png" alt="open" height="20" width="20" loading="lazy" />
+  <img class="dropdown-arrow" src="/static/images/dropdown-arrow.png" alt="ouvrir" height="20" width="20" loading="lazy" />
 </div>
 {% endmacro %}

--- a/src/templates/fr/2019/base.html
+++ b/src/templates/fr/2019/base.html
@@ -1,0 +1,166 @@
+{% extends "base.html" %}
+
+{% block styles %}
+  <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin>
+  <link href="https://fonts.googleapis.com/css?family=Lato:400,400i,700,700i,900%7CPoppins:300,400,700,900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/css/2019.css">
+{% endblock %}
+
+{% block content%}
+  {% block header %}
+  <header class="alt-bg">
+    <div class="top-header">
+      <a class="navigation-logo" href="{{ url_for('home', year=year, lang=lang) }}"><img src="/static/images/logo.svg" alt="Web Almanac par HTTP Archive"></a>
+      <nav>
+        <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}">Table des matières</a>
+        <a href="{{ url_for('contributors', year=year, lang=lang) }}">Contributeurs et contributrices</a>
+        <a href="{{ url_for('methodology', year=year, lang=lang) }}">Méthodologie</a>
+        {% if supported_years | length > 1 %}
+          {{ year_switcher() }}
+        {% endif %}
+      </nav>
+      <div class="cta">
+        {% if request.endpoint == 'home' %}
+          <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}" class="alt btn">
+            Commencer l'exploration
+          </a>
+        {% endif %}
+        {{ language_switcher() }}
+      </div>
+      <button type="button" class="menu-btn" arial-label="Menu">
+        <img class="menu-icon" src="/static/images/menu.png" data-src-close="/static/images/close.png" alt="" />
+      </button>
+      <nav class="menu">
+        <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}">Table des matières</a>
+        <a href="{{ url_for('contributors', year=year, lang=lang) }}">Contributeurs et contributrices</a>
+        <a href="{{ url_for('methodology', year=year, lang=lang) }}">Méthodologie</a>
+        <div class="misc">
+          <a href="https://httparchive.org/">
+            <img src="/static/images/ha-home.svg" alt="Page d'accueil HTTP Archive" height="35" width="70">
+          </a>
+          <div class="social-media">
+            <a href="https://twitter.com/HTTPArchive" class="twitter">
+              <img src="/static/images/twitter.png" height="80" width="65" alt="Twitter" loading="lazy" />
+            </a>
+            <a href="https://github.com/HTTPArchive/almanac.httparchive.org" class="github">
+              <img src="/static/images/github.png" height="80" width="78" alt="GitHub" loading="lazy" />
+            </a>
+          </div>
+          {{ language_switcher() }}
+        </div>
+      </nav>
+    </div>
+    {% if request.endpoint == 'home' %}
+    <div class="intro-container">
+      <div class="intro">
+        <div class="intro-year">2019</div>
+        <h1 class="title title-lg title-alt">Web Almanac</h1>
+        <h2>
+          Rapport annuel<br>
+          de HTTP Archive sur<br>
+          <b>l'état du Web</b>
+        </h2>
+        <p>
+          Notre mission est de combiner les statistiques brutes et les tendances de HTTP Archive avec l'expertise de la communauté web. Le Web Almanac est un rapport complet sur l'état du Web, soutenu par des données réelles et des experts du Web. Il est composé de 20 chapitres couvrant l'expérience utilisateur, le contenu des pages, leur publication et leur distribution.
+        </p>
+        <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}" class="btn">
+          Commencer l'exploration
+        </a>
+      </div>
+      <img class="intro-image-2019" src="/static/images/home-hero-2019.png" alt="The Web Almanac 2019 edition" />
+      <img class="intro-image" src="/static/images/home-hero.png" alt="The Web Almanac 2019 edition" />
+    </div>
+    {% endif %}
+  </header>
+  {% endblock %}
+
+  {% block main %}{% endblock %}
+
+  {% block footer %}
+    <footer class="alt-bg">
+      <a class="navigation-logo home-logo" href="{{ url_for('home', year=year, lang=lang) }}"><img src="/static/images/logo.svg" alt="Web Almanac by HTTP Archive"></a>
+      <a class="navigation-logo ha-logo" href="https://httparchive.org">
+        <img src="/static/images/ha-home.svg" alt="HTTP Archive home" height="35" width="70">
+      </a>
+      <nav class="nav-items">
+        <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}">Table des matières</a>
+        <a href="{{ url_for('contributors', year=year, lang=lang) }}">Contributeurs et contributrices</a>
+        <a href="{{ url_for('methodology', year=year, lang=lang) }}">Méthodologie</a>
+      </nav>
+      <div class="language-switcher">{{ language_switcher() }}</div>
+      <p class="copyright"><span>© 2019 Web Almanac. Sous licence <a href="https://github.com/HTTPArchive/almanac.httparchive.org/blob/master/LICENSE">Apache 2.0</a>.</span></p>
+      <div class="social-media">
+        <a href="https://twitter.com/HTTPArchive" class="twitter">
+          <img src="/static/images/twitter.png" alt="Twitter" height="80" width="65" loading="lazy" />
+        </a>
+        <a href="https://github.com/HTTPArchive/almanac.httparchive.org" class="github">
+          <img src="/static/images/github.png" alt="GitHub" height="80" width="78" loading="lazy" />
+        </a>
+      </div>
+      <hr>
+      <hr>
+    </footer>
+  {% endblock %}
+  {% block scripts %}
+    <script nonce="{{ csp_nonce() }}">
+      (function() {
+        // Language switching
+        var languageSwitchers = document.querySelectorAll('.language-switcher select');
+        for (var i = 0; i < languageSwitchers.length; i++) {
+          languageSwitchers[i].addEventListener('change', function(e) {
+            if (e.target.value) {
+              window.location = e.target.value;
+            }
+          });
+        }
+
+        // Mobile menu
+        var menuIcon = document.querySelector('.menu-icon');
+        var menuIconInitialSrc = document.querySelector('.menu-icon').src;
+        var menuIconSrcClose = document.querySelector('.menu-icon').dataset.srcClose;
+
+        document.querySelector('.menu-btn').addEventListener('click', function() {
+          var menuOpen = document.body.classList.toggle('menu-open');
+          menuIcon.src = menuOpen ? menuIconSrcClose : menuIconInitialSrc;
+        });
+      })();
+    </script>
+  {% endblock %}
+{% endblock %}
+
+{% macro language_switcher() %}
+{% if supported_languages | length > 1%}
+<div class="language-switcher">
+  {% if language is not none %}
+    <img src="/static/images/{{ language }}.png" class="flag" height="25" width="25" loading="lazy" />
+  {% else %}
+    <img src="/static/images/English.png" class="flag" height="25" width="25" loading="lazy" />
+  {% endif %}
+  <select>
+    {% for l in supported_languages %}
+      <option
+        {% if l == language %}selected="selected"{% endif %}
+        value="{{ url_for(request.endpoint, **get_view_args(lang=l.lang_code)) }}">
+        {{ l }}
+      </option>
+    {% endfor %}
+  </select>
+  <img class="dropdown-arrow" src="/static/images/dropdown-arrow.png" alt="open" height="20" width="20" loading="lazy" />
+</div>
+{% endif %}
+{% endmacro %}
+
+{% macro year_switcher() %}
+<div class="year-switcher">
+  <select>
+      {% for y in supported_years %}
+        <option
+          {% if y == year %}selected="selected"{% endif %}
+          value="{{ url_for('table_of_contents', **get_view_args(year=y)) }}">
+          Édition {{ y }}
+        </option>
+      {% endfor %}
+  </select>
+  <img class="dropdown-arrow" src="/static/images/dropdown-arrow.png" alt="open" height="20" width="20" loading="lazy" />
+</div>
+{% endmacro %}

--- a/src/templates/fr/2019/base_chapter.html
+++ b/src/templates/fr/2019/base_chapter.html
@@ -44,7 +44,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
 {% macro render_actions() %}
   <div class="discuss">
     <a class="alt btn" href="https://discuss.httparchive.org/t/{{ metadata.get('discuss') }}">
-      <img src="/static/images/discuss.png" alt="Discuss this chapter" height="24" width="24" loading="lazy" /><span id="num_comments"></span><span data-translation id="comment-singular">commentaire</span><span data-translation id="comment-plural">commentaires</span>
+      <img src="/static/images/discuss.png" alt="Discuss this chapter" height="24" width="24" loading="lazy" /><span id="num_comments"></span> <span data-translation id="comment-singular">commentaire</span><span data-translation id="comment-plural">commentaires</span>
     </a>
   </div>
 {% endmacro %}
@@ -121,7 +121,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
 
 {% macro render_prevnext() %}
   {% if prev_chapter %}
-      <a id="previous-chapter" title="Previous Chapter (press 'p' or ',')" href="/{{lang}}/{{year}}/{{prev_chapter['title'].lower().replace(' ', '-').replace('/', '')}}">
+      <a id="previous-chapter" title="Chapitre précédent (appuyez sur 'p' ou ',')" href="/{{lang}}/{{year}}/{{prev_chapter['title'].lower().replace(' ', '-').replace('/', '')}}">
           <span class="arrow">&#8963;</span>
           <span class="chapter-no">
               Chapitre {{ prev_chapter['chapter'] }}
@@ -133,7 +133,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
   {% endif %}
 
   {% if next_chapter %}
-      <a id="next-chapter" title="Next Chapter (press 'n' or '.')" href="/{{lang}}/{{year}}/{{next_chapter['title'].lower().replace(' ', '-').replace('/', '')}}">
+      <a id="next-chapter" title="Chapitre suivant (appuyez sur 'n' or '.')" href="/{{lang}}/{{year}}/{{next_chapter['title'].lower().replace(' ', '-').replace('/', '')}}">
               <span class="arrow">&#8963;</span>
               <span class="chapter-no">
                   Chapitre {{ next_chapter['chapter'] }}

--- a/src/templates/fr/2019/base_chapter.html
+++ b/src/templates/fr/2019/base_chapter.html
@@ -89,7 +89,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
               {% if authordata.twitter or authordata.github %}
                   <span class="social">
                   {% if authordata.twitter %}
-                  <a class="twitter" href="https://twitter.com/{{ authordata.twitter }}"><img src="/static/images/twitter.png" alt="@{{ authordata.twitter }} on Twitter" height="80" width="65" loading="lazy" /></a>
+                  <a class="twitter" href="https://twitter.com/{{ authordata.twitter }}"><img src="/static/images/twitter.png" alt="@{{ authordata.twitter }} sur Twitter" height="80" width="65" loading="lazy" /></a>
                   {% endif %}
                   {% if authordata.github %}
                   <a class="github" href="https://github.com/{{ authordata.github }}"><img src="/static/images/github.png" alt="{{ authordata.github }} on GitHub" height="80" width="78" loading="lazy" /></a>

--- a/src/templates/fr/2019/base_chapter.html
+++ b/src/templates/fr/2019/base_chapter.html
@@ -1,0 +1,146 @@
+{% extends "fr/2019/base.html" %}
+
+{% block title %}{{ metadata.get('title') }} | 2019 | Le Web Almanac par HTTP Archive{% endblock %}
+
+{% block styles %}
+{{ super() }}
+<link rel="stylesheet" href="/static/css/page.css">
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script nonce="{{ csp_nonce() }}">
+  
+var indexBox = document.querySelector('.index-box');
+var indexBoxTitle = document.querySelector('.index .header');
+ 
+indexBoxTitle.addEventListener('click', function(e) {
+  indexBox.classList.toggle('show');
+});
+
+document.addEventListener("keypress", function onPress(event) {
+ 	if (event.key === 'p' || event.key === 'P' || event.key === ',' || event.key === '<') {
+ 		var previous = document.getElementById('previous-chapter');
+ 		if (previous) {
+ 		  previous.click();
+ 		}
+ 	}
+ 	if (event.key === 'n' || event.key === 'N' || event.key === '.' || event.key === '>') {
+ 		var next = document.getElementById('next-chapter');
+ 		if (next) {
+ 		  next.click();
+ 		}
+ 	}
+});
+
+window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discuss') }}.json";
+</script>
+
+<script src='/static/js/chapter.js' defer></script>
+
+{% endblock %}
+
+{# Calls to action for readers who want to engage more with this chapter. #}
+{% macro render_actions() %}
+  <div class="discuss">
+    <a class="alt btn" href="https://discuss.httparchive.org/t/{{ metadata.get('discuss') }}">
+      <img src="/static/images/discuss.png" alt="Discuss this chapter" height="24" width="24" loading="lazy" /><span id="num_comments"></span><span data-translation id="comment-singular" style="display:none;">commentaire</span><span data-translation id="comment-plural">commentaires</span>
+    </a>
+  </div>
+{% endmacro %}
+
+
+{% macro render_byline() %}
+  <div class="byline">Écrit par
+  {% for author in metadata.get('authors') %}
+    <a class="author" href="{{ url_for('contributors', year=year, lang=lang, _anchor=author) }}">{{ config.contributors[author].name if author in config.contributors else author }}</a>{% if loop.index != loop.length and loop.length != 2 %},{% endif %}
+    {% if loop.index == loop.length - 1 %} et{% endif %}
+  {% endfor %}
+  </div>
+
+  <div class="byline reviewers">Relu par
+  {% for reviewer in metadata.get('reviewers') %}
+    <a class="reviewer" href="{{ url_for('contributors', year=year, lang=lang, _anchor=reviewer) }}">{{ config.contributors[reviewer].name if reviewer in config.contributors else reviewer }}</a>{% if loop.index != loop.length and loop.length != 2 %},{% endif %}
+    {% if loop.index == loop.length - 1 %} et{% endif %}
+  {% endfor %}
+  </div>
+
+  {% if metadata.get('translators') %}
+  <div class="byline translators">Traduit par
+  {% for translator in metadata.get('translators') %}
+    <a class="translator" href="{{ url_for('contributors', year=year, lang=lang, _anchor=translator) }}">{{ config.contributors[translator].name if translator in config.contributors else translator }}</a>{% if loop.index != loop.length and loop.length != 2 %},{% endif %}
+    {% if loop.index == loop.length - 1 %} et{% endif %}
+  {% endfor %}
+  </div>
+  {% endif %}
+{% endmacro %}
+
+{% macro render_authors() %}
+  {% for author in metadata.get('authors') %}
+  {% if loop.length == 1 %}<h4>Auteur·ice</h4>{% endif -%}
+  {% if loop.length > 1 and loop.index == 1 %}<h4>Auteur·ice·s</h4>{% endif %}
+  {% if loop.index == 1 %}<ul>{% endif %}
+      {% set authordata = config.contributors[author] if author in config.contributors else None %}
+    {% if authordata %}
+      <li>
+          <a href="https://almanac.httparchive.org{{ url_for('contributors', year=year, lang=lang, _anchor=author) }}"><img class="avatar" alt="{{ authordata.name }} avatar" src="{{ authordata.avatar_url }}" height="200" width="200" loading="lazy" /></a>
+          <div class="info">
+            <a href="https://almanac.httparchive.org{{ url_for('contributors', year=year, lang=lang, _anchor=author) }}"><span class="name">{{ authordata.name if authordata.name else author }}</span></a>
+              {% if authordata.twitter or authordata.github %}
+                  <span class="social">
+                  {% if authordata.twitter %}
+                  <a class="twitter" href="https://twitter.com/{{ authordata.twitter }}"><img src="/static/images/twitter.png" alt="@{{ authordata.twitter }} on Twitter" height="80" width="65" loading="lazy" /></a>
+                  {% endif %}
+                  {% if authordata.github %}
+                  <a class="github" href="https://github.com/{{ authordata.github }}"><img src="/static/images/github.png" alt="{{ authordata.github }} on GitHub" height="80" width="78" loading="lazy" /></a>
+                  {% endif %}
+                  </span>
+              {% endif %}
+              {% if authordata.tagline %}
+                  <div class="tagline">
+                      {{ authordata.tagline }}
+                  </div>
+              {% endif %}
+              {% if authordata.bio %}
+              <div class="bio">
+                  {{ authordata.bio | safe }}
+              </div>
+          {% endif %}
+          </div>
+      </li>
+    {% else %}
+      <li>
+          <div class="info">
+            <span class="name">{{ author }}</span>
+          </div>
+      </li>
+    {% endif %}
+  {% endfor %}
+</ul>
+{% endmacro %}
+
+{% macro render_prevnext() %}
+  {% if prev_chapter %}
+      <a id="previous-chapter" title="Previous Chapter (press 'p' or ',')" href="/{{lang}}/{{year}}/{{prev_chapter['title'].lower().replace(' ', '-').replace('/', '')}}">
+          <span class="arrow">&#8963;</span>
+          <span class="chapter-no">
+              Chapitre {{ prev_chapter['chapter'] }}
+          </span>
+          <span class="chapter-title">
+              {{ prev_chapter['title'] }}
+          </span>
+      </a>
+  {% endif %}
+
+  {% if next_chapter %}
+      <a id="next-chapter" title="Next Chapter (press 'n' or '.')" href="/{{lang}}/{{year}}/{{next_chapter['title'].lower().replace(' ', '-').replace('/', '')}}">
+              <span class="arrow">&#8963;</span>
+              <span class="chapter-no">
+                  Chapitre {{ next_chapter['chapter'] }}
+              </span>
+              <span class="chapter-title">
+                  {{ next_chapter['title'] }}
+              </span>
+      </a>
+  {% endif %}
+{% endmacro %}

--- a/src/templates/fr/2019/base_chapter.html
+++ b/src/templates/fr/2019/base_chapter.html
@@ -44,7 +44,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
 {% macro render_actions() %}
   <div class="discuss">
     <a class="alt btn" href="https://discuss.httparchive.org/t/{{ metadata.get('discuss') }}">
-      <img src="/static/images/discuss.png" alt="Discuss this chapter" height="24" width="24" loading="lazy" /><span id="num_comments"></span><span data-translation id="comment-singular" style="display:none;">commentaire</span><span data-translation id="comment-plural">commentaires</span>
+      <img src="/static/images/discuss.png" alt="Discuss this chapter" height="24" width="24" loading="lazy" /><span id="num_comments"></span><span data-translation id="comment-singular">commentaire</span><span data-translation id="comment-plural">commentaires</span>
     </a>
   </div>
 {% endmacro %}

--- a/src/templates/fr/2019/base_chapter.html
+++ b/src/templates/fr/2019/base_chapter.html
@@ -83,7 +83,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
       {% set authordata = config.contributors[author] if author in config.contributors else None %}
     {% if authordata %}
       <li>
-          <a href="https://almanac.httparchive.org{{ url_for('contributors', year=year, lang=lang, _anchor=author) }}"><img class="avatar" alt="{{ authordata.name }} avatar" src="{{ authordata.avatar_url }}" height="200" width="200" loading="lazy" /></a>
+          <a href="https://almanac.httparchive.org{{ url_for('contributors', year=year, lang=lang, _anchor=author) }}"><img class="avatar" alt="avatar de {{ authordata.name }}" src="{{ authordata.avatar_url }}" height="200" width="200" loading="lazy" /></a>
           <div class="info">
             <a href="https://almanac.httparchive.org{{ url_for('contributors', year=year, lang=lang, _anchor=author) }}"><span class="name">{{ authordata.name if authordata.name else author }}</span></a>
               {% if authordata.twitter or authordata.github %}

--- a/src/templates/fr/2019/base_chapter.html
+++ b/src/templates/fr/2019/base_chapter.html
@@ -95,7 +95,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
                   <a class="github" href="https://github.com/{{ authordata.github }}"><img src="/static/images/github.png" alt="{{ authordata.github }} sur GitHub" height="80" width="78" loading="lazy" /></a>
                   {% endif %}
                   {% if authordata.website %}
-                  <a class="website" href="{{ authordata.website }}"><img src="/static/images/blog.png" alt="{{ contributor.name }} site web" height="72" width="72" loading="lazy" /></a>
+                  <a class="website" href="{{ authordata.website }}"><img src="/static/images/blog.png" alt="site web de {{ contributor.name }}" height="72" width="72" loading="lazy" /></a>
                   {% endif %}
                   </span>
               {% endif %}

--- a/src/templates/fr/2019/base_chapter.html
+++ b/src/templates/fr/2019/base_chapter.html
@@ -94,6 +94,9 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
                   {% if authordata.github %}
                   <a class="github" href="https://github.com/{{ authordata.github }}"><img src="/static/images/github.png" alt="{{ authordata.github }} sur GitHub" height="80" width="78" loading="lazy" /></a>
                   {% endif %}
+                  {% if authordata.website %}
+                  <a class="website" href="{{ authordata.website }}"><img src="/static/images/blog.png" alt="{{ contributor.name }} site web" height="72" width="72" loading="lazy" /></a>
+                  {% endif %}
                   </span>
               {% endif %}
               {% if authordata.tagline %}

--- a/src/templates/fr/2019/base_chapter.html
+++ b/src/templates/fr/2019/base_chapter.html
@@ -92,7 +92,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
                   <a class="twitter" href="https://twitter.com/{{ authordata.twitter }}"><img src="/static/images/twitter.png" alt="@{{ authordata.twitter }} sur Twitter" height="80" width="65" loading="lazy" /></a>
                   {% endif %}
                   {% if authordata.github %}
-                  <a class="github" href="https://github.com/{{ authordata.github }}"><img src="/static/images/github.png" alt="{{ authordata.github }} on GitHub" height="80" width="78" loading="lazy" /></a>
+                  <a class="github" href="https://github.com/{{ authordata.github }}"><img src="/static/images/github.png" alt="{{ authordata.github }} sur GitHub" height="80" width="78" loading="lazy" /></a>
                   {% endif %}
                   </span>
               {% endif %}

--- a/src/templates/fr/2019/base_chapter.html
+++ b/src/templates/fr/2019/base_chapter.html
@@ -65,7 +65,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
   {% endfor %}
   </div>
 
-  {% if metadata.get('translators') %}
+  {% if metadata.get('translators') | length > 1 %}
   <div class="byline translators">Traduit par
   {% for translator in metadata.get('translators') %}
     <a class="translator" href="{{ url_for('contributors', year=year, lang=lang, _anchor=translator) }}">{{ config.contributors[translator].name if translator in config.contributors else translator }}</a>{% if loop.index != loop.length and loop.length != 2 %},{% endif %}

--- a/src/templates/fr/2019/base_chapter.html
+++ b/src/templates/fr/2019/base_chapter.html
@@ -44,7 +44,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
 {% macro render_actions() %}
   <div class="discuss">
     <a class="alt btn" href="https://discuss.httparchive.org/t/{{ metadata.get('discuss') }}">
-      <img src="/static/images/discuss.png" alt="Discuss this chapter" height="24" width="24" loading="lazy" /><span id="num_comments"></span> <span data-translation id="comment-singular">commentaire</span><span data-translation id="comment-plural">commentaires</span>
+      <img src="/static/images/discuss.png" alt="Discuter de ce chapitre" height="24" width="24" loading="lazy" /><span id="num_comments"></span> <span data-translation id="comment-singular">commentaire</span><span data-translation id="comment-plural">commentaires</span>
     </a>
   </div>
 {% endmacro %}

--- a/src/templates/fr/2019/chapter.html
+++ b/src/templates/fr/2019/chapter.html
@@ -1,0 +1,132 @@
+{% extends "fr/2019/base_chapter.html" %}
+
+<!--{# IMPORTANT!
+
+- `chapter.html` is a "template for templates" used by the `generate_chapters.js` script, hence the strange template syntax (eg, mixing ejs and jinja syntax)
+- if you want to modify `chapter.html`, you must also:
+  - translate the corresponding language-specific templates (eg `src/templates/<lang>/<year>/chapter.html`)
+  - run the generation script to update each chapter template
+- if you want to modify the chapter templates (eg `src/templates/<lang>/<year>/chapters/<chapter>.html`):
+  - make changes to the markdown content directly (`src/content/<lang>/<year>/<chapter>.md`) because any changes to the chapter templates will be overwritten by the generation script
+#}-->
+
+{% set metadata = <%- JSON.stringify(metadata) %> %}
+
+{% block description %}{{ metadata.get('description','Chapitre' + metadata.get('title') + ' du Web Almanac'+ year + " explorant l'utilisation des " + metadata.get('description',metadata.get('title')) + ' sur le web.') }}{% endblock %}
+
+{% block meta %}
+<meta name="description" content="{{ self.description() }}" />
+<meta property="og:title" content="{{ self.title() }}" />
+<meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}" />
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" />
+<meta property="og:image:height" content="433" />
+<meta property="og:image:width" content="866" />
+<meta property="og:type" content="article" />
+<meta property="og:description" content="{{ self.description() }}" />
+
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:site" content="@HTTPArchive" />
+<meta name="twitter:title" content="{{ self.title() }}" />
+<meta name="twitter:image" content="https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta name="twitter:image:alt" content="Image du chapitre {{ metadata.get('title') }} du Web Almanac {{ year }}" />
+<meta name="twitter:description" content="{{ self.description() }}" />
+
+<script type="application/ld+json">
+	{
+	  "@context": "http://schema.org",
+	  "@type": "Article",
+	  "mainEntityOfPage": {
+	  	  "@type": "WebPage",
+	  	  "@id": "https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}"
+	  },
+	  "headline": "{{ metadata.get('title') }}",
+	  "image": {
+	  	  "@type": "ImageObject",
+	  	  "url": "https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg",
+	  	  "height": 433,
+	  	  "width": 866
+	  },
+	  "publisher": {
+	  	  "@type": "Organization",
+	  	  "name": "HTTP Archive",
+	  	  "logo": {
+	  	      "@type": "ImageObject",
+	  	      "url": "https://almanac.httparchive.org/static/images/ha.png",
+	  	      "height": 160,
+	  	      "width": 320
+	  	  }
+      },
+	  "author":
+      {% for author in metadata.get('authors') %}{% if loop.length > 1 and loop.index == 1 %}[{% endif -%}
+      {% set authordata = config.contributors[author] if author in config.contributors else None -%}
+      {% if authordata -%}
+	  {
+	  	  "@type": "Person",
+          "sameas": [
+            "https://almanac.httparchive.org{{ url_for('contributors', year=year, lang=lang, _anchor=author) }}"
+            {% if authordata.twitter %},"https://twitter.com/{{ authordata.twitter }}"{% endif %}
+            {% if authordata.github %},"https://github.com/{{ authordata.github }}"{% endif %}
+            ],
+	  	  "name": "{{ authordata.name if authordata.name else author }}"
+      }{% if loop.index < loop.length %},{% endif %}
+      {%- endif %}{% if loop.index > 1 and loop.index == loop.length %}]{% endif -%}
+      {% endfor %},
+      "description": "{{ self.description() }}",
+      "datePublished": "{{ metadata.get('published','2019-11-04') + 'T12:00:00+00:00:00' }}",
+      "dateModified": "{{ metadata.get('last_updated','2019-11-04') + 'T12:00:00+00:00:00' }}"
+	}
+	</script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Page d'Accueil {{ year }} ({{ language }})",
+          "item": "https://almanac.httparchive.org{{  url_for('home', year=year, lang=lang) }}"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "{{ metadata.get('title') }}",
+          "item": "https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}"
+        }]
+      }
+      </script>
+{% endblock %}
+
+{% block main %}
+<article id="chapter" class="main">
+    <nav class="index">
+        <div class="index-box floating-card">
+            <h2 class="header">Index</h2>
+            <%- include('toc.html', { headings: toc }) %>
+        </div>
+    </nav>
+
+    <section class="content">
+        <section class="body">
+            <div class="subtitle">
+                Partie {{ metadata.get('part_number') }} Chapitre {{ metadata.get('chapter_number') }}
+            </div>
+            <h1 class="title title-lg">
+                {{ metadata.get('title') }}
+                {% if metadata.get('unedited', false) %}
+                <span class="chapter-unedited">[non corrigé]</span>
+                {% endif %}
+            </h1>
+            <img src="/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" class="content-banner" alt="" loading="eager" />
+            {{ render_byline() }}
+            <%- body %>
+        </section>
+        {{ render_actions() }}
+        <section class="authors">
+            {{ render_authors() }}
+        </section>
+
+        <nav id="chapter-navigation">
+            {{ render_prevnext() }}
+        </nav>
+    </section>
+</article>
+{% endblock %}

--- a/src/templates/fr/2019/chapter.html
+++ b/src/templates/fr/2019/chapter.html
@@ -27,7 +27,7 @@
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:site" content="@HTTPArchive" />
 <meta name="twitter:title" content="{{ self.title() }}" />
-<meta name="twitter:image" content="https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_sm.jpg" />
+<meta name="twitter:image" content="https://almanac.httparchive.org/static/images/{{ year }}/{{ get_chapter_image_dir(metadata) }}/hero_lg.jpg" />
 <meta name="twitter:image:alt" content="Image du chapitre {{ metadata.get('title') }} du Web Almanac {{ year }}" />
 <meta name="twitter:description" content="{{ self.description() }}" />
 

--- a/src/templates/fr/2019/contributors.html
+++ b/src/templates/fr/2019/contributors.html
@@ -69,7 +69,7 @@
       "itemListElement": [{
         "@type": "ListItem",
         "position": 1,
-        "name": "{{ year }} Home ({{ language }})",
+        "name": "Page d'accueil {{ year }} ({{ language }})",
         "item": "https://almanac.httparchive.org{{  url_for('home', year=year, lang=lang) }}"
       },{
         "@type": "ListItem",

--- a/src/templates/fr/2019/contributors.html
+++ b/src/templates/fr/2019/contributors.html
@@ -313,11 +313,7 @@
             "translators": "Traduction", 
             } %}
       {% for id, team in config.teams.items() %}
-        {% if localizedTeamNames[id]|length %}
-          <button class="{{ id }}" type="button">{{ localizedTeamNames[id] }}</button>
-        {% else %}
-          <button class="{{ id }}" type="button">{{ team.name }}</button>
-        {% endif %}
+        <button class="{{ id }}" type="button">{{ localizedTeamNames[id] if localizedTeamNames[id]|length else team.name }}</button>
       {% endfor %}
     </div>
 

--- a/src/templates/fr/2019/contributors.html
+++ b/src/templates/fr/2019/contributors.html
@@ -315,7 +315,7 @@
     <div class="contributor-grid">
     {% for id, contributor in config.contributors.items() %}
       <div class="contributor {{ ' '.join(contributor.teams) }}" id="{{ id }}" tabindex="-1">
-        <img class="contributor-avatar" src="{{contributor.avatar_url}}" height="100" width="100" alt="{{ contributor.name }} avatar" loading="lazy" />
+        <img class="contributor-avatar" src="{{contributor.avatar_url}}" height="100" width="100" alt="avatar de {{ contributor.name }}" loading="lazy" />
         <div class="contributor-name">{{ contributor.name }}</div>
 
         <div class="contributor-social">

--- a/src/templates/fr/2019/contributors.html
+++ b/src/templates/fr/2019/contributors.html
@@ -326,7 +326,7 @@
           <a href="https://twitter.com/{{ contributor.twitter }}" target="_blank" title="{{ contributor.twitter }} sur Twitter"><img src="/static/images/twitter.png" alt="Twitter" height="80" width="65" loading="lazy" /></a>
           {% endif %}
           {% if contributor.website %}
-          <a href="{{ contributor.website }}" target="_blank" title="{{ contributor.name }} website"><img src="/static/images/blog.png" alt="Site Web" height="72" width="72" loading="lazy" /></a>
+          <a href="{{ contributor.website }}" target="_blank" title="{{ contributor.name }} site web"><img src="/static/images/blog.png" alt="Site Web" height="72" width="72" loading="lazy" /></a>
           {% endif %}
         </div>
 

--- a/src/templates/fr/2019/contributors.html
+++ b/src/templates/fr/2019/contributors.html
@@ -302,14 +302,23 @@
     <div class="contributors-count"><span id="filtered-contributors">{{ config.contributors.items() | length }}</span> personnes</div>
     <div class="filter-container">
       <p>Filtrer par équipe&nbsp;:</p>
-      <button class="analysts" type="button">Analyse</button>
-      <button class="authors" type="button">Rédaction</button>
-      <button class="brainstormers" type="button">Réflexion</button>
-      <button class="designers" type="button">Design</button>
-      <button class="developers" type="button">Développement</button>
-      <button class="editors" type="button">Édition</button>
-      <button class="reviewers" type="button">Relecture</button>
-      <button class="translators" type="button">Traduction</button>
+      {% set localizedTeamNames = {
+            "analysts": "Analyse",
+            "authors": "Rédaction",
+            "brainstormers": "Réflexion",
+            "designers": "Design",
+            "developers": "Développement",
+            "editors": "Édition",
+            "reviewers": "Relecture",
+            "translators": "Traduction", 
+            } %}
+      {% for id, team in config.teams.items() %}
+        {% if localizedTeamNames[id]|length %}
+          <button class="{{ id }}" type="button">{{ localizedTeamNames[id] }}</button>
+        {% else %}
+          <button class="{{ id }}" type="button">{{ team.name }}</button>
+        {% endif %}
+      {% endfor %}
     </div>
 
     <div class="contributor-grid">

--- a/src/templates/fr/2019/contributors.html
+++ b/src/templates/fr/2019/contributors.html
@@ -320,7 +320,7 @@
 
         <div class="contributor-social">
           {% if contributor.github %}
-          <a href="https://github.com/{{ contributor.github }}" target="_blank" title="{{ contributor.github }} on GitHub"><img src="/static/images/github.png" alt="GitHub" height="80" width="78" loading="lazy" /></a>
+          <a href="https://github.com/{{ contributor.github }}" target="_blank" title="{{ contributor.github }} sur GitHub"><img src="/static/images/github.png" alt="GitHub" height="80" width="78" loading="lazy" /></a>
           {% endif %}
           {% if contributor.twitter %}
           <a href="https://twitter.com/{{ contributor.twitter }}" target="_blank" title="{{ contributor.twitter }} on Twitter"><img src="/static/images/twitter.png" alt="Twitter" height="80" width="65" loading="lazy" /></a>

--- a/src/templates/fr/2019/contributors.html
+++ b/src/templates/fr/2019/contributors.html
@@ -1,0 +1,432 @@
+{% extends "fr/2019/base.html" %}
+
+{% block title %}Contributeurs et contributrices 2019 | Web Almanac par HTTP Archive{% endblock %}
+
+{% block description %}Les {{ config.contributors.items() | length }} personnes ayant contribué au Web Almanac 2019 par leurs analyses, leurs écrits, leurs réflexions, leurs participations au design, leur code, leurs éditions, leurs relectures, ou leurs traductions.{% endblock %}
+
+{% block meta %}
+<meta name="description" content="{{ self.description() }}">
+
+<meta property="og:title" content="{{ self.title() }}">
+<meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint, year=year, lang=lang) }}">
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/methodology-characters-bg.png">
+<meta property="og:image:height" content="354">
+<meta property="og:image:width" content="984">
+<meta property="og:type" content="article">
+<meta property="og:description" content="{{ self.description() }}">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@HTTPArchive">
+<meta name="twitter:title" content="{{ self.title() }}">
+<meta name="twitter:image" content="https://almanac.httparchive.org/static/images/methodology-characters-bg.png">
+<meta name="twitter:image:alt" content="Méthodologie du Web Almanac {{ year }} " />
+<meta name="twitter:description" content="{{ self.description() }}">
+
+<script type="application/ld+json">
+	{
+	  "@context": "http://schema.org",
+	  "@type": "Article",
+	  "mainEntityOfPage": {
+	  	  "@type": "WebPage",
+	  	  "@id": "https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}"
+	  },
+	  "headline": "{{ self.title() }}",
+	  "image": {
+	  	  "@type": "ImageObject",
+	  	  "url": "https://almanac.httparchive.org/static/images/methodology-characters-bg.png",
+	  	  "height": 354,
+	  	  "width": 984
+	  },
+	  "publisher": {
+	  	  "@type": "Organization",
+	  	  "name": "HTTP Archive",
+	  	  "logo": {
+	  	      "@type": "ImageObject",
+	  	      "url": "https://almanac.httparchive.org/static/images/ha.png",
+	  	      "height": 160,
+	  	      "width": 320
+	  	  }
+      },
+    "author":
+      {
+	  	  "@type": "Person",
+          "sameas": [
+            "https://almanac.httparchive.org{{ url_for('contributors', year=year, lang=lang, _anchor='rviscomi') }}",
+            "https://twitter.com/rick_viscomi",
+            "https://github.com/rviscomi"
+            ],
+	  	  "name": "Rick Viscomi"
+      },
+      "description": "{{ self.description() }}",
+      "datePublished": "2019-11-04T12:00:00+00:00:00",
+      "dateModified": "2019-11-04T12:00:00+00:00:00"
+	}
+	</script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [{
+        "@type": "ListItem",
+        "position": 1,
+        "name": "{{ year }} Home ({{ language }})",
+        "item": "https://almanac.httparchive.org{{  url_for('home', year=year, lang=lang) }}"
+      },{
+        "@type": "ListItem",
+        "position": 2,
+        "name": "{{ year }} contributors",
+        "item": "https://almanac.httparchive.org{{  url_for(request.endpoint, year=year, lang=lang) }}"
+      }]
+    }
+    </script>
+{% endblock %}
+
+{% block styles %}
+{{ super() }}
+<style>
+.team {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  overflow: hidden;
+  height: 200px;
+  justify-content: space-between;
+  margin: 0 0 24px 0;
+}
+.team img {
+  height: 200px;
+  width: 200px;
+}
+.contributors {
+  margin: 0 0 100px 0;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.filter-container {
+  margin-bottom: 30px;
+}
+.contributors-count {
+  position: absolute;
+  right: 0;
+  top: 20px;
+}
+
+.filter-container button {
+  font-size: 1rem;
+  font-family: inherit;
+  line-height: 1.2;
+  background: none;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  margin: 0 8px 8px 0;
+  padding: 8px 16px;
+  -webkit-font-smoothing: antialiased;
+}
+
+.contributor-grid {
+  display: flex;
+  align-items: stretch;
+  flex-direction: row;
+  justify-content: start;
+  flex-wrap: wrap;
+  margin: 0 -15px;
+  justify-content: center;
+}
+
+.contributor-grid:not([data-rendered='true']) .contributor {
+  transform: translateY(30px);
+  opacity: 0;
+  will-change: opacity;
+}
+
+.contributor-grid[data-rendered='true'] .contributor {
+  animation-name: fade-in;
+  animation-duration: 750ms;
+}
+.contributor-grid[data-rendered='true'] .contributor:nth-of-type(0) {
+  animation-duration: 250ms;
+}
+.contributor-grid[data-rendered='true'] .contributor:nth-of-type(1) {
+  animation-duration: 350ms;
+}
+.contributor-grid[data-rendered='true'] .contributor:nth-of-type(2) {
+  animation-duration: 450ms;
+}
+.contributor-grid[data-rendered='true'] .contributor:nth-of-type(3) {
+  animation-duration: 600ms;
+}
+
+.contributor {
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  border-radius: 15px;
+  box-shadow: 0 0 16px 0 rgba(78, 85, 100, 0.2);
+  padding: 24px 34px;
+  width: 230px;
+  margin: 15px;
+}
+
+.contributor:focus .contributor-avatar{
+    transform: scale(1.1);
+}
+
+.contributor-avatar {
+  border-radius: 50px;
+  background-color: #f7f779;
+  margin-bottom: 10px;
+  width: 100px;
+  height: auto;
+  transition-duration: .3s;
+}
+
+.contributor-name {
+  text-align: center;
+  font-style: italic;
+  font-size: 17px;
+  margin-bottom: 10px;
+}
+
+.contributor-social {
+  flex: 1
+}
+
+.contributor-social img {
+  height: auto;
+  width: 18px;
+  margin: 0 6px 0 0;
+}
+
+.contributor-teams {
+  margin-top: 5px;
+  text-align: center;
+}
+
+.contributor-team {
+  font-size: 14px;
+  color: #868686;
+}
+.contributor-team::after {
+  content: ', ';
+}
+.contributor-team:last-child::after {
+  content: '';
+}
+
+{% for id in config.teams.keys() %}
+.contributors.{{ id }} .contributor.{{ id }} {
+  display: flex;
+}
+
+.contributors.{{ id }} button.{{ id }} {
+  background: #f7f779;
+  color: #333;
+}
+{% endfor %}
+
+@media (max-width: 600px) {
+  .team {
+    height: 100px;
+  }
+  .team img {
+     width: 100px;
+     height: 100px;
+  }
+  .filter-container {
+      margin: 0;
+  }
+
+  {% for id in config.teams.keys() %}
+  .contributors.{{ id }} .contributor.{{ id }} {
+    display: grid;
+  }
+  {% endfor %}
+
+  .contributor {
+    flex: 1;
+    display: none;/* will be set to grid */
+    grid-template-columns: 100px 3fr;
+    grid-column-gap: 10px;
+    grid-row-gap: 0;
+    padding: 20px 16px;
+
+  }
+  .contributor div {
+      text-align: left;
+  }
+
+  .contributor-avatar {
+    grid-column-start: 1;
+    grid-column-end: 1;
+    grid-row-start: 1;
+    grid-row-end: 4;
+    width: 80px;
+    height: auto;
+    margin: 0;
+  }
+}
+
+@keyframes fade-in {
+  0% {
+    transform: translateY(30px);
+    opacity: 0;
+  }
+  30% {
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+    }
+}
+</style>
+{% endblock %}
+
+{% block main %}
+<section class="main">
+  <h1 class="title title-lg">
+    Contributeurs et contributrices
+  </h1>
+  <div class="team">
+      <img src="/static/images/avatars/1.jpg" height="100" width="100" loading="lazy" />
+      <img src="/static/images/avatars/8.jpg" height="100" width="100" loading="lazy" />
+      <img src="/static/images/avatars/4.jpg" height="100" width="100" loading="lazy" />
+      <img src="/static/images/avatars/0.jpg" height="100" width="100" loading="lazy" />
+      <img src="/static/images/avatars/11.jpg" height="100" width="100" loading="lazy" />
+      <img src="/static/images/avatars/9.jpg" height="100" width="100" loading="lazy" />
+  </div>
+  <div class="contributors {{ ' '.join(config.teams.keys()) }}">
+    <div class="contributors-count"><span id="filtered-contributors">{{ config.contributors.items() | length }}</span> contributors</div>
+    <div class="filter-container">
+      <p>Filtrer par équipe (noms anglais)&nbsp;:</p>
+    {% for id, team in config.teams.items() %}
+      <button class="{{ id }}" type="button">{{ team.name }}</button>
+    {% endfor %}
+    </div>
+
+    <div class="contributor-grid">
+    {% for id, contributor in config.contributors.items() %}
+      <div class="contributor {{ ' '.join(contributor.teams) }}" id="{{ id }}" tabindex="-1">
+        <img class="contributor-avatar" src="{{contributor.avatar_url}}" height="100" width="100" alt="{{ contributor.name }} avatar" loading="lazy" />
+        <div class="contributor-name">{{ contributor.name }}</div>
+
+        <div class="contributor-social">
+          {% if contributor.github %}
+          <a href="https://github.com/{{ contributor.github }}" target="_blank" title="{{ contributor.github }} on GitHub"><img src="/static/images/github.png" alt="GitHub" height="80" width="78" loading="lazy" /></a>
+          {% endif %}
+          {% if contributor.twitter %}
+          <a href="https://twitter.com/{{ contributor.twitter }}" target="_blank" title="{{ contributor.twitter }} on Twitter"><img src="/static/images/twitter.png" alt="Twitter" height="80" width="65" loading="lazy" /></a>
+          {% endif %}
+          {% if contributor.website %}
+          <a href="{{ contributor.website }}" target="_blank" title="{{ contributor.name }} website"><img src="/static/images/blog.png" alt="Site Web" height="72" width="72" loading="lazy" /></a>
+          {% endif %}
+        </div>
+
+        <div class="contributor-teams">
+          {% for id in contributor.teams | sort() %}
+            <span class="contributor-team team-{{ id }}">{{ config.teams[id].name }}</span>
+          {% endfor %}
+        </div>
+      </div>
+    {% endfor %}
+    </div>
+  </div>
+</section>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script nonce="{{ csp_nonce() }}">
+(function loaded() {
+    var teams = ['{{ "','".join(config.teams.keys()) | safe }}'];
+    var buttons = document.querySelectorAll('.filter-container button');
+    var contributors = document.querySelector('.contributors');
+    var contributorsGrid = document.querySelector('.contributor-grid');
+    var counter = document.querySelector('#filtered-contributors');
+    var shadowNode = document.createElement('div');
+    var urlObject = new URL(document.location);
+
+    function getFilteredContributorCount() {
+      return Array.from(document.querySelectorAll('.contributor')).filter(function(el) {
+        return getComputedStyle(el).display != 'none';
+      }).length;
+    }
+
+    for (var i = 0; i < buttons.length; i++) {
+      var button = buttons[i];
+      button.addEventListener('click', function(event) {
+        event.preventDefault();
+
+        var teamName = event.target.className;
+
+        shadowNode.className = contributors.className;
+        if(shadowNode.classList.length == (teams.length + 1)) {
+            teams.forEach(function(team) {
+                if(team === teamName) {
+                    return;
+                }
+                shadowNode.classList.toggle(team);
+            });
+        } else if (shadowNode.classList.length == 2 && shadowNode.classList.contains(teamName)) {
+            teams.forEach(function(team) {
+                shadowNode.classList.add(team);
+            });
+        } else {
+            shadowNode.classList.toggle(teamName);
+        }
+
+        var selected = [];
+        teams.forEach(function(team) {
+            if(shadowNode.classList.contains(team)) {
+                selected.push(team);
+            }
+        });
+
+        if(selected.length > 0 && selected.length < teams.length){
+            urlObject.searchParams.set('teams', selected.join(','));
+            history.pushState(null, null, urlObject);
+            handleFilterUrl();
+        } else {
+            urlObject.searchParams.delete('teams');
+            history.pushState(null, null, urlObject);
+            handleFilterUrl();
+        }
+
+        counter.innerText = getFilteredContributorCount();
+      });
+    }
+
+    try {
+        var hash = document.location.hash;
+        var highlight = document.querySelector(hash);
+        highlight.focus();
+    } catch(e) { }
+
+    function handleFilterUrl(event) {
+
+        event && event.preventDefault();
+        var urlObject = new URL(document.location);
+        if(urlObject.searchParams.has('teams')) {
+
+            var hash = urlObject.searchParams.get('teams');
+            var filterTeams = hash.split(',');
+
+            if(teams.includes(filterTeams[0])) {
+                contributors.classList.remove(...teams);
+                contributors.classList.add(...filterTeams);
+            }
+        } else {
+            contributors.classList.add(...teams);
+        }
+    }
+    window.addEventListener('popstate', handleFilterUrl);
+    handleFilterUrl();
+
+    contributorsGrid.setAttribute('data-rendered', true);
+})();
+
+  </script>
+{% endblock %}

--- a/src/templates/fr/2019/contributors.html
+++ b/src/templates/fr/2019/contributors.html
@@ -326,7 +326,7 @@
           <a href="https://twitter.com/{{ contributor.twitter }}" target="_blank" title="{{ contributor.twitter }} sur Twitter"><img src="/static/images/twitter.png" alt="Twitter" height="80" width="65" loading="lazy" /></a>
           {% endif %}
           {% if contributor.website %}
-          <a href="{{ contributor.website }}" target="_blank" title="{{ contributor.name }} site web"><img src="/static/images/blog.png" alt="Site Web" height="72" width="72" loading="lazy" /></a>
+          <a href="{{ contributor.website }}" target="_blank" title="site web de {{ contributor.name }}"><img src="/static/images/blog.png" alt="Site Web" height="72" width="72" loading="lazy" /></a>
           {% endif %}
         </div>
 

--- a/src/templates/fr/2019/contributors.html
+++ b/src/templates/fr/2019/contributors.html
@@ -299,7 +299,7 @@
       <img src="/static/images/avatars/9.jpg" height="100" width="100" loading="lazy" />
   </div>
   <div class="contributors {{ ' '.join(config.teams.keys()) }}">
-    <div class="contributors-count"><span id="filtered-contributors">{{ config.contributors.items() | length }}</span> contributors</div>
+    <div class="contributors-count"><span id="filtered-contributors">{{ config.contributors.items() | length }}</span> personnes</div>
     <div class="filter-container">
       <p>Filtrer par équipe (noms anglais)&nbsp;:</p>
     {% for id, team in config.teams.items() %}

--- a/src/templates/fr/2019/contributors.html
+++ b/src/templates/fr/2019/contributors.html
@@ -323,7 +323,7 @@
           <a href="https://github.com/{{ contributor.github }}" target="_blank" title="{{ contributor.github }} sur GitHub"><img src="/static/images/github.png" alt="GitHub" height="80" width="78" loading="lazy" /></a>
           {% endif %}
           {% if contributor.twitter %}
-          <a href="https://twitter.com/{{ contributor.twitter }}" target="_blank" title="{{ contributor.twitter }} on Twitter"><img src="/static/images/twitter.png" alt="Twitter" height="80" width="65" loading="lazy" /></a>
+          <a href="https://twitter.com/{{ contributor.twitter }}" target="_blank" title="{{ contributor.twitter }} sur Twitter"><img src="/static/images/twitter.png" alt="Twitter" height="80" width="65" loading="lazy" /></a>
           {% endif %}
           {% if contributor.website %}
           <a href="{{ contributor.website }}" target="_blank" title="{{ contributor.name }} website"><img src="/static/images/blog.png" alt="Site Web" height="72" width="72" loading="lazy" /></a>

--- a/src/templates/fr/2019/contributors.html
+++ b/src/templates/fr/2019/contributors.html
@@ -301,10 +301,15 @@
   <div class="contributors {{ ' '.join(config.teams.keys()) }}">
     <div class="contributors-count"><span id="filtered-contributors">{{ config.contributors.items() | length }}</span> personnes</div>
     <div class="filter-container">
-      <p>Filtrer par équipe (noms anglais)&nbsp;:</p>
-    {% for id, team in config.teams.items() %}
-      <button class="{{ id }}" type="button">{{ team.name }}</button>
-    {% endfor %}
+      <p>Filtrer par équipe&nbsp;:</p>
+      <button class="analysts" type="button">Analyse</button>
+      <button class="authors" type="button">Rédaction</button>
+      <button class="brainstormers" type="button">Réflexion</button>
+      <button class="designers" type="button">Design</button>
+      <button class="developers" type="button">Développement</button>
+      <button class="editors" type="button">Édition</button>
+      <button class="reviewers" type="button">Relecture</button>
+      <button class="translators" type="button">Traduction</button>
     </div>
 
     <div class="contributor-grid">

--- a/src/templates/fr/2019/index.html
+++ b/src/templates/fr/2019/index.html
@@ -77,7 +77,7 @@
       "itemListElement": [{
         "@type": "ListItem",
         "position": 1,
-        "name": "{{ year }} Home ({{ language }})",
+        "name": "Page d'accueil {{ year }} ({{ language }})",
         "item": "https://almanac.httparchive.org{{  url_for('home', year=year, lang=lang) }}"
       }]
     }

--- a/src/templates/fr/2019/index.html
+++ b/src/templates/fr/2019/index.html
@@ -1,0 +1,169 @@
+{% extends "fr/2019/base.html" %}
+
+{% block title %}Web Almanac 2019{% endblock %}
+
+{% block description %}Le Web Almanac est un rapport annuel sur l'état du Web qui combine l'expertise de la communauté Web avec les données et tendances de HTTP Archive.{% endblock %}
+
+{% block meta %}
+<meta name="description" content="{{ self.description() }}">
+
+<meta property="og:title" content="{{ self.title() }}">
+<meta property="og:url" content="https://almanac.httparchive.org{{  url_for(request.endpoint , year=year, lang=lang) }}">
+<meta property="og:image" content="https://almanac.httparchive.org/static/images/home-hero-bg.png">
+<meta property="og:image:height" content="562">
+<meta property="og:image:width" content="715">
+<meta property="og:type" content="article">
+<meta property="og:description" content="{{ self.description() }}">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@HTTPArchive">
+<meta name="twitter:title" content="{{ self.title() }}">
+<meta name="twitter:image" content="https://almanac.httparchive.org/static/images/home-hero-bg.png">
+<meta name="twitter:image:alt" content="Web Almanac {{ year }}" />
+<meta name="twitter:description" content="{{ self.description() }}">
+
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "url": "https://almanac.httparchive.org",
+    "logo": "https://almanac.httparchive.org/static/images/ha.png"
+  }
+  </script>
+  <script type="application/ld+json">
+	{
+	  "@context": "http://schema.org",
+	  "@type": "Article",
+	  "mainEntityOfPage": {
+	  	  "@type": "WebPage",
+	  	  "@id": "https://almanac.httparchive.org{{  url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}"
+	  },
+	  "headline": "{{ self.title() }}",
+	  "image": {
+	  	  "@type": "ImageObject",
+	  	  "url": "https://almanac.httparchive.org/static/images/home-hero-bg.png",
+	  	  "height": 562,
+	  	  "width": 715
+	  },
+	  "publisher": {
+	  	  "@type": "Organization",
+	  	  "name": "Web Almanac by HTTP Archive",
+	  	  "logo": {
+	  	      "@type": "ImageObject",
+	  	      "url": "https://almanac.httparchive.org/static/images/ha.png",
+	  	      "height": 160,
+	  	      "width": 320
+	  	  }
+      },
+    "author":
+      {
+	  	  "@type": "Person",
+          "sameas": [
+            "https://almanac.httparchive.org{{ url_for('contributors', year=year, lang=lang, _anchor='rviscomi') }}",
+            "https://twitter.com/rick_viscomi",
+            "https://github.com/rviscomi"
+            ],
+	  	  "name": "Rick Viscomi"
+      },
+      "description": "{{ self.description() }}",
+      "datePublished": "2019-11-04T12:00:00+00:00:00",
+      "dateModified": "2019-11-04T12:00:00+00:00:00"
+	}
+	</script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [{
+        "@type": "ListItem",
+        "position": 1,
+        "name": "{{ year }} Home ({{ language }})",
+        "item": "https://almanac.httparchive.org{{  url_for('home', year=year, lang=lang) }}"
+      }]
+    }
+    </script>
+{% endblock %}
+
+{% block styles %}
+  {{ super() }}
+  <link rel="stylesheet" href="/static/css/index.css">
+{% endblock %}
+
+{% block main %}
+<div id="home">
+  <section class="featured-chapter">
+    <div class="featured-chapter-content">
+      <h2 class="title title-center">Focus sur le chapitre…</h2>
+      <h3>Parties tierces (3P)</h3>
+      <blockquote>
+          Le Web ouvert a été conçu pour être vaste, interconnectable et interopérable. La possibilité d’accéder à de puissantes librairies tierces et de les utiliser sur votre site avec des éléments <code>&lt;link></code> ou <code>&lt;script></code> a décuplé la productivité des développeurs et permis de nouvelles et incroyables expériences web ; par contre, l'immense popularité de quelques fournisseurs tiers pose d'importants problèmes en termes de performances et de confidentialité. Ce chapitre examine la prévalence et l'impact du code tiers sur le Web en 2019, les modèles d'utilisation du Web qui mènent à la popularité des solutions tierces et les répercussions potentielles sur l'avenir des performances Web et de la confidentialité.
+      </blockquote>
+      <div class="featured-chapter-content-data">
+        <div class="featured-chapter-content-data-item">
+          <div>93%</div>
+          <div>pages avec 3P</div>
+        </div>
+        <div class="featured-chapter-content-data-item">
+          <div>49%</div>
+          <div>des equêtes</div>
+        </div>
+        <div class="featured-chapter-content-data-item">
+          <div>28%</div>
+          <div>des octets</div>
+        </div>
+      </div>
+      <a href="{{ url_for('chapter', year=year, chapter='third-parties', lang=lang) }}" class="btn">
+        Lire le chapitre sur les Parties Tierces
+      </a>
+    </div>
+  </section>
+  <section class="contributors-container alt-bg">
+    {% set contributors = config.contributors.keys() | length %}
+    <div class="contributors">
+      <h2 class="title title-alt">Contributeurs et contributrices</h2>
+      <p>
+          L'Almanach Web a été rendu possible grâce au travail acharné de la communauté Web. {{ contributors }} personnes ont consacré bénévolement d'innombrables heures à le planifier, faire des recherches, le rédiger et le mettre à votre disposition.
+      </p>
+      <a href="{{ url_for('contributors', year=year, lang=lang) }}" class="alt btn">
+        Voir les contributeurs et contributrices
+      </a>
+    </div>
+    <div class="people">
+      <div class="people-number">{{ contributors }}</div>
+      <img id="character-markup" class="character" src="/static/images/character-markup.png" alt="" loading="lazy" />
+      <img id="character-star" class="character" src="/static/images/character-star.png" alt="" loading="lazy" />
+      <img id="character-hat" class="character" src="/static/images/character-hat.png" alt="" loading="lazy" />
+    </div>
+  </section>
+  <section class="methodology-container">
+    <div class="methodology">
+      <h2 class="title title-center">Méthodologie</h2>
+      <div class="methodology-data">
+        <div class="websites-tested">
+          <div>
+            Sites Web testés
+          </div>
+          <div>
+            5,8&nbsp;M
+          </div>
+        </div>
+        <div class="data-processed">
+          <div>
+              Données traitées
+          </div>
+          <div>
+            20,9&nbsp;TB
+          </div>
+        </div>
+      </div>
+      <p class="methodology-info">
+          Sauf indication contraire, les statistiques des 20 chapitres de l'Almanach Web proviennent du jeu de données HTTP Archiven, un projet communautaire qui suit l'évolution de la construction du web depuis 2010. Grâce à WebPageTest et Lighthouse, HTTP Archive collecte chaque mois les métadonnées de près de 6 millions de sites Web et les insère dans une base de données publique BigQuery pour les analyser. Le jeu de données de juillet 2019 a servi de base aux mesures du Web Almanac. Pour plus d'informations, consultez la page Méthodologie.
+      </p>
+      <a href="{{ url_for('methodology', year=year, lang=lang) }}" class="alt btn">
+        En savoir plus sur la Méthodologie
+      </a>
+      <img class="methodology-characters" src="/static/images/methodology-characters.png" alt="" loading="lazy" />
+    </div>
+  </section>
+</div>
+{% endblock %}

--- a/src/templates/fr/2019/index.html
+++ b/src/templates/fr/2019/index.html
@@ -122,7 +122,7 @@
     <div class="contributors">
       <h2 class="title title-alt">Contributeurs et contributrices</h2>
       <p>
-          L'Almanach Web a été rendu possible grâce au travail acharné de la communauté Web. {{ contributors }} personnes ont consacré bénévolement d'innombrables heures à le planifier, faire des recherches, le rédiger et le mettre à votre disposition.
+          Le Web Almanac a été rendu possible grâce au travail acharné de la communauté Web. {{ contributors }} personnes ont consacré bénévolement d'innombrables heures à le planifier, faire des recherches, le rédiger et le mettre à votre disposition.
       </p>
       <a href="{{ url_for('contributors', year=year, lang=lang) }}" class="alt btn">
         Voir les contributeurs et contributrices
@@ -157,7 +157,7 @@
         </div>
       </div>
       <p class="methodology-info">
-          Sauf indication contraire, les statistiques des 20 chapitres de l'Almanach Web proviennent du jeu de données HTTP Archiven, un projet communautaire qui suit l'évolution de la construction du web depuis 2010. Grâce à WebPageTest et Lighthouse, HTTP Archive collecte chaque mois les métadonnées de près de 6 millions de sites Web et les insère dans une base de données publique BigQuery pour les analyser. Le jeu de données de juillet 2019 a servi de base aux mesures du Web Almanac. Pour plus d'informations, consultez la page Méthodologie.
+          Sauf indication contraire, les statistiques des 20 chapitres du Web Almanac proviennent du jeu de données HTTP Archiven, un projet communautaire qui suit l'évolution de la construction du web depuis 2010. Grâce à WebPageTest et Lighthouse, HTTP Archive collecte chaque mois les métadonnées de près de 6 millions de sites Web et les insère dans une base de données publique BigQuery pour les analyser. Le jeu de données de juillet 2019 a servi de base aux mesures du Web Almanac. Pour plus d'informations, consultez la page Méthodologie.
       </p>
       <a href="{{ url_for('methodology', year=year, lang=lang) }}" class="alt btn">
         En savoir plus sur la Méthodologie


### PR DESCRIPTION
Translation for the following pages in [the language specific templates directory](https://github.com/HTTPArchive/almanac.httparchive.org/tree/master/src/templates) :

- base.html
- base_chapter.html
- chapter.html

done according to #539.

To manage the pluralization of the word "comments", I've added some JS to show or hide the right translation strings.