### PR TITLE
Adds nowrap whitespace for japanese language in contributor-team style

### DIFF
--- a/src/templates/base/2019/contributors.html
+++ b/src/templates/base/2019/contributors.html
@@ -147,6 +147,7 @@
   font-size: 14px;
   font-size: 0.875rem;
   color: #757575;
+  white-space: nowrap;
 }
 .contributor-team::after {
   content: ', ';
@@ -154,11 +155,6 @@
 .contributor-team:last-child::after {
   content: '';
 }
-{% if language.lang_attribute in ['ja'] %}
-.contributor-team {
-  white-space: nowrap;
-}
-{% endif %}
 
 {% for id in config.teams.keys() %}
 .contributors.{{ id }} .contributor.{{ id }} {

--- a/src/templates/base/2019/contributors.html
+++ b/src/templates/base/2019/contributors.html
@@ -154,6 +154,11 @@
 .contributor-team:last-child::after {
   content: '';
 }
+{% if language.lang_attribute in ['ja'] %}
+.contributor-team {
+  white-space: nowrap;
+}
+{% endif %}
 
 {% for id in config.teams.keys() %}
 .contributors.{{ id }} .contributor.{{ id }} {


### PR DESCRIPTION
Fixes #1074 

Adds nowrap whitespacing for japanese language in contributor-team styling. I have used a `in` logic instead of `==` logic so that if we need to add same style for more languages at a later stage we can just add that in the list.