### PR TITLE
Correct yaml file

### DIFF
--- a/src/app.yaml
+++ b/src/app.yaml
@@ -3,8 +3,9 @@ entrypoint: gunicorn -b :$PORT main:app
 default_expiration: 3h
 
 handlers:
-- url: /static/(.*\.(woff|woff2))$
+- url: /(.*\.(woff|woff2))$
   static_files: static/\1
+  upload: static/.*\.(woff|woff2)$
   secure: always
   expiration: 365d
 


### PR DESCRIPTION
Correcting error in https://github.com/HTTPArchive/almanac.httparchive.org/commit/809e4e480304c360f3ffd0123f2c2dc9b2a5959a#r36752216

Based on this documentation: https://cloud.google.com/appengine/docs/standard/python/config/appref#Static_File_Pattern_Handlers

Apologies - wasn't able to test this.