### PR TITLE
Stop showing scrollbars when not needed for code blocks

### DIFF
--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -33,7 +33,7 @@
 }
 .code-block, pre {
   overflow-y: hidden;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 .code-block code {
   width: 100%;
@@ -449,7 +449,7 @@ figure .fig-desktop {
 }
 .code-block pre {
   overflow-y: hidden;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 .code-block code {
   width: 100%;


### PR DESCRIPTION
Not sure how I never noticed this before but code blocks have a scroll bar when not needed:

![Scrollbars showing due to bad overflow setting](https://user-images.githubusercontent.com/10931297/79393114-91f26980-7f6c-11ea-9a86-84610b4a4ba7.png)

I presume this is not intentional @rviscomi ?