### PR TITLE
Fix Chinese language selector

### DIFF
--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -669,6 +669,10 @@ header .cta {
   min-width: 100px;
 }
 
+.language-switcher select {
+  min-width: 120px;
+}
+
 .language-switcher select::-ms-expand,
 .year-switcher select::-ms-expand {
   display: none;

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -667,10 +667,12 @@ header .cta {
   -moz-appearance: none;
   appearance: none;
   min-width: 100px;
+  min-width: 6.35rem;
 }
 
 .language-switcher select {
   min-width: 120px;
+  min-width: 7.5rem;
 }
 
 .language-switcher select::-ms-expand,


### PR DESCRIPTION
We currently have this:

![Drop down arrow covers Chinese language](https://user-images.githubusercontent.com/10931297/88951990-ac87ee80-d28e-11ea-9e46-9e57008a98db.png)

When we should have this:

![Drop down arrow to right of Chinese language](https://user-images.githubusercontent.com/10931297/88952790-cd9d0f00-d28f-11ea-93c2-1b48e036373e.png)

Wish there was a way of coding this based on length of current option selected, but `select` elements has very little styling support. Hopefully be fixes properly by #986 but this'll do for now.