### PR TITLE
Upgrade to Python 3.8

### DIFF
--- a/.github/workflows/generate_chapters.yml
+++ b/.github/workflows/generate_chapters.yml
@@ -44,10 +44,10 @@ jobs:
       uses: actions/setup-node@v1.4.2
       with:
         node-version: 12.x
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2.1.2
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Run the website
       run: ./src/tools/scripts/run_and_test_website.sh
     - name: Create Pull Request

--- a/.github/workflows/generate_ebooks.yml
+++ b/.github/workflows/generate_ebooks.yml
@@ -26,11 +26,10 @@ jobs:
       uses: actions/setup-node@v1.4.2
       with:
         version:  12.x
-    # Install Python 3.7 as used by Google Cloud Platform
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2.1.2
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install Asian Fonts
       run: |
         # Install Japanese san-serif font

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2.3.2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2.1.2
         with:
-          python-version: '3.7'
+          python-version: '3.8'
       - name: Install Requirements
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test_website.yml
+++ b/.github/workflows/test_website.yml
@@ -21,10 +21,10 @@ jobs:
       uses: actions/setup-node@v1.4.2
       with:
         node-version: 12.x
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2.1.2
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Run the website
       run: ./src/tools/scripts/run_and_test_website.sh
     - name: Remove node modules to avoid linting errors

--- a/src/app.yaml
+++ b/src/app.yaml
@@ -1,4 +1,4 @@
-runtime: python37
+runtime: python38
 entrypoint: gunicorn -b :$PORT main:app
 default_expiration: 3h
 


### PR DESCRIPTION
Looks like [Google App Engine now officially supports Python3.8](https://cloud.google.com/appengine/docs/standard/python3/runtime) - previously it was marked as beta so didn't want to upgrade to it.

To be honest I've been using Python 3.8 all along but let's make it official and run on 3.8 in the cloud too.

Deployed test version here and all good: https://20200914t192537-dot-webalmanac.uk.r.appspot.com/