### PR TITLE
Bump CSS version numbers

### DIFF
--- a/src/templates/base/2019/accessibility_statement.html
+++ b/src/templates/base/2019/accessibility_statement.html
@@ -20,7 +20,7 @@
 
 {% block styles %}
 {{ super() }}
-<link rel="stylesheet" href="/static/css/page.css?v=2">
+<link rel="stylesheet" href="/static/css/page.css?v=4">
 {% endblock %}
 
 {% block main %}

--- a/src/templates/base/2019/base.html
+++ b/src/templates/base/2019/base.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block styles %}
-  <link rel="stylesheet" href="/static/css/2019.css?v=3">
+  <link rel="stylesheet" href="/static/css/2019.css?v=4">
 {% endblock %}
 
 {% block page_url %}https://almanac.httparchive.org{{ url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}{% endblock %}

--- a/src/templates/base/2019/base_chapter.html
+++ b/src/templates/base/2019/base_chapter.html
@@ -28,7 +28,7 @@
 
 {% block styles %}
 {{ super() }}
-<link rel="stylesheet" href="/static/css/page.css?v=3">
+<link rel="stylesheet" href="/static/css/page.css?v=4">
 {% endblock %}
 
 {% block scripts %}

--- a/src/templates/base/2019/index.html
+++ b/src/templates/base/2019/index.html
@@ -21,7 +21,7 @@
 
 {% block styles %}
   {{ super() }}
-  <link rel="stylesheet" href="/static/css/index.css">
+  <link rel="stylesheet" href="/static/css/index.css?v=2">
 {% endblock %}
 
 {% block contributors %}{{ config.contributors.keys() | length }}{% endblock %}

--- a/src/templates/base/2019/methodology.html
+++ b/src/templates/base/2019/methodology.html
@@ -6,7 +6,7 @@
 
 {% block styles %}
 {{ super() }}
-<link rel="stylesheet" href="/static/css/page.css?v=2">
+<link rel="stylesheet" href="/static/css/page.css?v=4">
 {% endblock %}
 
 {% block main %}


### PR DESCRIPTION
FYI @catalinred need to remember to bump version numbers when making breaking changes to CSS in case browser (or more likely the CDN)  has old version cached as we cache for 3 hours.