### PR TITLE
Allow different commas per language

### DIFF
--- a/src/static/css/ebook.css
+++ b/src/static/css/ebook.css
@@ -160,20 +160,12 @@ tbody tr:nth-child(even) {
 
 .contributor-teams {
   margin-top: 5px;
+  color: #757575;
 }
 
 .contributor-team {
   font-size: 14px;
   font-size: 0.875rem;
-  color: #757575;
-}
-
-.contributor-team::after {
-  content: ', ';
-}
-
-.contributor-team:last-child::after {
-  content: '';
 }
 
 .social-icon {

--- a/src/templates/base/2019/base_ebook.html
+++ b/src/templates/base/2019/base_ebook.html
@@ -381,7 +381,7 @@
           <br>
           <span class="contributor-teams">
             {% for id in contributor.teams | sort() %}
-              <span class="contributor-team team-{{ id }}">{{ localizedTeamNames[id] if localizedTeamNames[id]|length else team.name }}</span>
+              <span class="contributor-team team-{{ id }}">{{ localizedTeamNames[id] if localizedTeamNames[id]|length else team.name }}</span>{{ self.comma() if not loop.last }}
             {% endfor %}
           </span>
         </div>

--- a/src/templates/base/2019/contributors.html
+++ b/src/templates/base/2019/contributors.html
@@ -129,6 +129,10 @@
   margin-bottom: 0.588em;
 }
 
+.contributor-social {	
+  flex: 1	
+}
+
 .contributor-social a {
   display: inline-block;
   margin: 0 5px;

--- a/src/templates/base/2019/contributors.html
+++ b/src/templates/base/2019/contributors.html
@@ -129,10 +129,6 @@
   margin-bottom: 0.588em;
 }
 
-.contributor-social {
-  flex: 1
-}
-
 .contributor-social a {
   display: inline-block;
   margin: 0 5px;
@@ -141,19 +137,13 @@
 .contributor-teams {
   margin-top: 5px;
   text-align: center;
+  color: #757575;
 }
 
 .contributor-team {
   font-size: 14px;
   font-size: 0.875rem;
-  color: #757575;
   white-space: nowrap;
-}
-.contributor-team::after {
-  content: ', ';
-}
-.contributor-team:last-child::after {
-  content: '';
 }
 
 {% for id in config.teams.keys() %}
@@ -356,7 +346,7 @@
 
         <div class="contributor-teams">
           {% for id in contributor.teams | sort() %}
-            <span class="contributor-team team-{{ id }}">{{ localizedTeamNames[id] if localizedTeamNames[id]|length else team.name }}</span>
+            <span class="contributor-team team-{{ id }}">{{ localizedTeamNames[id] if localizedTeamNames[id]|length else team.name }}</span>{{ self.comma() if not loop.last }}
           {% endfor %}
         </div>
       </li>

--- a/src/templates/base/2019/contributors.html
+++ b/src/templates/base/2019/contributors.html
@@ -129,8 +129,8 @@
   margin-bottom: 0.588em;
 }
 
-.contributor-social {	
-  flex: 1	
+.contributor-social {
+  flex: 1;
 }
 
 .contributor-social a {

--- a/src/templates/en/2019/base.html
+++ b/src/templates/en/2019/base.html
@@ -51,6 +51,7 @@ Our mission is to combine the raw stats and trends of the HTTP Archive with the 
 {% block close_the_index %}Close the Table of Contents{% endblock %}
 
 {% block and %}and{% endblock %}
+{% block comma %}, {% endblock %}
 
 {% block open %}Open{% endblock %}
 {% block close %}Close{% endblock %}

--- a/src/templates/es/2019/base.html
+++ b/src/templates/es/2019/base.html
@@ -51,6 +51,7 @@ Nuestra misión es combinar las estadísticas y tendencias sin procesar del HTTP
 {% block close_the_index %}Cerrar la tabla de contenido{% endblock %}
 
 {% block and %}y{% endblock %}
+{% block comma %}, {% endblock %}
 
 {% block open %}Abre{% endblock %}
 {% block close %}Cierra{% endblock %}

--- a/src/templates/fr/2019/base.html
+++ b/src/templates/fr/2019/base.html
@@ -51,6 +51,7 @@ Notre mission est de combiner les statistiques brutes et les tendances de HTTP A
 {% block close_the_index %}Fermer la table des matières{% endblock %}
 
 {% block and %}et{% endblock %}
+{% block comma %}, {% endblock %}
 
 {% block open %}Ouvrez{% endblock %}
 {% block close %}Fermez{% endblock %}

--- a/src/templates/ja/2019/base.html
+++ b/src/templates/ja/2019/base.html
@@ -48,6 +48,7 @@
 {% block close_the_index %}目次を閉じる{% endblock %}
 
 {% block and %} と {% endblock %}
+{% block comma %}、{% endblock %}
 
 {% block open %}開く{% endblock %}
 {% block close %}閉じる{% endblock %}

--- a/src/templates/zh-CN/2019/base.html
+++ b/src/templates/zh-CN/2019/base.html
@@ -51,6 +51,7 @@
 {% block close_the_index %}关闭目录{% endblock %}
 
 {% block and %}和{% endblock %}
+{% block comma %}、{% endblock %}
 
 {% block open %}打开{% endblock %}
 {% block close %}关闭{% endblock %}


### PR DESCRIPTION
Noticed we use Western commas even in Japanese and Chinese languages where a different comma is used ("、" instead of ","):

![Western commas](https://user-images.githubusercontent.com/10931297/89416867-d07f8000-d725-11ea-80f4-f69615622b5e.png)

This PR allows localized commas:

![Localized commas](https://user-images.githubusercontent.com/10931297/89417276-63b8b580-d726-11ea-8108-b28176bf3f1e.png)


