### PR TITLE
Stop the intersection observer menus on mobile

### DIFF
--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -442,6 +442,9 @@ figure .fig-desktop {
     display: block;
     transition: max-height 0.25s ease-in;
   }
+  .index li.active:before{
+    background-color: transparent;
+  }
   .table-wrap {
     justify-content: left;
   }

--- a/src/static/js/chapter.js
+++ b/src/static/js/chapter.js
@@ -259,6 +259,7 @@ function setDiscussionCount() {
 function indexHighlighter() {
 
   // Don't implement this on mobile as won't be used
+  // Note: do show on tablet in case needed when rotating into landscape
   if (window.matchMedia('(max-width: 600px)').matches) {
     return;
   }

--- a/src/static/js/chapter.js
+++ b/src/static/js/chapter.js
@@ -257,6 +257,12 @@ function setDiscussionCount() {
 }
 
 function indexHighlighter() {
+
+  // Don't implement this on mobile as won't be used
+  if (window.matchMedia('(max-width: 600px)').matches) {
+    return;
+  }
+
     //Only activate this if IntersectionObserver is supported
   if(!('IntersectionObserver' in window)) {
     gtag('event', 'index-highlighter', { 'event_category': 'user', 'event_label': 'not-enabled', 'value': 0 });
@@ -265,7 +271,7 @@ function indexHighlighter() {
 
   var chapterIndex = document.querySelector('.index-box');
 
-  // If not index - then nothing to do!
+  // If no index - then nothing to do!
   if (!chapterIndex) {
     return;
   }


### PR DESCRIPTION
Noticed the improved intersection observer index added in #732 is also implemented on mobile, even though it'll never be used, so let's disable it. Save CPU cycles and removes the confusing green highlight on introduction.

I've chosen 600px as breakpoint, even though the side index doesn't kick in until 900px so it still works if a tablet user loads in portrait and then rotates to landscape. However added CSS for < 900px to stop the highlighting in the mobile menu.