### PR TITLE
Add dimensions to Home Page Hero Image

### DIFF
--- a/src/templates/base/2019/index.html
+++ b/src/templates/base/2019/index.html
@@ -40,7 +40,7 @@
       <svg viewBox="0 0 50 16">
         <text x="7" y="15">{{ year }}</text>
       </svg>      
-      <img src="/static/images/home-hero.png" alt="">
+      <img src="/static/images/home-hero.png" alt="" width="562" height="820">
     </div>
   </section>
   {% include "%s/2019/featured_chapters.html" % lang %}

--- a/src/templates/base/2020/index.html
+++ b/src/templates/base/2020/index.html
@@ -73,7 +73,7 @@
       <svg viewBox="0 0 56 16">
         <text x="8" y="15">{{ year }}</text>
       </svg>
-      <img src="/static/images/home-hero.png" alt="">
+      <img src="/static/images/home-hero.png" alt="" width="562" height="820">
     </div>
   </section>
   <section id="methodology" class="methodology-container">


### PR DESCRIPTION
Just noticed dimensions not set on Home Page Hero Image which is [bad for performance](https://www.smashingmagazine.com/2020/03/setting-height-width-images-important-again/).