### PR TITLE
Fix colour on Language selector as causing Firefox issue

### DIFF
--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -588,7 +588,7 @@ header .cta {
 .language-switcher option,
 .year-switcher option {
   color: #1A2B49;
-  background-color: #F2F2F2;
+  background-color: white;
 }
 
 .language-switcher:focus-within,

--- a/src/templates/base/2019/base.html
+++ b/src/templates/base/2019/base.html
@@ -330,7 +330,7 @@
       {{ l }}
     </option>
     {% endfor %}
-    <option disabled="disabled">
+    <option disabled="disabled" aria-hidden="true">
       ────
     </option>
     <option value="https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Translators'-Guide">


### PR DESCRIPTION
Weirdly choosing any colour other than white (we added `#F2F2F2` in #868) causes a scrollbar to appear on Firefox:

![Weird scrollbar on Firefox](https://user-images.githubusercontent.com/10931297/83672274-e5c51a80-a5cd-11ea-852c-562c764f9836.png)

So setting it to White, and also marking the presentational spacing bar as `aria-hidden`. 
