### PR TITLE
Refactoring, sorting, and enhancing progress report

### DIFF
--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -213,7 +213,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: trackerIssueNumber,
-              body: progressContent.replace(/<!-- REPORT START -->[\s\S]*<!-- REPORT END -->/, `<!-- REPORT START -->\n${report}\n\n${stats}\n\n<details><summary>Contributors</summary>\n\n${teams}\n</details>\n<!-- REPORT END -->`)
+              body: progressContent.replace(/<!-- REPORT START -->[\s\S]*<!-- REPORT END -->/, `<!-- REPORT START -->\n${report}\n\n${stats}\n\n<details><summary><b>Contributor Details</b></summary>\n\n${teams}\n</details>\n<!-- REPORT END -->`)
             })
 
             core.info(`Updated report in issue #${trackerIssueNumber} with ${chapters.length} chapters`)

--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -28,6 +28,18 @@ jobs:
             const totalTrackedTasks = parseInt(process.env.TOTAL_TRACKED_TASKS, 10)
             const sqlBaseDir = process.env.SQL_BASE_DIR
 
+            const icons = {
+              draft: '📄',
+              sql: '🔍',
+              results: '📊'
+            }
+
+            const linkMap = {
+              draft: /^\[~draft-doc\]:\s*(?<link>\S+)/,
+              sql: /^\[~sql-dir\]:\s*(?<link>\S+)/,
+              results: /^\[~results-sheet\]:\s*(?<link>\S+)/
+            }
+
             const parseTasks = text => {
               const tasks = []
               text.split('\n').forEach(line => {
@@ -44,11 +56,6 @@ jobs:
             const parseLinks = text => {
               const links = {}
               text.split('\n').forEach(line => {
-                const linkMap = {
-                  draft: /^\[~draft-doc\]:\s*(?<link>\S+)/,
-                  sql: /^\[~sql-dir\]:\s*(?<link>\S+)/,
-                  results: /^\[~results-sheet\]:\s*(?<link>\S+)/
-                }
                 for (const [k, v] of Object.entries(linkMap)) {
                   const m = line.match(v)
                   if (m) {
@@ -57,6 +64,11 @@ jobs:
                 }
               })
               return links
+            }
+
+            const parseHeading = text => {
+              const m = text.match(/^#\s+Part\s+(?<part>\S+)\s+Chapter\s+(?<number>\S+)\s*:\s*(?<title>.+)/)
+              return m ? m.groups : {part: '', number: '', title: ''}
             }
 
             const parseUserNames = members => {
@@ -77,16 +89,15 @@ jobs:
             }
 
             const formatLinks = links => {
-              const icons = {
-                draft: '📄',
-                sql: '🔍',
-                results: '📊'
-              }
               return Object.entries(links).filter(l => !['#', sqlBaseDir].includes(l[1])).map(l => `[${icons[l[0]] || l[0]}](${l[1]})`).join(' ')
             }
 
             const formatTeam = team => {
               return Object.entries(team).map(([k, v]) => `<span title="${k}: ${v.length ? v.join(', ') : 'TBD'}">${v.length}</span>`).join('/')
+            }
+
+            const formatRow = chapter => {
+              return `${chapter.number ? `<span title="Part: ${chapter.part}, Chapter: ${chapter.number}">${chapter.number}</span> - ` : ''}[${chapter.title}](${chapter.url}) | ${formatLinks(chapter.links)} | ${formatTeam(chapter.team)} | ${chapter.tasks.join(' | ')}`
             }
 
             const taskIssues = await github.paginate(github.issues.listForRepo, {
@@ -96,8 +107,7 @@ jobs:
               labels: filterLabel
             })
 
-            let report = ''
-            let chapters = 0
+            let chapters = []
             for (const issue of taskIssues) {
               const tasksStatus = parseTasks(issue.body)
               const tasksCount = tasksStatus.length
@@ -105,16 +115,31 @@ jobs:
                 core.info(`Skipping issue #${issue.number} with ${tasksCount} instead of ${totalTrackedTasks} tasks`)
                 continue
               }
-              if(!report) {
-                report = `Chapters | Links | Team | ${tasksStatus.map((v, i) => i + 1).join(' | ')}\n`
-                report += `:--------|:------|:----:|:${tasksStatus.map(() => '-').join(':|:')}:\n`
-              }
-              const links = formatLinks(parseLinks(issue.body))
-              const team = formatTeam(parseTeam(issue.body))
               core.info(`Adding issue #${issue.number} with ${tasksCount} tasks`)
-              chapters++
-              report += `[${issue.title.replace(/\s+\d+$/, '')}](${issue.html_url}) | ${links} | ${team} | ${tasksStatus.join(' | ')}\n`
+              const heading = parseHeading(issue.body)
+              chapters.push({
+                id: issue.number,
+                url: issue.html_url,
+                title: heading.title || issue.title,
+                part: heading.part,
+                number: heading.number,
+                links: parseLinks(issue.body),
+                team: parseTeam(issue.body),
+                tasks: tasksStatus
+              })
             }
+
+            if(!chapters.length) {
+              core.info(`Nothing to report`)
+              return
+            }
+
+            chapters.sort((a, b) => a.number.localeCompare(b.number, undefined, {numeric: true}))
+
+            const report = [
+              `Chapters | Links | Team | ${Array(totalTrackedTasks).fill().map((v, i) => i + 1).join(' | ')}`,
+              `:--------|:------|:----:${'|:-:'.repeat(totalTrackedTasks)}`
+            ].concat(chapters.map(formatRow)).join('\n')
 
             const progressIssue = await github.issues.get({
               owner: context.repo.owner,
@@ -128,4 +153,5 @@ jobs:
               issue_number: trackerIssueNumber,
               body: progressIssue.data.body.replace(/<!-- REPORT START -->[\s\S]*<!-- REPORT END -->/, `<!-- REPORT START -->\n${report}<!-- REPORT END -->`)
             })
-            core.info(`Updated report in issue #${trackerIssueNumber} with ${chapters} chapters`)
+
+            core.info(`Updated report in issue #${trackerIssueNumber} with ${chapters.length} chapters`)

--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -4,7 +4,6 @@ env:
   # Update these environment variables every year
   FILTER_LABEL: '2020 chapter'
   TRACKER_ISSUE_NUMBER: 989
-  TOTAL_TRACKED_TASKS: 10
   SQL_BASE_DIR: 'https://github.com/HTTPArchive/almanac.httparchive.org/tree/main/sql/2020/'
 
 on:
@@ -25,7 +24,6 @@ jobs:
           script: |
             const filterLabel = process.env.FILTER_LABEL
             const trackerIssueNumber = process.env.TRACKER_ISSUE_NUMBER
-            const totalTrackedTasks = parseInt(process.env.TOTAL_TRACKED_TASKS, 10)
             const sqlBaseDir = process.env.SQL_BASE_DIR
 
             const icons = {
@@ -45,6 +43,33 @@ jobs:
               Reviewers: {},
               Analysts: {}
             }
+
+            const parseListItems = text => {
+              const items = []
+              text.split('\n').forEach(line => {
+                const m = line.trim().match(/^([*+-]|\d+\.)\s+(?<item>.+)/)
+                if (m) {
+                  items.push(m.groups.item)
+                }
+              })
+              return items
+            }
+
+            const progressIssue = await github.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: trackerIssueNumber
+            })
+            const progressContent = progressIssue.data.body
+
+            const m = progressContent.match(/<!-- TASKS BEGIN -->(?<tasks>[\s\S]*)<!-- TASKS END -->/)
+            if (!m) {
+              core.info(`Tasks list marker not found in issue #${trackerIssueNumber}, add list of tracked tasks as: <!-- TASKS BEGIN -->TRACKED TASKS LIST<!-- TASKS END -->`)
+              return
+            }
+            const trackedTasks = parseListItems(m.groups.tasks)
+            const totalTrackedTasks = trackedTasks.length
+            core.info(`Tracking progress of ${totalTrackedTasks} tasks across chapters`)
 
             const parseTasks = text => {
               const tasks = []
@@ -151,7 +176,7 @@ jobs:
             })
 
             const report = [
-              `Chapters | <span title="${Object.entries(icons).map(([k, v]) => `${v} (${k})`).join(', ')}">Links</span> | <span title="${Object.keys(teamMembers).join('/')}">Team</span> | ${Array(totalTrackedTasks).fill().map((v, i) => i + 1).join(' | ')}`,
+              `Chapters | <span title="${Object.entries(icons).map(([k, v]) => `${v} (${k})`).join(', ')}">Links</span> | <span title="${Object.keys(teamMembers).join('/')}">Team</span> | ${trackedTasks.map((v, i) => `<span title="${v}">${i + 1}<span>`).join(' | ')}`,
               `:--------|:------|:----:${'|:-:'.repeat(totalTrackedTasks)}`
             ].concat(chapters.map(formatRow)).join('\n')
 
@@ -159,17 +184,11 @@ jobs:
               return `*${k} (${Object.keys(v).length})*: ${Object.entries(v).sort().map(([m, c]) => `<span title="Chapters: ${c.join(', ')}">@${m} (${c.length})</span>`).join(', ')}`
             }).join('\n\n')
 
