### PR TITLE
Don't cache redirects and errors

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -255,7 +255,7 @@ def page_not_found(e):
 
 
 @app.errorhandler(500)
-def server_error_500(e):
+def handle_internal_server_error(e):
     logging.exception('An error occurred during a request due to internal server error: %s', request.path)
     return render_error_template(error=e, status_code=500)
 

--- a/src/main.py
+++ b/src/main.py
@@ -261,7 +261,7 @@ def handle_internal_server_error(e):
 
 
 @app.errorhandler(502)
-def server_error_502(e):
+def handle_bad_gateway(e):
     logging.exception('An error occurred during a request due to bad gateway: %s', request.path)
     return render_error_template(error=e, status_code=502)
 

--- a/src/main.py
+++ b/src/main.py
@@ -30,14 +30,21 @@ logging.basicConfig(level=logging.DEBUG)
 
 @app.after_request
 def add_header(response):
-    # Cache responses for 3 hours if no other Cache-Control header set
+    # Make sure bad responses are not cached
+    # 
+    # Cache good responses for 3 hours if no other Cache-Control header set
     # This is used for the dynamically generated files (e.g. the HTML)
     # (currently don't use unique filenames so cannot use long caches and
     # some say they are overrated anyway as caches smaller than we think).
     # Note this IS used by Google App Engine as dynamic content.
     if 'Cache-Control' not in response.headers:
-        response.cache_control.public = True
-        response.cache_control.max_age = 10800
+        if response.status_code != 200 and response.status_code != 304:
+            response.cache_control.no_store = True
+            response.cache_control.no_cache = True
+            response.cache_control.max_age = 0
+        if response.status_code == 200 or response.status_code == 304:
+            response.cache_control.public = True
+            response.cache_control.max_age = 10800
     return response
 
 def render_template(template, *args, **kwargs):
@@ -248,13 +255,13 @@ def page_not_found(e):
 
 
 @app.errorhandler(500)
-def server_error(e):
+def server_error_500(e):
     logging.exception('An error occurred during a request due to internal server error: %s', request.path)
     return render_error_template(error=e, status_code=500)
 
 
 @app.errorhandler(502)
-def server_error(e):
+def server_error_502(e):
     logging.exception('An error occurred during a request due to bad gateway: %s', request.path)
     return render_error_template(error=e, status_code=502)
 


### PR DESCRIPTION
Currently our 302 redirects (e.g. when a chapter doesn't exist) and other non-successfully error code (e.g. 404, 301...etc.) are cached for the same 3 hours that our main pages are cached for.

This changes it to not cache them so when a chapter is launched (inc Translations) it is available right away.

Also fixes a duplicate definition that VS Code flags as an error.