### PR TITLE
CSP for Sitemap

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -247,6 +247,11 @@ def sitemap():
     xml = render_template('sitemap.xml')
     resp = app.make_response(xml)
     resp.mimetype = "text/xml"
+    # Chrome and Safari use inline styles to display XMLs files.
+    # https://bugs.chromium.org/p/chromium/issues/detail?id=924962
+    # Override default CSP (including turning off nonce) to allow sitemap to display
+    talisman.content_security_policy_nonce_in=[]
+    talisman.content_security_policy = {'default-src': ['\'self\''], 'style-src': ['\'unsafe-inline\''],'img-src': ['\'self\'','data:']}
     return resp
 
 


### PR DESCRIPTION
In #1010 we removed `unsafe-inline` from our `style-src` in our Content Security Policy.

However, annoyingly [Chrome uses inline styles to display XMLs files](https://bugs.chromium.org/p/chromium/issues/detail?id=924962) so they look busted with this, which caused me a mild panic when about to release the site! Seems to affect Safari too but not Firefox.

It's only a display issue but still - it's annoying, so this PR overrides the default CSP (including turning off nonce otherwise `unsafe-inline` is ignored) to the minimal necessary CSP to allow sitemap to display properly.