### PR TITLE
Only modify changed or added files - not deleted ones

### DIFF
--- a/.github/workflows/generate_chapters.yml
+++ b/.github/workflows/generate_chapters.yml
@@ -37,8 +37,8 @@ jobs:
         echo "files changed in commit $COMMIT_SHA:"
         git diff-tree --no-commit-id --name-only -r $COMMIT_SHA
         echo "Incrementing any references to changed CSS files"
-        git diff-tree --no-commit-id --name-only -r $COMMIT_SHA src/static/css | grep "\.css" | sed 's!.*/!!' | sed "s/\(.*\)/s\/\1?v=[0-9][0-9]*\/\1?v=$(date +%Y%m%d%H%M%S)\//" | sed -f - -i src/templates/base/*/*.html
-        git diff-tree --no-commit-id --name-only -r $COMMIT_SHA src/static/css | grep "\.css" | sed 's!.*/!!' | sed "s/\(.*\)/s\/\1?v=[0-9][0-9]*\/\1?v=$(date +%Y%m%d%H%M%S)\//" | sed -f - -i src/templates/base.html
+        git diff-tree --diff-filter=AM --no-commit-id --name-only -r $COMMIT_SHA src/static/css | grep "\.css" | sed 's!.*/!!' | sed "s/\(.*\)/s\/\1?v=[0-9][0-9]*\/\1?v=$(date +%Y%m%d%H%M%S)\//" | sed -f - -i src/templates/base/*/*.html
+        git diff-tree --diff-filter=AM --no-commit-id --name-only -r $COMMIT_SHA src/static/css | grep "\.css" | sed 's!.*/!!' | sed "s/\(.*\)/s\/\1?v=[0-9][0-9]*\/\1?v=$(date +%Y%m%d%H%M%S)\//" | sed -f - -i src/templates/base.html
         git diff
     - name: Update JS version for modified CSS files
       env:
@@ -47,8 +47,8 @@ jobs:
         echo "files changed in commit $COMMIT_SHA:"
         git diff-tree --no-commit-id --name-only -r $COMMIT_SHA
         echo "Incrementing any references to changed JS files"
-        git diff-tree --no-commit-id --name-only -r $COMMIT_SHA src/static/js | grep "\.js" | sed 's!.*/!!' | sed "s/\(.*\)/s\/\1?v=[0-9][0-9]*\/\1?v=$(date +%Y%m%d%H%M%S)\//" | sed -f - -i src/templates/base/*/*.html
-        git diff-tree --no-commit-id --name-only -r $COMMIT_SHA src/static/js | grep "\.js" | sed 's!.*/!!' | sed "s/\(.*\)/s\/\1?v=[0-9][0-9]*\/\1?v=$(date +%Y%m%d%H%M%S)\//" | sed -f - -i src/templates/base.html
+        git diff-tree --diff-filter=AM --no-commit-id --name-only -r $COMMIT_SHA src/static/js | grep "\.js" | sed 's!.*/!!' | sed "s/\(.*\)/s\/\1?v=[0-9][0-9]*\/\1?v=$(date +%Y%m%d%H%M%S)\//" | sed -f - -i src/templates/base/*/*.html
+        git diff-tree --diff-filter=AM --no-commit-id --name-only -r $COMMIT_SHA src/static/js | grep "\.js" | sed 's!.*/!!' | sed "s/\(.*\)/s\/\1?v=[0-9][0-9]*\/\1?v=$(date +%Y%m%d%H%M%S)\//" | sed -f - -i src/templates/base.html
         git diff
     - name: Update timestamp for modified files
       env:
@@ -57,10 +57,10 @@ jobs:
         echo "files changed in commit $COMMIT_SHA:"
         git diff-tree --no-commit-id --name-only -r $COMMIT_SHA
         echo "Updating timestamp in any markdown chapter files"
-        git diff-tree --no-commit-id --name-only -r $COMMIT_SHA src/content | grep "^src\/content\/[a-z]*\/[0-9]*\/[a-z0-9-]*.md" | xargs -r sed -i "s/^last_updated: [0-9-]*T/last_updated: $(date '+%Y-%m-%d')T/"
+        git diff-tree --diff-filter=AM --no-commit-id --name-only -r $COMMIT_SHA src/content | grep "^src\/content\/[a-z]*\/[0-9]*\/[a-z0-9-]*.md" | xargs -r sed -i "s/^last_updated: [0-9-]*T/last_updated: $(date '+%Y-%m-%d')T/"
         echo "Updating timestamp in any template files"
-        git diff-tree --no-commit-id --name-only -r $COMMIT_SHA src/templates | grep "^src\/templates\/[a-z][a-z]\/20[0-9][0-9]\/[a-zA-Z0-9_]*.html" | xargs -r sed -i "s/{% block date_modified %}[0-9-]*T/{% block date_modified %}$(date '+%Y-%m-%d')T/"
-        git diff-tree --no-commit-id --name-only -r $COMMIT_SHA src/templates | grep "^src\/templates\/[a-z][a-z]\/[a-zA-Z0-9_]*.html" | xargs -r sed -i "s/{% block date_modified %}[0-9-]*T/{% block date_modified %}$(date '+%Y-%m-%d')T/"
+        git diff-tree --diff-filter=AM --no-commit-id --name-only -r $COMMIT_SHA src/templates | grep "^src\/templates\/[a-z][a-z]\/20[0-9][0-9]\/[a-zA-Z0-9_]*.html" | xargs -r sed -i "s/{% block date_modified %}[0-9-]*T/{% block date_modified %}$(date '+%Y-%m-%d')T/"
+        git diff-tree --diff-filter=AM --no-commit-id --name-only -r $COMMIT_SHA src/templates | grep "^src\/templates\/[a-z][a-z]\/[a-zA-Z0-9_]*.html" | xargs -r sed -i "s/{% block date_modified %}[0-9-]*T/{% block date_modified %}$(date '+%Y-%m-%d')T/"
         echo "Updated timestamps:"
         git diff
     - name: Setup Node.js for use with actions


### PR DESCRIPTION
The last generate chapters GitHub Action [failed](https://github.com/HTTPArchive/almanac.httparchive.org/runs/842478107?check_suite_focus=true) due to trying to update timestamps of deleted files.

We don't delete files often which was why this was only seen now.

This PR changes the diffs to only look at added (A) and modified (M) files.