### PR TITLE
Allow language and country code languages when choosing best site for visitor

### DIFF
--- a/src/validate.py
+++ b/src/validate.py
@@ -98,12 +98,21 @@ def parse_accept_language(header, supported_langs):
 
     if header is not None:
 
-        accepted_languages = re.findall(r'(?:^|\s|,)(\w+)', header)
-
+        # Looks for languages of the format en or en-US first
+        accepted_languages = re.findall(r'(?:^|\s|,)(\w+-?\w*)', header)
         logging.debug('Accepted languages: %s' % accepted_languages)
 
         # The header could contain multiple languages, in order of precedence
         # Limit the number of accepted languages tested to 10.
+        for lang in accepted_languages[:10]:
+            if lang in supported_langs:
+                # Return the first found supported language.
+                logging.debug('Using "%s" as the highest precedent language.' % lang)
+                return lang
+
+        # If that didn't find anything, then strip off the country code and try just the language
+        accepted_languages = re.findall(r'(?:^|\s|,)(\w+)', header)
+        logging.debug('Accepted languages (no country): %s' % accepted_languages)
         for lang in accepted_languages[:10]:
             if lang in supported_langs:
                 # Return the first found supported language.


### PR DESCRIPTION
To support the different Chinese languages (`zh-CN` and `zh-TW`) first check language and country code rather than just language.

Fall back to language only (`zh`) if needs be but most browsers are configured to have both country specific, and then generic so this fallback is unlikely to be used. My `Accept-Language` header for example includes British English, American English and then just English:

```
Accept-Language: en-GB,en-US;q=0.9,en;q=0.8
```

This is only used when visiting the top level site (https://almanac.httparchive.org/) so extra processing time is not a concern.