### PR TITLE
Remove dates from base templates

### DIFF
--- a/src/templates/base/2019/base_chapter.html
+++ b/src/templates/base/2019/base_chapter.html
@@ -6,9 +6,6 @@
 {% block image_height %}433{% endblock %}
 {% block image_width %}866{% endblock %}
 
-{% block date_published %}{{ metadata.get('published','2019-11-04') + 'T12:00:00.000Z' }}{% endblock %}
-{% block date_modified %}{{ metadata.get('last_updated','2019-11-04') + 'T12:00:00.000Z' }}{% endblock %}
-
 {% block author_structured_data %}
       {% for author in metadata.get('authors') %}{% if loop.length > 1 and loop.index == 1 %}[{% endif -%}
       {% set authordata = config.contributors[author] if author in config.contributors else None -%}

--- a/src/templates/base/2019/chapter.html
+++ b/src/templates/base/2019/chapter.html
@@ -12,6 +12,9 @@
 
 {% set metadata = <%- JSON.stringify(metadata) %> %}
 
+{% block date_published %}<%- metadata['published'] %>{% endblock %}
+{% block date_modified %}<%- metadata.last_updated %>{% endblock %}
+
 {% block index %}
   <%- include('toc.html', { headings: toc }) %>
 {% endblock %}

--- a/src/templates/en/2019/base.html
+++ b/src/templates/en/2019/base.html
@@ -4,9 +4,6 @@
 
 {% block twitter_image_alt %}{{ year }} Web Almanac{% endblock %}
 
-{% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
-{% block date_modified %}2020-08-03T00:00:00.000Z{% endblock %}
-
 {% block skip_navigation %}Skip navigation{% endblock %}
 
 {% block organization %}Web Almanac by HTTP Archive{% endblock %}

--- a/src/templates/en/2019/error.html
+++ b/src/templates/en/2019/error.html
@@ -1,5 +1,8 @@
 {% extends "base/2019/error.html" %}
 
+{% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
+{% block date_modified %}2020-08-03T00:00:00.000Z{% endblock %}
+
 {% block unknown_error %}Unknown Error{% endblock %}
 
 {% 

--- a/src/templates/es/2019/base.html
+++ b/src/templates/es/2019/base.html
@@ -4,9 +4,6 @@
 
 {% block twitter_image_alt %}{{ year }} Web Almanac{% endblock %}
 
-{% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
-{% block date_modified %}2020-08-03T00:00:00.000Z{% endblock %}
-
 {% block skip_navigation %}Saltar navegación{% endblock %}
 
 {% block organization %}Web Almanac por HTTP Archive{% endblock %}

--- a/src/templates/es/2019/error.html
+++ b/src/templates/es/2019/error.html
@@ -1,5 +1,8 @@
 {% extends "base/2019/error.html" %}
 
+{% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
+{% block date_modified %}2020-08-03T00:00:00.000Z{% endblock %}
+
 {% block unknown_error %}Error Desconocido{% endblock %}
 
 {% 

--- a/src/templates/fr/2019/base.html
+++ b/src/templates/fr/2019/base.html
@@ -4,9 +4,6 @@
 
 {% block twitter_image_alt %}Web Almanac {{ year }}{% endblock %}
 
-{% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
-{% block date_modified %}2020-08-03T00:00:00.000Z{% endblock %}
-
 {% block skip_navigation %}Sauter la navigation{% endblock %}
 
 {% block organization %}Web Almanac par HTTP Archive{% endblock %}

--- a/src/templates/fr/2019/error.html
+++ b/src/templates/fr/2019/error.html
@@ -1,5 +1,8 @@
 {% extends "base/2019/error.html" %}
 
+{% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
+{% block date_modified %}2020-08-03T00:00:00.000Z{% endblock %}
+
 {% block unknown_error %}Erreur inconnue{% endblock %}
 
 {% 

--- a/src/templates/ja/2019/base.html
+++ b/src/templates/ja/2019/base.html
@@ -4,8 +4,6 @@
 
 {% block twitter_image_alt %}{{ year }} Web Almanac{% endblock %}
 
-{% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
-{% block date_modified %}2020-08-03T00:00:00.000Z{% endblock %}
 {% block skip_navigation %}ナビゲーションをスキップ{% endblock %}
 
 {% block organization %}HTTP ArchiveによるWeb Almanac{% endblock %}

--- a/src/templates/ja/2019/error.html
+++ b/src/templates/ja/2019/error.html
@@ -1,5 +1,8 @@
 {% extends "base/2019/error.html" %}
 
+{% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
+{% block date_modified %}2020-08-03T00:00:00.000Z{% endblock %}
+
 {% block unknown_error %}不明なエラー{% endblock %}
 
 {% 

--- a/src/templates/pt/2019/base.html
+++ b/src/templates/pt/2019/base.html
@@ -4,9 +4,6 @@
 
 {% block twitter_image_alt %}{{ year }} Web Almanac{% endblock %}
 
-{% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
-{% block date_modified %}2020-08-05T00:00:00.000Z{% endblock %}
-
 {% block skip_navigation %}Pular navegação{% endblock %}
 
 {% block organization %}Web Almanac por HTTP Archive{% endblock %}

--- a/src/templates/zh-CN/2019/base.html
+++ b/src/templates/zh-CN/2019/base.html
@@ -4,9 +4,6 @@
 
 {% block twitter_image_alt %}{{ year }} Web Almanac{% endblock %}
 
-{% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
-{% block date_modified %}2020-07-14T00:00:00.000Z{% endblock %}
-
 {% block skip_navigation %}跳过导航{% endblock %}
 
 {% block organization %}Web Almanac 源于 HTTP Archive{% endblock %}

--- a/src/templates/zh-CN/2019/error.html
+++ b/src/templates/zh-CN/2019/error.html
@@ -1,5 +1,8 @@
 {% extends "base/2019/error.html" %}
 
+{% block date_published %}2019-11-04T12:00:00.000Z{% endblock %}
+{% block date_modified %}2020-08-03T00:00:00.000Z{% endblock %}
+
 {% block unknown_error %}未知错误{% endblock %}
 
 {% 


### PR DESCRIPTION
We have dates set in our base templates which are automatically updated when they are changed.

These dates from the base templates should not be used and the individual templates should have dates set in them instead so this is needless churn.

Let's move them out and add dates to the few templates that don't have them instead - most of them do already but error and chapter ones don't.