### PR TITLE
Fix empty image formats

### DIFF
--- a/sql/util/README.md
+++ b/sql/util/README.md
@@ -2,7 +2,7 @@
 
 This directory contains utilities for managing the Web Almanac dataset on BigQuery.
 
-## [summary_requests.sql](./summary_requests.sql)
+## [requests.sql](./requests.sql)
 
 This query generates summary metadata about each request from its JSON-encoded HAR object. For every Web Almanac crawl (eg 2019_07_01 and 2020_08_01) this query should be run once and configured to have its results appended to the `almanac.requests` table. This table is useful for Web Almanac analysis because it combines the metadata of the request with the HAR payload, more easily enabling queries that segment requests by resource type (script, style, image) and base HTML page.
 

--- a/sql/util/requests.sql
+++ b/sql/util/requests.sql
@@ -64,6 +64,7 @@ LANGUAGE js AS """
     return 'other';
   }
   function getFormat(prettyType, mimeType, ext) {
+    ext = ext.toLowerCase();
     if (prettyType == 'image') {
       for (type of ['jpg', 'png', 'gif', 'webp', 'svg', 'ico']) {
         if (mimeType.includes(type) || ext == type) {


### PR DESCRIPTION
If file extensions are mixed case, it won't match the list of known formats. Convert to lowercase before comparing against formats.

I updated the `almanac.requests` table to the new function with this query: (1.3 TB)

```sql
CREATE TEMP FUNCTION getFormat(prettyType STRING, mimeType STRING, ext STRING) RETURNS STRING LANGUAGE js AS '''
  ext = ext.toLowerCase();
  if (prettyType == 'image') {
    for (type of ['jpg', 'png', 'gif', 'webp', 'svg', 'ico']) {
      if (mimeType.includes(type) || ext == type) {
        return type;
      }
    }

    if (mimeType.includes('jpeg') || ext == 'jpeg') {
      return 'jpg'
    }
  } else if (prettyType == 'video') {
    for (type of ['flash', 'swf', 'mp4', 'flv', 'f4v', 'webm', 'ts', 'm4v', 'm4s', 'mov', 'ogv']) {
      if (mimeType.includes(type) || ext == type) {
        return type;
      }
    }
  }

  return '';
''';


UPDATE
  `httparchive.almanac.requests`
SET
  format = getFormat(type, mimeType, ext)
WHERE
  date = '2020-08-01' AND
  type = 'image' AND
  format = ''
```