### PR TITLE
Add Bash linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,6 +16,7 @@
 #
 name: Lint Code Base
 on:
+  - workflow_dispatch
   - push
   - pull_request
 jobs:
@@ -27,15 +28,20 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
+      - name: Set VALIDATE_ALL_CODEBASE variable
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        run: |
+          echo "::set-env name=VALIDATE_ALL_CODEBASE::false"
       - name: Lint Code Base
-        uses: docker://github/super-linter:v3.3.0
+        uses: docker://github/super-linter:v3
         env:
-          VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
-          VALIDATE_YAML: true
-          VALIDATE_JSON: true
-          VALIDATE_PYTHON: true
-          VALIDATE_JAVASCRIPT_ES: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_BASH: true
           VALIDATE_CSS: true
-          VALIDATE_MD: true
           VALIDATE_HTML: true
+          VALIDATE_JAVASCRIPT_ES: true
+          VALIDATE_JSON: true
+          VALIDATE_MD: true
+          VALIDATE_PYTHON_PYLINT: true
+          VALIDATE_YAML: true

--- a/src/tools/scripts/run_and_test_website.sh
+++ b/src/tools/scripts/run_and_test_website.sh
@@ -36,8 +36,7 @@ npm run generate
 echo "Starting website"
 python main.py background &
 # Check website is running as won't have got feedback as backgrounded
-# use [p]ython so we don't match the grep itself
-ps -ef | grep "[p]ython main.py"
+pgrep -f "python main.py"
 
 echo "Testing website"
 npm run test

--- a/src/tools/scripts/run_and_test_website.sh
+++ b/src/tools/scripts/run_and_test_website.sh
@@ -14,8 +14,6 @@
 
 # exit when any command fails instead of trying to continue on
 set -e
-# echo commands to screen for debugging
-set -x
 
 # This script must be run from src directory
 if [ -d "src" ]; then

--- a/src/tools/scripts/update_timestamps_versions.sh
+++ b/src/tools/scripts/update_timestamps_versions.sh
@@ -12,14 +12,11 @@
 # This script is run in a GitHub Action and should not need to be run manually
 #
 
-# echo commands to screen for debugging
-set -x
-
 if [ "$#" -eq 1 ]; then
 COMMIT_SHA=$1
 fi
 
-if [ "{COMMIT_SHA}" = "" ]; then
+if [ "${COMMIT_SHA}" = "" ]; then
     echo "Must supply commit sha"
     exit 1
 fi
@@ -27,7 +24,7 @@ fi
 
 # This script must be run from src directory
 if [ -d "src" ]; then
-  cd src
+  cd src || exit
 fi
 
 # You have to do some funky stuff for the version of sed on MacOS
@@ -36,24 +33,24 @@ fi
 # local development and debugging of this script.
 # Default case for Linux sed, just use "-i -r"
 SED_FLAGS=(-i -r)
-if [ $(uname) = 'Darwin' ]; then
+if [ "$(uname)" = "Darwin" ]; then
   echo "Running MacOS"
   SED_FLAGS=(-i "" -E)
 fi
 
-NEW_LONG_DATE=`date -u +%Y%m%d%H%M%S`
+NEW_LONG_DATE=$(date -u +%Y%m%d%H%M%S)
 NEW_SHORT_DATE=${NEW_LONG_DATE:0:4}-${NEW_LONG_DATE:4:2}-${NEW_LONG_DATE:6:2}
 
 echo "Files changed in this commit:"
-git diff-tree --diff-filter=AM --no-commit-id --name-only -r ${COMMIT_SHA}
+git diff-tree --diff-filter=AM --no-commit-id --name-only -r "${COMMIT_SHA}"
 
 function update_versions {
   FILE_TYPE=$1
   echo "Updating ${FILE_TYPE} versions"
-  CHANGED_FILES=`git diff-tree --diff-filter=AM --no-commit-id --name-only -r ${COMMIT_SHA} static/${FILE_TYPE} | grep "\.${FILE_TYPE}"`
+  CHANGED_FILES=$(git diff-tree --diff-filter=AM --no-commit-id --name-only -r "${COMMIT_SHA}" "static/${FILE_TYPE}" | grep "\.${FILE_TYPE}")
   for CHANGED_FILE in ${CHANGED_FILES}
   do
-    CHANGED_FILE=`basename ${CHANGED_FILE}`
+    CHANGED_FILE=$(basename "${CHANGED_FILE}")
     echo "Updating ${CHANGED_FILE} version number to ${NEW_LONG_DATE}"
     sed "${SED_FLAGS[@]}" "s/${CHANGED_FILE}\?v=[0-9]+/${CHANGED_FILE}\?v=${NEW_LONG_DATE}/" templates/base/*/*.html templates/base.html
   done
@@ -63,15 +60,15 @@ function update_timestamp {
   DIRECTORY=$1
   FILE_PATTERN=$2
   echo "Updating '${DIRECTORY}' timestamps which match '${FILE_PATTERN}'"
-  CHANGED_FILES=`git diff-tree --diff-filter=AM --no-commit-id --name-only -r ${COMMIT_SHA} ${DIRECTORY}`
+  CHANGED_FILES=$(git diff-tree --diff-filter=AM --no-commit-id --name-only -r "${COMMIT_SHA}" "${DIRECTORY}")
   for CHANGED_FILE in ${CHANGED_FILES}
   do
     if [[ "${CHANGED_FILE}" =~ ${FILE_PATTERN} ]]; then
       echo "Updating ${CHANGED_FILE} timestamp to ${NEW_SHORT_DATE}:"
       if [ "${DIRECTORY}" = "content" ]; then
-        sed "${SED_FLAGS[@]}" "s/^last_updated: [0-9-]+T/last_updated: ${NEW_SHORT_DATE}T/" ../${CHANGED_FILE}
+        sed "${SED_FLAGS[@]}" "s/^last_updated: [0-9-]+T/last_updated: ${NEW_SHORT_DATE}T/" "../${CHANGED_FILE}"
       else
-        sed "${SED_FLAGS[@]}" "s/block date_modified %}[0-9-]+T/block date_modified %}${NEW_SHORT_DATE}T/" ../${CHANGED_FILE}
+        sed "${SED_FLAGS[@]}" "s/block date_modified %}[0-9-]+T/block date_modified %}${NEW_SHORT_DATE}T/" "../${CHANGED_FILE}"
       fi
     fi
   done


### PR DESCRIPTION
This adds the bash linter to our GitHub super linter since we added some bash scripts in #1172 

It required a few small changes to the bash scripts to pass the linting - including identifying one bug on line 22!

Note I also turned off `set -x` as too noisy and unnecessarily verbose.

It also makes a couple of additional changes to the Linter config:
- Allows it to be run on demand where it will lint the full code base
- Updates to generic v3 now the issue with that branch has been resolved
- Adds in GitHub secret [see this issue](https://github.com/github/super-linter/issues/533).
- Orders the linters alphabetically

