### PR TITLE
Display Ebook download size on link

### DIFF
--- a/src/server/__init__.py
+++ b/src/server/__init__.py
@@ -1,7 +1,7 @@
 from flask import Flask
 from flask_talisman import Talisman
 from werkzeug.http import HTTP_STATUS_CODES
-from .helpers import get_view_args, chapter_lang_exists, ebook_exists, get_ebook_methodology, add_footnote_links, \
+from .helpers import get_view_args, chapter_lang_exists, get_ebook_methodology, add_footnote_links, \
     year_live, accentless_sort, RegexConverter
 from .config import TEMPLATES_DIR, STATIC_DIR
 from . import csp, feature_policy
@@ -55,7 +55,6 @@ app.url_map.converters['regex'] = RegexConverter
 # Make these functions available in templates.
 app.jinja_env.globals['get_view_args'] = get_view_args
 app.jinja_env.globals['chapter_lang_exists'] = chapter_lang_exists
-app.jinja_env.globals['ebook_exists'] = ebook_exists
 app.jinja_env.globals['HTTP_STATUS_CODES'] = HTTP_STATUS_CODES
 app.jinja_env.globals['get_ebook_methodology'] = get_ebook_methodology
 app.jinja_env.globals['add_footnote_links'] = add_footnote_links

--- a/src/server/helpers.py
+++ b/src/server/helpers.py
@@ -87,7 +87,7 @@ def get_chapter_nextprev(config, chapter_slug):
     return prev_chapter, next_chapter
 
 
-def get_ebook_size(lang, year):
+def get_ebook_size_in_mb(lang, year):
     ebook_file = STATIC_DIR + '/pdfs/web_almanac_%s_%s.pdf' % (year, lang)
     if os.path.isfile(ebook_file):
         size = os.path.getsize(ebook_file)

--- a/src/server/helpers.py
+++ b/src/server/helpers.py
@@ -91,10 +91,8 @@ def get_ebook_size(lang, year):
     ebook_file = STATIC_DIR + '/pdfs/web_almanac_%s_%s.pdf' % (year, lang)
     if os.path.isfile(ebook_file):
         size = os.path.getsize(ebook_file)
-        # Convert to MB with decimal point precision (e.g. 17.1MB)
-        # Note we use 1000 rather than 1024 as that's worst case and how
-        # MacOS reports it - Windows seems to use 1000 / 1024
-        size = int(round(size / 1024 / 1000, 0))
+        # Convert to MB
+        size = int(round(size / 1024 / 1024, 0))
         return size
 
     return 0

--- a/src/server/helpers.py
+++ b/src/server/helpers.py
@@ -87,8 +87,14 @@ def get_chapter_nextprev(config, chapter_slug):
     return prev_chapter, next_chapter
 
 
-def ebook_exists(lang, year):
-    return os.path.isfile(STATIC_DIR + '/pdfs/web_almanac_%s_%s.pdf' % (year, lang))
+def get_ebook_size(lang, year):
+    ebook_file = STATIC_DIR + '/pdfs/web_almanac_%s_%s.pdf' % (year, lang)
+    if os.path.isfile(ebook_file):
+        size = os.path.getsize(ebook_file)
+        size = round(size / 1000 / 1000, 1)
+        return size
+
+    return 0
 
 
 def get_view_args(lang=None, year=None):

--- a/src/server/helpers.py
+++ b/src/server/helpers.py
@@ -91,7 +91,10 @@ def get_ebook_size(lang, year):
     ebook_file = STATIC_DIR + '/pdfs/web_almanac_%s_%s.pdf' % (year, lang)
     if os.path.isfile(ebook_file):
         size = os.path.getsize(ebook_file)
-        size = round(size / 1000 / 1000, 1)
+        # Convert to MB with decimal point precision (e.g. 17.1MB)
+        # Note we use 1000 rather than 1024 as that's worst case and how
+        # MacOS reports it - Windows seems to use 1000 / 1024
+        size = int(round(size / 1024 / 1000, 0))
         return size
 
     return 0

--- a/src/server/routes.py
+++ b/src/server/routes.py
@@ -1,6 +1,6 @@
 from flask import redirect, url_for, request, send_from_directory
 from . import app, talisman
-from .helpers import render_template, convert_old_image_path, get_chapter_nextprev, get_ebook_size
+from .helpers import render_template, convert_old_image_path, get_chapter_nextprev, get_ebook_size_in_mb
 from .validate import validate
 from .config import get_config, DEFAULT_YEAR
 import random
@@ -31,8 +31,8 @@ def root(lang):
 @validate
 def table_of_contents(lang, year):
     config = get_config(year)
