### PR TITLE
Correct error where wrong date is used in sitemap for non-chapters

### DIFF
--- a/src/tools/generate/generate_sitemap.js
+++ b/src/tools/generate/generate_sitemap.js
@@ -52,7 +52,7 @@ const get_static_pages = async (sitemap_chapters) => {
   for (const loc of await files) {
     if (fs.existsSync(`templates/${loc}`)) {
       const file = await fs.readFile(`templates/${loc}`, 'utf-8');
-      const match = file.match(/"datePublished": "([0-9\-\+\:T]*)"/);
+      const match = file.match(/"dateModified": "([0-9\-\+\:T]*)"/);
       const lastmod = set_min_date(match[1]);
       const url = strip_html_extension(loc);
 


### PR DESCRIPTION
Just found out we're using the wrong date for the non-chapter files in the sitemap. Dates haven't changed since launch (as we're not good at remembering to change it! - see #317 ) but still, should fix.