### PR TITLE
Language and year specific error pages

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -163,7 +163,7 @@ def sitemap():
     return resp
 
 
-@app.route('/<lang>/<year>/<chapter>')
+@app.route('/<lang>/<year>/<path:chapter>')
 @validate
 def chapter(lang, year, chapter):
     config = get_config(year)
@@ -220,7 +220,7 @@ def redirect_old_images(folder, image):
 @app.route('/', defaults={'path': ''})
 @app.route('/<path:path>')
 def catch_all(path):
-    abort(404)
+    abort(404,"Not Found")
 
 
 @app.errorhandler(400)

--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,7 @@ from language import DEFAULT_LANGUAGE, get_language
 import logging
 import random
 from werkzeug.routing import BaseConverter
+from werkzeug.http import HTTP_STATUS_CODES
 from validate import validate
 import os.path
 
@@ -102,6 +103,7 @@ def convertOldImagePath(folder):
 # Make these functions available in templates.
 app.jinja_env.globals['get_view_args'] = get_view_args
 app.jinja_env.globals['chapter_lang_exists'] = chapter_lang_exists
+app.jinja_env.globals['HTTP_STATUS_CODES'] = HTTP_STATUS_CODES
 
 
 @app.route('/<lang>/<year>/')

--- a/src/templates/base/2019/error.html
+++ b/src/templates/base/2019/error.html
@@ -2,7 +2,7 @@
 
 {% block title %}
   {% block error %}
-    {{ localizedErrorTitle[error.code]|safe if localizedErrorTitle[error.code]|length else "Unknown Error" }}
+    {{ localizedStatusCode[error.code] if localizedStatusCode[error.code]|length else self.unknown_error() }}
   {% endblock %}
 {% endblock %}
 
@@ -42,15 +42,15 @@
 {% block main %}
   <main class="main">
     <h1>
-      {{ localizedErrorTitle[error.code]|safe if localizedErrorTitle[error.code]|length else error.code }}
+      {{ expandedTitle(self.error()) }}
     </h1>
     {% block custom %}
       <p class="error-message">
-        {% if localizedErrorMessage[error.description]|length %}
-        {{ error.code }} {{ localizedErrorDescription[error.code]|safe }}: {{ localizedErrorMessage[error.description] }}
-        {% else %}
+      {% if error.description|length %}
+        {{ expandedErrorMessage(error.code, HTTP_STATUS_CODES[error.code], localizedErrorMessage[error.description] if localizedErrorMessage[error.description]|length else error.Description) }}
+      {% else %}
         {{ error }}
-        {% endif %}
+      {% endif %}
       </p>
     {% endblock %}
     <div class="escape-hatch">

--- a/src/templates/base/2019/error.html
+++ b/src/templates/base/2019/error.html
@@ -1,6 +1,4 @@
-{% extends "en/2019/base.html" %}
-{% set year = '2019' %}
-{% set lang = 'en' %}
+{% extends "%s/2019/base.html" % lang %}
 
 {% block title %}
   {% block error %}Unknown Error{% endblock %}
@@ -42,17 +40,24 @@
 {% block main %}
   <main class="main">
     <h1>
-      Error: {{ self.error() }}
+      {{ localizedErrorTitle[error.code]|safe if localizedErrorTitle[error.code]|length else error.code }}
     </h1>
+    {{ DEFAULT_LANGUAGE }}
     {% block custom %}
-      <p class="error-message">{{ error }}</p>
+      <p class="error-message">
+        {% if localizedErrorDescription[error.code]|length %}
+        {{ error.code }} {{ localizedErrorDescription[error.code]|safe }}: {{ localizedErrorMessage[error.description] }}
+        {% else %}
+        {{ error }}
+        {% endif %}
+      </p>
     {% endblock %}
     <div class="escape-hatch">
