### PR TITLE
Fix incorrect colour for ToC highlighter

### DIFF
--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -129,7 +129,7 @@
 }
 
 .index li.active::before {
-  background-color: #1a2b49;
+  background-color: #a8caba;
 }
 
 .content {


### PR DESCRIPTION
Noticed while reviewing other changes tbhe the colour is broken in the Table of Contents highlighter:

![ToC with black highlighter](https://user-images.githubusercontent.com/10931297/86535485-93cb2980-bed8-11ea-8f58-e399cc1bda71.png)

should be this:

![ToC with green highlighter](https://user-images.githubusercontent.com/10931297/86535476-8746d100-bed8-11ea-8d70-c3bca3c3a388.png)

Looks like I broke this in #939.