-            const progressIssue = await github.issues.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: trackerIssueNumber
-            })
-
             github.issues.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: trackerIssueNumber,
-              body: progressIssue.data.body.replace(/<!-- REPORT START -->[\s\S]*<!-- REPORT END -->/, `<!-- REPORT START -->\n${report}\n\n${teams}\n<!-- REPORT END -->`)
+              body: progressContent.replace(/<!-- REPORT START -->[\s\S]*<!-- REPORT END -->/, `<!-- REPORT START -->\n${report}\n\n${teams}\n<!-- REPORT END -->`)
             })
 
             core.info(`Updated report in issue #${trackerIssueNumber} with ${chapters.length} chapters`)

--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -181,14 +181,14 @@ jobs:
             ].concat(chapters.map(formatRow)).join('\n')
 
             const teams = Object.entries(teamMembers).map(([k, v]) => {
-              return `*${k} (${Object.keys(v).length})*: ${Object.entries(v).sort().map(([m, c]) => `<span title="Chapters: ${c.join(', ')}">${m} (${c.length})</span>`).join(', ')}`
+              return `### ${k} (${Object.keys(v).length})\n\n${Object.entries(v).sort().map(([m, c]) => `<span title="Chapters: ${c.join(', ')}">${m} (${c.length})</span>`).join(', ')}`
             }).join('\n\n')
 
             github.issues.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: trackerIssueNumber,