-      <a href="{{ url_for('home', lang=lang, year=year) }}" class="btn">Home</a>
+      <a href="{{ url_for('home', lang=lang, year=year) }}" class="btn">{{ self.home() }}</a>
     </div>
     <img class="methodology-characters" src="/static/images/methodology-characters.png" alt="" />
   </main>
   <script nonce="{{ csp_nonce() }}">
-    gtag('event', '{{ self.error() }}', { 'event_category': 'error', 'event_label': '{{ request.path }}', 'value': 1 });
+    //gtag('event', '{{ self.error() }}', { 'event_category': 'error', 'event_label': '{{ request.path }}', 'value': 1 });
   </script>
 {% endblock %}

--- a/src/templates/base/2019/error.html
+++ b/src/templates/base/2019/error.html
@@ -1,7 +1,9 @@
 {% extends "%s/2019/base.html" % lang %}
 
 {% block title %}
-  {% block error %}Unknown Error{% endblock %}
+  {% block error %}
+    {{ localizedErrorTitle[error.code]|safe if localizedErrorTitle[error.code]|length else "Unknown Error" }}
+  {% endblock %}
 {% endblock %}
 
 {% block styles %}
@@ -42,10 +44,9 @@
     <h1>
       {{ localizedErrorTitle[error.code]|safe if localizedErrorTitle[error.code]|length else error.code }}
     </h1>
-    {{ DEFAULT_LANGUAGE }}
     {% block custom %}
       <p class="error-message">
-        {% if localizedErrorDescription[error.code]|length %}
+        {% if localizedErrorMessage[error.description]|length %}
         {{ error.code }} {{ localizedErrorDescription[error.code]|safe }}: {{ localizedErrorMessage[error.description] }}
         {% else %}
         {{ error }}
@@ -58,6 +59,6 @@
     <img class="methodology-characters" src="/static/images/methodology-characters.png" alt="" />
   </main>
   <script nonce="{{ csp_nonce() }}">
-    //gtag('event', '{{ self.error() }}', { 'event_category': 'error', 'event_label': '{{ request.path }}', 'value': 1 });
+    gtag('event', '{{ self.error() }}', { 'event_category': 'error', 'event_label': '{{ request.path }}', 'value': 1 });
   </script>
 {% endblock %}

--- a/src/templates/base/2019/error.html
+++ b/src/templates/base/2019/error.html
@@ -59,6 +59,6 @@
     <img class="methodology-characters" src="/static/images/methodology-characters.png" alt="" />
   </main>
   <script nonce="{{ csp_nonce() }}">
-    gtag('event', '{{ self.error() }}', { 'event_category': 'error', 'event_label': '{{ request.path }}', 'value': 1 });
+    gtag('event', '{{ HTTP_STATUS_CODES[error.code] }}', { 'event_category': 'error', 'event_label': '{{ request.path }}', 'value': 1 });
   </script>
 {% endblock %}

--- a/src/templates/en/2019/error.html
+++ b/src/templates/en/2019/error.html
@@ -22,6 +22,7 @@
   set localizedErrorMessage = {
     "Unsupported year requested": "Unsupported year requested",
     "Unsupported chapter requested": "Unsupported chapter requested",
-    "Unsupported language requested": "Unsupported language requested"
+    "Unsupported language requested": "Unsupported language requested",
+    "Not Found": "The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again."
   }
 %}

--- a/src/templates/en/2019/error.html
+++ b/src/templates/en/2019/error.html
@@ -1,0 +1,27 @@
+{% extends "base/2019/error.html" %}
+
+{% block home %}Home{% endblock %}
+
+{% 
+  set localizedErrorTitle = {
+    400: "Error: Bad Request",
+    404: "Error: Page Not Found",
+    500: "Error: Internal Server Error",
+    502: "Error: Temporary Server Error"
+  }
+%}
+{%
+  set localizedErrorDescription = {
+    400: "Bad Request",
+    404: "Not Found",
+    500: "Internal Server Error",
+    502: "Temporary Server Error"
+  }
+%}
+{%
+  set localizedErrorMessage = {
+    "Unsupported year requested": "Unsupported year requested",
+    "Unsupported chapter requested": "Unsupported chapter requested",
+    "Unsupported language requested": "Unsupported language requested"
+  }
+%}

