### PR TITLE
Add Docker-based development environment

### DIFF
--- a/src/.dockerignore
+++ b/src/.dockerignore
@@ -1,0 +1,3 @@
+__pycache__/
+.pytest_cache/
+node_modules/

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-ARG     PYTAG=latest
+ARG     PYTAG=3
 FROM    python:${PYTAG}
 
 # Enable unbuffered STDOUT logging

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,0 +1,23 @@
+ARG     PYTAG=latest
+FROM    python:${PYTAG}
+
+# Enable unbuffered STDOUT logging
+ENV     PYTHONUNBUFFERED=1
+
+ARG     NODEVER=12.x
+RUN     curl -sL https://deb.nodesource.com/setup_${NODEVER} | bash - \
+        && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list \
+        && curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+
+RUN     apt update && apt install -y \
+          google-cloud-sdk \
+          nodejs \
+        && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY    requirements.txt package*.json ./
+RUN     pip install -r requirements.txt
+RUN     npm install
+COPY    . ./
+
+CMD     ["python", "main.py"]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -5,14 +5,17 @@ FROM    python:${PYVER}
 ENV     PYTHONUNBUFFERED=1
 
 ARG     NODEVER=12.x
-RUN     curl -sL https://deb.nodesource.com/setup_${NODEVER} | bash - \
-        && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list \
-        && curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+RUN     curl -sL https://deb.nodesource.com/setup_${NODEVER} | bash -
 
 RUN     apt update && apt install -y \
