### PR TITLE
Lint all files on Super Linter upgrade

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           echo "::set-env name=VALIDATE_ALL_CODEBASE::false"
       - name: Lint Code Base
-        uses: github/super-linter@v3.9.3
+        uses: github/super-linter@v3.9.4
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -2,16 +2,8 @@
 ## Linter GitHub Actions ##
 ###########################
 #
-# Documentation:
-# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+# Documentation: https://github.com/github/super-linter/
 #
-# For the Web Almanac we have the following rule changes from the defaults:
-#  * Markdown - we're a bit more relaxed about this since authors may be less technical
-#  * Python - Only change from default is to set ignored-modules=flask, flask-talisman...etc.
-#  * CSS - Tweaked to ignore some Prince/Normalise exceptions and some whitespace exceptions
-#  * JS - default rules
-#  * JSON - default rules
-#  * YML - default rules
 # Exception config files are in the .github/linters directory
 #
 name: Lint Code Base
@@ -23,17 +15,24 @@ jobs:
   lint:
     name: Lint Code Base
     # Skip duplicate job for local branches
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    # except for linter upgrades (so it can be caught by below check to lint all)
+    if: |
+        github.event_name == 'push' ||
+        github.event.pull_request.head.repo.full_name != github.repository ||
+        startsWith(github.event.pull_request.title,'Bump github/super-linter')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2.3.2
-      - name: Set VALIDATE_ALL_CODEBASE variable
-        if: github.event_name == 'push' || github.event_name == 'pull_request'
+      - name: Set VALIDATE_ALL_CODEBASE variable to false
+        # Only run the full workflow for manual runs or if upgrading the super linter
+        if: |
+            github.event_name != 'workflow' &&
+            startsWith(github.event.pull_request.title,'Bump github/super-linter') != true
         run: |
           echo "::set-env name=VALIDATE_ALL_CODEBASE::false"
       - name: Lint Code Base
-        uses: github/super-linter@v3.9.4
+        uses: github/super-linter@v3.9.3
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
At the minute I run a manual full lint on the code base for Super Liunter upgrades. I'd like to automate this.
Also remove out of date comments.

@ibnesayeed can you think of any way to avoid the duplication required in the two `if` statements? Or this the cleanest we can get?