### PR TITLE
Swap language and year dropdown in nav

### DIFF
--- a/src/templates/base/2019/base.html
+++ b/src/templates/base/2019/base.html
@@ -117,10 +117,10 @@
           <ul>
             {{ self.non_chapter_nav_links() }}
             <li>
-              {{ year_switcher('header') }}
+              {{ language_switcher('header') }}
             </li>
             <li>
-              {{ language_switcher('header') }}
+              {{ year_switcher('header') }}
             </li>
           </ul>
         </nav>
@@ -300,12 +300,12 @@
           toggleNavMenu();
           event.stopPropagation();
         });
-        
+
         /* Add a click listener to menu so when it's open it swallows click to avoid above click closing it */
         menuNav.addEventListener('click', function () {
           event.stopPropagation();
         });
-        
+
         menuNav.addEventListener('keydown', function (event) {
           if (event.key === 'Escape') {
             if (menuBtn.getAttribute('aria-expanded') === 'true') {
@@ -388,14 +388,14 @@
 
   var indexBox = document.querySelector('.index-box');
   var indexBoxTitle = document.querySelector('.index .index-btn');
-  
+
   indexBoxTitle.addEventListener('click', function(e) {
     var indexOpen = indexBox.classList.toggle('show');
     indexBoxTitle.setAttribute('aria-expanded',indexOpen);
     var ariaLabel = indexOpen ?  "{{ self.close_the_index() }}" : "{{ self.open_the_index() }}";
     indexBoxTitle.setAttribute('aria-label',ariaLabel);
   });
-  
+
   indexBox.addEventListener("keydown", function onPress(event) {
     if (event.key === 'Escape') {
       if (indexBoxTitle.getAttribute('aria-expanded') === 'true') {

--- a/src/templates/base/2019/base.html
+++ b/src/templates/base/2019/base.html
@@ -133,10 +133,10 @@
           <ul class="menu">
             {{ self.non_chapter_nav_links() }}
             <li>
-              {{ year_switcher('mobile') }}
+              {{ language_switcher('mobile') }}
             </li>
             <li>
-              {{ language_switcher('mobile') }}
+              {{ year_switcher('mobile') }}
             </li>
             <li id="mobile-misc" class="misc">
               <ul class="misc">
@@ -194,10 +194,10 @@
           <ul>
             {{ self.non_chapter_nav_links() }}
             <li>
-              {{ year_switcher('footer') }}
+              {{ language_switcher('footer') }}
             </li>
             <li>
-              {{ language_switcher('footer') }}
+              {{ year_switcher('footer') }}
             </li>
           </ul>
         </nav>


### PR DESCRIPTION

This change is related to #1015 in effort to swap the positions of language and year
selector dropdowns in nav

This is sort of a prerequisite for #986 where we attempt to style these dropdowns

Verified the change in header, footer and mobile view

<img width="1680" alt="Screenshot 2020-07-14 at 7 42 52 PM" src="https://user-images.githubusercontent.com/10291571/87437020-69314d00-c60b-11ea-9371-fd746bec9d2a.png">

<img width="1678" alt="Screenshot 2020-07-14 at 7 55 11 PM" src="https://user-images.githubusercontent.com/10291571/87437444-f674a180-c60b-11ea-9e38-91cbedc8b32a.png">

<img width="400" alt="Screenshot 2020-07-14 at 7 54 49 PM" src="https://user-images.githubusercontent.com/10291571/87437503-07bdae00-c60c-11ea-8719-98361463d969.png">

