### PR TITLE
Better language code for Simplified Chinese

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -44,7 +44,7 @@ def get_languages(json_config):
   data = get_entries_from_json(json_config,'settings','supported_languages')
   for list in data:
     for entry in list:
-      languages.append(getattr(Language,entry.upper()))
+      languages.append(getattr(Language,entry.upper().replace('-','_')))
   return languages
 
 

--- a/src/config/2019.json
+++ b/src/config/2019.json
@@ -2,7 +2,7 @@
   "settings": [
     {
       "is_live": true,
-      "supported_languages": ["en","es","fr","ja","zh_CN"],
+      "supported_languages": ["en","es","fr","ja","zh-CN"],
       "ebook_languages": ["en","ja"]
     }
   ],

--- a/src/config/2020.json
+++ b/src/config/2020.json
@@ -2,7 +2,7 @@
   "settings": [
     {
       "is_live": true,
-      "supported_languages": ["en","es","fr","ja","zh_CN"],
+      "supported_languages": ["en","es","fr","ja","zh-CN"],
       "ebook_languages": []
     }
   ],


### PR DESCRIPTION
Currently the language code is converted to Python class references which cannot have underscores.

To allow that to work, at present we have the `zh_CN` code, which follows the convention of lowercase language used for other languages, but then doesn't follow ISO convention of using hyphen instead underscore so a weird hybrid.

Let's fix it!