### PR TITLE
Test website on pull requests as well as pushes to main

### DIFF
--- a/.github/workflows/generate_chapters.yml
+++ b/.github/workflows/generate_chapters.yml
@@ -37,7 +37,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: (github.event_name == 'push' && github.repository == 'HTTPArchive/almanac.httparchive.org') || github.event.pull_request.head.repo.full_name == 'HTTPArchive/almanac.httparchive.org'
+    if: github.repository == 'HTTPArchive/almanac.httparchive.org'
     steps:
     - name: Checkout branch
       uses: actions/checkout@v2

--- a/.github/workflows/generate_chapters.yml
+++ b/.github/workflows/generate_chapters.yml
@@ -126,5 +126,3 @@ jobs:
 
           [1]: https://github.com/peter-evans/create-pull-request
         labels: generate chapters
-    - name: Check outputs
-      run: echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"

--- a/.github/workflows/generate_chapters.yml
+++ b/.github/workflows/generate_chapters.yml
@@ -113,7 +113,6 @@ jobs:
         npm run test
     - name: Create Pull Request
       if: github.event_name != 'pull_request'
-      id: cpr
       uses: peter-evans/create-pull-request@v3
       with:
         title: Update datestamps and generate chapters

--- a/.github/workflows/generate_chapters.yml
+++ b/.github/workflows/generate_chapters.yml
@@ -2,22 +2,30 @@
 ## Custom Web Almanac GitHub action ##
 ######################################
 #
-# Updates timestamps, increments CSS, and then runs "npm run generate"
-# on any pushes to main for markdown, templates or generate scripts
+# This generates the chapters and tests the website
 #
-# Then it tests the website
+# For pushed to main it also updates timestamps and increments CSS.
+# Then we open a Pull Request for any changes generated. We do this
+# only on a push, rather than on pull request, and only on main to
+# avoid avoid merge conflicts acorss pull requests (and also because
+# that would require personal access tokens to be set up for pull
+# requests from forks).
 #
-# Then we open a Pull Request for any changes generated.
-#
-# We do it on a push, rather than on pull request, and only on main to
-# avoid needing GitHub Personal Access Tokens and to avoid merge conflicts
-#
-name: Generate Chapters on Push
+name: Generate Chapters
 on:
   workflow_dispatch:
   push:
     branches:
       - main
+    paths:
+      - src/**.js
+      - src/**.css
+      - src/**.html
+      - src/content/**.md
+      - src/**.py
+      - src/**.json
+      - src/requirements.txt
+  pull_request:
     paths:
       - src/**.js
       - src/**.css
@@ -104,6 +112,7 @@ jobs:
         cd src
         npm run test
     - name: Create Pull Request
+      if: github.event_name != 'pull_request'
       id: cpr
       uses: peter-evans/create-pull-request@v3
       with:

--- a/.github/workflows/generate_chapters.yml
+++ b/.github/workflows/generate_chapters.yml
@@ -37,7 +37,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.repository == 'HTTPArchive/almanac.httparchive.org'
+    if: (github.event_name == 'push' && github.repository == 'HTTPArchive/almanac.httparchive.org') || github.event.pull_request.head.repo.full_name == 'HTTPArchive/almanac.httparchive.org'
     steps:
     - name: Checkout branch
       uses: actions/checkout@v2

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,16 +1,6 @@
 name: Run Python Tests
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - src/config/**
-      - src/**.py
-      - src/requirements.txt
-  pull_request:
-    paths:
-      - src/config/**
-      - src/**.py
-      - src/requirements.txt
 jobs:
   tests:
     name: Run pytest


### PR DESCRIPTION
In #1124 we added the ability for GitHub Actions to build the chapters, run the site and run some tests. We kept that to only happen on pushes to main for now but since it is working well I want to now do this on each pull request too.

However for pull requests we do not update the timestamps, and also crucially do not commit any changes - they will continue to be done on pushes to main. This is to avoid merge conflicts when timestamps are updated and to keep pull requests smaller and easier to review.

I'd like to keep this check off from generic pushes, as it does take a few mins to run. Think it's find to only run on pull request when code should be ready to commit.

I've also turned off the pytest action since it is now covered by this. I'll keep it around as a manual GitHub action in case we want to run it (e.g. to test any pytest upgrades quickly).