### PR TITLE
Tweak the contributors SVG

### DIFF
--- a/src/templates/base/2019/contributors.html
+++ b/src/templates/base/2019/contributors.html
@@ -231,6 +231,7 @@
   display: flex;
   border: 5px dashed #5e687c;
   justify-content: center;
+  text-align: center;
 }
 
 .contributor-join:hover {
@@ -238,7 +239,8 @@
 }
 
 .contributor-join svg {
-  margin-bottom: -10px;
+  margin-bottom: -25px;
+  position: relative;
   z-index: 1;
 }
 
@@ -250,6 +252,7 @@
   fill: #fff;
   font-weight: bold;
   text-anchor: middle;
+  font-size: .9rem;
 }
 
 @media (max-width: 600px) {
@@ -293,11 +296,11 @@
     </form>
 
     <ul class="contributor-grid">
-      <li>
-        <a href="https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/README.md" class="contributor-join" aria-labelledby="jointheteam">
-          <svg xmlns="http://www.w3.org/2000/svg" role="img" width="174" height="100" viewBox="0 0 203 117">
+      <li class="contributor-join">
+        <a href="https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/README.md" aria-labelledby="jointheteam">
+          <svg xmlns="http://www.w3.org/2000/svg" role="img" width="174" height="100" viewBox="0 0 173 96">
             <title id="jointheteam">{{ self.join_the_team_title() }}</title>
-            <path d="M0 0l11 89 71 4.4L65.9 117l40.7-22.4L201 89l2-79z" />
+            <path d="M0,0l8.4,75.1l88.7,0.8L93.3,96l24.9-19.1l50.6-1.8l3.7-67.5L0,0z"/>
             <text x="50%" y="47%">
               {{ self.join_the_team_text() }}
             </text>


### PR DESCRIPTION
- Tweak the contributors SVG 
<img width="944" alt="almanac-contributors-update" src="https://user-images.githubusercontent.com/1867900/88329472-afd12680-cd32-11ea-82ca-8f0855e0a63e.PNG">



- Fix the scenario when the join the contributors block isn't always full height as its adjacent blocks (caused by some #1042 markup updates)

<img width="960" alt="almanac-contributors" src="https://user-images.githubusercontent.com/1867900/88328966-e9556200-cd31-11ea-8c21-349af2bed7fe.PNG">

---

Fixes #1076