### PR TITLE
Voiceover percentiles for English chapters

### DIFF
--- a/src/content/en/2019/cdn.md
+++ b/src/content/en/2019/cdn.md
@@ -486,11 +486,15 @@ In contrast, the median TLS negotiation for the majority of CDN providers is bet
     <thead>
       <tr>
         <td></td>
-        <th scope="col">p10</th>
-        <th scope="col">p25</th>
-        <th scope="col">p50</th>
-        <th scope="col">p75</th>
-        <th scope="col">p90</th>
+        <th colspan="5" scope="col">Percentile</th>
+      </tr>
+      <tr>
+        <td></td>
+        <th scope="col">10</th>
+        <th scope="col">25</th>
+        <th scope="col">50</th>
+        <th scope="col">75</th>
+        <th scope="col">90</th>
       </tr>
     </thead>
     <tbody>
@@ -649,7 +653,7 @@ For resource requests (including same-domain and third-party), the TLS negotiati
   <a href="/static/images/2019/cdn/resource_tls_negotiation_time.png">
     <img alt="Distribution of TLS negotiation time for site resources broken down by CDN" aria-labelledby="fig10-caption" aria-describedby="fig10-description" src="/static/images/2019/cdn/resource_tls_negotiation_time.png" width="600" height="371">
   </a>
-  <div id="fig10-description" class="visually-hidden">Graph showing most CDNs have a TLS negotiation time of around 80 ms, but some (Microsoft Azure, Yahoo, Edgecast, ORIGIN, and CDNetworks) start to creep out towards 200 ms - especially when going above the p50 percentile.</div>
+  <div id="fig10-description" class="visually-hidden">Graph showing most CDNs have a TLS negotiation time of around 80 ms, but some (Microsoft Azure, Yahoo, Edgecast, ORIGIN, and CDNetworks) start to creep out towards 200 ms - especially when going above the 50th percentile.</div>
   <figcaption id="fig10-caption">Figure 10. Resource TLS negotiation time.</figcaption>
 </figure>
 
@@ -683,11 +687,15 @@ Most CDNs balance the need for shared certificates and performance. Most cap the
     <thead>
       <tr>
         <td></td>
-        <th scope="col">p10</th>
-        <th scope="col">p25</th>
-        <th scope="col">p50</th>
-        <th scope="col">p75</th>
-        <th scope="col">p90</th>
+        <th colspan="5" scope="col">Percentile</th>
+      </tr>
+      <tr>
+        <td></td>
+        <th scope="col">10</th>
+        <th scope="col">25</th>
+        <th scope="col">50</th>
+        <th scope="col">75</th>
+        <th scope="col">90</th>
       </tr>
     </thead>
     <tbody>
@@ -842,10 +850,10 @@ Most CDNs balance the need for shared certificates and performance. Most cap the
 
 <figure>
   <a href="/static/images/2019/cdn/fig13.png">
-    <img src="/static/images/2019/cdn/fig13.png" alt="Figure 13. Resource SAN count (p50)." aria-labelledby="fig13-caption" aria-describedby="fig13-description" width="600" height="371" data-width="600" data-height="371" data-seamless data-frameborder="0" data-scrolling="no" data-iframe="https://docs.google.com/spreadsheets/d/e/2PACX-1vRzPn-1SGVa3rNCT0U9QeQNODE97fsmXyaJX1ZOoBNR8nPpclhC6fg8R_UpoodeiX6HkdHrp50WBQ5Q/pubchart?oid=528008536&format=interactive">
+    <img src="/static/images/2019/cdn/fig13.png" alt="Figure 13. Resource SAN count (50th percentile)." aria-labelledby="fig13-caption" aria-describedby="fig13-description" width="600" height="371" data-width="600" data-height="371" data-seamless data-frameborder="0" data-scrolling="no" data-iframe="https://docs.google.com/spreadsheets/d/e/2PACX-1vRzPn-1SGVa3rNCT0U9QeQNODE97fsmXyaJX1ZOoBNR8nPpclhC6fg8R_UpoodeiX6HkdHrp50WBQ5Q/pubchart?oid=528008536&format=interactive">
   </a>
-  <div id="fig13-description" class="visually-hidden">Bar chart showing the data from Table 14 for the p50 percentile.</div>
-  <figcaption id="fig13-caption">Figure 13. Resource SAN count (p50).</figcaption>
+  <div id="fig13-description" class="visually-hidden">Bar chart showing the data from Table 14 for the 50th percentile.</div>
+  <figcaption id="fig13-caption">Figure 13. Resource SAN count (50th percentile).</figcaption>
 </figure>
 
 <figure>
@@ -853,11 +861,15 @@ Most CDNs balance the need for shared certificates and performance. Most cap the
     <thead>
       <tr>
         <td></td>
-        <th scope="col">p10</th>
-        <th scope="col">p25</th>
-        <th scope="col">p50</th>
-        <th scope="col">p75</th>
-        <th scope="col">p90</th>
+        <th colspan="5" scope="col">Percentile</th>
+      </tr>
+      <tr>
+        <td></td>
+        <th scope="col">10</th>
+        <th scope="col">25</th>
+        <th scope="col">50</th>
+        <th scope="col">75</th>
+        <th scope="col">90</th>
       </tr>
     </thead>
     <tbody>

