### PR TITLE
Build site on Package.JSON change

### DIFF
--- a/.github/workflows/generate_chapters.yml
+++ b/.github/workflows/generate_chapters.yml
@@ -18,9 +18,10 @@ on:
     paths:
       - src/content/**
       - src/templates/**
-      - tools/generate/**
+      - src/tools/generate/**
       - src/static/css/**
       - src/static/js/**
+      - src/package.json
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Dependabot updated web-vitals in #1088 but that didn't trigger a build so let's add `package.json` to the list of files our build action watches.

Also fixed incorrect `tools` folder reference.