### PR TITLE
Support hyphens in usernames and sort contributors by most to least chapters

### DIFF
--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -75,14 +75,14 @@ jobs:
               if (!nums.length) {
                 return [0, 0, 0, 0, 0]
               }
-              nums.sort((a, b) => a - b)
+              nums.sort()
               const half = Math.floor(nums.length / 2)
               return [
                 nums.reduce((a,b) => a + b, 0),
                 Math.min(...nums),
                 Math.max(...nums),
                 (nums.reduce((a,b) => a + b, 0) / nums.length).toFixed(2),
-                (nums.length % 2 ? nums[half] : (nums[half - 1] + nums[half]) / 2.0).toFixed(2)
+                (nums.length % 2 == 0 ? nums[half] : (nums[half - 1] + nums[half]) / 2.0)
               ]
             }
 

--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -118,7 +118,7 @@ jobs:
             }
 
             const parseUserNames = members => {
-              return [...members.matchAll(/@(?<username>\w+)/g)].map(u => u.groups.username)
+              return [...members.matchAll(/@(?<username>[\w-]+)/g)].map(u => u.groups.username)
             }
 
             const parseTeam = text => {
@@ -205,8 +205,13 @@ jobs:
               ':-----------------|------:|----:|----:|-----:|------:'
             ].concat(Object.entries(teamStats).map(([k, v]) => `${k} | ${v.join(' | ')}`)).join('\n')
 
-            const teams = Object.entries(teamMembers).map(([k, v]) => {
-              return `### ${k} (${Object.keys(v).length})\n\n${Object.entries(v).sort().map(([m, c]) => `<span title="Chapters: ${c.join(', ')}">${m} (${c.length})</span>`).join(', ')}`
+            const teams = Object.entries(teamMembers).map(([team, contributors]) => {
+              const contributorList = ${Object.entries(contributors).sort(([x, a], [y, b]) => {
+                return b.length - a.length
+              }).map(([name, chapters]) => {
+                return `<span title="Chapters: ${chapters.join(', ')}">${name} (${chapters.length})</span>`).join(', ')
+              })
+              return `### ${team} (${Object.keys(contributors).length})\n\n${contributorList}`
             }).join('\n\n')
 
             github.issues.update({

--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -205,13 +205,13 @@ jobs:
               ':-----------------|------:|----:|----:|-----:|------:'
             ].concat(Object.entries(teamStats).map(([k, v]) => `${k} | ${v.join(' | ')}`)).join('\n')
 
-            const teams = Object.entries(teamMembers).sort().map(([team, contributors]) => {
-              const contributorList = Object.entries(contributors).sort(([x, a], [y, b]) => {
+            const teams = Object.entries(teamMembers).sort().map(([team, members]) => {
+              const memberList = Object.entries(members).sort(([x, a], [y, b]) => {
                 return b.length - a.length
-              }).map(([name, chapters]) => {
-                return `<span title="Chapters: ${chapters.join(', ')}">${name} (${chapters.length})</span>`
+              }).map(([member, chapters]) => {
+                return `<span title="Chapters: ${chapters.join(', ')}">${member} (${chapters.length})</span>`
               }).join(', ')
-              return `### ${team} (${Object.keys(contributors).length})\n\n${contributorList}`
+              return `### ${team} (${Object.keys(members).length})\n\n${memberList}`
             }).join('\n\n')
 
             github.issues.update({

--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -206,11 +206,11 @@ jobs:
             ].concat(Object.entries(teamStats).map(([k, v]) => `${k} | ${v.join(' | ')}`)).join('\n')
 
             const teams = Object.entries(teamMembers).sort().map(([team, contributors]) => {
-              const contributorList = ${Object.entries(contributors).sort(([x, a], [y, b]) => {
+              const contributorList = Object.entries(contributors).sort(([x, a], [y, b]) => {
                 return b.length - a.length
               }).map(([name, chapters]) => {
-                return `<span title="Chapters: ${chapters.join(', ')}">${name} (${chapters.length})</span>`).join(', ')
-              })
+                return `<span title="Chapters: ${chapters.join(', ')}">${name} (${chapters.length})</span>`
+              }).join(', ')
               return `### ${team} (${Object.keys(contributors).length})\n\n${contributorList}`
             }).join('\n\n')
 

--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -75,14 +75,14 @@ jobs:
               if (!nums.length) {
                 return [0, 0, 0, 0, 0]
               }
-              nums.sort()
+              nums.sort((a, b) => a - b)
               const half = Math.floor(nums.length / 2)
               return [
                 nums.reduce((a,b) => a + b, 0),
                 Math.min(...nums),
                 Math.max(...nums),
                 (nums.reduce((a,b) => a + b, 0) / nums.length).toFixed(2),
-                (nums.length % 2 == 0 ? nums[half] : (nums[half - 1] + nums[half]) / 2.0)
+                nums[half]
               ]
             }
 
@@ -205,7 +205,7 @@ jobs:
               ':-----------------|------:|----:|----:|-----:|------:'
             ].concat(Object.entries(teamStats).map(([k, v]) => `${k} | ${v.join(' | ')}`)).join('\n')
 
-            const teams = Object.entries(teamMembers).map(([team, contributors]) => {
+            const teams = Object.entries(teamMembers).sort().map(([team, contributors]) => {
               const contributorList = ${Object.entries(contributors).sort(([x, a], [y, b]) => {
                 return b.length - a.length
               }).map(([name, chapters]) => {

--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -205,8 +205,10 @@ jobs:
               ':-----------------|------:|----:|----:|-----:|------:'
             ].concat(Object.entries(teamStats).map(([k, v]) => `${k} | ${v.join(' | ')}`)).join('\n')
 
-            const teams = Object.entries(teamMembers).sort().map(([team, members]) => {
+            const teams = Object.entries(teamMembers).map(([team, members]) => {
               const memberList = Object.entries(members).sort(([x, a], [y, b]) => {
+                return x.toLocaleLowerCase().localeCompare(y.toLocaleLowerCase())
+              }).sort(([x, a], [y, b]) => {
                 return b.length - a.length
               }).map(([member, chapters]) => {
                 return `<span title="Chapters: ${chapters.join(', ')}">${member} (${chapters.length})</span>`


### PR DESCRIPTION
I noticed the analyst "max" showing up, but I know the full username should be "max-ostapenko". The `parseUserNames` function should support usernames with hyphens.

I also wanted to change the sort order of the contributors per team from alphabetical to number of chapters, so it's easier to see who is contributing the most. Changing this part was difficult because of the single character variable names and long lines, so I also fixed those things to make it more maintainable.

I also made a fix and improvement to the median calculation. It should take the middlemost value when the length is divisible by two. I also removed the `toFixed(2)` so the values appear as either whole numbers, or end in .5 (the only two possibilities).