--- a/src/content/en/2019/cdn.md
+++ b/src/content/en/2019/cdn.md
@@ -853,15 +853,11 @@ Most CDNs balance the need for shared certificates and performance. Most cap the
     <thead>
       <tr>
         <td></td>
-        <th colspan="5" scope="colgroup">Percentile</th>
-      </tr>
-      <tr>
-        <td></td>
-        <th scope="col">10</th>
-        <th scope="col">25</th>
-        <th scope="col">50</th>
-        <th scope="col">75</th>
-        <th scope="col">90</th>
+        <th scope="col"><span class="visually-hidden">10th percentile</span><span aria-hidden="true">p10</span></th>
+        <th scope="col"><span class="visually-hidden">25th percentile</span><span aria-hidden="true">p25</span></th>
+        <th scope="col"><span class="visually-hidden">50th percentile</span><span aria-hidden="true">p50</span></th>
+        <th scope="col"><span class="visually-hidden">75th percentile</span><span aria-hidden="true">p75</span></th>
+        <th scope="col"><span class="visually-hidden">90th percentile</span><span aria-hidden="true">p90</span></th>
       </tr>
     </thead>
     <tbody>

--- a/src/content/en/2019/cdn.md
+++ b/src/content/en/2019/cdn.md
@@ -486,15 +486,11 @@ In contrast, the median TLS negotiation for the majority of CDN providers is bet
     <thead>
       <tr>
         <td></td>
-        <th colspan="5" scope="colgroup">Percentile</th>
-      </tr>
-      <tr>
-        <td></td>
-        <th scope="col">10</th>
-        <th scope="col">25</th>
-        <th scope="col">50</th>
-        <th scope="col">75</th>
-        <th scope="col">90</th>
+        <th scope="col"><span class="visually-hidden">10th percentile</span><span aria-hidden="true">p10</span></th>
+        <th scope="col"><span class="visually-hidden">25th percentile</span><span aria-hidden="true">p25</span></th>
+        <th scope="col"><span class="visually-hidden">50th percentile</span><span aria-hidden="true">p50</span></th>
+        <th scope="col"><span class="visually-hidden">75th percentile</span><span aria-hidden="true">p75</span></th>
+        <th scope="col"><span class="visually-hidden">90th percentile</span><span aria-hidden="true">p90</span></th>
       </tr>
     </thead>
     <tbody>
@@ -687,15 +683,11 @@ Most CDNs balance the need for shared certificates and performance. Most cap the
     <thead>
       <tr>
         <td></td>
-        <th colspan="5" scope="colgroup">Percentile</th>
-      </tr>
-      <tr>
-        <td></td>
-        <th scope="col">10</th>
-        <th scope="col">25</th>
-        <th scope="col">50</th>
-        <th scope="col">75</th>
-        <th scope="col">90</th>
+        <th scope="col"><span class="visually-hidden">10th percentile</span><span aria-hidden="true">p10</span></th>
+        <th scope="col"><span class="visually-hidden">25th percentile</span><span aria-hidden="true">p25</span></th>
+        <th scope="col"><span class="visually-hidden">50th percentile</span><span aria-hidden="true">p50</span></th>
+        <th scope="col"><span class="visually-hidden">75th percentile</span><span aria-hidden="true">p75</span></th>
+        <th scope="col"><span class="visually-hidden">90th percentile</span><span aria-hidden="true">p90</span></th>
       </tr>
     </thead>
     <tbody>

--- a/src/content/en/2019/cdn.md
+++ b/src/content/en/2019/cdn.md
@@ -486,7 +486,7 @@ In contrast, the median TLS negotiation for the majority of CDN providers is bet
     <thead>
       <tr>
         <td></td>
-        <th colspan="5" scope="col">Percentile</th>
+        <th colspan="5" scope="colgroup">Percentile</th>
       </tr>
       <tr>
         <td></td>
@@ -687,7 +687,7 @@ Most CDNs balance the need for shared certificates and performance. Most cap the
     <thead>
       <tr>
         <td></td>
-        <th colspan="5" scope="col">Percentile</th>
+        <th colspan="5" scope="colgroup">Percentile</th>
       </tr>
       <tr>
         <td></td>
@@ -861,7 +861,7 @@ Most CDNs balance the need for shared certificates and performance. Most cap the
     <thead>
       <tr>
         <td></td>
-        <th colspan="5" scope="col">Percentile</th>
+        <th colspan="5" scope="colgroup">Percentile</th>
       </tr>
       <tr>
         <td></td>

--- a/src/content/en/2019/javascript.md
+++ b/src/content/en/2019/javascript.md
@@ -31,7 +31,7 @@ Sending smaller JavaScript bundles to the browser is the best way to reduce down
    <a href="/static/images/2019/javascript/fig1.png">
       <img src="/static/images/2019/javascript/fig1.png" alt="Figure 1. Distribution of JavaScript bytes per page." aria-labelledby="fig1-caption" aria-describedby="fig1-description" width="600" height="371" data-width="600" data-height="371" data-seamless data-frameborder="0" data-scrolling="no" data-iframe="https://docs.google.com/spreadsheets/d/e/2PACX-1vTpzDb9HGbdVvin6YPTOmw11qBVGGysltxmH545fUfnqIThAq878F_b-KxUo65IuXaeFVSnlmJ5K1Dm/pubchart?oid=1974602890&format=interactive">
    </a>