-          google-cloud-sdk \
           nodejs \
         && rm -rf /var/lib/apt/lists/*
+
+# Add Google Cloud SDK only if image is built with `--build-arg SKIPGC=false`
+ARG     SKIPGC=true
+RUN     $SKIPGC || (echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list \
+        && curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
+        && apt update && apt install -y google-cloud-sdk && rm -rf /var/lib/apt/lists/*)
 
 WORKDIR /app
 COPY    requirements.txt package*.json ./

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,5 @@
-ARG     PYTAG=3
-FROM    python:${PYTAG}
+ARG     PYVER=3
+FROM    python:${PYVER}
 
 # Enable unbuffered STDOUT logging
 ENV     PYTHONUNBUFFERED=1

--- a/src/README.md
+++ b/src/README.md
@@ -153,5 +153,7 @@ docker container run --rm -it -v "$PWD":/app webalmanac pytest
 docker container run --rm -it -v "$PWD":/app -v /app/node_modules -p 8080:8080 webalmanac bash
 root@[CID]:/app# pytest
 root@[CID]:/app# python main.py
+^C
 root@[CID]:/app# npm run generate
+root@[CID]:/app# exit
 ```

--- a/src/README.md
+++ b/src/README.md
@@ -139,7 +139,7 @@ docker image build -t webalmanac .
 docker container run --rm -it -v "$PWD":/app -p 8080:8080 webalmanac
 ```
 
-3. Open http://localhost:8080 in your web browser to access the site then kill the server (using `Ctrl+C`)
+3. Open http://localhost:8080 in your web browser to access the site. You can kill the server when it is no longer needed using `Ctrl+C`.
 
 4. Make changes in the code using any text editor and run tests (need to build the image again if any Python or Node dependencies are changed):
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,6 @@
 # Developing the Web Almanac
 
-The Web Almanac can be developed on MacOs, Windows or Linux. It required node v12 and python v3 to be installed.
+The Web Almanac can be developed on macOS, Windows or Linux. It requires Node v12 and Python v3 to be installed. Alternatively, use Docker to avoid manually configuring the development environment.
 
 ## Run Locally
 
@@ -122,3 +122,36 @@ npm run deploy
 ```
 
 5. Browse the website in production to verify that the new changes have taken effect
+
+## Developing in Docker
+
+Assuming that you have Docker installed and running, ensure that the working directory is `src`, where the `Dockerfile` is present, before running the following commands.
+
+1. Build a Docker image named `webalmanac` (if you choose a different name, adjust following commands accordingly):
+
+```
+docker image build -t webalmanac .
+```
+
+2. Run the application server (which is the default command of the Docker image, so no need to explicitly supply it as an argument):
+
+```
+docker container run --rm -it -v "$PWD":/app -p 8080:8080 webalmanac
+```
+
+3. Open http://localhost:8080 in your web browser to access the site then kill the server (using `Ctrl+C`)
+
+4. Make changes in the code using any text editor and run tests (need to build the image again if any Python or Node dependencies are changed):
+
+```
+docker container run --rm -it -v "$PWD":/app webalmanac pytest
+```
+
+5. To avoid running commands in one-off mode run `bash` in a container (with necessary volumes mounted and ports mapped) then run successive commands:
+
+```
+docker container run --rm -it -v "$PWD":/app -v /app/node_modules -p 8080:8080 webalmanac bash
+root@[CID]:/app# pytest
+root@[CID]:/app# python main.py
+root@[CID]:/app# npm run generate
+```

--- a/src/README.md
+++ b/src/README.md
@@ -157,3 +157,9 @@ root@[CID]:/app# python main.py
 root@[CID]:/app# npm run generate
 root@[CID]:/app# exit
 ```
+
+6. To customize the image use `PYVER`, `NODEVER`, and `SKIPGC` build arguments to control which versions of Python and Node are used and whether Google Cloud SDK is installed.
+
+```
+docker image build --build-arg PYVER=3.7 --build-arg NODEVER=14.x --build-arg SKIPGC=false -t webalmanac:custom .
+```

--- a/src/main.py
+++ b/src/main.py
@@ -151,7 +151,7 @@ def get_ebook_methodology(lang, year):
     methodology_maincontent = re.sub('href="\/%s\/%s\/' % (lang, year), 'href="#', methodology_maincontent)
     # For external links add footnote span
     methodology_maincontent = re.sub('href="http(.*?)"(.*?)>(.*?)<\/a>', 'href="http\\1"\\2>\\3<span class="fn">http\\1</span></a>', methodology_maincontent)
-    # Replace figure image links to full site, to avoid 127.0.0.1:8080 links
+    # Replace figure image links to full site, to avoid 0.0.0.0:8080 links
     methodology_maincontent = re.sub('href="\/', 'href="https://almanac.httparchive.org/', methodology_maincontent)
     # Replace other chapter references with hash to anchor link (e.g. ./javascript#fig-1 -> #javascript-fig-1)
     methodology_maincontent = re.sub('href="./([a-z0-9-]*)#', 'href="#\\1-', methodology_maincontent)
@@ -351,6 +351,6 @@ if __name__ == '__main__':
     if (len(sys.argv) > 1 and sys.argv[1] == 'background'):
         # Turn off HTTPS redirects (automatically turned off for debug)
         talisman.force_https=False
-        app.run(host='127.0.0.1', port=8080)
+        app.run(host='0.0.0.0', port=8080)
     else:
-        app.run(host='127.0.0.1', port=8080, debug=True)
+        app.run(host='0.0.0.0', port=8080, debug=True)

--- a/src/tools/generate/generate_ebooks.js
+++ b/src/tools/generate/generate_ebooks.js
@@ -22,7 +22,7 @@ const update_links = (chapter) => {
   body = body.replace(/<a href=".\//g,'<a href="#');
   // For external links add footnote span
   body = body.replace(/href="(http.*?)"(.*?)>(.*?)<\/a>/g,'href="$1"$2>$3<span class="fn">$1</span></a>');
-  // Replace figure image links to full site, to avoid 127.0.0.1:8080 links
+  // Replace figure image links to full site, to avoid 0.0.0.0:8080 links
   body = body.replace(/<a href="\/static\/images/g,'<a href="https://almanac.httparchive.org/static/images');
   // Remove lazy-loading attributes
   body = body.replace(/ loading="lazy"/g,'');

--- a/src/validate.py
+++ b/src/validate.py
@@ -98,7 +98,7 @@ def parse_accept_language(header, supported_langs):
 
     if header is not None:
 
-        accepted_languages = re.findall('(?:^|\s|,)(\w+)', header)
+        accepted_languages = re.findall(r'(?:^|\s|,)(\w+)', header)
 
         logging.debug('Accepted languages: %s' % accepted_languages)
 


### PR DESCRIPTION
Closes #937 with the following changes:

* Add new files: `Dockerfile` and `.gcloudignore`
* Update application server to listen on `0.0.0.0` interface as loopback interface of the container will not be accessible from outside
* Document the development procedure in Docker
* Fix a RegEx format deprecation warning in newer versions of Python
