### PR TITLE
Translate Accessibility Statement H1

### DIFF
--- a/src/templates/base/2019/accessibility_statement.html
+++ b/src/templates/base/2019/accessibility_statement.html
@@ -55,7 +55,6 @@
   </nav>
 
   <article id="maincontent" class="content">
-    <h1 class="title title-lg">Accessibility Statement</h1>
       
     {{ self.main_content() }}
 

--- a/src/templates/en/2019/accessibility_statement.html
+++ b/src/templates/en/2019/accessibility_statement.html
@@ -23,6 +23,7 @@
 {% endblock %}
 
 {% block main_content %}
+      <h1 class="title title-lg">Accessibility Statement</h1>
       <section>
         <h2 id="overview"><a href="#overview" class="anchor-link">Overview</a></h2>
 

--- a/src/templates/ja/2019/accessibility_statement.html
+++ b/src/templates/ja/2019/accessibility_statement.html
@@ -23,6 +23,7 @@
 {% endblock %}
 
 {% block main_content %}
+      <h1 class="title title-lg">アクセシビリティに関する声明</h1>
       <section>
         <h2 id="overview"><a href="#overview" class="anchor-link">概要</a></h2>
 

--- a/src/templates/zh-CN/2019/accessibility_statement.html
+++ b/src/templates/zh-CN/2019/accessibility_statement.html
@@ -23,6 +23,7 @@
 {% endblock %}
 
 {% block main_content %}
+      <h1 class="title title-lg">无障碍访问声明</h1>
       <section>
         <h2 id="overview"><a href="#overview" class="anchor-link">概览</a></h2>
 


### PR DESCRIPTION
Noticed the Accessibility Statement `<h1>` is not translated - though `<title>` is! This fixes this and I got the translation from the `<title>`