### PR TITLE
Fix bug where code block causes scrolling issues on mobile

### DIFF
--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -643,7 +643,7 @@ figure .fig-desktop {
   left: -1rem;
 }
 
-.code-block pre {
+.code-block, pre {
   overflow-y: hidden;
   overflow-x: auto;
   margin: 8px 0;


### PR DESCRIPTION
Noticed an overflow issues on mobile for code blocks:

![Code snipper overflowing text on mobile](https://user-images.githubusercontent.com/10931297/87829228-7f8f1100-c876-11ea-8edd-50bbd9bcaaf8.png)

Looks to have been caused by #939 where I removed duplicate code that wasn't actually duplicate!

This code removed:

![Code snippet with an all important comma](https://user-images.githubusercontent.com/10931297/87829385-e44a6b80-c876-11ea-90e7-8245aa7a6031.png)

Is not same as code, that I thought was duplicate!

![Same code without comma](https://user-images.githubusercontent.com/10931297/87829421-f75d3b80-c876-11ea-91fa-e3c0bb5258a7.png)



https://github.com/bazzadp/almanac.httparchive.org/blob/c0eb5425d44b353bd7a01cbc427f9348a011f88a/src/static/css/page.css#L580-L585
