### PR TITLE
Formatting changes to ToC page

### DIFF
--- a/src/config/2019.json
+++ b/src/config/2019.json
@@ -8,6 +8,7 @@
   "outline": [
     {
       "part": "I. Page Content",
+      "part_number": "1",
       "chapters": [
         {
           "part": "I",
@@ -49,6 +50,7 @@
     },
     {
       "part": "II. User Experience",
+      "part_number": "2",
       "chapters": [
         {
           "part": "II",
@@ -90,6 +92,7 @@
     },
     {
       "part": "III. Content Publishing",
+      "part_number": "3",
       "chapters": [
         {
           "part": "III",
@@ -107,6 +110,7 @@
     },
     {
       "part": "IV. Content Distribution",
+      "part_number": "4",
       "chapters": [
         {
           "part": "IV",

--- a/src/main.py
+++ b/src/main.py
@@ -97,7 +97,7 @@ def chapter_lang_exists(lang, year, chapter):
 
 
 def ebook_exists(lang, year):
-    return os.path.isfile('templates/%s/%s/ebook.html' % (lang, year))
+    return os.path.isfile('static/pdfs/web_almanac_%s_%s.pdf' % (year, lang))
 
 
 def get_view_args(lang=None, year=None):

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -512,6 +512,10 @@ figure .fig-desktop {
   .index .index-box {
     max-height: 100%;
   }
+  .anchor-link {
+    padding-left: 0;
+    margin-left: 0;
+  }
   .anchor-link:hover::before,
   .anchor-link:focus::before {
     content: '';

--- a/src/templates/ar/2019/base.html
+++ b/src/templates/ar/2019/base.html
@@ -118,6 +118,7 @@ Unless otherwise noted, the metrics in all of the 20 chapters of the Web Almanac
 {% block appendix %}Appendix{% endblock %}
 {% block appendices %}Appendices{% endblock %}
 
+{% block ebook_title %}Ebook{% endblock %}
 {% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format (generated with <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 {% block ebook_download_note %}(generated with <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 

--- a/src/templates/base/2019/contributors.html
+++ b/src/templates/base/2019/contributors.html
@@ -7,6 +7,10 @@
 {% block styles %}
 {{ super() }}
 <style>
+.main {
+  padding-left: 10px;
+  padding-right: 10px;
+}
 .team {
   display: flex;
   flex-direction: row;
@@ -149,6 +153,10 @@
 {% endfor %}
 
 @media (max-width: 600px) {
+  .main {
+    padding-left: 0;
+    padding-right: 0;
+  }
   .team {
     height: 100px;
   }

--- a/src/templates/base/2019/table_of_contents.html
+++ b/src/templates/base/2019/table_of_contents.html
@@ -9,6 +9,8 @@
 <style>
 .main {
   margin-bottom: 100px;
+  padding-left: 10px;
+  padding-right: 10px;
 }
 
 .contents-wrapper {
@@ -60,15 +62,42 @@
 .chapter a:focus {
   text-decoration: underline;
 }
+.anchor-link {
+    text-decoration: none;
+    padding-left: 30px;
+    margin-left: -30px;
+}
+.anchor-link:hover::before,
+.anchor-link:focus::before {
+  content: url('/static/images/link.svg');
+  content: url('/static/images/link.svg') / '';
+  left: -25px;
+  position: relative;
+  float: left;
+  width: 0px;
+  height: 0px;
+}
+
 @media (max-width: 600px) {
   .contents-wrapper {
     display: block;
+  }
+  .main {
+    padding-left: 0;
+    padding-right: 0;
   }
   .parts {
     max-width: 100%;
   }
   .characters {
     display: none;
+  }
+  .anchor-link {
+    padding-left: 0;
+    margin-left: 0;
+  }
+  .anchor-link:hover::before, .anchor-link:focus::before {
+    content: '';
   }
 }
 </style>
@@ -79,7 +108,7 @@
   <h1 class="title title-lg">{{ self.table_of_contents_title() }}</h1>
 
   <section>
-    <h2>{{ self.foreword_title() }}</h2>
+    <h2 id="forward"><a href="#forward" class="anchor-link">{{ self.foreword_title() }}</a></h2>
     {{ self.foreword() }}
   </section>
 
@@ -87,7 +116,7 @@
     <div class="parts">
       {% for part_config in config.outline %}
         <section class="part">
-          <h2 class="part-name">{{ self.part() }} {{ localizedPartTitles[part_config.part] if localizedPartTitles[part_config.part]|length else chapter_config.title }}</h2>
+          <h2 id="part-{{ part_config.part_number }}" class="part-name"><a href="#part-{{ part_config.part_number }}" class="anchor-link">{{ self.part() }} {{ localizedPartTitles[part_config.part] if localizedPartTitles[part_config.part]|length else chapter_config.title }}</a></h2>
           <div class="chapters">
             {% for chapter_config in part_config.chapters %}
               <div class="chapter">
@@ -110,7 +139,7 @@
         </section>
       {% endfor %}
       <section class="part">
-        <h2 class="part-name">{{ self.appendices() }}</h2>
+        <h2 id="appendices" class="part-name"><a href="#appendices" class="anchor-link">{{ self.appendices() }}</a></h2>
         <div class="chapters">
           <div class="chapter">
             <a href="{{ url_for('methodology', year=year, lang=lang) }}">{{ self.methodology_title() }}</a>
@@ -122,14 +151,17 @@
       </section>
     </div>
 
-    <div id="ebook-download">
-      {% if ebook_exists(lang, year) %}
-      <p>
-        <a href="/static/pdfs/web_almanac_{{ year }}_{{ lang }}.pdf">{{ self.ebook_download() }}</a><br>
-        <small>{{ self.ebook_download_note() }}</small>
-      </p>
-      {% endif %}
-    </div>
+    {% if ebook_exists(lang, year) %}
+    <section class="part">
+      <h2 id="ebook" class="part-name"><a href="#ebook" class="anchor-link">{{ self.ebook_title() }}</a></h2>
+      <div class="chapters">
+        <div id="ebook-download" class="chapter">
+          <a href="/static/pdfs/web_almanac_{{ year }}_{{ lang }}.pdf">{{ self.ebook_download() }}</a><br>
+          <small>{{ self.ebook_download_note() }}</small>
+        </div>
+      </div>
+    </section>
+    {% endif %}
 
     <div class="characters">
       <img class="character" src="/static/images/character-painter.png" alt="" loading="lazy" height="202" width="226" />

--- a/src/templates/en/2019/base.html
+++ b/src/templates/en/2019/base.html
@@ -114,6 +114,7 @@ Unless otherwise noted, the metrics in all of the 20 chapters of the Web Almanac
 {% block appendix %}Appendix{% endblock %}
 {% block appendices %}Appendices{% endblock %}
 
+{% block ebook_title %}Ebook{% endblock %}
 {% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format{% endblock %}
 {% block ebook_download_note %}(generated with <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 

--- a/src/templates/es/2019/base.html
+++ b/src/templates/es/2019/base.html
@@ -114,6 +114,7 @@ A menos que se indique lo contrario, las métricas en los 20 capítulos del Web 
 {% block appendix %}Apéndice{% endblock %}
 {% block appendices %}Apéndices{% endblock %}
 
+{% block ebook_title %}Libro electronico{% endblock %}
 {% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format{% endblock %}
 {% block ebook_download_note %}(generated with <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 

--- a/src/templates/fr/2019/base.html
+++ b/src/templates/fr/2019/base.html
@@ -114,6 +114,7 @@ Sauf indication contraire, les statistiques des 20 chapitres du Web Almanac prov
 {% block appendix %}Annexe{% endblock %}
 {% block appendices %}Annexes{% endblock %}
 
+{% block ebook_title %}Ebook{% endblock %}
 {% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format{% endblock %}
 {% block ebook_download_note %}(generated with <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 

--- a/src/templates/ja/2019/base.html
+++ b/src/templates/ja/2019/base.html
@@ -114,6 +114,7 @@ Web Almanacは、ウェブ・コミュニティの努力によって実現して
 {% block appendix %}付属資料{% endblock %}
 {% block appendices %}付属資料{% endblock %}
 
+{% block ebook_title %}電子ブック{% endblock %}
 {% block ebook_download %} {{ year }} Web AlmanacのPDFファイルをダウンロードする{% endblock %}
 {% block ebook_download_note %}(generated with <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 


### PR DESCRIPTION
Small tweaks to ToC page to make it more inline with the other pages:

- Added anchor links (see #733 and #737).
- Added EBook section.
- Removed underlining from Ebook download links in keeping with other link styles on the page.
- Changed ebook link check to check for existance of pdf and not the ebook.html (to allow the ebook.html template to be translated, before all chapters are ready, so before PDF can generated).

Screenshot:

![Table of Contents screenshot of eBook section](https://user-images.githubusercontent.com/10931297/83642140-5d7f4f00-a5a6-11ea-9866-2bf5710675ea.png)
