### PR TITLE
Restrict Image Compression Action to pull requests from this repo

### DIFF
--- a/.github/workflows/calibreapp-image-action.yml
+++ b/.github/workflows/calibreapp-image-action.yml
@@ -7,6 +7,8 @@ on:
       - '**.webp'
 jobs:
   build:
+    # Only run on Pull Requests within the same repository, and not from forks as they don't work
+    if: github.event.pull_request.head.repo.full_name == github.repository
     name: calibreapp/image-actions
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The [Calibre Image Compression GitHub Action](https://github.com/calibreapp/image-actions) we use only works for Pull Requests from this repo to this repo, and fails silently when run on pull requests from forks, so this PR restricts it to not run then, to stop wasting time and compute.

More detail [in this issue](https://github.com/calibreapp/image-actions/issues/53), and have submitted a [pull request](https://github.com/calibreapp/image-actions/pull/54) to allow alternative ways of handling pull requests from forks. If that is accepted than can add an additional workflow for that to handle compression after merges to master - similar to how we handle the [chapter generation](https://github.com/HTTPArchive/almanac.httparchive.org/blob/master/.github/workflows/generate_chapters.yml) and [CSS version bumping](https://github.com/HTTPArchive/almanac.httparchive.org/blob/master/.github/workflows/increment_css.yml).