### PR TITLE
Validate chapters, languages and years

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -16,8 +16,8 @@ DEFAULT_AVATAR_FOLDER_PATH = '/static/images/avatars/'
 AVATAR_SIZE = 200
 AVATARS_NUMBER = 15
 
-CHAPTERS = {}
-LANGUAGES = {}
+SUPPORTED_CHAPTERS = {}
+SUPPORTED_LANGUAGES = {}
 
 def get_config(year):
   global config_json
@@ -52,8 +52,8 @@ def get_languages(json_config):
 
 def update_config():
   global SUPPORTED_YEARS
-  global CHAPTERS
-  global LANGUAGES
+  global SUPPORTED_CHAPTERS
+  global SUPPORTED_LANGUAGES
   global config_json
 
   for root, directories, files in os.walk('config'):
@@ -69,8 +69,8 @@ def update_config():
       json_config = json.load(config_file)
       config_json[year] = json_config
 
-      LANGUAGES.update({year : get_languages(json_config)})
-      CHAPTERS.update({year : set(get_chapters(json_config))})
+      SUPPORTED_LANGUAGES.update({year : get_languages(json_config)})
+      SUPPORTED_CHAPTERS.update({year : set(get_chapters(json_config))})
 
       for contributor_id, contributor in json_config['contributors'].items():
         if 'avatar_url' not in contributor:

--- a/src/config.py
+++ b/src/config.py
@@ -8,9 +8,38 @@ DEFAULT_AVATAR_FOLDER_PATH = '/static/images/avatars/'
 AVATAR_SIZE = 200
 AVATARS_NUMBER = 15
 
+CHAPTERS = {}
+
 def get_config(year):
   global config_json
   return config_json[year] if year in config_json else None
+
+
+def get_entries_from_json(json_config, p_key, s_key):
+    entries = []
+    if p_key in json_config:
+        for values in json_config.get(p_key):
+             entries.append(values.get(s_key))
+    return entries
+
+
+def get_chapters(json_config):
+    chapters = []
+    data = get_entries_from_json(json_config,'outline','chapters')
+    for list in data:
+        for entry in list:
+            chapters.append(entry.get('slug'))
+    return chapters
+
+
+def get_languages(json_config):
+    languages = []
+    data = get_entries_from_json(json_config,'settings','supported_languages')
+    for list in data:
+        for entry in list:
+            languages.append(getattr(Language,entry.get('language')))
+    return languages
+
 
 def update_config():
   global config_json
@@ -27,5 +56,8 @@ def update_config():
           contributor['avatar_url'] = gravatar_url
         else:
           contributor['avatar_url'] = DEFAULT_AVATAR_FOLDER_PATH + str(hash(contributor_id) % AVATARS_NUMBER) + '.jpg'
+    
 
+    CHAPTERS.update({'2019' : set(get_chapters(config_json['2019']))})
+        
 update_config()

--- a/src/config.py
+++ b/src/config.py
@@ -44,17 +44,17 @@ def get_languages(json_config):
   data = get_entries_from_json(json_config,'settings','supported_languages')
   for list in data:
     for entry in list:
-      languages.append(getattr(Language,entry))
+      languages.append(getattr(Language,entry.upper()))
   return languages
 
 
 def get_live(json_config):
-  isLive = False
+  is_live = False
   data = get_entries_from_json(json_config,'settings','isLive')
   for list in data:
     if list == True:
-      isLive = True      
-  return isLive
+      is_live = True
+  return is_live
 
 
 def update_config():
@@ -89,5 +89,5 @@ def update_config():
               contributor['avatar_url'] = gravatar_url
             else:
               contributor['avatar_url'] = DEFAULT_AVATAR_FOLDER_PATH + str(hash(contributor_id) % AVATARS_NUMBER) + '.jpg'
-              
+
 update_config()

--- a/src/config.py
+++ b/src/config.py
@@ -46,9 +46,10 @@ def update_config():
 
   # TODO(rviscomi): Dynamically handle multiple annual configs.
   with open('config/2019.json', 'r') as config_file:
