### PR TITLE
Track changes between releases

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,6 @@
+template: |
+  ## What’s Changed
+
+  $CHANGES
+exclude-labels:
+  - 'generate chapters'

--- a/.github/workflows/add-to-release-notes.yml
+++ b/.github/workflows/add-to-release-notes.yml
@@ -1,0 +1,21 @@
+######################################
+## Custom Web Almanac GitHub action ##
+######################################
+#
+# This updates the current draft release notes with this commit
+# Excluding certain automated commits (e.g. Generate Chapters or Ebooks)
+#
+name: Add to Release Notes
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release-notes:
+    runs-on: ubuntu-latest
+    if: github.repository == 'HTTPArchive/almanac.httparchive.org'
+    steps:
+    - name: Update release notes
+      uses: release-drafter/release-drafter@v5.11.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Makes progress on #1086 

Adds a draft release note and updates with each pull request merged (except the Generate Chapter ones).

This can then be tagged as a release and started over again.

This will be useful to track what changes are in a release.