### PR TITLE
Fix font size for logo year

### DIFF
--- a/src/static/css/index.css
+++ b/src/static/css/index.css
@@ -116,7 +116,7 @@ p {
 
 .intro-image-wrapper svg {
   position: relative;
-  top: 25px;
+  top: 25.5px;
   fill: #f7f779;
 }
 

--- a/src/static/css/index.css
+++ b/src/static/css/index.css
@@ -116,8 +116,12 @@ p {
 
 .intro-image-wrapper svg {
   position: relative;
-  top: 28px;
+  top: 25px;
   fill: #f7f779;
+}
+
+.intro-image-wrapper img {
+  position: relative;
 }
 
 /* IE11 hack */


### PR DESCRIPTION
As discussed in https://github.com/HTTPArchive/almanac.httparchive.org/pull/954/files#r450474029 we meant to change this to 25px but looks like we never did! So now it overlaps too much:

![Year overlapping logo](https://user-images.githubusercontent.com/10931297/86744113-49a98b80-c031-11ea-9ec5-69b715c7535c.png)

Changing this to `25.5px;` (Firefox seems to need the extra .5), as discussed in the PR review fixes this:

![Less overlap with 25.5px](https://user-images.githubusercontent.com/10931297/86753474-01da3280-c038-11ea-889b-d3dafeac38c7.png)


I also add the `position: relative;` to the `img` so it floats above the year, which makes it look more like it sits on top:

![Text appears to sit on top when image is relative](https://user-images.githubusercontent.com/10931297/86753304-e1aa7380-c037-11ea-958f-fe88d12e2d95.png)


Without `positive: relative;`:
