### PR TITLE
Handle print mode

### DIFF
--- a/src/static/css/print.css
+++ b/src/static/css/print.css
@@ -4,10 +4,13 @@
 
 .alt-bg {
     background-color: white;
-    padding: 0;
 }
 
-p.copyright, p.copyright a {
+a.btn  {
+    display: none;
+}
+
+h1, h2, h3, p, p.copyright, p.copyright a {
     color:black;
 }
 

--- a/src/static/css/print.css
+++ b/src/static/css/print.css
@@ -1,5 +1,18 @@
-.top-header, .index, .discuss, #chapter-navigation, footer {
+.top-header, .index, .discuss, #chapter-navigation, footer .navigation-logo, footer .nav-items, footer .language-switcher, footer .social-media, footer hr {
     display: none;
+}
+
+.alt-bg {
+    background-color: white;
+    padding: 0;
+}
+
+p.copyright, p.copyright a {
+    color:black;
+}
+
+p.copyright {
+    margin: 0 auto;
 }
 
 figure iframe {

--- a/src/static/css/print.css
+++ b/src/static/css/print.css
@@ -1,0 +1,11 @@
+.top-header, .index, .discuss, #chapter-navigation, footer {
+    display: none;
+}
+
+figure iframe {
+    display: none;
+}
+figure .fig-mobile {
+    display: block;
+    max-width: 100%;
+}

