### PR TITLE
Fix misc errors and inconsistencies

### DIFF
--- a/src/content/en/2019/cdn.md
+++ b/src/content/en/2019/cdn.md
@@ -1560,7 +1560,6 @@ The reduction in latency that CDNs deliver along with their ability to store con
 
 Steve Souders' recommendation to use a CDN remains as valid today as it was 12 years ago, yet only 20% of sites serve their HTML content via a CDN, and only 40% are using a CDN for resources, so there's plenty of opportunity for their usage to grow further.
 
-There are some aspects of CDN adoption that aren't included in this analysis, sometimes 
-this was due to the limitations of the dataset and how it's collected, in other cases new research questions emerged during the analysis.
+There are some aspects of CDN adoption that aren't included in this analysis, sometimes this was due to the limitations of the dataset and how it's collected, in other cases new research questions emerged during the analysis.
 
 As the web continues to evolve, CDN vendors innovate, and sites use new practices CDN adoption remains an area rich for further research in future editions of the Web Almanac.

--- a/src/csp.py
+++ b/src/csp.py
@@ -26,7 +26,7 @@ csp = {
         'www.googletagmanager.com',
         'stats.g.doubleclick.net',
         '*.githubusercontent.com',
-        'docs.google.com',
+        '*.google.com',
         'ssl.gstatic.com',
         'data:'
     ],

--- a/src/templates/ar/2019/base.html
+++ b/src/templates/ar/2019/base.html
@@ -27,7 +27,7 @@
         {% endif %}
         {{ language_switcher() }}
       </div>
-      <button type="button" class="menu-btn" arial-label="Menu">
+      <button type="button" class="menu-btn" aria-label="Menu">
         <img class="menu-icon" src="/static/images/menu.png" data-src-close="/static/images/close.png" alt="" />
       </button>
       <nav class="menu">
@@ -40,10 +40,10 @@
           </a>
           <div class="social-media">
             <a href="https://twitter.com/HTTPArchive" class="twitter">
-              <img src="/static/images/twitter.png" height="80" width="65" alt="Twitter" loading="lazy" />
+              <img src="/static/images/twitter.png" height="65" width="80" alt="Twitter" loading="lazy" />
             </a>
             <a href="https://github.com/HTTPArchive/almanac.httparchive.org" class="github">
-              <img src="/static/images/github.png" height="80" width="78" alt="GitHub" loading="lazy" />
+              <img src="/static/images/github.png" height="75" width="80" alt="GitHub" loading="lazy" />
             </a>
           </div>
           {{ language_switcher() }}
@@ -94,10 +94,10 @@
       <p class="copyright"><span>© 2019 Web Almanac. Licensed under <a href="https://github.com/HTTPArchive/almanac.httparchive.org/blob/master/LICENSE">Apache 2.0</a>.</span></p>
       <div class="social-media">
         <a href="https://twitter.com/HTTPArchive" class="twitter">
-          <img src="/static/images/twitter.png" alt="Twitter" height="80" width="65" loading="lazy" />
+          <img src="/static/images/twitter.png" alt="Twitter" height="65" width="80" loading="lazy" />
         </a>
         <a href="https://github.com/HTTPArchive/almanac.httparchive.org" class="github">
-          <img src="/static/images/github.png" alt="GitHub" height="80" width="78" loading="lazy" />
+          <img src="/static/images/github.png" alt="GitHub" height="78" width="80" loading="lazy" />
         </a>
       </div>
       <hr>

--- a/src/templates/en/2019/base.html
+++ b/src/templates/en/2019/base.html
@@ -26,7 +26,7 @@
             </a>
           </div>
         {% endif %}
-        <button type="button" class="menu-btn" arial-label="Menu">
+        <button type="button" class="menu-btn" aria-label="Menu">
           <img class="menu-icon" src="/static/images/menu.png" data-src-close="/static/images/close.png" alt="" />
         </button>
         <nav class="menu">
@@ -39,10 +39,10 @@
             </a>
             <div class="social-media">
               <a href="https://twitter.com/HTTPArchive" class="twitter">
