### PR TITLE
Fixed typo in js featured snippet

### DIFF
--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -694,6 +694,7 @@ blockquote {
   font-style: italic;
   font-size: 19px;
   font-size: 1.1875rem;
+  line-height: 1.5em;
 }
 
 blockquote::before {

--- a/src/templates/en/2019/featured_chapters.html
+++ b/src/templates/en/2019/featured_chapters.html
@@ -2,7 +2,7 @@
 {%- if featured_chapter == "javascript" %}
   {%- set featured_chapter_name = "JavaScript" %}
   {%- set featured_chapter_quote = "JavaScript is the most costly resource we send to browsers; having to be downloaded, parsed, compiled, and finally executed. Although browsers have significantly decreased the time it takes to parse and compile scripts, download and execution have become the most expensive stages when JavaScript is processed by a web page." %}
-  {%- set featured_chapter_stats = {"stat1":"89%","label1":"Sites with more 3P code than 1P","stat2":"83%","label2":"Sites that use jQuery","stat3":"4.6%","label3":"Home pages using React"} %}
+  {%- set featured_chapter_stats = {"stat1":"89%","label1":"Sites with more third-party code than first-party","stat2":"83%","label2":"Sites that use jQuery","stat3":"4.6%","label3":"Home pages using React"} %}
 {%- elif featured_chapter == "css" %}
   {%- set featured_chapter_name = "CSS" %}
   {%- set featured_chapter_quote = "Cascading Style Sheets (CSS) are used to paint, format, and layout web pages. Their capabilities span concepts as simple as text color to 3D perspective. It also has hooks to empower developers to handle varying screen sizes, viewing contexts, and printing. CSS helps developers wrangle content and ensure it's adapting properly to the user." %}

--- a/src/templates/en/2019/featured_chapters.html
+++ b/src/templates/en/2019/featured_chapters.html
@@ -2,7 +2,7 @@
 {%- if featured_chapter == "javascript" %}
   {%- set featured_chapter_name = "JavaScript" %}
   {%- set featured_chapter_quote = "JavaScript is the most costly resource we send to browsers; having to be downloaded, parsed, compiled, and finally executed. Although browsers have significantly decreased the time it takes to parse and compile scripts, download and execution have become the most expensive stages when JavaScript is processed by a web page." %}
-  {%- set featured_chapter_stats = {"stat1":"89%","label1":"Sites with more 3P code that 1P","stat2":"83%","label2":"Sites that use jQuery","stat3":"4.6%","label3":"Home pages using React"} %}
+  {%- set featured_chapter_stats = {"stat1":"89%","label1":"Sites with more 3P code than 1P","stat2":"83%","label2":"Sites that use jQuery","stat3":"4.6%","label3":"Home pages using React"} %}
 {%- elif featured_chapter == "css" %}
   {%- set featured_chapter_name = "CSS" %}
   {%- set featured_chapter_quote = "Cascading Style Sheets (CSS) are used to paint, format, and layout web pages. Their capabilities span concepts as simple as text color to 3D perspective. It also has hooks to empower developers to handle varying screen sizes, viewing contexts, and printing. CSS helps developers wrangle content and ensure it's adapting properly to the user." %}

--- a/src/templates/es/2019/featured_chapters.html
+++ b/src/templates/es/2019/featured_chapters.html
@@ -7,7 +7,7 @@
 {%- if featured_chapter == "javascript" %}
   {%- set featured_chapter_name = "JavaScript" %}
   {%- set featured_chapter_quote = "JavaScript is the most costly resource we send to browsers; having to be downloaded, parsed, compiled, and finally executed. Although browsers have significantly decreased the time it takes to parse and compile scripts, download and execution have become the most expensive stages when JavaScript is processed by a web page." %}
-  {%- set featured_chapter_stats = {"stat1":"89%","label1":"Sites with more 3P code that 1P","stat2":"83%","label2":"Sites that use jQuery","stat3":"4.6%","label3":"Home pages using React"} %}
+  {%- set featured_chapter_stats = {"stat1":"89%","label1":"Sites with more 3P code than 1P","stat2":"83%","label2":"Sites that use jQuery","stat3":"4.6%","label3":"Home pages using React"} %}
 {%- elif featured_chapter == "css" %}
   {%- set featured_chapter_name = "CSS" %}
   {%- set featured_chapter_quote = "Cascading Style Sheets (CSS) are used to paint, format, and layout web pages. Their capabilities span concepts as simple as text color to 3D perspective. It also has hooks to empower developers to handle varying screen sizes, viewing contexts, and printing. CSS helps developers wrangle content and ensure it's adapting properly to the user." %}

--- a/src/templates/es/2019/featured_chapters.html
+++ b/src/templates/es/2019/featured_chapters.html
@@ -7,7 +7,7 @@
 {%- if featured_chapter == "javascript" %}
   {%- set featured_chapter_name = "JavaScript" %}
   {%- set featured_chapter_quote = "JavaScript is the most costly resource we send to browsers; having to be downloaded, parsed, compiled, and finally executed. Although browsers have significantly decreased the time it takes to parse and compile scripts, download and execution have become the most expensive stages when JavaScript is processed by a web page." %}
-  {%- set featured_chapter_stats = {"stat1":"89%","label1":"Sites with more 3P code than 1P","stat2":"83%","label2":"Sites that use jQuery","stat3":"4.6%","label3":"Home pages using React"} %}
+  {%- set featured_chapter_stats = {"stat1":"89%","label1":"Sites with more third-party code than first-party","stat2":"83%","label2":"Sites that use jQuery","stat3":"4.6%","label3":"Home pages using React"} %}
 {%- elif featured_chapter == "css" %}
   {%- set featured_chapter_name = "CSS" %}
   {%- set featured_chapter_quote = "Cascading Style Sheets (CSS) are used to paint, format, and layout web pages. Their capabilities span concepts as simple as text color to 3D perspective. It also has hooks to empower developers to handle varying screen sizes, viewing contexts, and printing. CSS helps developers wrangle content and ensure it's adapting properly to the user." %}

--- a/src/templates/fr/2019/featured_chapters.html
+++ b/src/templates/fr/2019/featured_chapters.html
@@ -7,7 +7,7 @@
 {%- if featured_chapter == "javascript" %}
   {%- set featured_chapter_name = "JavaScript" %}
   {%- set featured_chapter_quote = "JavaScript is the most costly resource we send to browsers; having to be downloaded, parsed, compiled, and finally executed. Although browsers have significantly decreased the time it takes to parse and compile scripts, download and execution have become the most expensive stages when JavaScript is processed by a web page." %}
-  {%- set featured_chapter_stats = {"stat1":"89%","label1":"Sites with more 3P code that 1P","stat2":"83%","label2":"Sites that use jQuery","stat3":"4.6%","label3":"Home pages using React"} %}
+  {%- set featured_chapter_stats = {"stat1":"89%","label1":"Sites with more 3P code than 1P","stat2":"83%","label2":"Sites that use jQuery","stat3":"4.6%","label3":"Home pages using React"} %}
 {%- elif featured_chapter == "css" %}
   {%- set featured_chapter_name = "CSS" %}
   {%- set featured_chapter_quote = "Cascading Style Sheets (CSS) are used to paint, format, and layout web pages. Their capabilities span concepts as simple as text color to 3D perspective. It also has hooks to empower developers to handle varying screen sizes, viewing contexts, and printing. CSS helps developers wrangle content and ensure it's adapting properly to the user." %}

--- a/src/templates/fr/2019/featured_chapters.html
+++ b/src/templates/fr/2019/featured_chapters.html
@@ -7,7 +7,7 @@
 {%- if featured_chapter == "javascript" %}
   {%- set featured_chapter_name = "JavaScript" %}
   {%- set featured_chapter_quote = "JavaScript is the most costly resource we send to browsers; having to be downloaded, parsed, compiled, and finally executed. Although browsers have significantly decreased the time it takes to parse and compile scripts, download and execution have become the most expensive stages when JavaScript is processed by a web page." %}
-  {%- set featured_chapter_stats = {"stat1":"89%","label1":"Sites with more 3P code than 1P","stat2":"83%","label2":"Sites that use jQuery","stat3":"4.6%","label3":"Home pages using React"} %}
+  {%- set featured_chapter_stats = {"stat1":"89%","label1":"Sites with more third-party code than first-party","stat2":"83%","label2":"Sites that use jQuery","stat3":"4.6%","label3":"Home pages using React"} %}
 {%- elif featured_chapter == "css" %}
   {%- set featured_chapter_name = "CSS" %}
   {%- set featured_chapter_quote = "Cascading Style Sheets (CSS) are used to paint, format, and layout web pages. Their capabilities span concepts as simple as text color to 3D perspective. It also has hooks to empower developers to handle varying screen sizes, viewing contexts, and printing. CSS helps developers wrangle content and ensure it's adapting properly to the user." %}


### PR DESCRIPTION
Fixes #895. 

I also replace **3P** with third-party and **1P** with first-party as @bazzadp mention in that issue. Then, I add `line-height`property with value `1.5em` in `blockquote` tag to make reader easy to read.

Here are the comparison before add line-height and after add line-height:

> Before add line-height in homepage in featured chapters section
![Screen Shot 2020-06-30 at 22 24 56](https://user-images.githubusercontent.com/11099186/86139285-1c854680-bb22-11ea-90be-fffeed8f3986.png)


> After add line-height in homepage in featured chapters section
![Screen Shot 2020-06-30 at 22 25 34](https://user-images.githubusercontent.com/11099186/86139234-1000ee00-bb22-11ea-9779-896c37cee92c.png)

> Before add line-height in markup chapter
![Screen Shot 2020-06-30 at 22 21 25](https://user-images.githubusercontent.com/11099186/86139505-6a01b380-bb22-11ea-9fed-5910b1336316.png)

> After add line-height in markup chapter
![Screen Shot 2020-06-30 at 22 21 38](https://user-images.githubusercontent.com/11099186/86139584-800f7400-bb22-11ea-839e-9d5354764fcf.png)

Thank you.