### PR TITLE
Add support for the old grid spec for IE

### DIFF
--- a/src/static/css/index.css
+++ b/src/static/css/index.css
@@ -33,6 +33,7 @@ header .container {
 
 #maincontent {
   overflow: hidden;
+  display: -ms-grid;
   display: grid;
   grid-template-areas:
     'intro'
@@ -76,6 +77,9 @@ p {
 .intro-container {
   color: #FFFFFF;
   grid-area: intro;
+  display: -ms-grid;
+  -ms-grid-row: 1;
+  -ms-grid-columns: 2fr 1fr;
   display: grid;
   grid-template-areas:
     'intro image';
@@ -84,18 +88,22 @@ p {
 }
 
 .intro {
+  -ms-grid-column: 1;
   grid-area: intro;
   width: 100%;
   max-width: 420px;
 }
 
 .intro-year {
+  -ms-grid-row: 1;
   grid-area: year;
   display: none;
   font-family: 'Poppins', sans-serif;
 }
 
 .intro-image-wrapper {
+  -ms-grid-column: 1;
+  -ms-grid-row: 2;
   grid-area: image;
   display: none;
   width:100%;
@@ -109,6 +117,7 @@ p {
 }
 
 .intro-image-2019-wrapper {
+  -ms-grid-column: 2;
   grid-area: image;
   width:100%;
 }
@@ -135,6 +144,7 @@ p {
 
 /* Featured Chapter */
 .featured-chapter {
+  -ms-grid-row: 2;
   grid-area: chapter;
   padding: 120px 0;
 }
@@ -178,6 +188,7 @@ p {
 
 /* Contributors */
 .contributors-container {
+  -ms-grid-row: 3;
   grid-area: contributors;
   display: flex;
   align-items: center;
@@ -230,6 +241,7 @@ p {
 
 /* Methodology */
 .methodology-container {
+  -ms-grid-row: 4;
   grid-area: methodology;
   padding: 0 60px;
 }

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -1,6 +1,8 @@
 .main {
+  display: -ms-grid;
   display: grid;
   grid-template-areas: 'index content';
+  -ms-grid-columns: 300px calc(100% - 300px);
   grid-template-columns: 300px auto;
   grid-template-columns: 300px calc(100% - 300px); /* auto sometimes not set correctly on font zoom */
 }
@@ -42,6 +44,7 @@
 
 .index {
   grid-area: index;
+  -ms-grid-column: 1;
 }
 .index .index-box {
   margin: 20px 0;
@@ -129,6 +132,7 @@
 
 .content {
   grid-area: content;
+  -ms-grid-column: 2;
   margin-left: 40px;
   min-width: 320px;
 }
@@ -394,6 +398,7 @@ figure .fig-desktop {
 
 @media (max-width: 900px) {
   .main {
+    -ms-grid-columns: 1fr;
     grid-template-areas:
       'index'
       'content';
@@ -401,11 +406,15 @@ figure .fig-desktop {
     grid-template-columns: 100%; /* auto sometimes not set correctly on font zoom */
   }
   .main .content {
+    -ms-grid-row: 2;
+    -ms-grid-column: 1;
     margin-left: 0;
   }
   .index {
+    -ms-grid-row: 1;
     margin: 30px 0;
   }
+
   .index-box .header {
     display: flex;
     justify-content: space-between;

--- a/src/templates/base/2019/contributors.html
+++ b/src/templates/base/2019/contributors.html
@@ -55,7 +55,7 @@
 }
 
 .contributor-grid:not([data-rendered='true']) .contributor {
-  transform: translateY(30px)
+  transform: translateY(30px);
   opacity: 1;
   will-change: opacity;
 }

--- a/src/templates/base/2019/contributors.html
+++ b/src/templates/base/2019/contributors.html
@@ -55,8 +55,8 @@
 }
 
 .contributor-grid:not([data-rendered='true']) .contributor {
-  transform: translateY(30px);
-  opacity: 0;
+  transform: translateY(30px)
+  opacity: 1;
   will-change: opacity;
 }
 


### PR DESCRIPTION
I still test most releases in IE11 – mostly cause I figure if it works there, it'll work anywhere!

It's always bugged me that the layout is shockingly bad because IE does not support grid. The content (the important part!) is at least readable so we can think of grid as a progressive enhancement but it still annoys me. The home page graphics are in one column, and the chapters have the Index if full screen and taking up all the space at the top.

And, as I'm trying to move to CSS Grid at work (where we still have to support IE11 for... reasons), I've been looking into this and it's quite easy to fix with a few small fallbacks. So, even though our IE user base is very small (< 2%), this bugs me and the fix is also small so here it is.

Note this is not a commitment to supporting IE going forward, nor an expectation that other developers should have to support it. Just it bugged me, so I fixed it.

Relevant links:
- https://medium.com/@elad/supporting-css-grid-in-internet-explorer-b38669e75d66
- https://rachelandrew.co.uk/archives/2016/11/26/should-i-try-to-use-the-ie-implementation-of-css-grid-layout/