--- a/src/templates/en/2019/error.html
+++ b/src/templates/en/2019/error.html
@@ -2,22 +2,17 @@
 
 {% block home %}Home{% endblock %}
 
+{% block unknown_error %}Unknown Error{% endblock %}
+
 {% 
-  set localizedErrorTitle = {
-    400: "Error: Bad Request",
-    404: "Error: Page Not Found",
-    500: "Error: Internal Server Error",
-    502: "Error: Temporary Server Error"
-  }
-%}
-{%
-  set localizedErrorDescription = {
+  set localizedStatusCode = {
     400: "Bad Request",
-    404: "Not Found",
+    404: "Page Not Found",
     500: "Internal Server Error",
     502: "Temporary Server Error"
   }
 %}
+{% macro expandedTitle(errorTitle) %}Error: {{ errorTitle }}{% endmacro %}
 {%
   set localizedErrorMessage = {
     "Unsupported year requested": "Unsupported year requested",
@@ -26,3 +21,6 @@
     "Not Found": "The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again."
   }
 %}
+{% macro expandedErrorMessage(errorCode, errorDescription, errorMessage) %}
+{{ errorCode }} {{ errorDescription }}: {{ errorMessage }}
+{% endmacro %}

--- a/src/templates/error/400.html
+++ b/src/templates/error/400.html
@@ -1,3 +1,0 @@
-{% extends "error/error.html" %}
-
-{% block error %}Bad Request{% endblock %}

--- a/src/templates/error/404.html
+++ b/src/templates/error/404.html
@@ -1,3 +1,0 @@
-{% extends "error/error.html" %}
-
-{% block error %}Page Not Found{% endblock %}

--- a/src/templates/error/500.html
+++ b/src/templates/error/500.html
@@ -1,3 +1,0 @@
-{% extends "error/error.html" %}
-
-{% block error %}Internal Server Error{% endblock %}

--- a/src/templates/error/502.html
+++ b/src/templates/error/502.html
@@ -1,3 +1,0 @@
-{% extends "error/error.html" %}
-
-{% block error %}Temporary Server Error{% endblock %}

--- a/src/templates/es/2019/error.html
+++ b/src/templates/es/2019/error.html
@@ -22,6 +22,7 @@
   set localizedErrorMessage = {
     "Unsupported year requested": "Año no Admitido Solicitado",
     "Unsupported chapter requested": "Capítulo no Admitido Solicitado",
-    "Unsupported language requested": "Idioma no Admitido Solicitado"
+    "Unsupported language requested": "Idioma no Admitido Solicitado",
+    "Not Found": "La URL solicitada no se encontró en el servidor. Si ingresó la URL manualmente, verifique su ortografía e intente nuevamente."
   }
 %}

--- a/src/templates/es/2019/error.html
+++ b/src/templates/es/2019/error.html
@@ -2,22 +2,17 @@
 
 {% block home %}Página de inicio{% endblock %}
 
