### PR TITLE
Tidy up breadcrumbs for multi-year support

### DIFF
--- a/src/templates/ar/2019/base.html
+++ b/src/templates/ar/2019/base.html
@@ -9,9 +9,6 @@
 {% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
 {% block date_modified %}2020-06-20T00:00:00.000Z{% endblock %}
 
-{% block breadcrumb_name_1 %}{{ year }} Home{% endblock %}
-{% block breadcrumb_name_2 %}{% endblock %}
-
 {% block skip_navigation %}Skip navigation{% endblock %}
 
 {% block organization %}Web Almanac by HTTP Archive{% endblock %}

--- a/src/templates/base/2019/accessibility_statement.html
+++ b/src/templates/base/2019/accessibility_statement.html
@@ -18,6 +18,21 @@
 }
 {% endblock %}
 
+{% block breadcrumb %}
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [{
+      "@type": "ListItem",
+      "position": 1,
+      "name": "{{ lang }}",
+      "item": "https://almanac.httparchive.org/{{lang}}/"
+    }]
+  }
+</script>
+{% endblock %}
+
 {% block styles %}
 {{ super() }}
 <link rel="stylesheet" href="/static/css/page.css?v=20200603172138">

--- a/src/templates/base/2019/base.html
+++ b/src/templates/base/2019/base.html
@@ -82,13 +82,13 @@
       "itemListElement": [{
         "@type": "ListItem",
         "position": 1,
-        "name": "{{ self.breadcrumb_name_1() }}",
-        "item": "https://almanac.httparchive.org/{{lang}}/{{year}}"
+        "name": "{{ lang }}",
+        "item": "https://almanac.httparchive.org/{{lang}}/"
       },{
         "@type": "ListItem",
         "position": 2,
-        "name": "{{ self.breadcrumb_name_2() }}",
-        "item": "{{ self.page_url() }}"
+        "name": "{{ year }}",
+        "item": "https://almanac.httparchive.org/{{lang}}/{{year}}"
       }]
     }
   </script>

--- a/src/templates/base/2019/index.html
+++ b/src/templates/base/2019/index.html
@@ -4,11 +4,6 @@
 {% block image_height %}562{% endblock %}
 {% block image_width %}715{% endblock %}
 
-{% block styles %}
-  {{ super() }}
-  <link rel="stylesheet" href="/static/css/index.css?v=2">
-{% endblock %}
-
 {% block breadcrumb %}
 <script type="application/ld+json">
   {
@@ -22,6 +17,11 @@
     }]
   }
 </script>
+{% endblock %}
+
+{% block styles %}
+  {{ super() }}
+  <link rel="stylesheet" href="/static/css/index.css?v=2">
 {% endblock %}
 
 {% block main %}

--- a/src/templates/base/2019/index.html
+++ b/src/templates/base/2019/index.html
@@ -4,24 +4,24 @@
 {% block image_height %}562{% endblock %}
 {% block image_width %}715{% endblock %}
 
-{% block breadcrumb %}
-  <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "BreadcrumbList",
-      "itemListElement": [{
-        "@type": "ListItem",
-        "position": 1,
-        "name": "{{ self.breadcrumb_name_1() }}",
-        "item": "https://almanac.httparchive.org{{  url_for('home', year=year, lang=lang) }}"
-      }]
-    }
-    </script>
-{% endblock %}
-
 {% block styles %}
   {{ super() }}
   <link rel="stylesheet" href="/static/css/index.css?v=2">
+{% endblock %}
+
+{% block breadcrumb %}
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [{
+      "@type": "ListItem",
+      "position": 1,
+      "name": "{{ lang }}",
+      "item": "https://almanac.httparchive.org/{{lang}}/"
+    }]
+  }
+</script>
 {% endblock %}
 
 {% block main %}

--- a/src/templates/en/2019/accessibility_statement.html
+++ b/src/templates/en/2019/accessibility_statement.html
@@ -9,8 +9,6 @@
 {% block date_published %}2020-02-03T12:00:00.000Z{% endblock %}
 {% block date_modified %}2020-06-03T00:00:00.000Z{% endblock %}
 
-{% block breadcrumb_name_2 %}Accessibility Statement{% endblock %}
-
 {% block index %}
       <ul>
         <li><a href="#overview">Overview</a></li>

