### PR TITLE
Add better default caching

### DIFF
--- a/src/app.yaml
+++ b/src/app.yaml
@@ -1,7 +1,13 @@
 runtime: python37
 entrypoint: gunicorn -b :$PORT main:app
+default_expiration: 3h
 
 handlers:
+- url: /static/(.*\.(woff|woff2))$
+  static_files: static/\1
+  secure: always
+  expiration: 365d
+
 - url: /static
   static_dir: static
   secure: always


### PR DESCRIPTION
Closes #413 

This sets the following cache control settings:
- Fonts - 1 year (currently not served locally but may be added by #607 )
- Other static files (JS, CSS, SVG, JPEG, PNG) - 3 hours
- Dynamic HTML - 3 hours

Note the static files need to be set in two different places depending whether they are served by Google App Engine (production) or Python/Flask (for local development) and I set in both for consistency. And I've not been able to test the App Engine changes so will need to double check it when deployed.

Background:

In #423 @paulcalvano noted the Google App engine default of 600 seconds (10 mins) for static content and no caching for dynamic content was too low but we didn't really agree what the higher limit should be.

Some advocate for extremely large times (e.g. 1 year) but this depends on immutable resources, which we don't currently have as we don't currently set a unique hash value in our static resource file names. The longer we make it, the more risk of showing broken content or not being in control to change it. I'm also sceptical as to the benefit of longer term caching to be honest: unless you are a very popular site visited frequently by the users, I'd imagine most users won't have your assets cached between sessions and caching is really for within a session when the user is browsing about the site so short term caching is actually fine in my opinion. However I agree 10 mins is too short - as some of our articles could easily take over 10 mins to read.

Therefore I've gone with a relatively small 3 hours for most resources. So if someone is browsing around the site then they should not have to reload caching - unless here for an extremely long time, in which case they might take a small hit every 3 hours! I could even be persuaded to move this to 1 hour. I'm also a fan of having a bit of caching for HTML since it shouldn't change much either and it makes browsing around the site a lot quicker.

This should also move us from the frankly embarrassing F we get in the caching when you run webpagetest on our site:

![image](https://user-images.githubusercontent.com/10931297/71563320-9bbb9400-2a85-11ea-8f83-a38ddff48d98.png)

However will likely still give us a lower ranking (my own blog follows the same rules and gets a D rating). Saying that, it does set us up for how to set this in future if we do want to make longer caching, for example if we move to immutable static resources with unique filenames.

Thoughts on this strategy - and on the PR in general - greatly appreciated!