### PR TITLE
Add unique id for each section to enable enhanced link tracking

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -20,7 +20,9 @@
               dataLayer.push(arguments);
           }
           gtag('js', new Date());
-          gtag('config', 'UA-22381566-3');
+          gtag('config', 'UA-22381566-3', {
+            'link_attribution': true
+          });
 
           function sendWebVitalsGAEvents(metric) {
             gtag('event', metric.name, {

--- a/src/templates/base/2019/base.html
+++ b/src/templates/base/2019/base.html
@@ -107,7 +107,7 @@
 {% block content%}
   <div id="skiptocontent"><a href="#maincontent">{{ self.skip_navigation() }}</a></div>
   {% block header %}
-  <header class="alt-bg">
+  <header id="header" class="alt-bg">
     <div class="container">
       <div class="top-header">
         <a class="navigation-logo" href="{{ url_for('home', year=year, lang=lang) }}">
@@ -182,7 +182,7 @@
   </div>
 
   {% block footer %}
-    <footer class="alt-bg">
+    <footer id="footer" class="alt-bg">
       <div class="container">
         <div class="home-logo">
           <a class="navigation-logo" href="{{ url_for('home', year=year, lang=lang) }}">

--- a/src/templates/base/2019/base.html
+++ b/src/templates/base/2019/base.html
@@ -113,7 +113,7 @@
         <a class="navigation-logo" href="{{ url_for('home', year=year, lang=lang) }}">
           {{ self.web_almanac_logo() }}
         </a>
-        <nav aria-label="{{ self.page_navigation() }}">
+        <nav id="header-page-navigation" aria-label="{{ self.page_navigation() }}">
           <ul>
             {{ self.non_chapter_nav_links() }}
             <li>
@@ -138,7 +138,7 @@
             <li>
               {{ language_switcher('mobile') }}
             </li>
-            <li class="misc">
+            <li id="mobile-misc" class="misc">
               <ul class="misc">
                 <li>
                   <a href="https://httparchive.org/" aria-labelledby="ha-logo-mobile">
@@ -190,7 +190,7 @@
           </a>
         </div>
         <hr>
-        <nav aria-label="{{ self.footer_title() }}" class="nav-items">
+        <nav id="footer-nav-items" aria-label="{{ self.footer_title() }}" class="nav-items">
           <ul>
             {{ self.non_chapter_nav_links() }}
             <li>
@@ -201,7 +201,7 @@
             </li>
           </ul>
         </nav>
-        <div class="mobile-ha-social-media">
+        <div id="footer-mobile-social-media" class="mobile-ha-social-media">
           <a class="ha-logo" href="https://httparchive.org/" aria-labelledby="httparchive-logo-footer-mobile">
             <svg width="70" height="35" role="img">
               <title id="httparchive-logo-footer-mobile">{{ self.http_archive_link() }}</title>

--- a/src/templates/base/2019/index.html
+++ b/src/templates/base/2019/index.html
@@ -26,7 +26,7 @@
 
 {% block main %}
 <main id="maincontent">
-  <section class="intro-container">
+  <section id="intro" class="intro-container">
     <div class="intro">
       <div class="intro-year">{{ year }}</div>
       <h1 class="title title-lg title-alt">{{ self.intro_title() }}</h1>
@@ -44,7 +44,7 @@
     </div>
   </section>
   {% include "%s/2019/featured_chapters.html" % lang %}
-  <section class="contributors-container alt-bg">
+  <section id="contributors" class="contributors-container alt-bg">
     <div class="contributors">
       <h2 class="title title-alt">{{ self.contributors_title() }}</h2>
       <p>{{ self.contributors_description() }}</p>
@@ -59,7 +59,7 @@
       <img id="character-hat" class="character" src="/static/images/character-hat.png" alt="" width="186" height="207" loading="lazy" />
     </div>
   </section>
-  <section class="methodology-container">
+  <section id="methodology" class="methodology-container">
     <div class="methodology">
       <h2 class="title title-center">{{ self.methodology_title() }}</h2>
       <div class="methodology-data">

--- a/src/templates/base/2020/index.html
+++ b/src/templates/base/2020/index.html
@@ -61,7 +61,7 @@
 
 {% block main %}
 <main id="maincontent">
-  <section class="intro-container">
+  <section id="intro" class="intro-container">
     <div class="intro">
       <div class="intro-year">{{ year }}</div>
       <h1 class="title title-lg title-alt">{{ self.intro_title() }}</h1>
@@ -75,7 +75,7 @@
       <img src="/static/images/home-hero.png" alt="">
     </div>
   </section>
-  <section class="methodology-container">
+  <section id="methodology" class="methodology-container">
     <div class="methodology">
       <img class="methodology-characters" src="/static/images/methodology-characters.png" alt="" width="984" height="354" loading="lazy" />
     </div>

--- a/src/templates/en/2019/featured_chapters.html
+++ b/src/templates/en/2019/featured_chapters.html
@@ -80,7 +80,7 @@
   {%- set featured_chapter_quote = "HTTP/2 was the first major update to the main transport protocol of the web in nearly 20 years. It arrived with a wealth of expectations: it promised a free performance boost with no downsides. More than that, we could stop doing all the hacks and work arounds that HTTP/1.1 forced us into, due to its inefficiencies. Bundling, spriting, inlining, and even sharding domains would all become anti-patterns in an HTTP/2 world, as improved performance would be provided by default. This chapter examines how this relatively new technology has fared in the real world." %}
   {%- set featured_chapter_stats = {"stat1":"95%","label1":"Users who can use HTTP/2","stat2":"27.83%","label2":"Requests with HTTP/2 prioritisation issues","stat3":"8.38%","label3":"Sites supporting QUIC"} %}
 {%- endif %}
-<section class="featured-chapter">
+<section id="featured-chapter" class="featured-chapter">
   <div class="featured-chapter-content">
     <h2 class="title title-center">Featured Chapter</h2>
     <h3>{{ featured_chapter_name }}</h3>

--- a/src/templates/es/2019/featured_chapters.html
+++ b/src/templates/es/2019/featured_chapters.html
@@ -85,7 +85,7 @@
   {%- set featured_chapter_quote = "HTTP/2 was the first major update to the main transport protocol of the web in nearly 20 years. It arrived with a wealth of expectations: it promised a free performance boost with no downsides. More than that, we could stop doing all the hacks and work arounds that HTTP/1.1 forced us into, due to its inefficiencies. Bundling, spriting, inlining, and even sharding domains would all become anti-patterns in an HTTP/2 world, as improved performance would be provided by default. This chapter examines how this relatively new technology has fared in the real world." %}
   {%- set featured_chapter_stats = {"stat1":"95%","label1":"Users who can use HTTP/2","stat2":"27.83%","label2":"Requests with HTTP/2 prioritisation issues","stat3":"8.38%","label3":"Sites supporting QUIC"} %}
 {%- endif %}
-<section class="featured-chapter">
+<section id="featured-chapter" class="featured-chapter">
   <div class="featured-chapter-content">
     <h2 class="title title-center">Capítulo Destacado</h2>
     <h3>{{ featured_chapter_name }}</h3>

--- a/src/templates/fr/2019/featured_chapters.html
+++ b/src/templates/fr/2019/featured_chapters.html
@@ -85,7 +85,7 @@
   {%- set featured_chapter_quote = "HTTP/2 was the first major update to the main transport protocol of the web in nearly 20 years. It arrived with a wealth of expectations: it promised a free performance boost with no downsides. More than that, we could stop doing all the hacks and work arounds that HTTP/1.1 forced us into, due to its inefficiencies. Bundling, spriting, inlining, and even sharding domains would all become anti-patterns in an HTTP/2 world, as improved performance would be provided by default. This chapter examines how this relatively new technology has fared in the real world." %}
   {%- set featured_chapter_stats = {"stat1":"95%","label1":"Users who can use HTTP/2","stat2":"27.83%","label2":"Requests with HTTP/2 prioritisation issues","stat3":"8.38%","label3":"Sites supporting QUIC"} %}
 {%- endif %}
-<section class="featured-chapter">
+<section id="featured-chapter" class="featured-chapter">
   <div class="featured-chapter-content">
     <h2 class="title title-center">Focus sur le chapitre…</h2>
     <h3>{{ featured_chapter_name }}</h3>

--- a/src/templates/ja/2019/featured_chapters.html
+++ b/src/templates/ja/2019/featured_chapters.html
@@ -85,7 +85,7 @@
   {%- set featured_chapter_quote = "HTTP/2は、ほぼ20年ぶりになるWebのメイン送信プロトコルの初となるメジャーアップデートでした。それは多くの期待を持って到来し、欠点なしで無料のパフォーマンス向上を約束しました。それ以上に、HTTP/1.1が非効率なため強制されていたすべてのハックや回避策をやめることができました。デフォルトでパフォーマンスが向上するため、ドメインのバンドル、分割、インライン化、さらにはシャーディングなどはすべてHTTP/2の世界でアンチパターンになります。" %}
   {%- set featured_chapter_stats = {"stat1":"95%","label1":"HTTP/2を使用できるグローバルユーザーの割合。","stat2":"27.83%","label2":"準最適なHTTP/2優先順位付けによるモバイル要求の割合。","stat3":"8.38%","label3":"QUICをサポートするモバイルサイトの割合。"} %}
 {%- endif %}
-<section class="featured-chapter">
+<section id="featured-chapter" class="featured-chapter">
   <div class="featured-chapter-content">
     <h2 class="title title-center">注目の章</h2>
     <h3>{{ featured_chapter_name }}</h3>


### PR DESCRIPTION
Adds a unique id to each home page section and enables [enhanced link attribution](https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-link-attribution), which allows us to see what bits of the home page people are actually clicking through the [Page Analytics Chrome Extension](https://support.google.com/analytics/answer/6047802?visit_id=637302587569733211-4025833548&rd=1#enable) as discussed in https://github.com/HTTPArchive/almanac.httparchive.org/issues/1016#issuecomment-657687326. Note this extension is deprecated but still works.

@rviscomi can you enable this in Google Analytics Admin screen? It's under the Property->Property Settings about half way down.

![Enabling ELA in GA](https://user-images.githubusercontent.com/10931297/87337376-3b7cd300-c53b-11ea-9488-10b8f0c5f5d3.png)
