### PR TITLE
Pin requirements version

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,5 @@
-Flask
-flask-talisman
-gunicorn
-pytest
-pytest-watch
+flask==1.1.1
+flask-talisman==0.7.0
+gunicorn==20.0.4
+pytest==4.6.11
+pytest-watch==4.2.0


### PR DESCRIPTION
Following on from #1004 this locks the version numbers in `requirements.txt` to ensure stability. Dependabot will automatically open PRs when they change which we can review before accepting.

I've deliberately set Flask to the older version (1.1.1) as want to test that Dependabot will spot this and suggest 1.1.2. There is nothing we're using in 1.1.2 so this is a safe test, and it checks dependencies daily so should see the upgrade PR shortly after merging this.