-    ebook_size = get_ebook_size(lang, year)
-    return render_template('%s/%s/table_of_contents.html' % (lang, year), config=config, ebook_size=ebook_size)
+    ebook_size_in_mb = get_ebook_size_in_mb(lang, year)
+    return render_template('%s/%s/table_of_contents.html' % (lang, year), config=config, ebook_size_in_mb=ebook_size_in_mb)
 
 
 @app.route('/<lang>/<year>/contributors')

--- a/src/server/routes.py
+++ b/src/server/routes.py
@@ -1,6 +1,6 @@
 from flask import redirect, url_for, request, send_from_directory
 from . import app, talisman
-from .helpers import render_template, convert_old_image_path, get_chapter_nextprev
+from .helpers import render_template, convert_old_image_path, get_chapter_nextprev, get_ebook_size
 from .validate import validate
 from .config import get_config, DEFAULT_YEAR
 import random
@@ -31,7 +31,8 @@ def root(lang):
 @validate
 def table_of_contents(lang, year):
     config = get_config(year)
-    return render_template('%s/%s/table_of_contents.html' % (lang, year), config=config)
+    ebook_size = get_ebook_size(lang, year)
+    return render_template('%s/%s/table_of_contents.html' % (lang, year), config=config, ebook_size=ebook_size)
 
 
 @app.route('/<lang>/<year>/contributors')

--- a/src/server/routes.py
+++ b/src/server/routes.py
@@ -32,7 +32,8 @@ def root(lang):
 def table_of_contents(lang, year):
     config = get_config(year)
     ebook_size_in_mb = get_ebook_size_in_mb(lang, year)
-    return render_template('%s/%s/table_of_contents.html' % (lang, year), config=config, ebook_size_in_mb=ebook_size_in_mb)
+    return render_template('%s/%s/table_of_contents.html' % (lang, year), config=config,
+                           ebook_size_in_mb=ebook_size_in_mb)
 
 
 @app.route('/<lang>/<year>/contributors')

--- a/src/templates/base/2019/table_of_contents.html
+++ b/src/templates/base/2019/table_of_contents.html
@@ -141,7 +141,7 @@
       </section>
     </div>
 
-    {% if ebook_size > 0 %}
+    {% if ebook_size_in_mb > 0 %}
     <section class="part">
       <h2 id="ebook" class="part-name"><a href="#ebook" class="anchor-link">{{ self.ebook_title() }}</a></h2>
       <div class="chapters">

--- a/src/templates/base/2019/table_of_contents.html
+++ b/src/templates/base/2019/table_of_contents.html
@@ -141,7 +141,7 @@
       </section>
     </div>
 
-    {% if ebook_exists(lang, year) %}
+    {% if ebook_size > 0 %}
     <section class="part">
       <h2 id="ebook" class="part-name"><a href="#ebook" class="anchor-link">{{ self.ebook_title() }}</a></h2>
       <div class="chapters">

--- a/src/templates/en/2019/base.html
+++ b/src/templates/en/2019/base.html
@@ -122,7 +122,7 @@ Unless otherwise noted, the metrics in all of the 20 chapters of the Web Almanac
 {% block appendices %}Appendices{% endblock %}
 
 {% block ebook_title %}Ebook{% endblock %}
