### PR TITLE
Spanish translation of the temp 2020 landing page

### DIFF
--- a/src/config/2020.json
+++ b/src/config/2020.json
@@ -856,6 +856,16 @@
       "avatar_url": "https://avatars1.githubusercontent.com/u/4273797?v=4&s=200",
       "github": "MikeBishop"
     },
+    "mcmd": {
+      "name": "Miguel Carlos Martínez Díaz",
+      "teams": [
+        "translators"
+      ],
+      "avatar_url": "https://avatars1.githubusercontent.com/u/868584?v=4&s=200",
+      "website": "https://www.linkedin.com/in/miguelcarlosmartinezdiaz/",
+      "github": "mcmd",
+      "twitter": "mcmd"
+    },
     "mgechev": {
       "name": "Minko Gechev",
       "teams": [

--- a/src/templates/es/2020/index.html
+++ b/src/templates/es/2020/index.html
@@ -1,7 +1,7 @@
 {% extends "base/2020/index.html" %}
 
 {% block title %}Web Almanac {{ year }}{% endblock %}
-{% block description %}Web Almanac es un informe anual del estado la web que combina la experiencia de la comunidad con los datos y tendencias del HTTP Archive.{% endblock %}
+{% block description %}Web Almanac es un informe anual del estado la Web que combina la experiencia de la comunidad con los datos y tendencias del HTTP Archive.{% endblock %}
 
 {% block twitter_image_alt %}Web Almanac {{ year }}{% endblock %}
 
@@ -9,7 +9,7 @@
 {% block date_modified %}2020-07-11T00:00:00.000Z{% endblock %}
 
 {% block intro_title %}¡Próximamente!{% endblock %}
-{% block intro_sub_title %}El informe del <b>estado de la web</b> de {{ year }}{% endblock %}
+{% block intro_sub_title %}El informe del <b>estado de la Web</b> de {{ year }}{% endblock %}
 
 {% block mission %}
 <p>

--- a/src/templates/es/2020/index.html
+++ b/src/templates/es/2020/index.html
@@ -1,23 +1,23 @@
 {% extends "base/2020/index.html" %}
 
 {% block title %}Web Almanac {{ year }}{% endblock %}
-{% block description %}Web Almanac es un estado anual de la web que combina las estadísticas y tendencias sin procesar del HTTP Archive con la experiencia de la comunidad web{% endblock %}
+{% block description %}Web Almanac es un informe anual del estado la web que combina la experiencia de la comunidad con los datos y tendencias del HTTP Archive.{% endblock %}
 
 {% block twitter_image_alt %}Web Almanac {{ year }}{% endblock %}
 
 {% block date_published %}2020-07-06T00:00:00.000Z{% endblock %}
 {% block date_modified %}2020-07-11T00:00:00.000Z{% endblock %}
 
-{% block intro_title %}Coming soon!{% endblock %}
-{% block intro_sub_title %}The {{ year }} <b>state of the web</b> report{% endblock %}
+{% block intro_title %}¡Próximamente!{% endblock %}
+{% block intro_sub_title %}El informe del <b>estado de la web</b> de {{ year }}{% endblock %}
 
 {% block mission %}
 <p>
-  Experts from around the web community are currently hard at work planning, analyzing, and writing content for the {{ year }} edition of the Web Almanac, which is on track to be published at the end of the year.
+  Expertos de la comunidad web están trabajando duro ahora mismo, preparando, analizando y escribiendo contenido para la edición del Web Almanac de {{ year }}, cuya publicación está prevista pra finales de año.
 </p>
 
 <p>
-  There are many opportunities available for new contributors to join the project, including: authors, reviewers, analysts, editors, translators, and developers. If you're interested in contributing to the {{ year }} edition, we'd love to have you!
+  Hay muchas oportunidades disponibles para nuevos colaboradores que quieran incorporarse al proyecto, incluyendo autoría, revisión, edición y traducción de contenidos, análisis de datos o desarrollo. Si estás interesado/a en participar en la edición de {{ year }}, nos encataría poder contar contigo.
 </p>
 
 <a href="https://github.com/HTTPArchive/almanac.httparchive.org#contributing" class="btn">¡Únete al equipo!</a>


### PR DESCRIPTION
Left 'Web Almanac' like that as it is a noun. Happy to translate too if that's what has been done in other languages.