-                <img src="/static/images/twitter.png" height="80" width="65" alt="Twitter" loading="lazy" />
+                <img src="/static/images/twitter.png" height="65" width="80" alt="Twitter" loading="lazy" />
               </a>
               <a href="https://github.com/HTTPArchive/almanac.httparchive.org" class="github">
-                <img src="/static/images/github.png" height="80" width="78" alt="GitHub" loading="lazy" />
+                <img src="/static/images/github.png" height="78" width="80" alt="GitHub" loading="lazy" />
               </a>
             </div>
             {{ language_switcher() }}
@@ -96,10 +96,10 @@
       <p class="copyright"><span>© 2019 Web Almanac. Licensed under <a href="https://github.com/HTTPArchive/almanac.httparchive.org/blob/master/LICENSE">Apache 2.0</a>.</span></p>
       <div class="social-media">
         <a href="https://twitter.com/HTTPArchive" class="twitter">
-          <img src="/static/images/twitter.png" alt="Twitter" height="80" width="65" loading="lazy" />
+          <img src="/static/images/twitter.png" alt="Twitter" height="65" width="80" loading="lazy" />
         </a>
         <a href="https://github.com/HTTPArchive/almanac.httparchive.org" class="github">
-          <img src="/static/images/github.png" alt="GitHub" height="80" width="78" loading="lazy" />
+          <img src="/static/images/github.png" alt="GitHub" height="78" width="80" loading="lazy" />
         </a>
       </div>
       <hr>

--- a/src/templates/en/2019/base_chapter.html
+++ b/src/templates/en/2019/base_chapter.html
@@ -89,10 +89,10 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
               {% if authordata.twitter or authordata.github %}
                   <span class="social">
                   {% if authordata.twitter %}
-                  <a class="twitter" href="https://twitter.com/{{ authordata.twitter }}"><img src="/static/images/twitter.png" alt="@{{ authordata.twitter }} on Twitter" height="80" width="65" loading="lazy" /></a>
+                  <a class="twitter" href="https://twitter.com/{{ authordata.twitter }}"><img src="/static/images/twitter.png" alt="@{{ authordata.twitter }} on Twitter" height="65" width="80" loading="lazy" /></a>
                   {% endif %}
                   {% if authordata.github %}
-                  <a class="github" href="https://github.com/{{ authordata.github }}"><img src="/static/images/github.png" alt="{{ authordata.github }} on GitHub" height="80" width="78" loading="lazy" /></a>
+                  <a class="github" href="https://github.com/{{ authordata.github }}"><img src="/static/images/github.png" alt="{{ authordata.github }} on GitHub" height="78" width="80" loading="lazy" /></a>
                   {% endif %}
                   {% if authordata.website %}
                   <a class="website" href="{{ authordata.website }}"><img src="/static/images/blog.png" alt="{{ authordata.name }} website" height="72" width="72" loading="lazy" /></a>

--- a/src/templates/en/2019/contributors.html
+++ b/src/templates/en/2019/contributors.html
@@ -364,11 +364,11 @@
         <div class="contributor-name">{{ contributor.name }}</div>
 
         <div class="contributor-social">
-          {% if contributor.github %}
-          <a href="https://github.com/{{ contributor.github }}" target="_blank" title="{{ contributor.github }} on GitHub"><img src="/static/images/github.png" alt="GitHub" height="80" width="78" loading="lazy" /></a>
-          {% endif %}
           {% if contributor.twitter %}
-          <a href="https://twitter.com/{{ contributor.twitter }}" target="_blank" title="{{ contributor.twitter }} on Twitter"><img src="/static/images/twitter.png" alt="Twitter" height="80" width="65" loading="lazy" /></a>
+          <a href="https://twitter.com/{{ contributor.twitter }}" target="_blank" title="{{ contributor.twitter }} on Twitter"><img src="/static/images/twitter.png" alt="Twitter" height="65" width="80" loading="lazy" /></a>
+          {% endif %}
+          {% if contributor.github %}
+          <a href="https://github.com/{{ contributor.github }}" target="_blank" title="{{ contributor.github }} on GitHub"><img src="/static/images/github.png" alt="GitHub" height="78" width="80" loading="lazy" /></a>
           {% endif %}
           {% if contributor.website %}
           <a href="{{ contributor.website }}" target="_blank" title="{{ contributor.name }} website"><img src="/static/images/blog.png" alt="website" height="72" width="72" loading="lazy" /></a>