-{% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format{% endblock %}
+{% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format (18MB){% endblock %}
 {% block ebook_download_note %}(generated with <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 
 {% 

--- a/src/templates/en/2019/base.html
+++ b/src/templates/en/2019/base.html
@@ -122,7 +122,7 @@ Unless otherwise noted, the metrics in all of the 20 chapters of the Web Almanac
 {% block appendices %}Appendices{% endblock %}
 
 {% block ebook_title %}Ebook{% endblock %}
-{% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format (18MB){% endblock %}
+{% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format ({{ ebook_size }}MB){% endblock %}
 {% block ebook_download_note %}(generated with <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 
 {% 

--- a/src/templates/en/2019/base.html
+++ b/src/templates/en/2019/base.html
@@ -122,7 +122,7 @@ Unless otherwise noted, the metrics in all of the 20 chapters of the Web Almanac
 {% block appendices %}Appendices{% endblock %}
 
 {% block ebook_title %}Ebook{% endblock %}
-{% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format ({{ ebook_size }}MB){% endblock %}
+{% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format ({{ ebook_size_in_mb }}MB){% endblock %}
 {% block ebook_download_note %}(generated with <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 
 {% 

--- a/src/templates/es/2019/base.html
+++ b/src/templates/es/2019/base.html
@@ -122,7 +122,7 @@ A menos que se indique lo contrario, las métricas en los 20 capítulos del Web 
 {% block appendices %}Apéndices{% endblock %}
 
 {% block ebook_title %}Libro electronico{% endblock %}
-{% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format ({{ ebook_size }}MB){% endblock %}
+{% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format ({{ ebook_size_in_mb }}MB){% endblock %}
 {% block ebook_download_note %}(generated with <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 
 {% 

--- a/src/templates/es/2019/base.html
+++ b/src/templates/es/2019/base.html
@@ -122,7 +122,7 @@ A menos que se indique lo contrario, las métricas en los 20 capítulos del Web 
 {% block appendices %}Apéndices{% endblock %}
 
 {% block ebook_title %}Libro electronico{% endblock %}
-{% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format{% endblock %}
+{% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format (18MB){% endblock %}
 {% block ebook_download_note %}(generated with <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 
 {% 

--- a/src/templates/es/2019/base.html
+++ b/src/templates/es/2019/base.html
@@ -122,7 +122,7 @@ A menos que se indique lo contrario, las métricas en los 20 capítulos del Web 
 {% block appendices %}Apéndices{% endblock %}
 
 {% block ebook_title %}Libro electronico{% endblock %}
-{% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format (18MB){% endblock %}
+{% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format ({{ ebook_size }}MB){% endblock %}
 {% block ebook_download_note %}(generated with <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 
 {% 

--- a/src/templates/fr/2019/base.html
+++ b/src/templates/fr/2019/base.html
@@ -122,7 +122,7 @@ Sauf indication contraire, les statistiques des 20 chapitres du Web Almanac prov
 {% block appendices %}Annexes{% endblock %}
 
 {% block ebook_title %}Ebook{% endblock %}
-{% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format ({{ ebook_size }}MB){% endblock %}
+{% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format ({{ ebook_size_in_mb }}MB){% endblock %}
 {% block ebook_download_note %}(generated with <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 
 {%

--- a/src/templates/fr/2019/base.html
+++ b/src/templates/fr/2019/base.html
@@ -122,7 +122,7 @@ Sauf indication contraire, les statistiques des 20 chapitres du Web Almanac prov
 {% block appendices %}Annexes{% endblock %}
 
 {% block ebook_title %}Ebook{% endblock %}
-{% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format (18MB){% endblock %}
+{% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format ({{ ebook_size }}MB){% endblock %}
 {% block ebook_download_note %}(generated with <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 
 {%

--- a/src/templates/fr/2019/base.html
+++ b/src/templates/fr/2019/base.html
@@ -122,7 +122,7 @@ Sauf indication contraire, les statistiques des 20 chapitres du Web Almanac prov
 {% block appendices %}Annexes{% endblock %}
 
 {% block ebook_title %}Ebook{% endblock %}
-{% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format{% endblock %}
+{% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format (18MB){% endblock %}
 {% block ebook_download_note %}(generated with <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 
 {%

--- a/src/templates/ja/2019/base.html
+++ b/src/templates/ja/2019/base.html
@@ -122,7 +122,7 @@ Web Almanacは、ウェブ・コミュニティの努力によって実現して
 {% block appendices %}付属資料{% endblock %}
 
 {% block ebook_title %}電子ブック{% endblock %}
-{% block ebook_download %} {{ year }} Web AlmanacのPDFファイルをダウンロードする (18MB){% endblock %}
+{% block ebook_download %} {{ year }} Web AlmanacのPDFファイルをダウンロードする ({{ ebook_size }}MB){% endblock %}
 {% block ebook_download_note %}(generated with <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 
 {% 

--- a/src/templates/ja/2019/base.html
+++ b/src/templates/ja/2019/base.html
@@ -122,7 +122,7 @@ Web Almanacは、ウェブ・コミュニティの努力によって実現して
 {% block appendices %}付属資料{% endblock %}
 
 {% block ebook_title %}電子ブック{% endblock %}
-{% block ebook_download %} {{ year }} Web AlmanacのPDFファイルをダウンロードする{% endblock %}
+{% block ebook_download %} {{ year }} Web AlmanacのPDFファイルをダウンロードする (18MB){% endblock %}
 {% block ebook_download_note %}(generated with <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 
 {% 

--- a/src/templates/ja/2019/base.html
+++ b/src/templates/ja/2019/base.html
@@ -122,7 +122,7 @@ Web Almanacは、ウェブ・コミュニティの努力によって実現して
 {% block appendices %}付属資料{% endblock %}
 
 {% block ebook_title %}電子ブック{% endblock %}
-{% block ebook_download %} {{ year }} Web AlmanacのPDFファイルをダウンロードする ({{ ebook_size }}MB){% endblock %}
+{% block ebook_download %} {{ year }} Web AlmanacのPDFファイルをダウンロードする ({{ ebook_size_in_mb }}MB){% endblock %}
 {% block ebook_download_note %}(generated with <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 
 {% 

--- a/src/templates/pt/2019/base.html
+++ b/src/templates/pt/2019/base.html
@@ -122,7 +122,7 @@ Salvo indicação em contrário, as métricas em todos os 20 capítulos do Web A
 {% block appendices %}Apêndices{% endblock %}
 
 {% block ebook_title %}Ebook{% endblock %}
-{% block ebook_download %}Faça o download do Web Almanac {{ year }} completo em formato PDF (18MB){% endblock %}
+{% block ebook_download %}Faça o download do Web Almanac {{ year }} completo em formato PDF ({{ ebook_size }}MB){% endblock %}
 {% block ebook_download_note %}(gerado em <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 
 {% 

--- a/src/templates/pt/2019/base.html
+++ b/src/templates/pt/2019/base.html
@@ -122,7 +122,7 @@ Salvo indicação em contrário, as métricas em todos os 20 capítulos do Web A
 {% block appendices %}Apêndices{% endblock %}
 
 {% block ebook_title %}Ebook{% endblock %}
-{% block ebook_download %}Faça o download do Web Almanac {{ year }} completo em formato PDF ({{ ebook_size }}MB){% endblock %}
+{% block ebook_download %}Faça o download do Web Almanac {{ year }} completo em formato PDF ({{ ebook_size_in_mb }}MB){% endblock %}
 {% block ebook_download_note %}(gerado em <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 
 {% 

--- a/src/templates/pt/2019/base.html
+++ b/src/templates/pt/2019/base.html
@@ -122,7 +122,7 @@ Salvo indicação em contrário, as métricas em todos os 20 capítulos do Web A
 {% block appendices %}Apêndices{% endblock %}
 
 {% block ebook_title %}Ebook{% endblock %}
-{% block ebook_download %}Faça o download do Web Almanac {{ year }} completo em formato PDF{% endblock %}
+{% block ebook_download %}Faça o download do Web Almanac {{ year }} completo em formato PDF (18MB){% endblock %}
 {% block ebook_download_note %}(gerado em <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 
 {% 

--- a/src/templates/zh-CN/2019/base.html
+++ b/src/templates/zh-CN/2019/base.html
@@ -122,7 +122,7 @@
 {% block appendices %}附录{% endblock %}
 
 {% block ebook_title %}Ebook{% endblock %}
-{% block ebook_download %}下载 {{ year }} Web Almanac网络年鉴 ：PDF 格式 (18MB){% endblock %}
+{% block ebook_download %}下载 {{ year }} Web Almanac网络年鉴 ：PDF 格式 ({{ ebook_size }}MB){% endblock %}
 {% block ebook_download_note %}(使用 <a href="https://www.princexml.com/">www.princexml.com</a>生成){% endblock %}
 
 {% 

--- a/src/templates/zh-CN/2019/base.html
+++ b/src/templates/zh-CN/2019/base.html
@@ -122,7 +122,7 @@
 {% block appendices %}附录{% endblock %}
 
 {% block ebook_title %}Ebook{% endblock %}
-{% block ebook_download %}下载 {{ year }} Web Almanac网络年鉴 ：PDF 格式{% endblock %}
+{% block ebook_download %}下载 {{ year }} Web Almanac网络年鉴 ：PDF 格式 (18MB){% endblock %}
 {% block ebook_download_note %}(使用 <a href="https://www.princexml.com/">www.princexml.com</a>生成){% endblock %}
 
 {% 

--- a/src/templates/zh-CN/2019/base.html
+++ b/src/templates/zh-CN/2019/base.html
@@ -122,7 +122,7 @@
 {% block appendices %}附录{% endblock %}
 
 {% block ebook_title %}Ebook{% endblock %}
-{% block ebook_download %}下载 {{ year }} Web Almanac网络年鉴 ：PDF 格式 ({{ ebook_size }}MB){% endblock %}
+{% block ebook_download %}下载 {{ year }} Web Almanac网络年鉴 ：PDF 格式 ({{ ebook_size_in_mb }}MB){% endblock %}
 {% block ebook_download_note %}(使用 <a href="https://www.princexml.com/">www.princexml.com</a>生成){% endblock %}
 
 {% 


### PR DESCRIPTION
The Ebook is quite large (approx 17Mb) so we should make people aware of this before they click on the download link.

Previous:
![Ebook downlink without size](https://user-images.githubusercontent.com/10931297/91163657-d84b9800-e6c5-11ea-85c4-81672c7a9f15.png)

With this change:
![Ebook downlink with size](https://user-images.githubusercontent.com/10931297/91164581-2ad98400-e6c7-11ea-83bb-825caa084936.png)
