### PR TITLE
Home page Hero Image fix

### DIFF
--- a/src/static/css/index.css
+++ b/src/static/css/index.css
@@ -98,32 +98,28 @@ p {
 .intro-image-wrapper {
   grid-area: image;
   display: none;
-  width: 100%;
-  padding-bottom: 78.6%;
-  position: relative;
+  width:100%;
 }
 
 .intro-image {
   background-image: url(/static/images/home-hero.png);
   background-size: cover;
-  position: absolute;
-  top: 0; bottom: 0; left: 0; right: 0;
+  height: 67.5vw;
+  width: 86vw;
 }
 
 .intro-image-2019-wrapper {
   grid-area: image;
-  max-height: 470px;
-  max-width: 100%;
-  height: auto;
-  padding-bottom: 103%;
-  margin-bottom: -90px;
+  width:100%;
 }
 
 .intro-image-2019 {
   background-image: url(/static/images/home-hero-2019.png);
   background-size: cover;
-  height: 470px;
-  width: 458px;
+  max-height: 470px;
+  max-width: 458px;
+  height: 41vw;
+  width: 40vw;
 }
 
 .intro .btn {

--- a/src/static/css/index.css
+++ b/src/static/css/index.css
@@ -95,17 +95,35 @@ p {
   font-family: 'Poppins', sans-serif;
 }
 
-.intro-image {
+.intro-image-wrapper {
   grid-area: image;
   display: none;
+  width: 100%;
+  padding-bottom: 78.6%;
+  position: relative;
 }
 
-.intro-image-2019 {
+.intro-image {
+  background-image: url(/static/images/home-hero.png);
+  background-size: cover;
+  position: absolute;
+  top: 0; bottom: 0; left: 0; right: 0;
+}
+
+.intro-image-2019-wrapper {
   grid-area: image;
   max-height: 470px;
   max-width: 100%;
   height: auto;
+  padding-bottom: 103%;
   margin-bottom: -90px;
+}
+
+.intro-image-2019 {
+  background-image: url(/static/images/home-hero-2019.png);
+  background-size: cover;
+  height: 470px;
+  width: 458px;
 }
 
 .intro .btn {
@@ -345,13 +363,13 @@ p {
     font-weight: bold;
   }
 
-  .intro-image {
+  .intro-image-wrapper {
     display: block;
     max-width: 100%;
     margin-top: 80px;
     margin-right: -46px;
   }
-  .intro-image-2019 {
+  .intro-image-2019-wrapper {
     display: none;
   }
 
@@ -490,14 +508,14 @@ p {
     font-weight: bold;
   }
 
-  .intro-image {
+  .intro-image-wrapper {
     display: block;
     max-width: 100%;
     margin-top: 60px;
     margin-right: -46px;
   }
 
-  .intro-image-2019 {
+  .intro-image-2019-wrapper {
     display: none;
   }
 

--- a/src/templates/ar/2019/base.html
+++ b/src/templates/ar/2019/base.html
@@ -68,8 +68,12 @@
           Start exploring
         </a>
       </div>
-      <img class="intro-image-2019" src="/static/images/home-hero-2019.png" alt="The Web Almanac 2019 edition" />
-      <img class="intro-image" src="/static/images/home-hero.png" alt="The Web Almanac 2019 edition" />
+      <div class="intro-image-2019-wrapper">
+        <div class="intro-image-2019"></div>
+      </div>
+      <div class="intro-image-wrapper">
+        <div class="intro-image"></div>
+      </div>
     </div>
     {% endif %}
   </header>

--- a/src/templates/en/2019/base.html
+++ b/src/templates/en/2019/base.html
@@ -68,8 +68,12 @@
           Start exploring
         </a>
       </div>
-      <img class="intro-image-2019" src="/static/images/home-hero-2019.png" alt="The Web Almanac 2019 edition" />
-      <img class="intro-image" src="/static/images/home-hero.png" alt="The Web Almanac 2019 edition" />
+      <div class="intro-image-2019-wrapper">
+        <div class="intro-image-2019"></div>
+      </div>
+      <div class="intro-image-wrapper">
+        <div class="intro-image"></div>
+      </div>
     </div>
     {% endif %}
   </header>

--- a/src/templates/es/2019/base.html
+++ b/src/templates/es/2019/base.html
@@ -65,8 +65,12 @@
           Empieza a explorar
         </a>
       </div>
-      <img class="intro-image-2019" src="/static/images/home-hero-2019.png" alt="Web Almanac edición 2019" />
-      <img class="intro-image" src="/static/images/home-hero.png" alt="Web Almanac edición 2019" />
+      <div class="intro-image-2019-wrapper">
+        <div class="intro-image-2019"></div>
+      </div>
+      <div class="intro-image-wrapper">
+        <div class="intro-image"></div>
+      </div>
     </div>
     {% endif %}    
   </header>

--- a/src/templates/fr/2019/base.html
+++ b/src/templates/fr/2019/base.html
@@ -68,8 +68,12 @@
           Commencer l’exploration
         </a>
       </div>
-      <img class="intro-image-2019" src="/static/images/home-hero-2019.png" alt="Édition 2019 du Web Almanac" />
-      <img class="intro-image" src="/static/images/home-hero.png" alt="Web Almanac" />
+      <div class="intro-image-2019-wrapper">
+        <div class="intro-image-2019"></div>
+      </div>
+      <div class="intro-image-wrapper">
+        <div class="intro-image"></div>
+      </div>
     </div>
     {% endif %}
   </header>


### PR DESCRIPTION
Stop loading both desktop and mobile image on home page and only load appropriate image.

Fixes #361 

I went with the wrapper `display:none` of a background-image fix rather than `<picture>` or `<img srcset>` method because [they no not allow you to hide an image based on media queries](https://github.com/ResponsiveImagesCG/picture-element/issues/243) which means you can't have two fall backs. And since some clients (e.g. IE11, Android 4.4) [do not support `<picture>`](https://caniuse.com/#feat=picture), I thought best to implement the other way.