--- a/src/templates/es/2019/base.html
+++ b/src/templates/es/2019/base.html
@@ -24,7 +24,7 @@
         {% endif %}
         {{ language_switcher() }}
       </div>
-      <button type="button" class="menu-btn" arial-label="Menú">
+      <button type="button" class="menu-btn" aria-label="Menú">
         <img class="menu-icon" src="/static/images/menu.png" data-src-close="/static/images/close.png" alt="" />
       </button>
       <nav class="menu">
@@ -37,10 +37,10 @@
           </a>
           <div class="social-media">
             <a href="https://twitter.com/HTTPArchive" class="twitter">
-              <img src="/static/images/twitter.png" alt="Twitter" height="80" width="65" loading="lazy" />
+              <img src="/static/images/twitter.png" alt="Twitter" height="65" width="80" loading="lazy" />
             </a>
             <a href="https://github.com/HTTPArchive/almanac.httparchive.org" class="github">
-              <img src="/static/images/github.png" alt="GitHub" height="80" width="78" loading="lazy" />
+              <img src="/static/images/github.png" alt="GitHub" height="78" width="80" loading="lazy" />
             </a>
           </div>
           {{ language_switcher() }}
@@ -91,10 +91,10 @@
       <p class="copyright">Copyright © 2019 Web Almanac. Todos los derechos reservados.</p>
       <div class="social-media">
         <a href="https://twitter.com/HTTPArchive" class="twitter">
-          <img src="/static/images/twitter.png" alt="Twitter" height="80" width="65" loading="lazy" />
+          <img src="/static/images/twitter.png" alt="Twitter" height="65" width="80" loading="lazy" />
         </a>
         <a href="https://github.com/HTTPArchive/almanac.httparchive.org" class="github">
-          <img src="/static/images/github.png" alt="GitHub" height="80" width="78" loading="lazy" />
+          <img src="/static/images/github.png" alt="GitHub" height="78" width="80" loading="lazy" />
         </a>
       </div>
       <hr>

--- a/src/templates/fr/2019/base.html
+++ b/src/templates/fr/2019/base.html
@@ -26,7 +26,7 @@
             </a>
           </div>
         {% endif %}
-        <button type="button" class="menu-btn" arial-label="Menu">
+        <button type="button" class="menu-btn" aria-label="Menu">
           <img class="menu-icon" src="/static/images/menu.png" data-src-close="/static/images/close.png" alt="" />
         </button>
         <nav class="menu">
@@ -39,10 +39,10 @@
             </a>
             <div class="social-media">
               <a href="https://twitter.com/HTTPArchive" class="twitter">
-                <img src="/static/images/twitter.png" height="80" width="65" alt="Twitter" loading="lazy" />
+                <img src="/static/images/twitter.png" height="65" width="80" alt="Twitter" loading="lazy" />
               </a>
               <a href="https://github.com/HTTPArchive/almanac.httparchive.org" class="github">
-                <img src="/static/images/github.png" height="80" width="78" alt="GitHub" loading="lazy" />
+                <img src="/static/images/github.png" height="78" width="80" alt="GitHub" loading="lazy" />
               </a>
             </div>
             {{ language_switcher() }}
@@ -96,10 +96,10 @@
       <p class="copyright"><span>© 2019 Web Almanac. Sous licence <a href="https://github.com/HTTPArchive/almanac.httparchive.org/blob/master/LICENSE">Apache 2.0</a>.</span></p>
       <div class="social-media">
         <a href="https://twitter.com/HTTPArchive" class="twitter">
-          <img src="/static/images/twitter.png" alt="Twitter" height="80" width="65" loading="lazy" />
+          <img src="/static/images/twitter.png" alt="Twitter" height="65" width="80" loading="lazy" />
         </a>
         <a href="https://github.com/HTTPArchive/almanac.httparchive.org" class="github">
