### PR TITLE
Add more test cases

### DIFF
--- a/src/tools/generate/generate_chapters.js
+++ b/src/tools/generate/generate_chapters.js
@@ -3,7 +3,7 @@ const showdown = require('showdown');
 const ejs = require('ejs');
 const prettier = require('prettier');
 
-const { find_markdown_files, get_config_files, size_of, parse_array } = require('./shared');
+const { find_markdown_files, get_yearly_configs, size_of, parse_array } = require('./shared');
 const { generate_table_of_contents } = require('./generate_table_of_contents');
 const { generate_header_links } = require('./generate_header_links');
 const { generate_figure_ids } = require('./generate_figure_ids');
@@ -27,7 +27,7 @@ const generate_chapters = async () => {
   let ebook_chapters = [];
   let configs = {};
   
-  configs = await get_config_files();
+  configs = await get_yearly_configs();
   for (const year in configs) {  
     sitemap_languages[year] = configs[year].settings[0].supported_languages
   }

--- a/src/tools/generate/generate_chapters.js
+++ b/src/tools/generate/generate_chapters.js
@@ -3,7 +3,7 @@ const showdown = require('showdown');
 const ejs = require('ejs');
 const prettier = require('prettier');
 
-const { find_markdown_files, find_config_files, size_of, parse_array } = require('./shared');
+const { find_markdown_files, get_config_files, size_of, parse_array } = require('./shared');
 const { generate_table_of_contents } = require('./generate_table_of_contents');
 const { generate_header_links } = require('./generate_header_links');
 const { generate_figure_ids } = require('./generate_figure_ids');
@@ -27,15 +27,9 @@ const generate_chapters = async () => {
   let ebook_chapters = [];
   let configs = {};
   
-  for (const config_file of await find_config_files()) {
-    const re = (process.platform != 'win32') 
-                  ? /config\/([0-9]*).json/ 
-                  : /config\\([0-9]*).json/;
-    const [path,year] = config_file.match(re);
-    
-    configs[year] = JSON.parse(await fs.readFile(`config/${year}.json`, 'utf8'));
+  configs = await get_config_files();
+  for (const year in configs) {  
     sitemap_languages[year] = configs[year].settings[0].supported_languages
-
   }
 
   for (const file of await find_markdown_files()) {

--- a/src/tools/generate/shared.js
+++ b/src/tools/generate/shared.js
@@ -33,6 +33,21 @@ const find_config_files = async () => {
   return await recursive('config', [filter]);
 };
 
+const get_config_files = async () => {
+
+  let configs = {};
+
+  for (const config_file of await find_config_files()) {
+    const re = (process.platform != 'win32') 
+                  ? /config\/([0-9]*).json/ 
+                  : /config\\([0-9]*).json/;
+    const [path,year] = config_file.match(re);
+    
+    configs[year] = JSON.parse(await fs.readFile(`config/${year}.json`, 'utf8'));
+  }
+  return configs;
+};
+
 const size_of = async (path) => {
   let b = (await fs.stat(path)).size;
 
@@ -58,6 +73,7 @@ module.exports = {
   find_markdown_files,
   find_template_files,
   find_config_files,
+  get_config_files,
   size_of,
   parse_array
 };

--- a/src/tools/generate/shared.js
+++ b/src/tools/generate/shared.js
@@ -33,7 +33,7 @@ const find_config_files = async () => {
   return await recursive('config', [filter]);
 };
 
-const get_config_files = async () => {
+const get_yearly_configs = async () => {
 
   let configs = {};
 
@@ -73,7 +73,7 @@ module.exports = {
   find_markdown_files,
   find_template_files,
   find_config_files,
-  get_config_files,
+  get_yearly_configs,
   size_of,
   parse_array
 };

--- a/src/tools/test/test_status_codes.js
+++ b/src/tools/test/test_status_codes.js
@@ -2,7 +2,7 @@ const fs = require("fs-extra");
 const fetch = require("node-fetch");
 const convert = require('xml-js');
 
-const { get_config_files } = require('../generate/shared');
+const { get_yearly_configs } = require('../generate/shared');
 
 const default_year = 2019;
 const default_language = 'en';
@@ -17,7 +17,7 @@ let ebooks = {};
 
 const get_config = async () => {
 
-  configs = await get_config_files();
+  configs = await get_yearly_configs();
   for (const year in configs) {
     languages[year] = configs[year].settings[0].supported_languages;
     ebooks[year] = configs[year].settings[0].ebook_languages;

--- a/src/tools/test/test_status_codes.js
+++ b/src/tools/test/test_status_codes.js
@@ -2,10 +2,27 @@ const fs = require("fs-extra");
 const fetch = require("node-fetch");
 const convert = require('xml-js');
 
+const { get_config_files } = require('../generate/shared');
+
+const default_year = 2019;
+const default_language = 'en';
 const base_url = "http://127.0.0.1:8080";
 
 let failures = 0;
 let passes = 0;
+  
+let configs = {};
+let languages = {};
+let ebooks = {};
+
+const get_config = async () => {
+
+  configs = await get_config_files();
+  for (const year in configs) {
+    languages[year] = configs[year].settings[0].supported_languages;
+    ebooks[year] = configs[year].settings[0].ebook_languages;
+  }
+};
 
 const test_status_code = async (page, status, location) => {
 
@@ -28,7 +45,7 @@ const test_status_code = async (page, status, location) => {
       console.log('Success - expected:', status, 'got:',response.status, 'for page:', page);
       passes++;
     } else {
-      console.error('Failed - expected:', status, 'got:',response.status, 'for page:', page);
+      console.error('Failed - expected:', status, 'got:',response.status, 'for page:', page, 'location:', location);
       failures++;
     }
 
@@ -50,18 +67,49 @@ const test_sitemap_pages = async () => {
   }
 }
 
+const test_ebooks = async () => {
+  for (const year in ebooks) {
+    for (const language in ebooks[year]) {
+      await test_status_code(`/${ebooks[year][language]}/${year}/ebook`, 200);
+    }
+  }
+}
+
+const test_404_pages = async () => {
+  for (const year in languages) {
+    for (const language in languages[year]) {
+      await test_status_code(`/${languages[year][language]}/${year}/random`, 404);
+    }
+  }
+}
+
+const test_no_year_redirects = async () => {
+  for (const year in languages) {
+    for (const language in languages[year]) {
+      await test_status_code(`/${languages[year][language]}/`, 302, `/${languages[year][language]}/${default_year}/`);
+    }
+  }
+}
+
 const test_status_codes = async () => {
+
+  await get_config();
 
   // Test success pages
   await test_sitemap_pages();
+  await test_ebooks();
   await test_status_code('/sitemap.xml', 200);
+  await test_status_code('/robots.txt', 200);
+  await test_status_code('/favicon.ico', 200);
 
   // Test Redirects
-  await test_status_code('/', 302, '/en/2019/');
-  await test_status_code('/en/', 302, '/en/2019/');
+  await test_status_code('/', 302, `/${default_language}/${default_year}/`);
+  await test_no_year_redirects();
+  await test_status_code('/zz', 308, `/zz/`);
 
-  //Test 404
-  await test_status_code('/en/2019/random', 404);
+  //Test 404s
+  await test_404_pages();
+  await test_status_code('/zz/', 404);
   
   console.log('Passes:', passes, "Failures:", failures);
   process.exitCode = failures;


### PR DESCRIPTION
Add more test cases to test script added in #1124 for fuller coverage.

Goes from 92 test cases to 116 test cases by adding the following:

- ebook pages
- robots.txt
- favicon.ico
- no year redirects (e.g. `/en/` -> `/en/2019/`) for each supported language
- unsupported language (`zz`) redirect
- 404s for each supported language and year

Also moves the reading of config files to `shared.js` as now used in two places.