### PR TITLE
Fix index font zoom

### DIFF
--- a/src/content/en/2020/README.md
+++ b/src/content/en/2020/README.md
@@ -1,1 +1,0 @@
-This is the directory in which content teams add the markdown version of their chapters.

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -462,6 +462,7 @@ h2.header {
   color: #fff;
   white-space: nowrap;
   text-decoration: none;
+  font-size: 16px;
   font-size: 1rem;
 }
 

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -99,6 +99,7 @@
   display: block;
   padding: 24px 16px;
   line-height: 24px;
+  line-height: 1.5rem;
   color: #1A2B49;
 }
 .index li li {


### PR DESCRIPTION
Just noticed while reviewing another PR that when font zooming to 32px base font, that the chapter table of contents look a little squished (especially on Firefox):

<img src="https://user-images.githubusercontent.com/10931297/85958031-5ae7fd80-b98a-11ea-93a4-501e35491e95.png" alt="Bad font zoom with fixed line height" height="259" width="327">

This PR adds `rem` sizing to the `line-height` to fix this.

<img src="https://user-images.githubusercontent.com/10931297/85958087-be722b00-b98a-11ea-8d57-13e5cf93e556.png" alt="Better font zoom with relative line height" height="379" width="311">