+{% block unknown_error %}Error Desconocido{% endblock %}
+
 {% 
-  set localizedErrorTitle = {
-    400: "Error: Solicitud Incorrecta",
-    404: "Error: Página no Encontrada",
+  set localizedStatusCode = {
+    400: "Solicitud Incorrecta",
+    404: "Página no Encontrada",
     500: "Error de Servidor Interno",
     502: "Error Temporal del Servidor"
   }
 %}
-{%
-  set localizedErrorDescription = {
-    400: "<i lang=\"en\">Bad Request</i>",
-    404: "<i lang=\"en\">Not Found</i>",
-    500: "<i lang=\"en\">Internal Server Error</i>",
-    502: "<i lang=\"en\">Temporary Server Error</i>"
-  }
-%}
+{% macro expandedTitle(errorTitle) %}Error: {{ errorTitle }}{% endmacro %}
 {%
   set localizedErrorMessage = {
     "Unsupported year requested": "Año no Admitido Solicitado",
@@ -26,3 +21,6 @@
     "Not Found": "La URL solicitada no se encontró en el servidor. Si ingresó la URL manualmente, verifique su ortografía e intente nuevamente."
   }
 %}
+{% macro expandedErrorMessage(errorCode, errorDescription, errorMessage) %}
+{{ errorCode }} <i lang="en">{{ errorDescription }}</i>: {{ errorMessage }}
+{% endmacro %}

--- a/src/templates/es/2019/error.html
+++ b/src/templates/es/2019/error.html
@@ -1,0 +1,27 @@
+{% extends "base/2019/error.html" %}
+
+{% block home %}Página de inicio{% endblock %}
+
+{% 
+  set localizedErrorTitle = {
+    400: "Error: Solicitud Incorrecta",
+    404: "Error: Página no Encontrada",
+    500: "Error de Servidor Interno",
+    502: "Error Temporal del Servidor"
+  }
+%}
+{%
+  set localizedErrorDescription = {
+    400: "<i lang=\"en\">Bad Request</i>",
+    404: "<i lang=\"en\">Not Found</i>",
+    500: "<i lang=\"en\">Internal Server Error</i>",
+    502: "<i lang=\"en\">Temporary Server Error</i>"
+  }
+%}
+{%
+  set localizedErrorMessage = {
+    "Unsupported year requested": "Año no Admitido Solicitado",
+    "Unsupported chapter requested": "Capítulo no Admitido Solicitado",
+    "Unsupported language requested": "Idioma no Admitido Solicitado"
+  }
+%}

--- a/src/templates/fr/2019/error.html
+++ b/src/templates/fr/2019/error.html
@@ -2,28 +2,26 @@
 
 {% block home %}Accueil{% endblock %}
 
+{% block unknown_error %}Erreur inconnue{% endblock %}
+
 {% 
-  set localizedErrorTitle = {
-    400: "Erreur:&nbsp;Mauvaise Demande",
-    404: "Erreur:&nbsp;Page Non Trouvée",
-    500: "Erreur:&nbsp;Erreur Interne du Serveur",
-    502: "Erreur:&nbsp;Erreur de Serveur Temporaire"
+  set localizedStatusCode = {
+    400: "Mauvaise Demande",
+    404: "Page Non Trouvée",
+    500: "Erreur Interne du Serveur",
+    502: "Erreur de Serveur Temporaire"
   }
 %}
-{%
-  set localizedErrorDescription = {
-    400: "<i lang=\"en\">Bad Request</i>",
-    404: "<i lang=\"en\">Not Found</i>",
-    500: "<i lang=\"en\">Internal Server Error</i>",
-    502: "<i lang=\"en\">Temporary Server Error</i>"
-  }
-%}
+{% macro expandedTitle(errorTitle) %}Erreur&nbsp;: {{ errorTitle }}{% endmacro %}
 {%
   set localizedErrorMessage = {
     "Unsupported year requested": "Année non prise en charge demandée",
     "Unsupported chapter requested": "Chapitre non pris en charge demandé",
     "Unsupported language requested": "Langue non prise en charge demandée",
     "Not Found": "L'URL demandée est introuvable sur le serveur. Si vous avez entré l'URL manuellement, vérifiez l'orthographe et réessayez."
-
   }
 %}
+
+{% macro expandedErrorMessage(errorCode, errorDescription, errorMessage) %}
+{{ errorCode }} <i lang="en">{{ errorDescription }}</i>&nbsp;: {{ errorMessage }}
+{% endmacro %}

--- a/src/templates/fr/2019/error.html
+++ b/src/templates/fr/2019/error.html
@@ -1,0 +1,27 @@
+{% extends "base/2019/error.html" %}
+
+{% block home %}Accueil{% endblock %}
+
+{% 
+  set localizedErrorTitle = {
+    400: "Erreur:&nbsp;Mauvaise Demande",
+    404: "Erreur:&nbsp;Page Non Trouvée",
+    500: "Erreur:&nbsp;Erreur Interne du Serveur",
+    502: "Erreur:&nbsp;Erreur de Serveur Temporaire"
+  }
+%}
+{%
+  set localizedErrorDescription = {
+    400: "<i lang=\"en\">Bad Request</i>",
+    404: "<i lang=\"en\">Not Found</i>",
+    500: "<i lang=\"en\">Internal Server Error</i>",
+    502: "<i lang=\"en\">Temporary Server Error</i>"
+  }
+%}
+{%
+  set localizedErrorMessage = {
+    "Unsupported year requested": "Année non prise en charge demandée",
+    "Unsupported chapter requested": "Chapitre non pris en charge demandé",
+    "Unsupported language requested": "Langue non prise en charge demandée"
+  }
+%}

--- a/src/templates/fr/2019/error.html
+++ b/src/templates/fr/2019/error.html
@@ -22,6 +22,8 @@
   set localizedErrorMessage = {
     "Unsupported year requested": "Année non prise en charge demandée",
     "Unsupported chapter requested": "Chapitre non pris en charge demandé",
-    "Unsupported language requested": "Langue non prise en charge demandée"
+    "Unsupported language requested": "Langue non prise en charge demandée",
+    "Not Found": "L'URL demandée est introuvable sur le serveur. Si vous avez entré l'URL manuellement, vérifiez l'orthographe et réessayez."
+
   }
 %}

--- a/src/templates/ja/2019/error.html
+++ b/src/templates/ja/2019/error.html
@@ -1,0 +1,27 @@
+{% extends "base/2019/error.html" %}
+
+{% block home %}ホームページ{% endblock %}
+
+{% 
+  set localizedErrorTitle = {
+    400: "Error: 要求の形式が正しくありません",
+    404: "Error: ページが見つかりません",
+    500: "Error: 内部サーバーエラー",
+    502: "Error: 一時的なサーバーエラー"
+  }
+%}
+{%
+  set localizedErrorDescription = {
+    400: "<i lang=\"en\">Bad Request</i>",
+    404: "<i lang=\"en\">Not Found</i>",
+    500: "<i lang=\"en\">Internal Server Error</i>",
+    502: "<i lang=\"en\">Temporary Server Error</i>"
+  }
+%}
+{%
+  set localizedErrorMessage = {
+    "Unsupported year requested": "サポートされていない年がリクエストされました",
+    "Unsupported chapter requested": "サポートされていない章が要求されました",
+    "Unsupported language requested": "サポートされていない言語がリクエストされました"
+  }
+%}

--- a/src/templates/ja/2019/error.html
+++ b/src/templates/ja/2019/error.html
@@ -2,22 +2,17 @@
 
 {% block home %}ホームページ{% endblock %}
 
+{% block unknown_error %}不明なエラー{% endblock %}
+
 {% 
-  set localizedErrorTitle = {
-    400: "Error: 要求の形式が正しくありません",
-    404: "Error: ページが見つかりません",
-    500: "Error: 内部サーバーエラー",
-    502: "Error: 一時的なサーバーエラー"
+  set localizedStatusCode = {
+    400: "要求の形式が正しくありません",
+    404: "ページが見つかりません",
+    500: "内部サーバーエラー",
+    502: "一時的なサーバーエラー"
   }
 %}
-{%
-  set localizedErrorDescription = {
-    400: "<i lang=\"en\">Bad Request</i>",
-    404: "<i lang=\"en\">Not Found</i>",
-    500: "<i lang=\"en\">Internal Server Error</i>",
-    502: "<i lang=\"en\">Temporary Server Error</i>"
-  }
-%}
+{% macro expandedTitle(errorTitle) %}エラー: {{ errorTitle }}{% endmacro %}
 {%
   set localizedErrorMessage = {
     "Unsupported year requested": "サポートされていない年がリクエストされました",
@@ -26,3 +21,6 @@
     "Not Found": "要求されたURLはサーバーで見つかりませんでした。 URLを手動で入力した場合は、スペルを確認してもう一度お試しください。"
   }
 %}
+{% macro expandedErrorMessage(errorCode, errorDescription, errorMessage) %}
+{{ errorCode }} <i lang="en">{{ errorDescription }}</i>: {{ errorMessage }}
+{% endmacro %}

--- a/src/templates/ja/2019/error.html
+++ b/src/templates/ja/2019/error.html
@@ -22,6 +22,7 @@
   set localizedErrorMessage = {
     "Unsupported year requested": "サポートされていない年がリクエストされました",
     "Unsupported chapter requested": "サポートされていない章が要求されました",
-    "Unsupported language requested": "サポートされていない言語がリクエストされました"
+    "Unsupported language requested": "サポートされていない言語がリクエストされました",
+    "Not Found": "要求されたURLはサーバーで見つかりませんでした。 URLを手動で入力した場合は、スペルを確認してもう一度お試しください。"
   }
 %}

--- a/src/validate.py
+++ b/src/validate.py
@@ -38,7 +38,7 @@ def validate(func):
 
         if chapter:
 
-            validated_chapter = validate_chapter(chapter,year)
+            validated_chapter = validate_chapter(chapter, year)
 
             if chapter != validated_chapter:
                 return redirect('/%s/%s/%s' % (lang, year, validated_chapter), code=301)
@@ -63,6 +63,7 @@ def validate_chapter(chapter,year):
 
 
 def validate_lang_and_year(lang, year):
+
     if year is None:
         logging.debug('Defaulting the year to: %s' % year)
         year = DEFAULT_YEAR
@@ -71,14 +72,12 @@ def validate_lang_and_year(lang, year):
         logging.debug('Unsupported year requested: %s' % year)
         abort(404, 'Unsupported year requested')
 
-    supported_langs = [l.lang_code for l in SUPPORTED_LANGUAGES.get(year)]
+    supported_langs = [l.lang_code for l in (SUPPORTED_LANGUAGES.get(year) or [DEFAULT_LANGUAGE])]
 
     # If an unsupported language code is passed in, abort.
     if lang is not None and lang not in supported_langs:
         logging.debug('Unsupported language set: %s.' % lang)
-        # TODO: Return this as an  error message to the user, and display
-        # it in the custom error page.
-        abort(404)
+        abort(404, 'Unsupported language requested')
 
     if lang is None:
         # Extract the language from the Accept-Language header.


### PR DESCRIPTION
This creates language-specific error pages.

At present if you get a 404 for a French page, for example, you get the English error page:

![Generic English 404 error page](https://user-images.githubusercontent.com/10931297/79039061-8ef72200-7bd6-11ea-8a74-4e94529b3649.png)

This is not the most friendly to our foreign readers. Also notice that the Language drop down isn't rendered correctly (as there are no translations of this page).

This PR changes it to the following (and similarly for Japanese and Spanish):

![Language specific 404 error page](https://user-images.githubusercontent.com/10931297/79039203-979c2800-7bd7-11ea-8514-06fa30b8f731.png)

This will also become more important when we have different years, which might have completely different styles. This will allow us to keep the user in the same design and flow rather than a jarring move to another year's design on error.

It drops back to default year (currently 2019), and then default lang and year (currently en and 2019) if an error page doesn't exist.

@borisschapira / @ksakae1216 / @c-torres - it would be good if you could give your respective language error pages a once over if you get a chance. Mostly done with Google Translate.