### PR TITLE
Freeze GitHub Action versions so they can be managed via dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: daily
   - package-ecosystem: "npm"
     directory: "/src/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
   - package-ecosystem: "npm"
     directory: "/src/"
     schedule:

--- a/.github/workflows/calibreapp-image-action.yml
+++ b/.github/workflows/calibreapp-image-action.yml
@@ -31,7 +31,7 @@ jobs:
     name: calibreapp/image-actions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@2.3.2
       - name: calibreapp/image-actions
         uses: docker://calibreapp/github-image-actions
         env:

--- a/.github/workflows/generate_chapters.yml
+++ b/.github/workflows/generate_chapters.yml
@@ -31,7 +31,7 @@ jobs:
     if: github.repository == 'HTTPArchive/almanac.httparchive.org'
     steps:
     - name: Checkout branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.2
       with:
         fetch-depth: 0
     - name: Update version numbers and timestamps
@@ -40,11 +40,11 @@ jobs:
         COMMIT_SHA: ${{ github.sha }}
       run: ./src/tools/scripts/update_timestamps_versions.sh
     - name: Setup Node.js for use with actions
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v1.4.2
       with:
         version:  12.x
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v2.1.1
       with:
         python-version: '3.7'
     - name: Run the website

--- a/.github/workflows/generate_ebooks.yml
+++ b/.github/workflows/generate_ebooks.yml
@@ -20,14 +20,14 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.2
     - name: Setup Node.js for use with actions
-      uses: actions/setup-node@v1.1.0
+      uses: actions/setup-node@v1.4.2
       with:
         version:  12.x
     # Install Python 3.7 as used by Google Cloud Platform
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v2.1.1
       with:
         python-version: '3.7'
     - name: Install Asian Fonts

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.2
       - name: Set VALIDATE_ALL_CODEBASE variable
         if: github.event_name == 'push' || github.event_name == 'pull_request'
         run: |

--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.repository == 'HTTPArchive/almanac.httparchive.org'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v2
+      - uses: actions/github-script@v2.0.1
         if: github.event_name == 'workflow_dispatch' || contains(github.event.issue.labels.*.name, env.FILTER_LABEL)
         with:
           script: |

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.2
       - name: Set up Python 3.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v2.1.1
         with:
           python-version: '3.7'
       - name: Install Requirements

--- a/.github/workflows/test_website.yml
+++ b/.github/workflows/test_website.yml
@@ -23,13 +23,13 @@ jobs:
     if: github.repository == 'HTTPArchive/almanac.httparchive.org'
     steps:
     - name: Checkout branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.2
     - name: Setup Node.js for use with actions
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v1.4.2
       with:
         version:  12.x
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v2.1.1
       with:
         python-version: '3.7'
     - name: Run the website


### PR DESCRIPTION
This unifies our version numbers as they've got a bit out of hand, and also gives us heads up when new versions are released.