### PR TITLE
Adds focus back to highlighted contributor

### DIFF
--- a/src/templates/base/2019/contributors.html
+++ b/src/templates/base/2019/contributors.html
@@ -107,8 +107,13 @@
   margin: 10px;
 }
 
-.contributor:focus .contributor-avatar{
-    transform: scale(1.1);
+.contributor:focus .contributor-avatar {
+  transform: scale(1.1);
+}
+
+.contributor:focus {
+  border: 2px solid #f7f779;
+  outline: none;
 }
 
 .contributor-avatar {
@@ -319,7 +324,7 @@
         </a>
       </li>
     {% for id, contributor in config.contributors.items() %}
-      <li class="contributor {{ ' '.join(contributor.teams) }}" id="{{ id }}">
+      <li class="contributor {{ ' '.join(contributor.teams) }}" id="{{ id }}" tabindex="-1">
         <img class="contributor-avatar" src="{{contributor.avatar_url}}" height="100" width="100" alt="{{ contributor.name }} avatar" loading="lazy" />
         <div class="contributor-name">{{ contributor.name }}</div>
 


### PR DESCRIPTION
For some reason I removed the `tabindex='-1'` from the contributors in #645 which removes the focus ring when using links like https://almanac.httparchive.org/en/2019/contributors#bazzadp

Can't remember why I removed this, but suspected it was a misguided attempt to stop allowing focus on non-interactive elements - but this is a special case that should be allowed and the `-1` value means it can only be set by JavaScript (indeed that's exactly what it's there for!). Highlighting the currently selected author is **better** for accessibility to this change I did was wrong.

This adds this back in and also changes the focus outline to yellow border more in keeping with our style as it's clearly differentiated from non-highlighted contributors: 
![Highlighted contributor](https://user-images.githubusercontent.com/10931297/89432256-c9ae3880-d738-11ea-826c-711fa2c8b662.png)
