### PR TITLE
Move contribution info to own file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+There are several ways to contribute to the Web Almanac:
+
+**[Authors](https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide)** are subject matter experts and lead the content direction for each chapter. Chapters typically have one or two authors. Authors are responsible for planning the outline of the chapter, analyzing stats and trends, and writing the annual report.
+
+**[Reviewers](https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Reviewers'-Guide)** are also subject matter experts and assist authors with technical reviews during the planning, analyzing, and writing phases.
+
+**[Analysts](https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Analysts'-Guide)** are responsible for researching the stats and trends used throughout the Almanac. Analysts work closely with authors and reviewers during the planning phase to give direction on the types of stats that are possible from the dataset, and during the analyzing/writing phases to ensure that the stats are used correctly.
+
+**[Developers](https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Developers'-Guide)** are responsible for the technical infrastructure of the website and solve complex problems about accessibility, performance, internationalization, SEO, and more.
+
+**[Editors](https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Editors'-Guide)** are technical writers who have a penchant for both technical and non-technical content correctness. Editors have a mastery of the English language and work closely with authors to help wordsmith content and ensure that everything fits together as a cohesive unit.
+
+**[Translators](https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Translators'-Guide)** are technical writers who help internationalize the Almanac and make it globally accessible to the web community.
+
+## Diversity and inclusion
+
+We strive to make the Web Almanac a diverse and inclusive project. If you bring a unique perspective, we want to hear from you. Members of the web community that bring a valuable set of diverse perspectives from underrepresented groups or those with unique experiences like standards work or browser/framework development are highly encouraged to participate, especially as content authors and reviewers.
+
+If you're interested in contributing to the project, please follow the links above.

--- a/README.md
+++ b/README.md
@@ -12,25 +12,7 @@ The 2019 Web Almanac is available in:
 
 ## Contributing
 
-There are several ways to contribute to the Web Almanac:
-
-**[Authors](https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide)** are subject matter experts and lead the content direction for each chapter. Chapters typically have one or two authors. Authors are responsible for planning the outline of the chapter, analyzing stats and trends, and writing the annual report.
-
-**[Reviewers](https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Reviewers'-Guide)** are also subject matter experts and assist authors with technical reviews during the planning, analyzing, and writing phases.
-
-**[Analysts](https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Analysts'-Guide)** are responsible for researching the stats and trends used throughout the Almanac. Analysts work closely with authors and reviewers during the planning phase to give direction on the types of stats that are possible from the dataset, and during the analyzing/writing phases to ensure that the stats are used correctly.
-
-**[Developers](https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Developers'-Guide)** are responsible for the technical infrastructure of the website and solve complex problems about accessibility, performance, internationalization, SEO, and more.
-
-**[Editors](https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Editors'-Guide)** are technical writers who have a penchant for both technical and non-technical content correctness. Editors have a mastery of the English language and work closely with authors to help wordsmith content and ensure that everything fits together as a cohesive unit.
-
-**[Translators](https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Translators'-Guide)** are technical writers who help internationalize the Almanac and make it globally accessible to the web community.
-
-### Diversity and inclusion
-
-We strive to make the Web Almanac a diverse and inclusive project. If you bring a unique perspective, we want to hear from you. Members of the web community that bring a valuable set of diverse perspectives from underrepresented groups or those with unique experiences like standards work or browser/framework development are highly encouraged to participate, especially as content authors and reviewers.
-
-If you're interested in contributing to the project, please follow the links above.
+See [our contributing guide](CONTRIBUTING.md).
 
 ## 2020 Timeline
 


### PR DESCRIPTION
GitHub encourages having a CONTRIBUTING.md file, so I split that out of the default README.