-    config_json['2019'] = json.load(config_file)
+    json_config = json.load(config_file)
+    config_json['2019'] = json_config
 
-    for contributor_id, contributor in config_json['2019']['contributors'].items():
+    for contributor_id, contributor in json_config['contributors'].items():
       if 'avatar_url' not in contributor:
         if 'gravatar' in contributor:
           gravatar_url = 'https://www.gravatar.com/avatar/' + hashlib.md5(contributor['gravatar'].lower().encode()).hexdigest() + '.jpg?'
@@ -57,7 +58,6 @@ def update_config():
         else:
           contributor['avatar_url'] = DEFAULT_AVATAR_FOLDER_PATH + str(hash(contributor_id) % AVATARS_NUMBER) + '.jpg'
     
-
-    CHAPTERS.update({'2019' : set(get_chapters(config_json['2019']))})
+    CHAPTERS.update({'2019' : set(get_chapters(json_config))})
         
 update_config()

--- a/src/config.py
+++ b/src/config.py
@@ -7,8 +7,6 @@ from language import Language, DEFAULT_LANGUAGE
 
 SUPPORTED_YEARS = []
 DEFAULT_YEAR = '2019'
-#Use the following variable to temporarily exclude years until they are ready to be published
-EXCLUDED_YEARS = ['2020']
 
 config_json = {}
 
@@ -25,29 +23,38 @@ def get_config(year):
 
 
 def get_entries_from_json(json_config, p_key, s_key):
-    entries = []
-    if p_key in json_config:
-        for values in json_config.get(p_key):
-             entries.append(values.get(s_key))
-    return entries
+  entries = []
+  if p_key in json_config:
+    for values in json_config.get(p_key):
+      entries.append(values.get(s_key))
+  return entries
 
 
 def get_chapters(json_config):
-    chapters = []
-    data = get_entries_from_json(json_config,'outline','chapters')
-    for list in data:
-        for entry in list:
-            chapters.append(entry.get('slug'))
-    return chapters
+  chapters = []
+  data = get_entries_from_json(json_config,'outline','chapters')
+  for list in data:
+    for entry in list:
+      chapters.append(entry.get('slug'))
+  return chapters
 
 
 def get_languages(json_config):
-    languages = []
-    data = get_entries_from_json(json_config,'settings','supported_languages')
-    for list in data:
-        for entry in list:
-            languages.append(getattr(Language,entry))
-    return languages
+  languages = []
+  data = get_entries_from_json(json_config,'settings','supported_languages')
+  for list in data:
+    for entry in list:
+      languages.append(getattr(Language,entry))
+  return languages
+
+
+def get_live(json_config):
+  isLive = False
+  data = get_entries_from_json(json_config,'settings','isLive')
+  for list in data:
+    if list == True:
+      isLive = True      
+  return isLive
 
 
 def update_config():
@@ -56,29 +63,31 @@ def update_config():
   global SUPPORTED_LANGUAGES
   global config_json
 
+  config_files = []
+
   for root, directories, files in os.walk('config'):
     for file in files:
       if '.json' in file:
-        year = file[0:4]
-        if year not in EXCLUDED_YEARS:
-          SUPPORTED_YEARS.append(year)
+        config_files.append(file[0:4])
 
-  for year in SUPPORTED_YEARS:
+  for year in config_files:
     config_filename = 'config/%s.json' % year
     with open(config_filename, 'r') as config_file:
       json_config = json.load(config_file)
       config_json[year] = json_config
 
-      SUPPORTED_LANGUAGES.update({year : get_languages(json_config)})
-      SUPPORTED_CHAPTERS.update({year : set(get_chapters(json_config))})
+      if get_live(json_config):
+        SUPPORTED_YEARS.append(year)
+        SUPPORTED_LANGUAGES.update({year : get_languages(json_config)})
+        SUPPORTED_CHAPTERS.update({year : set(get_chapters(json_config))})
 
