### PR TITLE
Fix Join the Team contributor card on mobile

### DIFF
--- a/src/templates/base/2019/contributors.html
+++ b/src/templates/base/2019/contributors.html
@@ -242,6 +242,7 @@
   margin-bottom: -25px;
   position: relative;
   z-index: 1;
+  display: block;
 }
 
 .contributor-join path {


### PR DESCRIPTION
Looks like we broke this as part of #1085 with the addition of `position: relative`.

![Join the Team text side by side with character](https://user-images.githubusercontent.com/10931297/88450439-d1233700-ce46-11ea-83f9-678003bbb91c.png)

This fixes it to:

![Join the Team text above with character](https://user-images.githubusercontent.com/10931297/88450479-3119dd80-ce47-11ea-9cc9-b8e73252b2e8.png)