-   <div id="fig1-description" class="visually-hidden">Bar chart showing 70 bytes of JavaScript are used in the p10 percentile, 174 bytes for p25, 373 bytes for p50, 693 bytes for p75, and 1,093 bytes for p90</div>
+   <div id="fig1-description" class="visually-hidden">Bar chart showing 70 bytes of JavaScript are used in the 10th percentile, 174 bytes for 25th percentile, 373 bytes for 50th percentile, 693 bytes for 75th percentile, and 1,093 bytes for 90th percentile</div>
    <figcaption id="fig1-caption">Figure 1. Distribution of JavaScript bytes per page.</figcaption>
 </figure>
 
@@ -43,7 +43,7 @@ Looking at these numbers, it's only natural to wonder if this is too much JavaSc
    <a href="/static/images/2019/javascript/fig2.png">
       <img src="/static/images/2019/javascript/fig2.png" alt="Figure 2. Distribution of JavaScript per page by device." aria-labelledby="fig2-caption" aria-describedby="fig2-description" width="600" height="371" data-width="600" data-height="371" data-seamless data-frameborder="0" data-scrolling="no" data-iframe="https://docs.google.com/spreadsheets/d/e/2PACX-1vTpzDb9HGbdVvin6YPTOmw11qBVGGysltxmH545fUfnqIThAq878F_b-KxUo65IuXaeFVSnlmJ5K1Dm/pubchart?oid=1914565673&format=interactive">
    </a>
-   <div id="fig2-description" class="visually-hidden">Bar chart showing 76 bytes/65 bytes of JavaScript are used in the p10 percentile on desktop and mobile respectively, 186/164 bytes for p25, 391/359 bytes for p50, 721/668 bytes for p75, and 1,131/1,060 bytes for p90.</div>
+   <div id="fig2-description" class="visually-hidden">Bar chart showing 76 bytes/65 bytes of JavaScript are used in the 10th percentile on desktop and mobile respectively, 186/164 bytes for 25th percentile, 391/359 bytes for 50th percentile, 721/668 bytes for 75th percentile, and 1,131/1,060 bytes for 90th percentile.</div>
    <figcaption id="fig2-caption">Figure 2. Distribution of JavaScript per page by device.</figcaption>
 </figure>
 
@@ -59,7 +59,7 @@ We can get an idea by analyzing main thread processing times for V8 at different
    <a href="/static/images/2019/javascript/fig3.png">
       <img src="/static/images/2019/javascript/fig3.png" alt="Figure 3. V8 Main thread processing times by device." aria-labelledby="fig3-caption" aria-describedby="fig3-description" width="600" height="371" data-width="600" data-height="371" data-seamless data-frameborder="0" data-scrolling="no" data-iframe="https://docs.google.com/spreadsheets/d/e/2PACX-1vTpzDb9HGbdVvin6YPTOmw11qBVGGysltxmH545fUfnqIThAq878F_b-KxUo65IuXaeFVSnlmJ5K1Dm/pubchart?oid=924000517&format=interactive">
    </a>
-   <div id="fig3-description" class="visually-hidden">Bar chart showing 141 ms/377 ms of processing time is used in the p10 percentile on desktop and mobile respectively, 352/988 ms for p25, 849/2,437 ms for p50, 1,850/5,518 ms for p75, and 3,543/10,735 ms for p90.</div>
+   <div id="fig3-description" class="visually-hidden">Bar chart showing 141 ms/377 ms of processing time is used in the 10th percentile on desktop and mobile respectively, 352/988 ms for 25th percentile, 849/2,437 ms for 50th percentile, 1,850/5,518 ms for 75th percentile, and 3,543/10,735 ms for 90th percentile.</div>
    <figcaption id="fig3-caption">Figure 3. V8 Main thread processing times by device.</figcaption>
 </figure>
 
@@ -83,7 +83,7 @@ One avenue worth exploring when trying to analyze the amount of JavaScript used 
    <a href="/static/images/2019/javascript/fig5.png">
       <img src="/static/images/2019/javascript/fig5.png" alt="Figure 5. Distribution of total JavaScript requests." aria-labelledby="fig5-caption" aria-describedby="fig5-description" width="600" height="371" data-width="600" data-height="371" data-seamless data-frameborder="0" data-scrolling="no" data-iframe="https://docs.google.com/spreadsheets/d/e/2PACX-1vTpzDb9HGbdVvin6YPTOmw11qBVGGysltxmH545fUfnqIThAq878F_b-KxUo65IuXaeFVSnlmJ5K1Dm/pubchart?oid=1632335480&format=interactive">
    </a>
-   <div id="fig5-description" class="visually-hidden">Bar chart showing 4/4 requests for desktop and mobile respectively are used in the p10 percentile, 10/9 in p25, 19/18 in p50, 33/32 in p75 and 53/52 in p90.</div>
+   <div id="fig5-description" class="visually-hidden">Bar chart showing 4/4 requests for desktop and mobile respectively are used in the 10th percentile, 10/9 in 25th percentile, 19/18 in 50th percentile, 33/32 in 75th percentile and 53/52 in 90th percentile.</div>
    <figcaption id="fig5-caption">Figure 5. Distribution of total JavaScript requests.</figcaption>
 </figure>
 
