### PR TITLE
FR - "’" instead of "'" (French microtypography)

### DIFF
--- a/src/templates/fr/2019/base.html
+++ b/src/templates/fr/2019/base.html
@@ -22,7 +22,7 @@
       <div class="cta">
         {% if request.endpoint == 'home' %}
           <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}" class="alt btn">
-            Commencer l'exploration
+            Commencer l’exploration
           </a>
         {% endif %}
         {{ language_switcher() }}
@@ -36,7 +36,7 @@
         <a href="{{ url_for('methodology', year=year, lang=lang) }}">Méthodologie</a>
         <div class="misc">
           <a href="https://httparchive.org/">
-            <img src="/static/images/ha-home.svg" alt="Page d'accueil HTTP Archive" height="35" width="70">
+            <img src="/static/images/ha-home.svg" alt="Page d’accueil HTTP Archive" height="35" width="70">
           </a>
           <div class="social-media">
             <a href="https://twitter.com/HTTPArchive" class="twitter">
@@ -58,13 +58,13 @@
         <h2>
           Rapport annuel<br>
           de HTTP Archive sur<br>
-          <b>l'état du Web</b>
+          <b>l’état du Web</b>
         </h2>
         <p>
-          Notre mission est de combiner les statistiques brutes et les tendances de HTTP Archive avec l'expertise de la communauté web. Le Web Almanac est un rapport complet sur l'état du Web, soutenu par des données réelles et des experts du Web. Il est composé de 20 chapitres couvrant l'expérience utilisateur, le contenu des pages, leur publication et leur distribution.
+          Notre mission est de combiner les statistiques brutes et les tendances de HTTP Archive avec l’expertise de la communauté web. Le Web Almanac est un rapport complet sur l’état du Web, soutenu par des données réelles et des experts du Web. Il est composé de 20 chapitres couvrant l’expérience utilisateur, le contenu des pages, leur publication et leur distribution.
         </p>
         <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}" class="btn">
-          Commencer l'exploration
+          Commencer l’exploration
         </a>
       </div>
       <img class="intro-image-2019" src="/static/images/home-hero-2019.png" alt="Édition 2019 du Web Almanac" />
@@ -80,7 +80,7 @@
     <footer class="alt-bg">
       <a class="navigation-logo home-logo" href="{{ url_for('home', year=year, lang=lang) }}"><img src="/static/images/logo.svg" alt="Web Almanac par HTTP Archive"></a>
       <a class="navigation-logo ha-logo" href="https://httparchive.org">
-        <img src="/static/images/ha-home.svg" alt="Page d'accueil HTTP Archive" height="35" width="70">
+        <img src="/static/images/ha-home.svg" alt="Page d’accueil HTTP Archive" height="35" width="70">
       </a>
       <nav class="nav-items">
         <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}">Table des matières</a>

--- a/src/templates/fr/2019/chapter.html
+++ b/src/templates/fr/2019/chapter.html
@@ -12,7 +12,7 @@
 
 {% set metadata = <%- JSON.stringify(metadata) %> %}
 
-{% block description %}{{ metadata.get('description','Chapitre' + metadata.get('title') + ' du Web Almanac'+ year + " explorant l'utilisation des " + metadata.get('description',metadata.get('title')) + ' sur le web.') }}{% endblock %}
+{% block description %}{{ metadata.get('description','Chapitre' + metadata.get('title') + ' du Web Almanac'+ year + " explorant l’utilisation des " + metadata.get('description',metadata.get('title')) + ' sur le web.') }}{% endblock %}
 
 {% block meta %}
 <meta name="description" content="{{ self.description() }}" />
