### PR TITLE
Enable first translations boris review

### DIFF
--- a/src/templates/base/2019/contributors.html
+++ b/src/templates/base/2019/contributors.html
@@ -254,7 +254,7 @@
     <div class="filter-container">
       <p>
         {{ self.filter_by_team() }}
-        <span id="filtered-contributors">{{ config.contributors.items() | length }}</span> contributors
+        <span id="filtered-contributors">{{ config.contributors.items() | length }}</span> {{ self.contributors_title() }}
       </p>
         {% for id, team in config.teams.items() %}
           <button class="{{ id }}" type="button">{{ localizedTeamNames[id] if localizedTeamNames[id]|length else team.name }}</button>

--- a/src/templates/base/2019/methodology.html
+++ b/src/templates/base/2019/methodology.html
@@ -22,7 +22,7 @@
   </nav>
 
   <article id="maincontent" class="content">
-    <h1 class="title title-lg">Methodology</h1>
+    <h1 class="title title-lg">{{ self.methodology_title() }}</h1>
     {{ self.main_content() }}
   </article>
 </main>

--- a/src/templates/fr/2019/index.html
+++ b/src/templates/fr/2019/index.html
@@ -27,6 +27,6 @@ Le Web Almanac a été rendu possible grâce au travail acharné de la communaut
 {% block methodology_stat_2_title %}Données traitées{% endblock %}
 {% block methodology_stat_2 %}20,9&nbsp;TB{% endblock %}
 {% block methodology_description %}
-Sauf indication contraire, les statistiques des 20 chapitres du Web Almanac proviennent du jeu de données HTTP Archiven, un projet communautaire qui suit l’évolution de la construction du web depuis 2010. Grâce à WebPageTest et Lighthouse, HTTP Archive collecte chaque mois les métadonnées de près de 6 millions de sites Web et les insère dans une base de données publique BigQuery pour les analyser. Le jeu de données de juillet 2019 a servi de base aux mesures du Web Almanac. Pour plus d’informations, consultez la page Méthodologie.
+Sauf indication contraire, les statistiques des 20 chapitres du Web Almanac proviennent du jeu de données HTTP Archive, un projet communautaire qui suit l’évolution de la construction du web depuis 2010. Grâce à WebPageTest et Lighthouse, HTTP Archive collecte chaque mois les métadonnées de près de 6 millions de sites Web et les insère dans une base de données publique BigQuery pour les analyser. Le jeu de données de juillet 2019 a servi de base aux mesures du Web Almanac. Pour plus d’informations, consultez la page Méthodologie.
 {% endblock %}
 {% block methodology_link %}En savoir plus sur la Méthodologie{% endblock %}

--- a/src/templates/fr/2019/index.html
+++ b/src/templates/fr/2019/index.html
@@ -20,7 +20,7 @@ Notre mission est de combiner les statistiques brutes et les tendances de HTTP A
 {% block contributors_description %}
 Le Web Almanac a été rendu possible grâce au travail acharné de la communauté Web. {{ contributors }} personnes ont consacré bénévolement d’innombrables heures à le planifier, faire des recherches, le rédiger et le mettre à votre disposition.
 {% endblock %}
-{% block contributors_link %}See the contributors{% endblock %}
+{% block contributors_link %}Voir les contributeurs et contributrices{% endblock %}
 
 {% block methodology_stat_1_title %}Sites Web testés{% endblock %}
 {% block methodology_stat_1 %}5,8&nbsp;M{% endblock %}


### PR DESCRIPTION
Some modifications to improve the French translation because making it public.

I'm not sure about the usage of `{{ self.contributors_title() }}` in the contributors.html base template, but I wanted to reuse a preexisting block rather than create another one. WDYT?