### PR TITLE
Update Flask version to fix a deprecation warning

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.0.4
+Flask
 flask-talisman
 gunicorn==19.9.0
 matplotlib

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,6 @@
 Flask
 flask-talisman
-gunicorn==19.9.0
+gunicorn
 matplotlib
 mistune
 pandas

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.0.2
+Flask==1.0.4
 flask-talisman
 gunicorn==19.9.0
 matplotlib


### PR DESCRIPTION
Closes #957 by updating the Flask version. While the latest version of Flask is `1.1.2` and all the tests are passing with that, I only updated it to the latest patch version of of the `1.0.x` series to avoid any untested failures.