### PR TITLE
Add fallbacks for browsers which don't support content alt text

### DIFF
--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -600,6 +600,7 @@ blockquote {
 }
 
 blockquote::before {
+  content: '"';
   content: '"' / "";
   position: absolute;
   top: -4rem;

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -370,9 +370,11 @@ figure .fig-desktop {
   .index-box .index-btn::after {
     font-weight: normal;
     float: right;
+    content: "+";
     content: "+" / "";
   }
   .index-box.show .index-btn::after {
+    content: "-";
     content: "-" / "";
   }
 


### PR DESCRIPTION
A new feature of CSS allows you to specify Alt text for `content` styling after a / like below:

```
  .index-box .index-btn::after {
    content: "+" / "";
  }
```

This is useful for accessibility to either explain the content better for visually impaired, or if content is presentational it can be removed completely to AT device (which is what above does).

However not all browsers understand this syntax and Safari no ignores this line completely so no longer displays the + or - buttons on the menu!

So this PR changes all these to this so we have a fallback:

```
  .index-box .index-btn::after {
    content: "+";
    content: "+" / "";
  }
```
