### PR TITLE
Encode Unicode bullet character in before content

### DIFF
--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -118,7 +118,7 @@
 }
 .content ul li::before {
   position: absolute;
-  content: "•";
+  content: "\2022";
   font-size: 16px;
   color: #a9cbbb;
   display: inline-block;


### PR DESCRIPTION
Fixes the issue illustrated in the attachment below:

![unicode-bullet-in-css-content](https://user-images.githubusercontent.com/65147/71373051-ef107c80-2583-11ea-8d51-b9db9a1e2512.png)