-              body: progressContent.replace(/<!-- REPORT START -->[\s\S]*<!-- REPORT END -->/, `<!-- REPORT START -->\n${report}\n\n${teams}\n<!-- REPORT END -->`)
+              body: progressContent.replace(/<!-- REPORT START -->[\s\S]*<!-- REPORT END -->/, `<!-- REPORT START -->\n${report}\n\n<details><summary>Contributors</summary>\n\n${teams}\n</details>\n<!-- REPORT END -->`)
             })
 
             core.info(`Updated report in issue #${trackerIssueNumber} with ${chapters.length} chapters`)

--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -71,6 +71,21 @@ jobs:
             const totalTrackedTasks = trackedTasks.length
             core.info(`Tracking progress of ${totalTrackedTasks} tasks across chapters`)
 
+            const stats = nums => {
+              if (!nums.length) {
+                return [0, 0, 0, 0, 0]
+              }
+              nums.sort((a, b) => a - b)
+              const half = Math.floor(nums.length / 2)
+              return [
+                nums.reduce((a,b) => a + b, 0),
+                Math.min(...nums),
+                Math.max(...nums),
+                nums.reduce((a,b) => a + b, 0) / nums.length,
+                nums.length % 2 ? nums[half] : (nums[half - 1] + nums[half]) / 2.0
+              ]
+            }
+
             const parseTasks = text => {
               const tasks = []
               text.split('\n').forEach(line => {

--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -181,7 +181,7 @@ jobs:
             ].concat(chapters.map(formatRow)).join('\n')
 
             const teams = Object.entries(teamMembers).map(([k, v]) => {
-              return `*${k} (${Object.keys(v).length})*: ${Object.entries(v).sort().map(([m, c]) => `<span title="Chapters: ${c.join(', ')}">@${m} (${c.length})</span>`).join(', ')}`
+              return `*${k} (${Object.keys(v).length})*: ${Object.entries(v).sort().map(([m, c]) => `<span title="Chapters: ${c.join(', ')}">${m} (${c.length})</span>`).join(', ')}`
             }).join('\n\n')
 
             github.issues.update({

--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -29,15 +29,15 @@ jobs:
             const sqlBaseDir = process.env.SQL_BASE_DIR
 
             const icons = {
-              draft: '📄',
-              sql: '🔍',
-              results: '📊'
+              Draft: '📄',
+              SQL: '🔍',
+              Results: '📊'
             }
 
             const linkMap = {
-              draft: /^\[~draft-doc\]:\s*(?<link>\S+)/,
-              sql: /^\[~sql-dir\]:\s*(?<link>\S+)/,
-              results: /^\[~results-sheet\]:\s*(?<link>\S+)/
+              Draft: /^\[~draft-doc\]:\s*(?<link>\S+)/,
+              SQL: /^\[~sql-dir\]:\s*(?<link>\S+)/,
+              Results: /^\[~results-sheet\]:\s*(?<link>\S+)/
             }
 
             const parseTasks = text => {
@@ -136,10 +136,13 @@ jobs:
 
             chapters.sort((a, b) => a.number.localeCompare(b.number, undefined, {numeric: true}))
 
-            const report = [
+            let report = [
               `Chapters | Links | Team | ${Array(totalTrackedTasks).fill().map((v, i) => i + 1).join(' | ')}`,
               `:--------|:------|:----:${'|:-:'.repeat(totalTrackedTasks)}`
             ].concat(chapters.map(formatRow)).join('\n')
+
+            report += `\n\n**Links** = ${Object.entries(icons).map(([k, v]) => `${v} (${k})`).join(', ')}\n**Team** = Authors/Reviewers/Analysts`
+            report += '\n\n✨ This issue is automatically maintained by [progress-tracker.yml](https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/.github/workflows/progress-tracker.yml) ✨'
 
             const progressIssue = await github.issues.get({
               owner: context.repo.owner,
@@ -151,7 +154,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: trackerIssueNumber,
-              body: progressIssue.data.body.replace(/<!-- REPORT START -->[\s\S]*<!-- REPORT END -->/, `<!-- REPORT START -->\n${report}<!-- REPORT END -->`)
+              body: progressIssue.data.body.replace(/<!-- REPORT START -->[\s\S]*<!-- REPORT END -->/, `<!-- REPORT START -->\n${report}\n<!-- REPORT END -->`)
             })
 
             core.info(`Updated report in issue #${trackerIssueNumber} with ${chapters.length} chapters`)

--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -71,7 +71,7 @@ jobs:
             const totalTrackedTasks = trackedTasks.length
             core.info(`Tracking progress of ${totalTrackedTasks} tasks across chapters`)
 
-            const stats = nums => {
+            const calcStats = nums => {
               if (!nums.length) {
                 return [0, 0, 0, 0, 0]
               }
@@ -81,8 +81,8 @@ jobs:
                 nums.reduce((a,b) => a + b, 0),
                 Math.min(...nums),
                 Math.max(...nums),
-                nums.reduce((a,b) => a + b, 0) / nums.length,
-                nums.length % 2 ? nums[half] : (nums[half - 1] + nums[half]) / 2.0
+                (nums.reduce((a,b) => a + b, 0) / nums.length).toFixed(2),
+                (nums.length % 2 ? nums[half] : (nums[half - 1] + nums[half]) / 2.0).toFixed(2)
               ]
             }
 
@@ -180,6 +180,11 @@ jobs:
               return
             }
 
+            const teamStats = {}
+            Object.keys(teamMembers).forEach(t => {
+              teamStats[t] = calcStats(chapters.map(c => (c.team[t] || []).length))
+            })
+
             chapters.sort((a, b) => a.number.localeCompare(b.number, undefined, {numeric: true}))
 
             chapters.forEach(c => {
@@ -195,6 +200,11 @@ jobs:
               `:--------|:------|:----:${'|:-:'.repeat(totalTrackedTasks)}`
             ].concat(chapters.map(formatRow)).join('\n')
 
+            const stats = [
+              'Contributor Stats | Total | Min | Max | Mean | Median',
+              ':-----------------|------:|----:|----:|-----:|------:'
+            ].concat(Object.entries(teamStats).map(([k, v]) => `${k} | ${v.join(' | ')}`)).join('\n')
+
             const teams = Object.entries(teamMembers).map(([k, v]) => {
               return `### ${k} (${Object.keys(v).length})\n\n${Object.entries(v).sort().map(([m, c]) => `<span title="Chapters: ${c.join(', ')}">${m} (${c.length})</span>`).join(', ')}`
             }).join('\n\n')
@@ -203,7 +213,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: trackerIssueNumber,
-              body: progressContent.replace(/<!-- REPORT START -->[\s\S]*<!-- REPORT END -->/, `<!-- REPORT START -->\n${report}\n\n<details><summary>Contributors</summary>\n\n${teams}\n</details>\n<!-- REPORT END -->`)
+              body: progressContent.replace(/<!-- REPORT START -->[\s\S]*<!-- REPORT END -->/, `<!-- REPORT START -->\n${report}\n\n${stats}\n\n<details><summary>Contributors</summary>\n\n${teams}\n</details>\n<!-- REPORT END -->`)
             })
 
             core.info(`Updated report in issue #${trackerIssueNumber} with ${chapters.length} chapters`)

--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -136,13 +136,10 @@ jobs:
 
             chapters.sort((a, b) => a.number.localeCompare(b.number, undefined, {numeric: true}))
 
-            let report = [
-              `Chapters | Links | Team | ${Array(totalTrackedTasks).fill().map((v, i) => i + 1).join(' | ')}`,
+            const report = [
+              `Chapters | <span title="${Object.entries(icons).map(([k, v]) => `${v} (${k})`).join(', ')}">Links</span> | <span title="Authors/Reviewers/Analysts">Team</span> | ${Array(totalTrackedTasks).fill().map((v, i) => i + 1).join(' | ')}`,
               `:--------|:------|:----:${'|:-:'.repeat(totalTrackedTasks)}`
             ].concat(chapters.map(formatRow)).join('\n')
-
-            report += `\n\n**Links** = ${Object.entries(icons).map(([k, v]) => `${v} (${k})`).join(', ')}\n**Team** = Authors/Reviewers/Analysts`
-            report += '\n\n✨ This issue is automatically maintained by [progress-tracker.yml](https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/.github/workflows/progress-tracker.yml) ✨'
 
             const progressIssue = await github.issues.get({
               owner: context.repo.owner,

--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -128,7 +128,7 @@ jobs:
             }
 
             const formatRow = chapter => {
-              return `${chapter.number ? `<span title="Part: ${chapter.part}, Chapter: ${chapter.number}">${chapter.number}</span> - ` : ''}[${chapter.title}](${chapter.url}) | ${formatLinks(chapter.links)} | ${formatTeam(chapter.team)} | ${chapter.tasks.join(' | ')}`
+              return `${chapter.number ? `<span title="Part: ${chapter.part}, Chapter: ${chapter.number}">${chapter.number}</span>. ` : ''}[${chapter.title}](${chapter.url}) | ${formatLinks(chapter.links)} | ${formatTeam(chapter.team)} | ${chapter.tasks.join(' | ')}`
             }
 
             const taskIssues = await github.paginate(github.issues.listForRepo, {

--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -40,6 +40,12 @@ jobs:
               Results: /^\[~results-sheet\]:\s*(?<link>\S+)/
             }
 
+            const teamMembers = {
+              Authors: {},
+              Reviewers: {},
+              Analysts: {}
+            }
+
             const parseTasks = text => {
               const tasks = []
               text.split('\n').forEach(line => {
@@ -136,10 +142,22 @@ jobs:
 
             chapters.sort((a, b) => a.number.localeCompare(b.number, undefined, {numeric: true}))
 
+            chapters.forEach(c => {
+              Object.entries(c.team).forEach(([k, v]) => {
+                v.forEach(m => {
+                  teamMembers[k][m] = (teamMembers[k][m] || []).concat(c.title)
+                })
+              })
+            })
+
             const report = [
-              `Chapters | <span title="${Object.entries(icons).map(([k, v]) => `${v} (${k})`).join(', ')}">Links</span> | <span title="Authors/Reviewers/Analysts">Team</span> | ${Array(totalTrackedTasks).fill().map((v, i) => i + 1).join(' | ')}`,
+              `Chapters | <span title="${Object.entries(icons).map(([k, v]) => `${v} (${k})`).join(', ')}">Links</span> | <span title="${Object.keys(teamMembers).join('/')}">Team</span> | ${Array(totalTrackedTasks).fill().map((v, i) => i + 1).join(' | ')}`,
               `:--------|:------|:----:${'|:-:'.repeat(totalTrackedTasks)}`
             ].concat(chapters.map(formatRow)).join('\n')
+
+            const teams = Object.entries(teamMembers).map(([k, v]) => {
+              return `*${k} (${Object.keys(v).length})*: ${Object.entries(v).sort().map(([m, c]) => `<span title="Chapters: ${c.join(', ')}">@${m} (${c.length})</span>`).join(', ')}`
+            }).join('\n\n')
 
             const progressIssue = await github.issues.get({
               owner: context.repo.owner,
@@ -151,7 +169,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: trackerIssueNumber,
-              body: progressIssue.data.body.replace(/<!-- REPORT START -->[\s\S]*<!-- REPORT END -->/, `<!-- REPORT START -->\n${report}\n<!-- REPORT END -->`)
+              body: progressIssue.data.body.replace(/<!-- REPORT START -->[\s\S]*<!-- REPORT END -->/, `<!-- REPORT START -->\n${report}\n\n${teams}\n<!-- REPORT END -->`)
             })
 
             core.info(`Updated report in issue #${trackerIssueNumber} with ${chapters.length} chapters`)


### PR DESCRIPTION
* Refactors the code
    * Moves code outside of functions that were constants, but unnecessarily getting reinitialized
    * Builds nested objects after parsing issues then serializes them instead of serializing as processing
* Reads tracked tasks/milestones from the reporting issue itself
    * No need to set `TOTAL_TRACKED_TASKS` config
    * Must include a list of tasks surrounded by `<!-- TASKS BEGIN -->` and `<!-- TASKS END -->` comments in the reporting post (#989 is updated already with this change)
    * Adds tooltip to each numbered column with milestone description
* Parses heading from the content to extract Part Number, Chapter Number, and Title
    * Uses extracted title, but falls back to issue title (earlier trailing year was removed, but not anymore, as that sounded a hacky approach)
    * Prefixes chapter number in front of the title in the table cell and adds a tooltip on it to show Part and Chapter numbers
* Sorts chapters according to their chapter numbers (as per #946)
    * Currently, unumbered chapters will bubble on top
* Adds tooltip to Links and Teams table column heads (eliminates the need of manual legend placement, as is the case in #989 currently)
    * It is better because things will reflect automatically if, say, icons change
* Adds chapter-wise statistical summary
    * Which includes Total, Min, Max, Mean, and Median number of contributors per chapter
* Lists all the team members in sorted order under each team
    * Adds number of chapters they are contributing to with corresponding role
    * Adds all the chapters in tooltip on each member's username