-      for contributor_id, contributor in json_config['contributors'].items():
-        if 'avatar_url' not in contributor:
-          if 'gravatar' in contributor:
-            gravatar_url = 'https://www.gravatar.com/avatar/' + hashlib.md5(contributor['gravatar'].lower().encode()).hexdigest() + '.jpg?'
-            gravatar_url += urllib.parse.urlencode({'d': 'mp','s':str(AVATAR_SIZE)})
-            contributor['avatar_url'] = gravatar_url
-          else:
-            contributor['avatar_url'] = DEFAULT_AVATAR_FOLDER_PATH + str(hash(contributor_id) % AVATARS_NUMBER) + '.jpg'
-        
+        for contributor_id, contributor in json_config['contributors'].items():
+          if 'avatar_url' not in contributor:
+            if 'gravatar' in contributor:
+              gravatar_url = 'https://www.gravatar.com/avatar/' + hashlib.md5(contributor['gravatar'].lower().encode()).hexdigest() + '.jpg?'
+              gravatar_url += urllib.parse.urlencode({'d': 'mp','s':str(AVATAR_SIZE)})
+              contributor['avatar_url'] = gravatar_url
+            else:
+              contributor['avatar_url'] = DEFAULT_AVATAR_FOLDER_PATH + str(hash(contributor_id) % AVATARS_NUMBER) + '.jpg'
+              
 update_config()

