### PR TITLE
Fix fonts 404ing

### DIFF
--- a/src/app.yaml
+++ b/src/app.yaml
@@ -3,9 +3,9 @@ entrypoint: gunicorn -b :$PORT main:app
 default_expiration: 3h
 
 handlers:
-- url: /(.*\.(woff|woff2))$
-  static_files: static/\1
-  upload: static/.*\.(woff|woff2)$
+- url: /static/fonts/(.*\.(woff|woff2))$
+  static_files: static/fonts/\1
+  upload: static/fonts/.*\.(woff|woff2)$
   secure: always
   expiration: 365d
 


### PR DESCRIPTION
No fonts are loading

Non-directory static_files (needed to pattern match) in App Engine is confusing [and not just to me](https://stackoverflow.com/a/34196068/2144578).