@@ -99,7 +99,7 @@ Third-party JavaScript can come from any external, third-party source. Ads, anal
    <a href="/static/images/2019/javascript/fig6.png">
       <img src="/static/images/2019/javascript/fig6.png" alt="Figure 6. Distribution of first and third-party scripts on desktop." aria-labelledby="fig6-caption" aria-describedby="fig6-description" width="600" height="371" data-width="600" data-height="371" data-seamless data-frameborder="0" data-scrolling="no" data-iframe="https://docs.google.com/spreadsheets/d/e/2PACX-1vTpzDb9HGbdVvin6YPTOmw11qBVGGysltxmH545fUfnqIThAq878F_b-KxUo65IuXaeFVSnlmJ5K1Dm/pubchart?oid=1108490&format=interactive">
    </a>
-   <div id="fig6-description" class="visually-hidden">Bar chart showing 0/1 request on desktop are first-party and third-party respectively in p10 percentile, 2/4 in p25, 6/10 in p50, 13/21 in p75, and 24/38 in p90.</div>
+   <div id="fig6-description" class="visually-hidden">Bar chart showing 0/1 request on desktop are first-party and third-party respectively in 10th percentile, 2/4 in 25th percentile, 6/10 in 50th percentile, 13/21 in 75th percentile, and 24/38 in 90th percentile.</div>
    <figcaption id="fig6-caption">Figure 6. Distribution of first and third-party scripts on desktop.</figcaption>
 </figure>
 
@@ -107,7 +107,7 @@ Third-party JavaScript can come from any external, third-party source. Ads, anal
    <a href="/static/images/2019/javascript/fig7.png">
       <img src="/static/images/2019/javascript/fig7.png" alt="Figure 7. Distribution of first and third party scripts on mobile." aria-labelledby="fig7-caption" aria-describedby="fig7-description" width="600" height="371" data-width="600" data-height="371" data-seamless data-frameborder="0" data-scrolling="no" data-iframe="https://docs.google.com/spreadsheets/d/e/2PACX-1vTpzDb9HGbdVvin6YPTOmw11qBVGGysltxmH545fUfnqIThAq878F_b-KxUo65IuXaeFVSnlmJ5K1Dm/pubchart?oid=998640509&format=interactive">
    </a>
-   <div id="fig7-description" class="visually-hidden">Bar chart showing 0/1 request on mobile are first-party and third-party respectively in p10 percentile, 2/3 in p25, 5/9 in p50, 13/20 in p75, and 23/36 in p90.</div>
+   <div id="fig7-description" class="visually-hidden">Bar chart showing 0/1 request on mobile are first-party and third-party respectively in 10th percentile, 2/3 in 25th percentile, 5/9 in 50th percentile, 13/20 in 75th percentile, and 23/36 in 90th percentile.</div>
    <figcaption id="fig7-caption">Figure 7. Distribution of first and third party scripts on mobile.</figcaption>
 </figure>
 
@@ -117,7 +117,7 @@ For both mobile and desktop clients, more third-party requests are sent than fir
    <a href="/static/images/2019/javascript/fig8.png">
       <img src="/static/images/2019/javascript/fig8.png" alt="Figure 8. Distribution of total JavaScript downloaded on desktop." aria-labelledby="fig8-caption" aria-describedby="fig8-description" width="600" height="371" data-width="600" data-height="371" data-seamless data-frameborder="0" data-scrolling="no" data-iframe="https://docs.google.com/spreadsheets/d/e/2PACX-1vTpzDb9HGbdVvin6YPTOmw11qBVGGysltxmH545fUfnqIThAq878F_b-KxUo65IuXaeFVSnlmJ5K1Dm/pubchart?oid=633945705&format=interactive">
    </a>
-   <div id="fig8-description" class="visually-hidden">Bar chart showing 0/17 bytes of JavaScript are downloaded on desktop for first-party and third-party requests respectively in the p10 percentile, 11/62 in p25, 89/232 in p50, 200/525 in p75, and 404/900 in p90.</div>
+   <div id="fig8-description" class="visually-hidden">Bar chart showing 0/17 bytes of JavaScript are downloaded on desktop for first-party and third-party requests respectively in the 10th percentile, 11/62 in 25th percentile, 89/232 in 50th percentile, 200/525 in 75th percentile, and 404/900 in 90th percentile.</div>
    <figcaption id="fig8-caption">Figure 8. Distribution of total JavaScript downloaded on desktop.</figcaption>
 </figure>
 
@@ -125,7 +125,7 @@ For both mobile and desktop clients, more third-party requests are sent than fir
    <a href="/static/images/2019/javascript/fig9.png">
       <img src="/static/images/2019/javascript/fig9.png" alt="Figure 9. Distribution of total JavaScript downloaded on mobile." aria-labelledby="fig9-caption" aria-describedby="fig9-description" width="600" height="371" data-width="600" data-height="371" data-seamless data-frameborder="0" data-scrolling="no" data-iframe="https://docs.google.com/spreadsheets/d/e/2PACX-1vTpzDb9HGbdVvin6YPTOmw11qBVGGysltxmH545fUfnqIThAq878F_b-KxUo65IuXaeFVSnlmJ5K1Dm/pubchart?oid=1611383649&format=interactive">
    </a>