@@ -83,7 +83,7 @@
         "itemListElement": [{
           "@type": "ListItem",
           "position": 1,
-          "name": "Page d'Accueil {{ year }} ({{ language }})",
+          "name": "Page d’Accueil {{ year }} ({{ language }})",
           "item": "https://almanac.httparchive.org{{  url_for('home', year=year, lang=lang) }}"
         },{
           "@type": "ListItem",

--- a/src/templates/fr/2019/contributors.html
+++ b/src/templates/fr/2019/contributors.html
@@ -69,7 +69,7 @@
       "itemListElement": [{
         "@type": "ListItem",
         "position": 1,
-        "name": "Page d'accueil {{ year }} ({{ language }})",
+        "name": "Page d’accueil {{ year }} ({{ language }})",
         "item": "https://almanac.httparchive.org{{  url_for('home', year=year, lang=lang) }}"
       },{
         "@type": "ListItem",

--- a/src/templates/fr/2019/index.html
+++ b/src/templates/fr/2019/index.html
@@ -2,7 +2,7 @@
 
 {% block title %}Web Almanac 2019{% endblock %}
 
-{% block description %}Le Web Almanac est un rapport annuel sur l'état du Web qui combine l'expertise de la communauté Web avec les données et tendances de HTTP Archive.{% endblock %}
+{% block description %}Le Web Almanac est un rapport annuel sur l’état du Web qui combine l’expertise de la communauté Web avec les données et tendances de HTTP Archive.{% endblock %}
 
 {% block meta %}
 <meta name="description" content="{{ self.description() }}">
@@ -77,7 +77,7 @@
       "itemListElement": [{
         "@type": "ListItem",
         "position": 1,
-        "name": "Page d'accueil {{ year }} ({{ language }})",
+        "name": "Page d’accueil {{ year }} ({{ language }})",
         "item": "https://almanac.httparchive.org{{  url_for('home', year=year, lang=lang) }}"
       }]
     }
@@ -96,7 +96,7 @@
       <h2 class="title title-center">Focus sur le chapitre…</h2>
       <h3>Parties tierces (3P)</h3>
       <blockquote>
-          Le Web ouvert a été conçu pour être vaste, interconnectable et interopérable. La possibilité d’accéder à de puissantes librairies tierces et de les utiliser sur votre site avec des éléments <code>&lt;link></code> ou <code>&lt;script></code> a décuplé la productivité des développeurs et permis de nouvelles et incroyables expériences web ; par contre, l'immense popularité de quelques fournisseurs tiers pose d'importants problèmes en termes de performances et de confidentialité. Ce chapitre examine la prévalence et l'impact du code tiers sur le Web en 2019, les modèles d'utilisation du Web qui mènent à la popularité des solutions tierces et les répercussions potentielles sur l'avenir des performances Web et de la confidentialité.
+          Le Web ouvert a été conçu pour être vaste, interconnectable et interopérable. La possibilité d’accéder à de puissantes librairies tierces et de les utiliser sur votre site avec des éléments <code>&lt;link></code> ou <code>&lt;script></code> a décuplé la productivité des développeurs et permis de nouvelles et incroyables expériences web ; par contre, l’immense popularité de quelques fournisseurs tiers pose d’importants problèmes en termes de performances et de confidentialité. Ce chapitre examine la prévalence et l’impact du code tiers sur le Web en 2019, les modèles d’utilisation du Web qui mènent à la popularité des solutions tierces et les répercussions potentielles sur l’avenir des performances Web et de la confidentialité.
       </blockquote>
       <div class="featured-chapter-content-data">
         <div class="featured-chapter-content-data-item">
@@ -122,7 +122,7 @@
     <div class="contributors">
       <h2 class="title title-alt">Contributeurs et contributrices</h2>
       <p>
-          Le Web Almanac a été rendu possible grâce au travail acharné de la communauté Web. {{ contributors }} personnes ont consacré bénévolement d'innombrables heures à le planifier, faire des recherches, le rédiger et le mettre à votre disposition.
+          Le Web Almanac a été rendu possible grâce au travail acharné de la communauté Web. {{ contributors }} personnes ont consacré bénévolement d’innombrables heures à le planifier, faire des recherches, le rédiger et le mettre à votre disposition.
       </p>
       <a href="{{ url_for('contributors', year=year, lang=lang) }}" class="alt btn">
         Voir les contributeurs et contributrices
@@ -157,7 +157,7 @@
         </div>
       </div>
       <p class="methodology-info">
-          Sauf indication contraire, les statistiques des 20 chapitres du Web Almanac proviennent du jeu de données HTTP Archiven, un projet communautaire qui suit l'évolution de la construction du web depuis 2010. Grâce à WebPageTest et Lighthouse, HTTP Archive collecte chaque mois les métadonnées de près de 6 millions de sites Web et les insère dans une base de données publique BigQuery pour les analyser. Le jeu de données de juillet 2019 a servi de base aux mesures du Web Almanac. Pour plus d'informations, consultez la page Méthodologie.
+          Sauf indication contraire, les statistiques des 20 chapitres du Web Almanac proviennent du jeu de données HTTP Archiven, un projet communautaire qui suit l’évolution de la construction du web depuis 2010. Grâce à WebPageTest et Lighthouse, HTTP Archive collecte chaque mois les métadonnées de près de 6 millions de sites Web et les insère dans une base de données publique BigQuery pour les analyser. Le jeu de données de juillet 2019 a servi de base aux mesures du Web Almanac. Pour plus d’informations, consultez la page Méthodologie.
       </p>
       <a href="{{ url_for('methodology', year=year, lang=lang) }}" class="alt btn">
         En savoir plus sur la Méthodologie


### PR DESCRIPTION
@nico3333fr made me realize an issue with template currently PR'ed. The issue is already in merged FR templates, so here's a fix.