### PR TITLE
Only compress images if including images in PR

### DIFF
--- a/.github/workflows/calibreapp-image-action.yml
+++ b/.github/workflows/calibreapp-image-action.yml
@@ -1,5 +1,6 @@
 name: Compress images
-on: pull_request:
+on:
+  pull_request:
     paths:
       - '**.jpg'
       - '**.png'

--- a/.github/workflows/calibreapp-image-action.yml
+++ b/.github/workflows/calibreapp-image-action.yml
@@ -1,5 +1,9 @@
 name: Compress images
-on: pull_request
+on: pull_request:
+    paths:
+      - '**.jpg'
+      - '**.png'
+      - '**.webp'
 jobs:
   build:
     name: calibreapp/image-actions


### PR DESCRIPTION
Currently we run the calibre app every time we commit - even if no images to compress. Bit of a waste so let's limit it to only when we include image files.