--- a/src/config/2019.json
+++ b/src/config/2019.json
@@ -1,6 +1,7 @@
 {
   "settings": [
     {
+      "isLive": true,
       "supported_languages": ["en","es","fr","ja"]
     }
   ],

--- a/src/config/2019.json
+++ b/src/config/2019.json
@@ -1,4 +1,9 @@
 {
+  "settings": [
+    {
+      "supported_languages": ["en","es","fr","ja"]
+    }
+  ],
   "outline": [
     {
       "part": "I. Page Content",

--- a/src/language.py
+++ b/src/language.py
@@ -27,12 +27,12 @@ class _Language(object):
 
 # Currently we are only supporting languages and not regions
 class Language(object):
-  JAPANESE = _Language('日本語', 'ja', 'JP')
-  ENGLISH = _Language('English', 'en', 'US')
-  SPANISH = _Language('Español', 'es', 'ES')
-  FRENCH = _Language('Français', 'fr', 'FR')
+  ja = _Language('日本語', 'ja', 'JP')
+  en = _Language('English', 'en', 'US')
+  es = _Language('Español', 'es', 'ES')
+  fr = _Language('Français', 'fr', 'FR')
 
-DEFAULT_LANGUAGE = Language.ENGLISH
+DEFAULT_LANGUAGE = Language.en
 
 # Maps language codes to _Language objects.
 language_map = {v.lang_code: v for k,v in Language.__dict__.items() if k[:1] != '_'}

--- a/src/language.py
+++ b/src/language.py
@@ -27,12 +27,12 @@ class _Language(object):
 
 # Currently we are only supporting languages and not regions
 class Language(object):
-  ja = _Language('日本語', 'ja', 'JP')
-  en = _Language('English', 'en', 'US')
-  es = _Language('Español', 'es', 'ES')
-  fr = _Language('Français', 'fr', 'FR')
+  JA = _Language('日本語', 'ja', 'JP')
+  EN = _Language('English', 'en', 'US')
+  ES = _Language('Español', 'es', 'ES')
+  FR = _Language('Français', 'fr', 'FR')
 
-DEFAULT_LANGUAGE = Language.en
+DEFAULT_LANGUAGE = Language.EN
 
 # Maps language codes to _Language objects.
 language_map = {v.lang_code: v for k,v in Language.__dict__.items() if k[:1] != '_'}

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,4 @@
-import config as config_util
+from config import get_config, SUPPORTED_YEARS, LANGUAGES, DEFAULT_YEAR
 from csp import csp
 from flask import Flask, abort, redirect, render_template as flask_render_template, request, send_from_directory, url_for
 from flask_talisman import Talisman
@@ -6,7 +6,7 @@ from language import DEFAULT_LANGUAGE, get_language
 import logging
 import random
 from werkzeug.routing import BaseConverter
-from validate import validate, SUPPORTED_YEARS, DEFAULT_YEAR
+from validate import validate
 import os.path
 
 # Set WOFF and WOFF2 caching to return 1 year as they should never change
@@ -41,7 +41,7 @@ def add_header(response):
 
 def render_template(template, *args, **kwargs):
     year = request.view_args.get('year', DEFAULT_YEAR)
-    supported_languages = SUPPORTED_YEARS.get(year, (DEFAULT_LANGUAGE,))
+    supported_languages = LANGUAGES.get(year, (DEFAULT_LANGUAGE,))
 
     lang = request.view_args.get('lang') or ''
     language = get_language(lang)
@@ -59,7 +59,7 @@ def render_template(template, *args, **kwargs):
         if (os.path.isfile(langTemplate)):
             template_supported_languages.append(l)
 
-    kwargs.update(supported_languages=template_supported_languages, year=year, lang=lang, language=language, supported_years=list(SUPPORTED_YEARS.keys()))
+    kwargs.update(supported_languages=template_supported_languages, year=year, lang=lang, language=language, supported_years=SUPPORTED_YEARS)
     return flask_render_template(template, *args, **kwargs)
 
 
@@ -94,7 +94,7 @@ app.jinja_env.globals['chapter_lang_exists'] = chapter_lang_exists
 @app.route('/<lang>/<year>/')
 @validate
 def home(lang, year):
-    config = config_util.get_config(year)
+    config = get_config(year)
     return render_template('%s/%s/index.html' % (lang, year), config=config)
 
 
@@ -113,14 +113,14 @@ def root(lang):
 @app.route('/<lang>/<year>/table-of-contents')
 @validate
 def table_of_contents(lang, year):
-    config = config_util.get_config(year)
+    config = get_config(year)
     return render_template('%s/%s/table_of_contents.html' % (lang, year), config=config)
 
 
 @app.route('/<lang>/<year>/contributors')
 @validate
 def contributors(lang, year):
-    config = config_util.get_config(year)
+    config = get_config(year)
     contributors = list(config["contributors"].items())
     random.shuffle(contributors)
     config["contributors"] = dict(contributors)
@@ -151,7 +151,7 @@ def sitemap():
 @app.route('/<lang>/<year>/<chapter>')
 @validate
 def chapter(lang, year, chapter):
-    config = config_util.get_config(year)
+    config = get_config(year)
     (prev_chapter, next_chapter) = get_chapter_nextprev(config, chapter)
     return render_template('%s/%s/chapters/%s.html' % (lang, year, chapter), config=config, prev_chapter=prev_chapter, next_chapter=next_chapter)
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,4 @@
-from config import get_config, SUPPORTED_YEARS, LANGUAGES, DEFAULT_YEAR
+from config import get_config, SUPPORTED_YEARS, SUPPORTED_LANGUAGES, DEFAULT_YEAR
 from csp import csp
 from flask import Flask, abort, redirect, render_template as flask_render_template, request, send_from_directory, url_for
 from flask_talisman import Talisman
@@ -41,7 +41,7 @@ def add_header(response):
 
 def render_template(template, *args, **kwargs):
     year = request.view_args.get('year', DEFAULT_YEAR)
-    supported_languages = LANGUAGES.get(year, (DEFAULT_LANGUAGE,))
+    supported_languages = SUPPORTED_LANGUAGES.get(year, (DEFAULT_LANGUAGE,))
 
     lang = request.view_args.get('lang') or ''
     language = get_language(lang)

--- a/src/validate.py
+++ b/src/validate.py
@@ -19,7 +19,6 @@ SUPPORTED_YEARS = {
     '2019': (Language.ENGLISH,Language.FRENCH,Language.JAPANESE,Language.SPANISH)
 }
 
-#TO DO - Stop Hardcoding these
 CHAPTERS = {}
 
 TYPO_CHAPTERS = {

--- a/src/validate.py
+++ b/src/validate.py
@@ -6,13 +6,7 @@ from flask import request, abort, redirect
 from functools import wraps
 from language import Language, DEFAULT_LANGUAGE
 
-from config import CHAPTERS
-
-DEFAULT_YEAR = '2019'
-SUPPORTED_YEARS = {
-    # When there is one supported language, it must have a trailing comma.
-    '2019': (Language.ENGLISH,Language.FRENCH,Language.JAPANESE,Language.SPANISH)
-}
+from config import SUPPORTED_YEARS, DEFAULT_YEAR, CHAPTERS, LANGUAGES
 
 TYPO_CHAPTERS = {
     'http-2': 'http2',
@@ -77,7 +71,7 @@ def validate_lang_and_year(lang, year):
         logging.debug('Unsupported year requested: %s' % year)
         abort(404, 'Unsupported year requested')
 
-    supported_langs = [l.lang_code for l in SUPPORTED_YEARS.get(year)]
+    supported_langs = [l.lang_code for l in LANGUAGES.get(year)]
     logging.debug('Languages supported for %s: %s.' % (year, supported_langs))
 
     # If an unsupported language code is passed in, abort.

--- a/src/validate.py
+++ b/src/validate.py
@@ -8,7 +8,7 @@ from flask import request, abort, redirect
 from functools import wraps
 from language import Language, DEFAULT_LANGUAGE
 
-import config as config_util
+from config import CHAPTERS
 
 CONFIG_DIR = './config'
 
@@ -17,7 +17,7 @@ SUPPORTED_YEARS = {
     '2019': (Language.ENGLISH,Language.FRENCH,Language.JAPANESE,Language.SPANISH)
 }
 
-CHAPTERS = {}
+DEFAULT_YEAR = '2019'
 
 TYPO_CHAPTERS = {
     'http-2': 'http2',
@@ -125,54 +125,3 @@ def parse_accept_language(header, supported_langs):
 
     # If all else fails, default the language.
     return DEFAULT_LANGUAGE.lang_code
-
-
-def get_json_files(path):
-
-    files_found = []
-    for root, directories, files in os.walk(path):
-        for file in files:
-            if '.json' in file:
-                files_found.append(os.path.join(root, file))
-
-    return files_found
-
-
-def get_entries_from_json(path, p_key, s_key):
-
-    with open(path) as json_file:
-        data = json.load(json_file)
-
-    entries = []
-
-    if p_key in data:
-        for values in data.get(p_key):
-             entries.append(values.get(s_key))
-
-    return entries
-
-
-def get_chapters(file):
-
-    chapters = []
-
-    data = get_entries_from_json(file,'outline','chapters')
-    for list in data:
-        for entry in list:
-            logging.debug('Adding chapter:' + entry.get('slug'))
-            chapters.append(entry.get('slug'))
-	
-    return chapters
-
-
-def init():
-    year_config_files = get_json_files(CONFIG_DIR)
-
-    for file in year_config_files:
-        logging.debug('Reading file:' + file)
-        CHAPTERS.update({file[9:-5] : set(get_chapters(file))})
-
-    return sorted(CHAPTERS.keys())[-1]
-
-
-DEFAULT_YEAR = init()

--- a/src/validate.py
+++ b/src/validate.py
@@ -1,8 +1,6 @@
 import logging
 import re
 import inspect
-import json
-import os
 
 from flask import request, abort, redirect
 from functools import wraps
@@ -10,14 +8,11 @@ from language import Language, DEFAULT_LANGUAGE
 
 from config import CHAPTERS
 
-CONFIG_DIR = './config'
-
+DEFAULT_YEAR = '2019'
 SUPPORTED_YEARS = {
     # When there is one supported language, it must have a trailing comma.
     '2019': (Language.ENGLISH,Language.FRENCH,Language.JAPANESE,Language.SPANISH)
 }
-
-DEFAULT_YEAR = '2019'
 
 TYPO_CHAPTERS = {
     'http-2': 'http2',

--- a/src/validate.py
+++ b/src/validate.py
@@ -6,7 +6,7 @@ from flask import request, abort, redirect
 from functools import wraps
 from language import Language, DEFAULT_LANGUAGE
 
-from config import SUPPORTED_YEARS, DEFAULT_YEAR, CHAPTERS, LANGUAGES
+from config import SUPPORTED_YEARS, DEFAULT_YEAR, SUPPORTED_CHAPTERS, SUPPORTED_LANGUAGES
 
 TYPO_CHAPTERS = {
     'http-2': 'http2',
@@ -48,7 +48,7 @@ def validate(func):
 
 def validate_chapter(chapter,year):
 
-    chapters_for_year = CHAPTERS.get(year)
+    chapters_for_year = SUPPORTED_CHAPTERS.get(year)
     if chapter not in chapters_for_year:
         if chapter in TYPO_CHAPTERS:
             logging.debug('Typo chapter requested: %s, redirecting to %s' % (chapter, TYPO_CHAPTERS.get(chapter)))
@@ -71,7 +71,7 @@ def validate_lang_and_year(lang, year):
         logging.debug('Unsupported year requested: %s' % year)
         abort(404, 'Unsupported year requested')
 
-    supported_langs = [l.lang_code for l in LANGUAGES.get(year)]
+    supported_langs = [l.lang_code for l in SUPPORTED_LANGUAGES.get(year)]
     logging.debug('Languages supported for %s: %s.' % (year, supported_langs))
 
     # If an unsupported language code is passed in, abort.

--- a/src/validate.py
+++ b/src/validate.py
@@ -13,7 +13,6 @@ import config as config_util
 
 CONFIG_DIR = './config'
 
-#DEFAULT_YEAR = '2019'
 SUPPORTED_YEARS = {
     # When there is one supported language, it must have a trailing comma.
     '2019': (Language.ENGLISH,Language.FRENCH,Language.JAPANESE,Language.SPANISH)

--- a/src/validate.py
+++ b/src/validate.py
@@ -7,7 +7,6 @@ import os
 from flask import request, abort, redirect
 from functools import wraps
 from language import Language, DEFAULT_LANGUAGE
-from datetime import date
 
 import config as config_util
 

--- a/src/validate_test.py
+++ b/src/validate_test.py
@@ -1,9 +1,10 @@
+from config import DEFAULT_YEAR, SUPPORTED_YEARS
 from language import Language, DEFAULT_LANGUAGE
-from validate import parse_accept_language, DEFAULT_YEAR, SUPPORTED_YEARS
+from validate import parse_accept_language
 
-SUPPORTED_LANGUAGES = (Language.ENGLISH.lang_code, Language.JAPANESE.lang_code)
+SUPPORTED_LANGUAGES = (Language.en.lang_code, Language.ja.lang_code)
 DEFAULT_LANGUAGE_CODE = DEFAULT_LANGUAGE.lang_code
-JAPANESE_LANGUAGE_CODE = Language.JAPANESE.lang_code
+JAPANESE_LANGUAGE_CODE = Language.ja.lang_code
 
 
 def assert_language(accept_language_header, expected_lang):

--- a/src/validate_test.py
+++ b/src/validate_test.py
@@ -2,9 +2,9 @@ from config import DEFAULT_YEAR, SUPPORTED_YEARS
 from language import Language, DEFAULT_LANGUAGE
 from validate import parse_accept_language
 
-SUPPORTED_LANGUAGES = (Language.en.lang_code, Language.ja.lang_code)
+SUPPORTED_LANGUAGES = (Language.EN.lang_code, Language.JA.lang_code)
 DEFAULT_LANGUAGE_CODE = DEFAULT_LANGUAGE.lang_code
-JAPANESE_LANGUAGE_CODE = Language.ja.lang_code
+JAPANESE_LANGUAGE_CODE = Language.JA.lang_code
 
 
 def assert_language(accept_language_header, expected_lang):


### PR DESCRIPTION
Fixes #400 
Fixes #713 
Makes progress on #686

This implements @arsenicraghav 's fix for hardcoded chapters in validation (#400) from https://github.com/HTTPArchive/almanac.httparchive.org/pull/557 (though in config.py instead of validate.py to avoid multiple loads of JSON file). We had delayed this before but we're not making any progress on #561 and not entirely convinced we should do that any more anyway!

It also allows loading of multiple year config JSONs (#713 ) including the ability to exclude some years in JSON config (while we work on them and before they are ready for release).

It also makes languages configureable per year and in JSON as part of #686. The JavaScript side still needs to be done.
