### PR TITLE
Reorganise HEAD to load CSS as quickly as possible

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -11,7 +11,7 @@
     {% endblock %}
     <link rel="shortcut icon" href="/static/images/favicon.ico">
     <link rel="apple-touch-icon" href="/static/images/apple-touch-icon.png">
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-22381566-3" nonce="{{ csp_nonce() }}"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-22381566-3"></script>
     <script nonce="{{ csp_nonce() }}">
         window.dataLayer = window.dataLayer || [];
         function gtag() {

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -3,50 +3,31 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    {% block head %}
+      <title>{% block title %}The Web Almanac{% endblock %}</title>
+      <link rel="stylesheet" href="/static/css/normalize.css?v=20200630133215">
+      {% block styles %}{% endblock %}
+      <link rel="stylesheet" media="print" href="/static/css/print.css?v=20200630133215">
+    {% endblock %}
+    <link rel="shortcut icon" href="/static/images/favicon.ico">
+    <link rel="apple-touch-icon" href="/static/images/apple-touch-icon.png">
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-22381566-3" nonce="{{ csp_nonce() }}"></script>
+    <script nonce="{{ csp_nonce() }}">
+        window.dataLayer = window.dataLayer || [];
+        function gtag() {
+            dataLayer.push(arguments);
+        }
+        gtag('js', new Date());
+        gtag('config', 'UA-22381566-3', {
+          'link_attribution': true
+        });
+    </script>
     {%- if request.url_root != "https://almanac.httparchive.org/" %}
     <meta name="robots" content="noindex">
     {%- endif %}
     {% block meta %}
       <meta property="og:title" content="{{ self.title() }}">
       <meta property="og:image" content="/static/images/ha.png">
-    {% endblock %}
-    {% block head %}
-      <title>{% block title %}The Web Almanac{% endblock %}</title>
-      <script async src="https://www.googletagmanager.com/gtag/js?id=UA-22381566-3" nonce="{{ csp_nonce() }}"></script>
-      <script async src="/static/js/web-vitals.js" ></script>
-      <script nonce="{{ csp_nonce() }}">
-          window.dataLayer = window.dataLayer || [];
-          function gtag() {
-              dataLayer.push(arguments);
-          }
-          gtag('js', new Date());
-          gtag('config', 'UA-22381566-3', {
-            'link_attribution': true
-          });
-
-          function sendWebVitalsGAEvents(metric) {
-            gtag('event', metric.name, {
-              event_category: 'Web Vitals',
-              value: Math.round(metric.name === 'CLS' ? metric.delta * 1000 : metric.delta),
-              event_label: metric.id,
-              non_interaction: true,
-            });
-          }
-
-          window.addEventListener('load', function() {
-            webVitals.getFCP(sendWebVitalsGAEvents);
-            webVitals.getLCP(sendWebVitalsGAEvents);
-            webVitals.getCLS(sendWebVitalsGAEvents);
-            webVitals.getTTFB(sendWebVitalsGAEvents);
-            webVitals.getFID(sendWebVitalsGAEvents);
-          });
-
-      </script>
-      <link rel="shortcut icon" href="/static/images/favicon.ico">
-      <link rel="apple-touch-icon" href="/static/images/apple-touch-icon.png">
-      <link rel="stylesheet" href="/static/css/normalize.css?v=20200630133215">
-      {% block styles %}{% endblock %}
-      <link rel="stylesheet" media="print" href="/static/css/print.css?v=20200630133215">
     {% endblock %}
     <link rel="canonical" href="https://almanac.httparchive.org{{ url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}" />
     {% if supported_languages | length > 1%}
@@ -92,5 +73,28 @@
       </symbol>
     </svg>
     {% block content %}{% endblock %}
+
+    {% block bodyend %}
+    <script defer src="/static/js/web-vitals.js" ></script>
+    <script nonce="{{ csp_nonce() }}">
+        function sendWebVitalsGAEvents(metric) {
+          gtag('event', metric.name, {
+            event_category: 'Web Vitals',
+            value: Math.round(metric.name === 'CLS' ? metric.delta * 1000 : metric.delta),
+            event_label: metric.id,
+            non_interaction: true,
+          });
+        }
+
+        window.addEventListener('load', function() {
+          webVitals.getFCP(sendWebVitalsGAEvents);
+          webVitals.getLCP(sendWebVitalsGAEvents);
+          webVitals.getCLS(sendWebVitalsGAEvents);
+          webVitals.getTTFB(sendWebVitalsGAEvents);
+          webVitals.getFID(sendWebVitalsGAEvents);
+        });
+
+    </script>
+    {% endblock %}
   </body>
 </html>


### PR DESCRIPTION
Happened to notice that the Web Vitals script we added in #944 is the first thing loaded in our page:

![WebPageTest loading of home page](https://user-images.githubusercontent.com/10931297/87578689-b0cbdd80-c6cc-11ea-896f-aae752c97384.png)

Now it's not a big script, but still - it's not used until after the page loads so definitely doesn't need to be first. It is also `async` when I think `defer` is sufficient [and is recommended](https://github.com/GoogleChrome/web-vitals#load-web-vitals-from-a-cdn).

This made me have a bigger look at our `<HEAD>` and seems all in the wrong order. So reorganised it a bit better.

I've left Google Analytics call in the head as per advice from Google, but not 100% convinced it needs to be there, and tempted to move it to the end of the page. Still, as it requires another connection, and that takes time, it doesn't really change page load.