### PR TITLE
Automatically remove any trailing slashes

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -160,6 +160,13 @@ def accessibility_statement(lang):
     return render_template('%s/2019/accessibility_statement.html' % (lang))
 
 
+# Handle trailing slashes for accessibility statement (as it's a special case)
+@app.route('/<lang>/accessibility-statement/')
+@validate
+def accessibility_statement_with_trailing_slash(lang):
+    return redirect("/%s/accessibility-statement" % (lang)), 301
+
+
 @app.route('/sitemap.xml')
 def sitemap():
     xml = render_template('sitemap.xml')

--- a/src/main.py
+++ b/src/main.py
@@ -43,12 +43,12 @@ def add_header(response):
 def render_template(template, *args, **kwargs):
     # If the year has already been set (e.g. for error pages) then use that
     # Otherwise the requested year, otherwise the default year
-    year = kwargs.get('year',request.view_args.get('year', DEFAULT_YEAR))
+    year = kwargs.get('year', request.view_args.get('year', DEFAULT_YEAR))
     supported_languages = SUPPORTED_LANGUAGES.get(year, (DEFAULT_LANGUAGE,))
 
     # If the lang has already been set (e.g. for error pages) then use that
     # Otherwise the requested lang, otherwise the default lang
-    lang = kwargs.get('lang',request.view_args.get('lang', DEFAULT_LANGUAGE))
+    lang = kwargs.get('lang', request.view_args.get('lang', DEFAULT_LANGUAGE.lang_code))
 
     language = get_language(lang)
     langcode_length = len(lang) + 1 # Probably always 2-character language codes but who knows!
@@ -162,7 +162,6 @@ def accessibility_statement(lang):
 
 
 @app.route('/sitemap.xml')
-@validate
 def sitemap():
     xml = render_template('sitemap.xml')
     resp = app.make_response(xml)

--- a/src/main.py
+++ b/src/main.py
@@ -154,10 +154,13 @@ def methodology(lang, year):
     return render_template('%s/%s/methodology.html' % (lang, year))
 
 
-@app.route('/<lang>/accessibility-statement')
+@app.route('/<lang>/accessibility-statement', strict_slashes=False)
 @validate
 def accessibility_statement(lang):
-    return render_template('%s/2019/accessibility_statement.html' % (lang))
+    if request.url[-1] == "/":
+        return redirect("/%s/accessibility-statement" % (lang)), 301
+    else:
+        return render_template('%s/2019/accessibility_statement.html' % (lang))
 
 
 # Handle trailing slashes for accessibility statement (as it's a special case)

--- a/src/main.py
+++ b/src/main.py
@@ -155,11 +155,12 @@ def methodology(lang, year):
 
 
 # Accessibility Statement needs special case handling for trailing slashes
-# as validate function won't catch it.
+# as, unlike Flask, we generally prefer no trailing slashes
+# For chapters we handle this in the validate function
 @app.route('/<lang>/accessibility-statement', strict_slashes=False)
 @validate
 def accessibility_statement(lang):
-    if request.url[-1] == "/":
+    if request.base_url[-1] == "/":
         return redirect("/%s/accessibility-statement" % (lang)), 301
     else:
         return render_template('%s/2019/accessibility_statement.html' % (lang))

--- a/src/main.py
+++ b/src/main.py
@@ -154,6 +154,8 @@ def methodology(lang, year):
     return render_template('%s/%s/methodology.html' % (lang, year))
 
 
+# Accessibility Statement needs special case handling for trailing slashes
+# as validate function won't catch it.
 @app.route('/<lang>/accessibility-statement', strict_slashes=False)
 @validate
 def accessibility_statement(lang):
@@ -161,13 +163,6 @@ def accessibility_statement(lang):
         return redirect("/%s/accessibility-statement" % (lang)), 301
     else:
         return render_template('%s/2019/accessibility_statement.html' % (lang))
-
-
-# Handle trailing slashes for accessibility statement (as it's a special case)
-@app.route('/<lang>/accessibility-statement/')
-@validate
-def accessibility_statement_with_trailing_slash(lang):
-    return redirect("/%s/accessibility-statement" % (lang)), 301
 
 
 @app.route('/sitemap.xml')

--- a/src/validate.py
+++ b/src/validate.py
@@ -26,8 +26,8 @@ def validate(func):
         year = kwargs.get('year')
         chapter = kwargs.get('chapter')
 
-        # Handle the pages that don't follow /lang/year/page
-        # which can end up here if they have trailing slashes
+        # Handle the pages that don't follow /lang/year/page structure
+        # which can end up here if they have trailing slashes in URL
         if lang == "sitemap.xml":
             return redirect('/sitemap.xml', code=301)
         if year == "accessibility-statement":