--- a/src/templates/en/2019/base.html
+++ b/src/templates/en/2019/base.html
@@ -7,9 +7,6 @@
 {% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
 {% block date_modified %}2020-06-20T00:00:00.000Z{% endblock %}
 
-{% block breadcrumb_name_1 %}{{ year }} Home{% endblock %}
-{% block breadcrumb_name_2 %}{% endblock %}
-
 {% block skip_navigation %}Skip navigation{% endblock %}
 
 {% block organization %}Web Almanac by HTTP Archive{% endblock %}

--- a/src/templates/en/2019/base_chapter.html
+++ b/src/templates/en/2019/base_chapter.html
@@ -6,8 +6,6 @@
 
 {% block twitter_image_alt %}Chapter image for the {{ metadata.get('title') }} chapter of the {{ year }} Web Almanac{% endblock %}
 
-{% block breadcrumb_name_2 %}{{ metadata.get('title') }}{% endblock %}
-
 {% block unedited %}[Unedited]{% endblock %}
 
 {% block prev_next_title %}Previous and next chapter navigation{% endblock %}

--- a/src/templates/en/2019/base_ebook.html
+++ b/src/templates/en/2019/base_ebook.html
@@ -13,5 +13,3 @@
 {% block description %}Ebook version of the {{ year }} Web Almanac{% endblock %}
 
 {% block twitter_image_alt %}The {{ year }} Web Almanac{% endblock %}
-
-{% block breadcrumb_name_2 %}The Web Almanac {{ year }} EBook{% endblock %}

--- a/src/templates/en/2019/contributors.html
+++ b/src/templates/en/2019/contributors.html
@@ -7,8 +7,6 @@
 {% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
 {% block date_modified %}2020-03-06T00:00:00.000Z{% endblock %}
 
-{% block breadcrumb_name_2 %}{{ year }} Contributors{% endblock %}
-
 {% block filter_by_team %}Filter by team: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> of <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> contributors.{% endblock %}
 
 {% block join_the_team_title%}Join the Web Almanac team{% endblock %}

--- a/src/templates/en/2019/index.html
+++ b/src/templates/en/2019/index.html
@@ -8,8 +8,6 @@
 {% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
 {% block date_modified %}2020-05-14T00:00:00.000Z{% endblock %}
 
-{% block breadcrumb_name_1 %}{{ year }} Home{% endblock %}
-
 {% block intro_title %}Web Almanac{% endblock %}
 {% block intro_sub_title %}HTTP Archive's annual<br> <b>state of the web</b> report{% endblock %}
 

--- a/src/templates/en/2019/methodology.html
+++ b/src/templates/en/2019/methodology.html
@@ -9,8 +9,6 @@
 {% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
 {% block date_modified %}2020-06-20T00:00:00.000Z{% endblock %}
 
-{% block breadcrumb_name_2 %}{{ year }} Methodology{% endblock %}
-
 {% block index %}
       <ul>
         <li><a href="#overview">Overview</a></li>

--- a/src/templates/en/2019/table_of_contents.html
+++ b/src/templates/en/2019/table_of_contents.html
@@ -8,5 +8,3 @@
 
 {% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
 {% block date_modified %}2020-05-14T00:00:00.000Z{% endblock %}
-
-{% block breadcrumb_name_2 %}{{ year }} Table of Contents{% endblock %}

--- a/src/templates/es/2019/base.html
+++ b/src/templates/es/2019/base.html
@@ -7,9 +7,6 @@
 {% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
 {% block date_modified %}2020-06-20T00:00:00.000Z{% endblock %}
 
-{% block breadcrumb_name_1 %}{{ year }} Home{% endblock %}
-{% block breadcrumb_name_2 %}{% endblock %}
-
 {% block skip_navigation %}Saltar navegación{% endblock %}
 
 {% block organization %}Web Almanac por HTTP Archive{% endblock %}

--- a/src/templates/es/2019/base_chapter.html
+++ b/src/templates/es/2019/base_chapter.html
@@ -6,8 +6,6 @@
 
 {% block twitter_image_alt %}Imagen del Capítulo {{ metadata.get('title') }} del Web Almanac {{ year }}{% endblock %}
 
-{% block breadcrumb_name_2 %}{{ metadata.get('title') }}{% endblock %}
-
 {% block unedited %}[no corregido]{% endblock %}
 
 {% block prev_next_title %}Navegación a capítulos anteriores y siguientes.{% endblock %}

--- a/src/templates/es/2019/contributors.html
+++ b/src/templates/es/2019/contributors.html
@@ -7,8 +7,6 @@
 {% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
 {% block date_modified %}2020-03-06T00:00:00.000Z{% endblock %}
 
-{% block breadcrumb_name_2 %}{{ year }} Contribuidores{% endblock %}
-
 {% block filter_by_team %}Filtrar por equipo: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> de <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> contributors.{% endblock %}
 
 {% block join_the_team_title%}Únete al equipo de Web Almanac{% endblock %}

--- a/src/templates/es/2019/index.html
+++ b/src/templates/es/2019/index.html
@@ -8,7 +8,5 @@
 {% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
 {% block date_modified %}2020-05-14T00:00:00.000Z{% endblock %}
 
-{% block breadcrumb_name_1 %}{{ year }} Home{% endblock %}
-
 {% block intro_title %}Web Almanac{% endblock %}
 {% block intro_sub_title %}HTTP Archive informe del<br><b>estado de la web</b> anual{% endblock %}

--- a/src/templates/es/2019/table_of_contents.html
+++ b/src/templates/es/2019/table_of_contents.html
@@ -8,5 +8,3 @@
 
 {% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
 {% block date_modified %}2020-05-14T00:00:00.000Z{% endblock %}
-
-{% block breadcrumb_name_2 %}{{ year }} Table of Contents{% endblock %}

--- a/src/templates/fr/2019/base.html
+++ b/src/templates/fr/2019/base.html
@@ -7,9 +7,6 @@
 {% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
 {% block date_modified %}2020-06-20T00:00:00.000Z{% endblock %}
 
-{% block breadcrumb_name_1 %}Page d’accueil {{ year }}{% endblock %}
-{% block breadcrumb_name_2 %}{% endblock %}
-
 {% block skip_navigation %}Sauter la navigation{% endblock %}
 
 {% block organization %}Web Almanac par HTTP Archive{% endblock %}

--- a/src/templates/fr/2019/base_chapter.html
+++ b/src/templates/fr/2019/base_chapter.html
@@ -6,8 +6,6 @@
 
 {% block twitter_image_alt %}Image du chapitre {{ metadata.get('title') }} du Web Almanac {{ year }}{% endblock %}
 
-{% block breadcrumb_name_2 %}{{ metadata.get('title') }}{% endblock %}
-
 {% block unedited %}[non corrigé]{% endblock %}
 
 {% block prev_next_title %}Navigation vers les chapitres précédent et suivant{% endblock %}

--- a/src/templates/fr/2019/contributors.html
+++ b/src/templates/fr/2019/contributors.html
@@ -9,8 +9,6 @@
 {% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
 {% block date_modified %}2020-03-06T00:00:00.000Z{% endblock %}
 
-{% block breadcrumb_name_2 %}{{ year }} Contributeurs et contributrices{% endblock %}
-
 {% block filter_by_team %}Filtrer par équipe&nbsp;: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> sur <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> contributeurs et contributrices.{% endblock %}
 
 {% block join_the_team_title %}Rejoignez les équipe Web Almanac{% endblock %}

--- a/src/templates/fr/2019/index.html
+++ b/src/templates/fr/2019/index.html
@@ -8,7 +8,5 @@
 {% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
 {% block date_modified %}2020-05-14T00:00:00.000Z{% endblock %}
 
-{% block breadcrumb_name_1 %}Page d’accueil {{ year }}{% endblock %}
-
 {% block intro_title %}Web Almanac{% endblock %}
 {% block intro_sub_title %}Rapport annuel<br>de HTTP Archive sur<br><b>l’état du Web</b>{% endblock %}

--- a/src/templates/fr/2019/methodology.html
+++ b/src/templates/fr/2019/methodology.html
@@ -9,8 +9,6 @@
 {% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
 {% block date_modified %}2020-06-20T00:00:00.000Z{% endblock %}
 
-{% block breadcrumb_name_2 %}Méthodologie {{ year }}{% endblock %}
-
 {% block index %}
       <ul>
         <li><a href="#overview">Vue d’ensemble</a></li>

--- a/src/templates/fr/2019/table_of_contents.html
+++ b/src/templates/fr/2019/table_of_contents.html
@@ -8,5 +8,3 @@
 
 {% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
 {% block date_modified %}2020-05-14T00:00:00.000Z{% endblock %}
-
-{% block breadcrumb_name_2 %}{{ year }} Table des matières{% endblock %}

--- a/src/templates/ja/2019/accessibility_statement.html
+++ b/src/templates/ja/2019/accessibility_statement.html
@@ -9,8 +9,6 @@
 {% block date_published %}2020-02-03T12:00:00.000Z{% endblock %}
 {% block date_modified %}2020-06-03T00:00:00.000Z{% endblock %}
 
-{% block breadcrumb_name_2 %}アクセシビリティに関する声明{% endblock %}
-
 {% block index %}
       <ul>
         <li><a href="#overview">概要</a></li>

--- a/src/templates/ja/2019/base.html
+++ b/src/templates/ja/2019/base.html
@@ -6,10 +6,6 @@
 
 {% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
 {% block date_modified %}2020-06-20T00:00:00.000Z{% endblock %}
-
-{% block breadcrumb_name_1 %}{{ year }} ホーム{% endblock %}
-{% block breadcrumb_name_2 %}{% endblock %}
-
 {% block skip_navigation %}ナビゲーションをスキップ{% endblock %}
 
 {% block organization %}HTTP ArchiveによるWeb Almanac{% endblock %}

--- a/src/templates/ja/2019/base_chapter.html
+++ b/src/templates/ja/2019/base_chapter.html
@@ -6,8 +6,6 @@
 
 {% block twitter_image_alt %}のチャプター画像 {{ metadata.get('title') }} の章 {{ year }} Web Almanac{% endblock %}
 
-{% block breadcrumb_name_2 %}{{ metadata.get('title') }}{% endblock %}
-
 {% block unedited %}[未編集]{% endblock %}
 
 {% block prev_next_title %}前後の章のナビゲーション{% endblock %}

--- a/src/templates/ja/2019/base_ebook.html
+++ b/src/templates/ja/2019/base_ebook.html
@@ -13,5 +13,3 @@
 {% block description %}{{ year }} Web Almanacの電子書籍版{% endblock %}
 
 {% block twitter_image_alt %}{{ year }} Web Almanac{% endblock %}
-
-{% block breadcrumb_name_2 %}Web Almanac {{ year }} 電子書籍{% endblock %}

--- a/src/templates/ja/2019/contributors.html
+++ b/src/templates/ja/2019/contributors.html
@@ -7,8 +7,6 @@
 {% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
 {% block date_modified %}2020-04-03T00:00:00.000Z{% endblock %}
 
-{% block breadcrumb_name_2 %}{{ year }} 貢献者{% endblock %}
-
 {% block filter_by_team %}チームでフィルタリング： <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> の <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> 貢献者。{% endblock %}
 
 {% block join_the_team_title%}Web Almanacチームに参加しましょう{% endblock %}

--- a/src/templates/ja/2019/index.html
+++ b/src/templates/ja/2019/index.html
@@ -8,7 +8,5 @@
 {% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
 {% block date_modified %}2020-05-14T00:00:00.000Z{% endblock %}
 
-{% block breadcrumb_name_1 %}{{ year }} ホーム{% endblock %}
-
 {% block intro_title %}Web Almanac{% endblock %}
 {% block intro_sub_title %}HTTP Archiveの年次報告書<br> <b>ウェブの状態</b>レポート{% endblock %}

--- a/src/templates/ja/2019/methodology.html
+++ b/src/templates/ja/2019/methodology.html
@@ -9,8 +9,6 @@
 {% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
 {% block date_modified %}2020-06-20T00:00:00.000Z{% endblock %}
 
-{% block breadcrumb_name_2 %}{{ year }} 方法論{% endblock %}
-
 {% block index %}
       <ul>
         <li><a href="#overview">概要</a></li>

--- a/src/templates/ja/2019/table_of_contents.html
+++ b/src/templates/ja/2019/table_of_contents.html
@@ -8,5 +8,3 @@
 
 {% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
 {% block date_modified %}2020-05-14T00:00:00.000Z{% endblock %}
-
-{% block breadcrumb_name_2 %}{{ year }} 目次{% endblock %}


### PR DESCRIPTION
Fixes #885 

Tidies up the breadcrumbs, which appears at the top of the SERP results:

![SERP result for Web Alamanc SEO showing breadcrumbs](https://user-images.githubusercontent.com/10931297/85234071-d7b32e80-b402-11ea-8656-fce38e241ea5.png)

We have added the language and year (where applicable).

We've also been putting the page name in the breadcrumb which, along wiht creating a lot of code, [isn't what Google recommends](https://developers.google.com/search/docs/data-types/breadcrumb) so removed now. Which massively simplifies this as can be just in base templates.