### PR TITLE
Fix spacing issues in header on tablet

### DIFF
--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -488,6 +488,7 @@ h2.header {
   text-decoration: none;
   font-size: 16px;
   font-size: 1rem;
+  margin-right: 40px;
 }
 
 .navigation-logo:hover,
@@ -586,6 +587,7 @@ header nav {
 
 header nav > ul > li > * {
   margin-right: 50px;
+  margin-right: 2vw;
 }
 
 header nav > ul > li:last-child > * {

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -586,7 +586,6 @@ header nav {
 }
 
 header nav > ul > li > * {
-  margin-right: 50px;
   margin-right: 2vw;
 }
 


### PR DESCRIPTION
Closes #815 by fixing https://github.com/HTTPArchive/almanac.httparchive.org/issues/815#issuecomment-654444252

Ipad:

![Ipad header](https://user-images.githubusercontent.com/10931297/86655714-d7a85680-bfde-11ea-8f7b-0e00e9e28a07.png)

Desktop:

![Desktop header](https://user-images.githubusercontent.com/10931297/86655860-f27acb00-bfde-11ea-99e9-e8eb1010cfed.png)

Table of Contents can still go to two lines on widths of between 900px and 1000px (iPad is 1024px so just misses this):

![Tablet header with two line Table of Contents](https://user-images.githubusercontent.com/10931297/86656908-bb58e980-bfdf-11ea-92eb-d28bcdc29fb9.png)

However with the various languages, we'll need a very wide tablet breakpoint to avoid this completely so think this is acceptable.

Talking of which, this also looks better for French on iPad width (though ToC and Contributors still on two lines, while Methodology is not):

![French iPad header](https://user-images.githubusercontent.com/10931297/86656344-500f1780-bfdf-11ea-83c9-37f4af0e7858.png)

Compared to production:

![French Ipad header on production](https://user-images.githubusercontent.com/10931297/86656222-38d02a00-bfdf-11ea-97c2-6f2b107700de.png)

