### PR TITLE
Better chapter dates to avoid duplication

### DIFF
--- a/src/templates/base/2019/base_chapter.html
+++ b/src/templates/base/2019/base_chapter.html
@@ -2,6 +2,9 @@
 
 {% set chapter_image_dir = ("/static/images/2019/%s" % metadata.chapter) %}
 
+{% block date_published %}{{ metadata.published }}{% endblock %}
+{% block date_modified %}{{ metadata.last_updated }}{% endblock %}
+
 {% block image_url %}https://almanac.httparchive.org{{ chapter_image_dir }}/hero_lg.jpg{% endblock %}
 {% block image_height %}433{% endblock %}
 {% block image_width %}866{% endblock %}

--- a/src/templates/base/2019/chapter.html
+++ b/src/templates/base/2019/chapter.html
@@ -12,9 +12,6 @@
 
 {% set metadata = <%- JSON.stringify(metadata) %> %}
 
-{% block date_published %}<%- metadata['published'] %>{% endblock %}
-{% block date_modified %}<%- metadata.last_updated %>{% endblock %}
-
 {% block index %}
   <%- include('toc.html', { headings: toc }) %>
 {% endblock %}


### PR DESCRIPTION
Noticed while merging #1166 that we're duplicating the dates in chapter's HTML now, so did this a better way.