-   <div id="fig9-description" class="visually-hidden">Bar chart showing 0/17 bytes of JavaScript are downloaded on mobile for first-party and third-party requests respectively in the p10 percentile, 6/54 in p25, 83/217 in p50, 189/477 in p75, and 380/827 in p90.</div>
+   <div id="fig9-description" class="visually-hidden">Bar chart showing 0/17 bytes of JavaScript are downloaded on mobile for first-party and third-party requests respectively in the 10th percentile, 6/54 in 25th percentile, 83/217 in 50th percentile, 189/477 in 75th percentile, and 380/827 in 90th percentile.</div>
    <figcaption id="fig9-caption">Figure 9. Distribution of total JavaScript downloaded on mobile.</figcaption>
 </figure>
 

--- a/src/content/en/2019/media.md
+++ b/src/content/en/2019/media.md
@@ -22,7 +22,7 @@ From a pure bytes perspective, HTTP Archive has [historically reported](https://
   <a href="/static/images/2019/media/fig1_bytes_images_and_video_versus_other.png">
     <img src="/static/images/2019/media/fig1_bytes_images_and_video_versus_other.png" alt="Figure 1. Web page bytes: image and video versus other." aria-labelledby="fig1-caption" aria-describedby="fig1-description" width="600" height="371" data-width="600" data-height="371" data-seamless data-frameborder="0" data-scrolling="no" data-iframe="https://docs.google.com/spreadsheets/d/e/2PACX-1vSViHIntdF6-bHAI0cl1HelY_X8rR4lf0P3W2Y8I5SyVMxG-ptggTHfWA0qrrU47RvuAydLE6Zex6L3/pubchart?oid=1189524305&format=interactive">
   </a>
-  <div id="fig1-description" class="visually-hidden">Bar chart showing in the p10 percentile 44.1% of page bytes are media, in the p25 percentile 52.7% is media, in the p50 percentile 67.0% is media, in the p75 percentile 81.7% is media, and in the p90 percentile 91.2% is media.</div>
+  <div id="fig1-description" class="visually-hidden">Bar chart showing in the 10th percentile 44.1% of page bytes are media, in the 25th percentile 52.7% is media, in the 50th percentile 67.0% is media, in the 75th percentile 81.7% is media, and in the 90th percentile 91.2% is media.</div>
   <figcaption id="fig1-caption">Figure 1. Web page bytes: image and video versus other.</figcaption>
 </figure>
 
@@ -54,7 +54,7 @@ There are three metrics to consider when looking at pixel volume: CSS pixels, na
   <a href="/static/images/2019/media/fig3_image_pixel_per_page_mobile_css_v_actual.png">
     <img src="/static/images/2019/media/fig3_image_pixel_per_page_mobile_css_v_actual.png" alt="Figure 3. Image pixels per page (mobile): CSS versus actual." aria-labelledby="fig3-caption" aria-describedby="fig3-description" width="600" height="371" data-width="600" data-height="371" data-seamless data-frameborder="0" data-scrolling="no" data-iframe="https://docs.google.com/spreadsheets/d/e/2PACX-1vSViHIntdF6-bHAI0cl1HelY_X8rR4lf0P3W2Y8I5SyVMxG-ptggTHfWA0qrrU47RvuAydLE6Zex6L3/pubchart?oid=2027393897&format=interactive">
   </a>
-  <div id="fig3-description" class="visually-hidden">A comparison of the CSS pixels allocated to image content compared to the actual image pixels for mobile, showing p10 (0.07 MP actual, 0.04 MP CSS), p25 (0.38 MP actual, 0.18 MP CSS), p50 (1.6 MP actual, 0.65 MP CSS), p75 (5.1 MP actual, 1.8 MP CSS), and p90 (12 MP actual, 4.6 MP CSS)</div>
+  <div id="fig3-description" class="visually-hidden">A comparison of the CSS pixels allocated to image content compared to the actual image pixels for mobile, showing 10th percentile (0.07 MP actual, 0.04 MP CSS), 25th percentile (0.38 MP actual, 0.18 MP CSS), 50th percentile (1.6 MP actual, 0.65 MP CSS), 75th percentile (5.1 MP actual, 1.8 MP CSS), and 90th percentile (12 MP actual, 4.6 MP CSS)</div>
   <figcaption id="fig3-caption">Figure 3. Image pixels per page (mobile): CSS versus actual.</figcaption>
 </figure>
 
@@ -62,7 +62,7 @@ There are three metrics to consider when looking at pixel volume: CSS pixels, na
   <a href="/static/images/2019/media/fig4_image_pixel_per_page_desktop_css_v_actual.png">
     <img src="/static/images/2019/media/fig4_image_pixel_per_page_desktop_css_v_actual.png" alt="Figure 4. Image pixels per page (desktop): CSS versus actual." aria-labelledby="fig4-caption" aria-describedby="fig4-description" width="600" height="371" data-width="600" data-height="371" data-seamless data-frameborder="0" data-scrolling="no" data-iframe="https://docs.google.com/spreadsheets/d/e/2PACX-1vSViHIntdF6-bHAI0cl1HelY_X8rR4lf0P3W2Y8I5SyVMxG-ptggTHfWA0qrrU47RvuAydLE6Zex6L3/pubchart?oid=1364487787&format=interactive">
   </a>
-  <div id="fig4-description" class="visually-hidden">A comparison of the CSS pixels allocated to image content compared to the actual image pixels for desktop, showing p10 (0.09 MP actual, 0.05 MP CSS), p25 (0.52 MP actual, 0.29 MP CSS), p50 (2.1 MP actual, 1.1 MP CSS), p75 (6.0 MP actual, 2.8 MP CSS), and p90 (14 MP actual, 6.3 MP CSS)</div>
+  <div id="fig4-description" class="visually-hidden">A comparison of the CSS pixels allocated to image content compared to the actual image pixels for desktop, showing 10th percentile (0.09 MP actual, 0.05 MP CSS), 25th percentile (0.52 MP actual, 0.29 MP CSS), 50th percentile (2.1 MP actual, 1.1 MP CSS), 75th percentile (6.0 MP actual, 2.8 MP CSS), and 90th percentile (14 MP actual, 6.3 MP CSS)</div>
   <figcaption id="fig4-caption">Figure 4. Image pixels per page (desktop): CSS versus actual.</figcaption>
 </figure>
 
@@ -84,7 +84,7 @@ If we had one image that filled the entire screen perfectly, this would be a 1x 
   <a href="/static/images/2019/media/fig5_image_pixel_volume_v_css_pixels.png">
     <img src="/static/images/2019/media/fig5_image_pixel_volume_v_css_pixels.png" alt="Figure 5. Image pixel volume versus screen size (CSS pixels)." aria-labelledby="fig5-caption" aria-describedby="fig5-description" width="600" height="371" data-width="600" data-height="371" data-seamless data-frameborder="0" data-scrolling="no" data-iframe="https://docs.google.com/spreadsheets/d/e/2PACX-1vSViHIntdF6-bHAI0cl1HelY_X8rR4lf0P3W2Y8I5SyVMxG-ptggTHfWA0qrrU47RvuAydLE6Zex6L3/pubchart?oid=1889020047&format=interactive">
   </a>
-  <div id="fig5-description" class="visually-hidden">A comparison of the pixel volume required per page relative to the actual screen size CSS pixels, showing p10 (20% mobile, 2% desktop), p25 (97% mobile, 13% desktop), p50 (354% mobile, 46% desktop), p75 (1003% mobile, 123% desktop), and p90 (2477% mobile, 273% desktop).</div>
+  <div id="fig5-description" class="visually-hidden">A comparison of the pixel volume required per page relative to the actual screen size CSS pixels, showing 10th percentile (20% mobile, 2% desktop), 25th percentile (97% mobile, 13% desktop), 50th percentile (354% mobile, 46% desktop), 75th percentile (1003% mobile, 123% desktop), and 90th percentile (2477% mobile, 273% desktop).</div>
   <figcaption id="fig5-caption">Figure 5. Image pixel volume versus screen size (CSS pixels).</figcaption>
 </figure>
 
@@ -168,7 +168,7 @@ Of course, web pages are not uniform in their use of image content. Some depend 
   <a href="/static/images/2019/media/fig8_image_format_usage_per_page.png">
     <img src="/static/images/2019/media/fig8_image_format_usage_per_page.png" alt="Figure 8. Image format usage per page." aria-labelledby="fig8-caption" aria-describedby="fig8-description" width="600" height="371" data-width="600" data-height="371" data-seamless data-frameborder="0" data-scrolling="no" data-iframe="https://docs.google.com/spreadsheets/d/e/2PACX-1vSViHIntdF6-bHAI0cl1HelY_X8rR4lf0P3W2Y8I5SyVMxG-ptggTHfWA0qrrU47RvuAydLE6Zex6L3/pubchart?oid=294858455&format=interactive">
   </a>
-  <div id="fig8-description" class="visually-hidden">A bar chart showing in p10 percentile no image formats are used at all, in the p25 percentile three JPGs and four PNGs are used, in the p50 percentile nine JPGs, four PNGs, and one GIF are used, in the p75 percentile 39 JPEGs, 18 PNGs, two SVGs, and two GIFs are used and in the p99 percentile, 119 JPGs, 49 PNGs, 28 WebPs, 19 SVGs and 14 GIFs are used.</div>
+  <div id="fig8-description" class="visually-hidden">A bar chart showing in 10th percentile no image formats are used at all, in the 25th percentile three JPGs and four PNGs are used, in the 50th percentile nine JPGs, four PNGs, and one GIF are used, in the 75th percentile 39 JPEGs, 18 PNGs, two SVGs, and two GIFs are used and in the 99th percentile, 119 JPGs, 49 PNGs, 28 WebPs, 19 SVGs and 14 GIFs are used.</div>
   <figcaption id="fig8-caption">Figure 8. Image format usage per page.</figcaption>
 </figure>
 
@@ -192,7 +192,7 @@ There are two ways to look at image file sizes: absolute bytes per resource and 
   <a href="/static/images/2019/media/fig10_image_format_size.png">
     <img alt="A comparison of image formats by file size" aria-labelledby="fig10-caption" aria-describedby="fig10-description" src="/static/images/2019/media/fig10_image_format_size.png" width="600" height="371">
   </a>
-  <div id="fig10-description" class="visually-hidden">A chart showing in p10 percentile 4 KB of JPEGs, 2 KB of PNG and 2 KB of GIFs are used, in the p25 percentile 9 KB JPGs, 4 KB of PNGs, 7 KB of WebP, and 3 KB of GIFs are used, in the p50 percentile 24 KB of JPGs, 11 KB of PNGs, 17 KB of WebP, 6 KB of GIFs, and 1 KB of SVGs are used, in the p75 percentile 68 KB of JPEGs, 43 KB of PNGs, 41 KB of WebPs, 17 KB of GIFs and 2 KB of SVGs are used and in the p90 percentile, 116 KB of JPGs, 152 KB of PNGs, 90 KB of WebPs, 87 KB of GIFs, and 8 KB of SVGs are used.</div>
+  <div id="fig10-description" class="visually-hidden">A chart showing in 10th percentile 4 KB of JPEGs, 2 KB of PNG and 2 KB of GIFs are used, in the 25th percentile 9 KB JPGs, 4 KB of PNGs, 7 KB of WebP, and 3 KB of GIFs are used, in the 50th percentile 24 KB of JPGs, 11 KB of PNGs, 17 KB of WebP, 6 KB of GIFs, and 1 KB of SVGs are used, in the 75th percentile 68 KB of JPEGs, 43 KB of PNGs, 41 KB of WebPs, 17 KB of GIFs and 2 KB of SVGs are used and in the 90th percentile, 116 KB of JPGs, 152 KB of PNGs, 90 KB of WebPs, 87 KB of GIFs, and 8 KB of SVGs are used.</div>
   <figcaption id="fig10-caption">Figure 10. File size (KB) by image format.</figcaption>
 </figure>
 
@@ -202,7 +202,7 @@ From this we can start to get a sense of how large or small a typical resource i
   <a href="/static/images/2019/media/fig11_bytes_per_pixel.png">
     <img src="/static/images/2019/media/fig11_bytes_per_pixel.png" alt="Figure 11. Bytes per pixel." aria-labelledby="fig11-caption" aria-describedby="fig11-description" width="600" height="371" data-width="600" data-height="371" data-seamless data-frameborder="0" data-scrolling="no" data-iframe="https://docs.google.com/spreadsheets/d/e/2PACX-1vSViHIntdF6-bHAI0cl1HelY_X8rR4lf0P3W2Y8I5SyVMxG-ptggTHfWA0qrrU47RvuAydLE6Zex6L3/pubchart?oid=1379541850&format=interactive">
   </a>
-  <div id="fig11-description" class="visually-hidden">A candlestick chart showing in p10 percentile we have 0.1175 bytes-per-pixel for JPEG, 0.1197 for PNG, 0.1702 for GIF, 0.0586 for WebP, and 0.0293 for SVG. In the p25 percentile we have 0.1848 bytes-per-pixel for JPEGs, 0.2874 for PNG, 0.3641 for GIF, 0.1025 for WebP, and 0.174 for SVG. In the p50 percentile we have 0.2997 bytes-per-pixel for JPEGs, 0.6918 for PNG, 0.7967 for GIF, 0.183 for WebP, and 0.6766 for SVG. In the p75 percentile we have 0.5456 bytes-per-pixel for JPEGs, 1.4548 for PNG, 2.515 for GIF, 0.3272 for WebP, and 1.9261 for SVG. In the p90 percentile we have 0.9822 bytes-per-pixel for JPEGs, 2.5026 for PNG, 8.5151 for GIF, 0.6474 for WebP, and 4.1075 for SVG</div>
+  <div id="fig11-description" class="visually-hidden">A candlestick chart showing in 10th percentile we have 0.1175 bytes-per-pixel for JPEG, 0.1197 for PNG, 0.1702 for GIF, 0.0586 for WebP, and 0.0293 for SVG. In the 25th percentile we have 0.1848 bytes-per-pixel for JPEGs, 0.2874 for PNG, 0.3641 for GIF, 0.1025 for WebP, and 0.174 for SVG. In the 50th percentile we have 0.2997 bytes-per-pixel for JPEGs, 0.6918 for PNG, 0.7967 for GIF, 0.183 for WebP, and 0.6766 for SVG. In the 75th percentile we have 0.5456 bytes-per-pixel for JPEGs, 1.4548 for PNG, 2.515 for GIF, 0.3272 for WebP, and 1.9261 for SVG. In the 90th percentile we have 0.9822 bytes-per-pixel for JPEGs, 2.5026 for PNG, 8.5151 for GIF, 0.6474 for WebP, and 4.1075 for SVG</div>
   <figcaption id="fig11-caption">Figure 11. Bytes per pixel.</figcaption>
 </figure>
 
@@ -226,17 +226,17 @@ One [Lighthouse](./methodology#lighthouse) test is an A/B comparing baseline wit
   <a href="/static/images/2019/media/fig12_percentage_optimized_images.png">
     <img src="/static/images/2019/media/fig12_percentage_optimized_images.png" alt="Figure 12. Percent 'optimized' images." aria-labelledby="fig12-caption" aria-describedby="fig12-description" width="600" height="371" data-width="600" data-height="371" data-seamless data-frameborder="0" data-scrolling="no" data-iframe="https://docs.google.com/spreadsheets/d/e/2PACX-1vSViHIntdF6-bHAI0cl1HelY_X8rR4lf0P3W2Y8I5SyVMxG-ptggTHfWA0qrrU47RvuAydLE6Zex6L3/pubchart?oid=1569150767">
   </a>
-  <div id="fig12-description" class="visually-hidden">Bar chart showing in the p10 percentile 100% of images are optimized, same in p25 percentile, in the p50 percentile 98% of images are optimized (2% not), in the p75 percentile 83% of images are optimized (17% not), and in the p90 percentile 59% of images are optimized and 41% are not.</div>
+  <div id="fig12-description" class="visually-hidden">Bar chart showing in the 10th percentile 100% of images are optimized, same in 25th percentile, in the 50th percentile 98% of images are optimized (2% not), in the 75th percentile 83% of images are optimized (17% not), and in the 90th percentile 59% of images are optimized and 41% are not.</div>
   <figcaption id="fig12-caption">Figure 12. Percent "optimized" images.</figcaption>
 </figure>
 
-The savings in this AB Lighthouse test is not just about potential byte savings, which can accrue to several MBs at the p95, it also demonstrates the page performance improvement. 
+The savings in this AB Lighthouse test is not just about potential byte savings, which can accrue to several MBs at the 95th percentile, it also demonstrates the page performance improvement. 
 
  <figure>
   <a href="/static/images/2019/media/fig13_project_perf_improvements_image_optimization.png">
     <img src="/static/images/2019/media/fig13_project_perf_improvements_image_optimization.png" alt="Figure 13. Projected page performance improvements from image optimization from Lighthouse." aria-labelledby="fig12-caption" aria-describedby="fig13-description" width="600" height="371" data-width="600" data-height="371" data-seamless data-frameborder="0" data-scrolling="no" data-iframe="https://docs.google.com/spreadsheets/d/e/2PACX-1vSViHIntdF6-bHAI0cl1HelY_X8rR4lf0P3W2Y8I5SyVMxG-ptggTHfWA0qrrU47RvuAydLE6Zex6L3/pubchart?oid=167590779">
   </a>
-  <div id="fig13-description" class="visually-hidden">Bar chart showing in the p10 percentile 0 ms could be sized, same in p25 percentile, in the p50 percentile 150 ms could be saved, in the p75 percentile 1,460 ms could be saved and in the p90 percentile 5,720 ms could be saved.</div>
+  <div id="fig13-description" class="visually-hidden">Bar chart showing in the 10th percentile 0 ms could be sized, same in 25th percentile, in the 50th percentile 150 ms could be saved, in the 75th percentile 1,460 ms could be saved and in the 90th percentile 5,720 ms could be saved.</div>
   <figcaption id="fig13-caption">Figure 13. Projected page performance improvements from image optimization from Lighthouse.</figcaption>
 </figure>
 
@@ -331,7 +331,7 @@ Earlier, in <a href="#fig-5">Figure 5</a>, we showed that the volume of image co
   <a href="/static/images/2019/media/fig19_lighthouse_audit_offscreen.png">
     <img src="/static/images/2019/media/fig19_lighthouse_audit_offscreen.png" alt="Figure 19. Lighthouse audit: Offscreen." aria-labelledby="fig19-caption" aria-describedby="fig19-description" width="600" height="371" data-width="600" data-height="371" data-seamless data-frameborder="0" data-scrolling="no" data-iframe="https://docs.google.com/spreadsheets/d/e/2PACX-1vSViHIntdF6-bHAI0cl1HelY_X8rR4lf0P3W2Y8I5SyVMxG-ptggTHfWA0qrrU47RvuAydLE6Zex6L3/pubchart?oid=2123391693&format=interactive">
   </a>
-  <div id="fig19-description" class="visually-hidden">A bar chart showing in the p10 percentile 0% of images are offscreen, in the p25 percentile 2% are offscreen, in the p50 percentile, 27% are offscreen, in the p75 percentile 64% are offscreen, and in the p90 percentile 84% of images are offscreen.</div>
+  <div id="fig19-description" class="visually-hidden">A bar chart showing in the 10th percentile 0% of images are offscreen, in the 25th percentile 2% are offscreen, in the 50th percentile, 27% are offscreen, in the 75th percentile 64% are offscreen, and in the 90th percentile 84% of images are offscreen.</div>
   <figcaption id="fig19-caption">Figure 19. Lighthouse audit: Offscreen.</figcaption>
 </figure>
 


### PR DESCRIPTION
Makes progress on #1254 

Note this adds another heading to the CDN tables:

Old:
![Percentile's marked p10 - p90](https://user-images.githubusercontent.com/10931297/91230118-dfed5a00-e722-11ea-8e73-2c14a4bc0fa9.png)

New:
![Percentile's marked 10 - 90 with a percentile heading](https://user-images.githubusercontent.com/10931297/91230167-f0053980-e722-11ea-92ab-fc0b6b01709c.png)