@@ -62,6 +62,7 @@ def validate_chapter(chapter,year):
             # Automatically remove any trailing slashes
             return chapter[:-1]
         elif chapter in TYPO_CHAPTERS:
+            # Automatically redirect for configured typos
             logging.debug('Typo chapter requested: %s, redirecting to %s' % (chapter, TYPO_CHAPTERS.get(chapter)))
             return TYPO_CHAPTERS.get(chapter)
         else:

--- a/src/validate.py
+++ b/src/validate.py
@@ -52,7 +52,10 @@ def validate_chapter(chapter,year):
 
     chapters_for_year = SUPPORTED_CHAPTERS.get(year)
     if chapter not in chapters_for_year:
-        if chapter in TYPO_CHAPTERS:
+        if (chapter[-1] == "/"):
+            # Automatically remove any trailing slashes
+            return chapter[:-1]
+        elif chapter in TYPO_CHAPTERS:
             logging.debug('Typo chapter requested: %s, redirecting to %s' % (chapter, TYPO_CHAPTERS.get(chapter)))
             return TYPO_CHAPTERS.get(chapter)
         else:

--- a/src/validate.py
+++ b/src/validate.py
@@ -26,6 +26,13 @@ def validate(func):
         year = kwargs.get('year')
         chapter = kwargs.get('chapter')
 
+        # Handle the pages that don't follow /lang/year/page
+        # which can end up here if they have trailing slashes
+        if lang == "sitemap.xml":
+            return redirect('/sitemap.xml', code=301)
+        if year == "accessibility-statement":
+            return redirect('/%s/accessibility-statement' % lang, code=301)
+
         accepted_args = inspect.getargspec(func).args
 
         lang, year = validate_lang_and_year(lang, year)
@@ -49,7 +56,6 @@ def validate(func):
 
 
 def validate_chapter(chapter,year):
-
     chapters_for_year = SUPPORTED_CHAPTERS.get(year)
     if chapter not in chapters_for_year:
         if (chapter[-1] == "/"):
@@ -66,7 +72,6 @@ def validate_chapter(chapter,year):
 
 
 def validate_lang_and_year(lang, year):
-
     if year is None:
         logging.debug('Defaulting the year to: %s' % year)
         year = DEFAULT_YEAR

--- a/src/validate.py
+++ b/src/validate.py
@@ -28,8 +28,6 @@ def validate(func):
 
         # Handle the pages that don't follow /lang/year/page structure
         # which can end up here if they have trailing slashes in URL
-        if lang == "sitemap.xml":
-            return redirect('/sitemap.xml', code=301)
         if year == "accessibility-statement":
             return redirect('/%s/accessibility-statement' % lang, code=301)
 

--- a/src/validate.py
+++ b/src/validate.py
@@ -26,11 +26,6 @@ def validate(func):
         year = kwargs.get('year')
         chapter = kwargs.get('chapter')
 
-        # Handle the pages that don't follow /lang/year/page structure
-        # which can end up here if they have trailing slashes in URL
-        if year == "accessibility-statement":
-            return redirect('/%s/accessibility-statement' % lang, code=301)
-
         accepted_args = inspect.getargspec(func).args
 
         lang, year = validate_lang_and_year(lang, year)


### PR DESCRIPTION
Happened to notice that the following doesn't work: /en/2019/css/ (i.e. URLs with a trailing slash)
Best practice is to handle this, so this PR 301s to /en/2019/css. It also works for the other static pages (e.g. methodology, ToC...etc.).

@rviscomi on a separate note can you look at my GCloud permissions? Get the following when trying to deploy:

```
MaxRetrialsException: last_result=(None, (<class 'googlecloudsdk.api_lib.storage.storage_api.UploadError'>, 
UploadError(u'403 Could not upload file [/Users/barry/almanac.httparchive.org/src/content/ja/2019/compressio
n.md] to [staging.webalmanac.appspot.com/03836fa1b7206614bdaa2154f6b610712bfe4e93]: barry@tunetheweb.com doe
s not have storage.objects.delete access to staging.webalmanac.appspot.com/03836fa1b7206614bdaa2154f6b610712
bfe4e93.',), <traceback object at 0x1072d9f38>)), last_retrial=3, time_passed_ms=1837,time_to_wait=0
```

Weirdly I am still able to delete old version from https://console.cloud.google.com/appengine/versions?project=webalmanac&serviceId=default&versionssize=50 and tested that by cleaning up the old versions. So a bit confused why I have access to do that from the web console, but not deploy from the command line?