### PR TITLE
Remove offset for image which is now no longer required

### DIFF
--- a/src/templates/base/2020/index.html
+++ b/src/templates/base/2020/index.html
@@ -45,9 +45,7 @@
   .intro h2 b {
     display: block;
   }
-  .intro-image-wrapper {
-    margin-right: -100px;
-  }
+  
   .methodology-container {
     margin-top: 200px;
     padding: 0;


### PR DESCRIPTION
Fixes bug noticed by @rviscomi https://github.com/HTTPArchive/almanac.httparchive.org/issues/815#issuecomment-654877828

Closes #815 

See - I knew there was a reason I didn't want all that CSS in the 2020 page! 😉