### PR TITLE
Fix lighthouse regressions

### DIFF
--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -280,8 +280,7 @@
 }
 
 .authors .social a {
-  margin-right: 10px;
-  margin-right: 0.625rem;
+  margin: 0.25rem 1rem 0.25rem 0;
   white-space: nowrap;
   display: inline-flex;
   align-items: center;
@@ -298,7 +297,7 @@
 }
 
 .authors .social svg {
-  width: 1em;
+  width: 1.5em;
   height: auto;
   margin-right: 4px;
   margin-right: 0.25rem;

--- a/src/templates/base/2019/base_chapter.html
+++ b/src/templates/base/2019/base_chapter.html
@@ -134,7 +134,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
                 <div class="social">
                   {% if authordata.twitter %}
                   <a class="twitter" href="https://twitter.com/{{ authordata.twitter }}" aria-labelledby="author-{{ author }}-twitter">
-                    <svg width="22" height="22" role="img" aria-hidden>
+                    <svg width="22" height="22" role="img">
                       <title id="author-{{ author }}-twitter">{{ onTwitter(authordata.twitter) }}</title>
                       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#twitter"></use>
                     </svg>
@@ -143,7 +143,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
                   {% endif %}
                   {% if authordata.github %}
                   <a class="github" href="https://github.com/{{ authordata.github }}" aria-labelledby="author-{{ author }}-github">
-                    <svg width="22" height="22" aria-hidden>
+                    <svg width="22" height="22">
                       <title id="author-{{ author }}-github">{{ onGitHub(authordata.github) }}</title>
                       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#github"></use>
                     </svg>
@@ -152,7 +152,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
                   {% endif %}
                   {% if authordata.linkedin %}
                   <a class="linkedin" href="https://www.linkedin.com/in/{{ authordata.linkedin }}/" aria-labelledby="author-{{ author }}-linkedin">
-                    <svg width="22" height="22" aria-hidden>
+                    <svg width="22" height="22">
                       <title id="author-{{ author }}-linkedin">{{ onLinkedIn(authordata.name) }}</title>
                       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#linkedin"></use>
                     </svg>
@@ -161,7 +161,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
                   {% endif %}
                   {% if authordata.website %}
                   <a class="website" href="{{ authordata.website }}" aria-labelledby="author-{{ author }}-website">
-                    <svg width="22" height="22" aria-hidden>
+                    <svg width="22" height="22">
                       <title id="author-{{ author }}-website">{{ website(authordata.name) }}</title>
                       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#globe"></use>
                     </svg>


### PR DESCRIPTION
We’ve recently lost some Lighthouse points on Accessibility and SEO due to #1185 meaning we’re no longer getting 100% for them:

![Lighthouse Score for 2019 JavaScript chapter showing 92 for Performance, 94 for Accessibility, 100 for Best Practices and 99 for SEO](https://user-images.githubusercontent.com/10931297/90308931-c60a7680-dedb-11ea-912a-4c0e72c32f3c.jpeg)

This PR fixes it.

Hopefully when we complete #1178 this won’t be allowed to happen.