### PR TITLE
Track ebook link clicks

### DIFF
--- a/src/templates/base/2019/table_of_contents.html
+++ b/src/templates/base/2019/table_of_contents.html
@@ -122,7 +122,7 @@
       </section>
     </div>
 
-    <div class="ebook-download">
+    <div id="ebook-download">
       {% if ebook_exists(lang, year) %}
       <p><a href="/static/pdfs/web_almanac_{{ year }}_{{ lang }}.pdf">{{ self.ebook_download() }}</a></p>
       {% endif %}
@@ -136,4 +136,16 @@
     </div>
   </div>
 </main>
+{% endblock %}
+
+
+{% block scripts %}
+{{ super() }}
+<script nonce="{{ csp_nonce() }}">
+  var ebookLink = document.querySelector('#ebook-download');
+
+  ebookLink && ebookLink.addEventListener("click", function (event) {
+    gtag('event', 'ebook-click', { 'event_category': 'clicks', 'event_label': 'toc-page', 'value': 1 })
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
Thanks to #817 we're about to launch the PDF ebook of the Almanac. There's a link on the ToC page. Let's track clicks on that link since the PDF page won't be track in Google Analytics.

Still won't track direct downloads of the PDF but, hey it's something.