### PR TITLE
Add Author LinkedIn data

### DIFF
--- a/src/config/2019.json
+++ b/src/config/2019.json
@@ -339,6 +339,7 @@
       "avatar_url": "https://avatars3.githubusercontent.com/u/10931297?v=4&s=200",
       "website": "https://www.tunetheweb.com",
       "github": "bazzadp",
+      "linkedin": "barry-pollard-developer",
       "twitter": "tunetheweb"
     },
     "borisschapira": {

--- a/src/config/2020.json
+++ b/src/config/2020.json
@@ -329,6 +329,7 @@
       "avatar_url": "https://avatars3.githubusercontent.com/u/10931297?v=4&s=200",
       "website": "https://www.tunetheweb.com",
       "github": "bazzadp",
+      "linkedin": "barry-pollard-developer",
       "twitter": "tunetheweb"
     },
     "bseymour": {

--- a/src/templates/base/2019/base_chapter.html
+++ b/src/templates/base/2019/base_chapter.html
@@ -147,6 +147,14 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
                     </svg>
                   </a>
                   {% endif %}
+                  {% if authordata.linkedin %}
+                  <a class="linkedin" href="https://www.linkedin.com/in/{{ authordata.linkedin }}/" aria-labelledby="author-{{ author }}-linkedin">
+                    <svg width="22" height="22" role="img">
+                      <title id="author-{{ author }}-linkedin">{{ onLinkedIn(authordata.name) }}</title>
+                      <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#linkedin"></use>
+                    </svg>
+                  </a>
+                  {% endif %}
                   {% if authordata.website %}
                   <a class="website" href="{{ authordata.website }}" aria-labelledby="author-{{ author }}-website">
                     <svg width="22" height="22" role="img">

--- a/src/templates/base/2019/base_ebook.html
+++ b/src/templates/base/2019/base_ebook.html
@@ -361,6 +361,14 @@
             </svg>
           </a>
           {% endif %}
+          {% if contributor.linkedin %}
+          <a href="https://github.com/{{ contributor.linkedin }}" aria-labelledby="contributors-{{ id }}-linkedin">
+            <svg role="img">
+              <title id="contributors-{{ id }}-linkedin">{{ onLinkedIn(contributor.name) }}</title>
+              <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#linkedin"></use>
+            </svg>
+          </a>
+          {% endif %}
           {% if contributor.website %}
           <a href="{{ contributor.website }}" aria-labelledby="contributors-{{ id }}-website">
             <svg role="img">

--- a/src/templates/base/2019/contributors.html
+++ b/src/templates/base/2019/contributors.html
@@ -339,7 +339,7 @@
           </a>
           {% endif %}
           {% if contributor.linkedin %}
-          <a href="https://www.linkedin.com/in/{{ contributor.linkedin }}" aria-label="{{ website(contributor.name) }}">
+          <a href="https://www.linkedin.com/in/{{ contributor.linkedin }}/" aria-label="{{ onLinkedIn(contributor.name) }}">
             <svg width="22" height="22">
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#linkedin"></use>
             </svg>

--- a/src/templates/base/2019/ebook.ejs.html
+++ b/src/templates/base/2019/ebook.ejs.html
@@ -92,6 +92,14 @@
                                     </svg>
                                 </a>
                                 {% endif %}
+                                {% if authordata.linkedin %}
+                                <a class="linkedin" href="https://www.linkedin.com/in/{{ authordata.linkedin }}/" aria-labelledby="{{ metadata.get('chapter') }}-author-{{ author }}-linkedin">
+                                    <svg role="img">
+                                        <title id="{{ metadata.get('chapter') }}-author-{{ author }}-linkedin">{{ onLinkedIn(authordata.name) }}</title>
+                                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#linkedin"></use>
+                                    </svg>
+                                </a>
+                                {% endif %}
                                 {% if authordata.website %}
                                 <a class="website" href="{{ authordata.website }}" aria-labelledby="{{ metadata.get('chapter') }}-author-{{ author }}-website">
                                     <svg role="img">

--- a/src/templates/en/2019/base.html
+++ b/src/templates/en/2019/base.html
@@ -70,6 +70,7 @@ Our mission is to combine the raw stats and trends of the HTTP Archive with the 
 
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} on Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} on GitHub{% endmacro %}
+{% macro onLinkedIn(authorName) %}{{authorName}} on LinkedIn{% endmacro %}
 {% macro website(authorName) %}{{authorName}} website{% endmacro %}
 
 {% macro edition(year) %}{{ year }} Edition{% endmacro %}

--- a/src/templates/es/2019/base.html
+++ b/src/templates/es/2019/base.html
@@ -70,6 +70,7 @@ Nuestra misión es combinar las estadísticas y tendencias sin procesar del HTTP
 
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} en Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} en GitHub{% endmacro %}
+{% macro onLinkedIn(authorName) %}{{authorName}} en LinkedIn{% endmacro %}
 {% macro website(authorName) %}{{authorName}} sitio web{% endmacro %}
 
 {% macro edition(year) %}Edición {{ year }}{% endmacro %}

--- a/src/templates/fr/2019/base.html
+++ b/src/templates/fr/2019/base.html
@@ -70,6 +70,7 @@ Notre mission est de combiner les statistiques brutes et les tendances de HTTP A
 
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} sur Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} sur GitHub{% endmacro %}
+{% macro onLinkedIn(authorName) %}{{authorName}} sur LinkedIn{% endmacro %}
 {% macro website(authorName) %}site web de {{authorName}}{% endmacro %}
 
 {% macro edition(year) %}Édition {{ year }}{% endmacro %}

--- a/src/templates/ja/2019/base.html
+++ b/src/templates/ja/2019/base.html
@@ -65,8 +65,9 @@
 {% macro show_description(id) %}図{{ id }}の説明を表示{% endmacro %}
 {% macro hide_description(id) %}図{{ id }}の説明を非表示{% endmacro %}
 
-{% macro onTwitter(twitterHandle) %}@{{twitterHandle}} on Twitter{% endmacro %}
-{% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} on GitHub{% endmacro %}
+{% macro onTwitter(twitterHandle) %}Twitterの@{{twitterHandle}}{% endmacro %}
+{% macro onGitHub(gitHubHandle) %}GitHubの{{gitHubHandle}}{% endmacro %}
+{% macro onLinkedIn(authorName) %}LinkedInの{{authorName}}{% endmacro %}
 {% macro website(authorName) %}{{authorName}} ウェブサイト{% endmacro %}
 
 {% macro edition(year) %}{{ year }} 版{% endmacro %}

--- a/src/templates/zh-CN/2019/base.html
+++ b/src/templates/zh-CN/2019/base.html
@@ -70,6 +70,7 @@
 
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} 在 Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} 在 GitHub{% endmacro %}
+{% macro onLinkedIn(authorName) %}{{authorName}} 在 LinkedIn{% endmacro %}
 {% macro website(authorName) %}{{authorName}} 网站{% endmacro %}
 
 {% macro edition(year) %}{{ year }} 版{% endmacro %}


### PR DESCRIPTION
As an extension to #1150 this also adds LinkedIn profile to Authors and Ebooks.

@catalinred decided to do this as a separate PR anyway despite what I said at https://github.com/HTTPArchive/almanac.httparchive.org/pull/1150#issuecomment-668211488 as involved more files than I thought so thought worth it's own PR.