### PR TITLE
Lang selector fix

### DIFF
--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -426,6 +426,7 @@ h2.header {
 
 a.navigation-logo {
   color: white;
+  min-width: 250px;
 }
 a.navigation-logo img:hover,
 a.navigation-logo:focus img {
@@ -704,8 +705,69 @@ p.copyright a {
 }
 
 @media (max-width: 900px) and (min-width: 601px) {
+  
+  /* Header */
+  .top-header, footer {
+    position: relative;
+    padding-top: 30px;
+    padding-bottom: 30px;
+  }
+  header nav:first-of-type,
   header .cta {
     display: none;
+  }
+  header nav > ul > li > * {
+    margin: 0;
+  }
+  header nav > ul > li > a {
+    margin-bottom: 50px;
+    font-size: 16px;
+    line-height: 1.4em
+  }
+  header nav > ul > li:last-child {
+    margin: 0;
+  }
+  header .social-media li {
+    display: inline;
+  }
+
+  #menu {
+    display: block;
+  }
+  .menu {
+    position: absolute;
+    display: none;
+    flex-direction: column;
+    top: 100%;
+    /* overcome the parent container's 20px side padding */    
+    left: -20px;
+    right: -20px;
+    border-top: 1px solid rgba(242, 242, 242, 0.2);
+    padding: 60px 30px 30px;
+    background-color: #677486;
+    box-shadow: 0 0 16px 0 rgba(78, 85, 100, 1);
+    z-index: 1;
+  }
+
+  .menu-btn {
+    background: none;
+    border: 0;
+    display: block;
+    cursor: pointer;
+  }
+
+  .menu-open .menu {
+    display: flex;
+  }
+  .menu-open header {
+    background-color: #667384;
+  }
+  .menu .misc {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-evenly;
+    margin-top: 20px;
   }
 
   footer {

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -525,7 +525,6 @@ header .btn + .language-switcher {
   color: inherit;
   cursor: pointer;
   border-color: #f2f2f2;
-  padding-right: 2rem;
 }
 
 .language-switcher option,

--- a/src/templates/base/2019/base.html
+++ b/src/templates/base/2019/base.html
@@ -219,8 +219,11 @@
         var languageSwitchers = document.querySelectorAll('.language-switcher select');
         for (var i = 0; i < languageSwitchers.length; i++) {
           languageSwitchers[i].addEventListener('change', function(e) {
-            if (e.target.value) {
-              window.location = e.target.value;
+            //Reset the selector back in case user uses Back button
+            var selectedLanguage = e.target.value;
+            if (selectedLanguage && selectedLanguage !== window.location.pathname) {
+              e.target.value = window.location.pathname;
+              window.location = selectedLanguage;
             }
           });
         }


### PR DESCRIPTION
@rviscomi noticed that going back after choosing a language leaves the selector on the language selected. This PR resets it back to current language before navigation to avoid confusion when using the Back button. Also means we don't need the wider language selector added in #692 so have reverted that is this.

Also noticed the header was a bit broken on certain screen sizes (e.g. iPad portrait) with the addition of the language selector so added some fixes for that - including keeping the mobile menu for a bit longer (iPad portrait but not iPad landscape).