### PR TITLE
Fix contributor padding issues and wrap control in a form

### DIFF
--- a/src/templates/base/2019/contributors.html
+++ b/src/templates/base/2019/contributors.html
@@ -35,6 +35,10 @@
   margin-bottom: 30px;
 }
 
+.filter-container ul {
+  padding: 0;
+}
+
 .filter-container li {
   list-style-type: none;
   display: inline-block
@@ -61,6 +65,7 @@
   flex-wrap: wrap;
   margin: 0 -15px;
   justify-content: center;
+  padding: 0;
 }
 
 .contributor-grid li {
@@ -270,7 +275,7 @@
       <img src="/static/images/avatars/9.jpg" alt="" height="100" width="100" loading="lazy" />
   </div>
   <div class="contributors {{ ' '.join(config.teams.keys()) }}">
-    <div class="filter-container">
+    <form class="filter-container">
       <p aria-live="polite" aria-atomic="true">
         {{ self.filter_by_team() }}
       </p>
@@ -285,7 +290,7 @@
         {% endif %}
         {% endfor %}
       </ul>
-    </div>
+    </form>
 
     <ul class="contributor-grid">
       <li>


### PR DESCRIPTION
Fixes #1058 and also https://github.com/HTTPArchive/almanac.httparchive.org/pull/1042#discussion_r456808654

@ericwbailey I've added the `<form>` element as requested. I've decided to leave the default yellow for now. Visually I think it makes more sense that all filters are "on" in initial state, even though by `aria-pressed` they are all "off". Without at least one yellow button these don't look like buttons to visual visitors.
