### PR TITLE
Add collective team in the progress report

### DIFF
--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -41,7 +41,8 @@ jobs:
             const teamMembers = {
               Authors: {},
               Reviewers: {},
-              Analysts: {}
+              Analysts: {},
+              All: {}
             }
 
             const parseListItems = text => {

--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -72,17 +72,18 @@ jobs:
             core.info(`Tracking progress of ${totalTrackedTasks} tasks across chapters`)
 
             const calcStats = nums => {
-              if (!nums.length) {
+              const size = nums.length
+              if (!size) {
                 return [0, 0, 0, 0, 0]
               }
               nums.sort((a, b) => a - b)
-              const half = Math.floor(nums.length / 2)
+              const sum = nums.reduce((a,b) => a + b, 0)
               return [
-                nums.reduce((a,b) => a + b, 0),
-                Math.min(...nums),
-                Math.max(...nums),
-                (nums.reduce((a,b) => a + b, 0) / nums.length).toFixed(2),
-                nums[half]
+                sum,
+                nums[0],
+                nums[size - 1],
+                (sum / size).toFixed(2),
+                nums[Math.floor(size / 2)]
               ]
             }
 

--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -129,6 +129,7 @@ jobs:
                   team.Authors = parseUserNames(authors)
                   team.Reviewers = parseUserNames(reviewers)
                   team.Analysts = parseUserNames(analysts)
+                  team.All = [...team.Authors, ...team.Reviewers, ...team.Analysts]
                 }
               })
               return team
@@ -139,7 +140,7 @@ jobs:
             }
 
             const formatTeam = team => {
-              return Object.entries(team).map(([k, v]) => `<span title="${k}: ${v.length ? v.join(', ') : 'TBD'}">${v.length}</span>`).join('/')
+              return Object.entries(team).map(([k, v]) => `<span title="${k}: ${v.length ? v.join(', ') : 'TBD'}">${v.length}</span>`).join('+').replace(/\+([^+]*)$/, '=$1')
             }
 
             const formatRow = chapter => {

--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -198,7 +198,7 @@ jobs:
             })
 
             const report = [
-              `Chapters | <span title="${Object.entries(icons).map(([k, v]) => `${v} (${k})`).join(', ')}">Links</span> | <span title="${Object.keys(teamMembers).join('/')}">Team</span> | ${trackedTasks.map((v, i) => `<span title="${v}">${i + 1}<span>`).join(' | ')}`,
+              `Chapters | <span title="${Object.entries(icons).map(([k, v]) => `${v} (${k})`).join(', ')}">Links</span> | <span title="${Object.keys(teamMembers).join('+').replace(/\+([^+]*)$/, '=$1')}">Team</span> | ${trackedTasks.map((v, i) => `<span title="${v}">${i + 1}<span>`).join(' | ')}`,
               `:--------|:------|:----:${'|:-:'.repeat(totalTrackedTasks)}`
             ].concat(chapters.map(formatRow)).join('\n')
 

--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -179,7 +179,7 @@ jobs:
             }
 
             if(!chapters.length) {
-              core.info(`Nothing to report`)
+              core.info('Nothing to report')
               return
             }
 

--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -131,7 +131,7 @@ jobs:
                   team.Authors = parseUserNames(authors)
                   team.Reviewers = parseUserNames(reviewers)
                   team.Analysts = parseUserNames(analysts)
-                  team.All = [...team.Authors, ...team.Reviewers, ...team.Analysts]
+                  team.All = [...new Set([...team.Authors, ...team.Reviewers, ...team.Analysts])]
                 }
               })
               return team
@@ -142,7 +142,7 @@ jobs:
             }
 
             const formatTeam = team => {
-              return Object.entries(team).map(([k, v]) => `<span title="${k}: ${v.length ? v.join(', ') : 'TBD'}">${v.length}</span>`).join('+').replace(/\+([^+]*)$/, '=$1')
+              return Object.entries(team).map(([k, v]) => `<span title="${k}: ${v.length ? v.join(', ') : 'TBD'}">${v.length}</span>`).join('+').replace(/\+([^+]*)$/, '≥$1')
             }
 
             const formatRow = chapter => {
@@ -199,7 +199,7 @@ jobs:
             })
 
             const report = [
-              `Chapters | <span title="${Object.entries(icons).map(([k, v]) => `${v} (${k})`).join(', ')}">Links</span> | <span title="${Object.keys(teamMembers).join('+').replace(/\+([^+]*)$/, '=$1')}">Team</span> | ${trackedTasks.map((v, i) => `<span title="${v}">${i + 1}<span>`).join(' | ')}`,
+              `Chapters | <span title="${Object.entries(icons).map(([k, v]) => `${v} (${k})`).join(', ')}">Links</span> | <span title="${Object.keys(teamMembers).join('+').replace(/\+([^+]*)$/, '≥$1')}">Team</span> | ${trackedTasks.map((v, i) => `<span title="${v}">${i + 1}<span>`).join(' | ')}`,
               `:--------|:------|:----:${'|:-:'.repeat(totalTrackedTasks)}`
             ].concat(chapters.map(formatRow)).join('\n')
 


### PR DESCRIPTION
* Adds `All` as a derived field in teams that reflects in the both the tables
* Changes `Authors/Reviewers/Analysts` format to `Authors+Reviewers+Analysts=All`
* Refactors stats calculation function without changing the logic