-          <img src="/static/images/github.png" alt="GitHub" height="80" width="78" loading="lazy" />
+          <img src="/static/images/github.png" alt="GitHub" height="78" width="80" loading="lazy" />
         </a>
       </div>
       <hr>

--- a/src/templates/fr/2019/base_chapter.html
+++ b/src/templates/fr/2019/base_chapter.html
@@ -89,10 +89,10 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
               {% if authordata.twitter or authordata.github %}
                   <span class="social">
                   {% if authordata.twitter %}
-                  <a class="twitter" href="https://twitter.com/{{ authordata.twitter }}"><img src="/static/images/twitter.png" alt="@{{ authordata.twitter }} sur Twitter" height="80" width="65" loading="lazy" /></a>
+                  <a class="twitter" href="https://twitter.com/{{ authordata.twitter }}"><img src="/static/images/twitter.png" alt="@{{ authordata.twitter }} sur Twitter" height="65" width="80" loading="lazy" /></a>
                   {% endif %}
                   {% if authordata.github %}
-                  <a class="github" href="https://github.com/{{ authordata.github }}"><img src="/static/images/github.png" alt="{{ authordata.github }} sur GitHub" height="80" width="78" loading="lazy" /></a>
+                  <a class="github" href="https://github.com/{{ authordata.github }}"><img src="/static/images/github.png" alt="{{ authordata.github }} sur GitHub" height="78" width="80" loading="lazy" /></a>
                   {% endif %}
                   {% if authordata.website %}
                   <a class="website" href="{{ authordata.website }}"><img src="/static/images/blog.png" alt="site web de {{ authordata.name }}" height="72" width="72" loading="lazy" /></a>

--- a/src/templates/fr/2019/contributors.html
+++ b/src/templates/fr/2019/contributors.html
@@ -321,11 +321,11 @@
         <div class="contributor-name">{{ contributor.name }}</div>
 
         <div class="contributor-social">
-          {% if contributor.github %}
-          <a href="https://github.com/{{ contributor.github }}" target="_blank" title="{{ contributor.github }} sur GitHub"><img src="/static/images/github.png" alt="GitHub" height="80" width="78" loading="lazy" /></a>
-          {% endif %}
           {% if contributor.twitter %}
-          <a href="https://twitter.com/{{ contributor.twitter }}" target="_blank" title="{{ contributor.twitter }} sur Twitter"><img src="/static/images/twitter.png" alt="Twitter" height="80" width="65" loading="lazy" /></a>
+          <a href="https://twitter.com/{{ contributor.twitter }}" target="_blank" title="{{ contributor.twitter }} sur Twitter"><img src="/static/images/twitter.png" alt="Twitter" height="65" width="80" loading="lazy" /></a>
+          {% endif %}
+          {% if contributor.github %}
+          <a href="https://github.com/{{ contributor.github }}" target="_blank" title="{{ contributor.github }} sur GitHub"><img src="/static/images/github.png" alt="GitHub" height="78" width="80" loading="lazy" /></a>
           {% endif %}
           {% if contributor.website %}
           <a href="{{ contributor.website }}" target="_blank" title="site web de {{ contributor.name }}"><img src="/static/images/blog.png" alt="Site Web" height="72" width="72" loading="lazy" /></a>


### PR DESCRIPTION
Fixes the following highlighted by [Lighthouse](https://lighthouse-dot-webdotdevsite.appspot.com//lh/html?url=https://almanac.httparchive.org/en/2019/css):

- Twitter and Github image heights and width were transposed
- Typo in button aria attribute (`arial-label` instead of `aria-label`)
- Console error as CSP doesn't allow www.google.com - made this more generic as Google keeps adding things.

Also fixed these at same time:

- Contributors Twitter and Github links were Github and Twitter when it's the other way around for everything else
- CDN markdown as a line break mid-paragraph [as notice here](https://github.com/HTTPArchive/almanac.httparchive.org/pull/643#discussion_r368224167)