--- a/src/static/js/chapter.js
+++ b/src/static/js/chapter.js
@@ -2,58 +2,39 @@
 //Useful for print view for example (https://bugs.chromium.org/p/chromium/issues/detail?id=875403)
 function removeLazyLoading() {
 
-  console.log("Removing lazy loading...");
-
-  var all_imgs = document.querySelectorAll('img');
-  for (index = 0; index < all_imgs.length; ++index) {
-    var img = all_imgs[index];
-    if (img.getAttribute('loading')) {
-      img.removeAttribute('loading');
-    }
-  }
-  
-  var all_iframes = document.querySelectorAll('iframe');
-  for (index = 0; index < all_iframes.length; ++index) {
-    var iframe = all_iframes[index];
-    if (iframe.getAttribute('loading')) {
-      iframe.removeAttribute('loading');
-    }
+  //If no Array.from then pretty sure there will be no native lazy-loading support to remove!
+  if (Array.from) {
+    console.log("Removing lazy loading...");
+    
+    Array.from(document.querySelectorAll('img[loading], iframe[loading]')).forEach(function(element) {
+      element.removeAttribute('loading');
+    });
   }
 }
 
 //Add an event handler to remove LazyLoading when entering print mode
 function removeLazyLoadingOnPrint() {
   if ("onbeforeprint" in window) {
-    window.onbeforeprint = function() {
-      removeLazyLoading();
-    }
+   window.onbeforeprint = removeLazyLoading;
   }
 
 }
 
 //Check if in print mode so we can remove lazy loading and block interactive visuals
-function printMode() {
+function isInPrintMode() {
   var printMode = false;
-  var field = 'print';
-  var url = window.location.href;
 
-  if(url.indexOf('?' + field + '=') != -1) {
-    printMode = true;
-  } else if(url.indexOf('&' + field + '=') != -1) {
-    printMode = true;
+  if (window.URL && window.URLSearchParams) {
+    var url = new URL(window.location);
+    printMode = url.searchParams.has('print');
   }
-
   if (printMode) {
-    console.log("Print mode");
-    gtag('event', 'print-mode', { 'event_category': 'user', 'event_label': 'true', 'value': 1 });
-    
+    console.log ("Print Mode");
     removeLazyLoading();
-
-    return true;
-  } else {
-    gtag('event', 'print-mode', { 'event_category': 'user', 'event_label': 'false', 'value': 0 });
-    return false;
   }
+  gtag('event', 'print-mode', { 'event_category': 'user', 'event_label': '' + printMode, 'value': +printMode })
+  return printMode;
+  
 }
 
 //Check if the screen meets minimum size requirements for Interactive figures
@@ -178,7 +159,7 @@ function googleSheetsPixelNotLoaded() {
 function upgradeInteractiveFigures() {
 
   try {
-    if (!printMode() && bigEnoughForInteractiveFigures() && !dataSaverEnabled() && highBandwidthConnection() && highResolutionCanvasSupported()) {
+    if (!isInPrintMode() && bigEnoughForInteractiveFigures() && !dataSaverEnabled() && highBandwidthConnection() && highResolutionCanvasSupported()) {
 
       console.log('Upgrading to interactive figures');
 
@@ -245,7 +226,7 @@ function upgradeInteractiveFigures() {
 
 function setDiscussionCount() {
   try {
-    if (window.discussion_url) {
+    if (window.discussion_url && window.fetch) {
       fetch(window.discussion_url)
         .then(function (response) { return response.json(); })
         .then(function (response) {

--- a/src/static/js/chapter.js
+++ b/src/static/js/chapter.js
@@ -37,9 +37,9 @@ function printMode() {
   var field = 'print';
   var url = window.location.href;
 
-  if(url.indexOf('?' + field) != -1) {
+  if(url.indexOf('?' + field + '=') != -1) {
     printMode = true;
-  } else if(url.indexOf('&' + field) != -1) {
+  } else if(url.indexOf('&' + field + '=') != -1) {
     printMode = true;
   }
 

--- a/src/static/js/chapter.js
+++ b/src/static/js/chapter.js
@@ -1,3 +1,61 @@
+//This function removes the lazy-loading attributes from all img and iframe tags
+//Useful for print view for example (https://bugs.chromium.org/p/chromium/issues/detail?id=875403)
+function removeLazyLoading() {
+
+  console.log("Removing lazy loading...");
+
+  var all_imgs = document.querySelectorAll('img');
+  for (index = 0; index < all_imgs.length; ++index) {
+    var img = all_imgs[index];
+    if (img.getAttribute('loading')) {
+      img.removeAttribute('loading');
+    }
+  }
+  
+  var all_iframes = document.querySelectorAll('iframe');
+  for (index = 0; index < all_iframes.length; ++index) {
+    var iframe = all_iframes[index];
+    if (iframe.getAttribute('loading')) {
+      iframe.removeAttribute('loading');
+    }
+  }
+}
+
+//Add an event handler to remove LazyLoading when entering print mode
+function removeLazyLoadingOnPrint() {
+  if ("onbeforeprint" in window) {
+    window.onbeforeprint = function() {
+      removeLazyLoading();
+    }
+  }
+
+}
+
+//Check if in print mode so we can remove lazy loading and block interactive visuals
+function printMode() {
+  var printMode = false;
+  var field = 'print';
+  var url = window.location.href;
+
+  if(url.indexOf('?' + field) != -1) {
+    printMode = true;
+  } else if(url.indexOf('&' + field) != -1) {
+    printMode = true;
+  }
+
+  if (printMode) {
+    console.log("Print mode");
+    gtag('event', 'print-mode', { 'event_category': 'user', 'event_label': 'true', 'value': 1 });
+    
+    removeLazyLoading();
+
+    return true;
+  } else {
+    gtag('event', 'print-mode', { 'event_category': 'user', 'event_label': 'false', 'value': 0 });
+    return false;
+  }
+}
+
 //Check if the screen meets minimum size requirements for Interactive figures
 //At the moment we base it on 600px break point matching CSS but it does not need to be the same
 function bigEnoughForInteractiveFigures() {
@@ -120,7 +178,7 @@ function googleSheetsPixelNotLoaded() {
 function upgradeInteractiveFigures() {
 
   try {
-    if (bigEnoughForInteractiveFigures() && !dataSaverEnabled() && highBandwidthConnection() && highResolutionCanvasSupported()) {
+    if (!printMode() && bigEnoughForInteractiveFigures() && !dataSaverEnabled() && highBandwidthConnection() && highResolutionCanvasSupported()) {
 
       console.log('Upgrading to interactive figures');
 
@@ -214,5 +272,6 @@ function setDiscussionCount() {
   }
 }
 
+removeLazyLoadingOnPrint();
 upgradeInteractiveFigures();
 setDiscussionCount();

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -22,6 +22,7 @@
       <link rel="apple-touch-icon" href="/static/images/apple-touch-icon.png">
       <link rel="stylesheet" href="/static/css/normalize.css">
       {% block styles %}{% endblock %}
+      <link rel="stylesheet" media="print" href="/static/css/print.css">
     {% endblock %}
     <link rel="canonical" href="https://almanac.httparchive.org{{ url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}" />
     {% if supported_languages | length > 1%}

--- a/src/templates/en/2019/contributors.html
+++ b/src/templates/en/2019/contributors.html
@@ -429,4 +429,6 @@
 })();
 
   </script>
+  <!-- add chapter.js to handle print mode and avoid duplicating code -->
+  <script src='/static/js/chapter.js' defer></script>
 {% endblock %}


### PR DESCRIPTION
Closes #520 

Note it does it in two ways:

1. if `print=` is provided as a URL param it avoids the upgrade to interactive JS (and also removes Lazy Loading).
2. if print event is called, even after the upgrade, then it removes lazy-loading in js, and hides some elements and switches visuals in print.css. No need for an `onafterprint` as no need to re-add lazyloading and only switch the visuals in print stylesheet.

So a bit of duplication and they aren't exactly the same, but think it's good.
