### PR TITLE
Compress Images on pushes to main and at other times

### DIFF
--- a/.github/workflows/calibreapp-image-action.yml
+++ b/.github/workflows/calibreapp-image-action.yml
@@ -37,12 +37,8 @@ jobs:
     name: calibreapp/image-actions
     runs-on: ubuntu-latest
     # Only run on main repo on and PRs that match the main repo
-    if: |
-      (github.event_name != 'pull_request' &&
-       github.repository == 'HTTPArchive/almanac.httparchive.org')
-      ||
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name == github.repository)
+    if: github.repository == 'HTTPArchive/almanac.httparchive.org' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2.3.2

--- a/.github/workflows/calibreapp-image-action.yml
+++ b/.github/workflows/calibreapp-image-action.yml
@@ -64,4 +64,6 @@ jobs:
           body: ${{ steps.calibre.outputs.markdown }}
           labels: performance
       - name: Check outputs
+        # If it's not a pull request then commit any changes as a new PR
+        if: steps.cpr.outputs.pull-request-number != ''
         run: echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"

--- a/.github/workflows/calibreapp-image-action.yml
+++ b/.github/workflows/calibreapp-image-action.yml
@@ -4,35 +4,66 @@
 # 
 # This runs the calibre GitHub action to compress our images
 #
-# This Action has a few limitations:
-#
-# 1) This currently only works on pull requests from this repo
-#    and fails silently for PRs from forks. We've added a PR
-#    to handle this better (https://github.com/calibreapp/image-actions/pull/54)
-#    and after that can probably combine to the generate_chapters.yml.
-#
-# 2) It seems to only do a basic level of optimisations and better results can
-#    be achieved from https://tinypng.com/ or https://squoosh.app/ but not as automated
-#    so still good to have this.
-#
-# 3) Currently doesn't handle WebP (https://github.com/calibreapp/image-actions/issues/31)
+# This Action has a few different methoids for running:
+# 1) For Pull Requests from and to the main repo it can run and update the PR
+# 2) For pushes to main, it will run and create a new PR. This captures PR from
+#    Forks.
+# 3) It also runs every sunday at 11pm in case anything else sneaks in or any
+#    improvements are added to Calibre. This will also open a PR if necessary.
+# 4) Finally it can be kicked off manually and it will open a PR if necessary.
 #
 name: Compress images
 on:
+  schedule:
+    # Run a full compression every Sunday at 11pm to start the week right
+    - cron: '00 23 * * 0'
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '**.jpg'
+      - '**.jpeg'
+      - '**.png'
+      - '**.webp'
   pull_request:
     paths:
       - '**.jpg'
+      - '**.jpeg'
       - '**.png'
       - '**.webp'
 jobs:
   build:
-    # Only run on Pull Requests within the same repository, and not from forks as they don't work
-    if: github.event.pull_request.head.repo.full_name == github.repository
     name: calibreapp/image-actions
     runs-on: ubuntu-latest
+    # Only run on main repo as PRs can't be updated on forks
+    if: github.repository == 'HTTPArchive/almanac.httparchive.org'
+    env:
+      COMPRESS_ONLY: false
     steps:
-      - uses: actions/checkout@v2.3.2
-      - name: calibreapp/image-actions
-        uses: docker://calibreapp/github-image-actions
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Set COMPRESS_ONLY variable to true
+      # If it's not a pull request then run in compressOnly mode
+      if: github.event_name != 'pull_request'
+      run: |
+        echo "::set-env name=COMPRESS_ONLY::true"
+    - name: Checkout branch
+      uses: actions/checkout@v2.3.2
+    - name: calibreapp/image-actions
+      id: calibre
+      uses: calibreapp/image-actions@master
+      with:
+        githubToken: ${{ secrets.GITHUB_TOKEN }}
+        compressOnly: ${{ env.COMPRESS_ONLY }}
+    - name: Create Pull Request
+      # If it's not a pull request then commit any changes as a new PR
+      if: |
+        github.event_name != 'pull_request' &&
+        steps.calibre.outputs.markdown != ''
+      id: cpr
+      uses: peter-evans/create-pull-request@v3.3.0
+      with:
+        title: Auto Compress Images
+        branch-suffix: timestamp
+        commit-message: Compress Images
+        body: ${{ steps.calibre.outputs.markdown }}
+        labels: performance

--- a/.github/workflows/calibreapp-image-action.yml
+++ b/.github/workflows/calibreapp-image-action.yml
@@ -54,6 +54,7 @@ jobs:
       with:
         githubToken: ${{ secrets.GITHUB_TOKEN }}
         compressOnly: ${{ env.COMPRESS_ONLY }}
+        jpegProgressive: true
     - name: Create Pull Request
       # If it's not a pull request then commit any changes as a new PR
       if: |

--- a/.github/workflows/calibreapp-image-action.yml
+++ b/.github/workflows/calibreapp-image-action.yml
@@ -41,30 +41,27 @@ jobs:
     env:
       COMPRESS_ONLY: false
     steps:
-    - name: Set COMPRESS_ONLY variable to true
-      # If it's not a pull request then run in compressOnly mode
-      if: github.event_name != 'pull_request'
-      run: |
-        echo "::set-env name=COMPRESS_ONLY::true"
-    - name: Checkout branch
-      uses: actions/checkout@v2.3.2
-    - name: calibreapp/image-actions
-      id: calibre
-      uses: calibreapp/image-actions@master
-      with:
-        githubToken: ${{ secrets.GITHUB_TOKEN }}
-        compressOnly: ${{ env.COMPRESS_ONLY }}
-        jpegProgressive: true
-    - name: Create Pull Request
-      # If it's not a pull request then commit any changes as a new PR
-      if: |
-        github.event_name != 'pull_request' &&
-        steps.calibre.outputs.markdown != ''
-      id: cpr
-      uses: peter-evans/create-pull-request@v3.3.0
-      with:
-        title: Auto Compress Images
-        branch-suffix: timestamp
-        commit-message: Compress Images
-        body: ${{ steps.calibre.outputs.markdown }}
-        labels: performance
+      - name: Checkout branch
+        uses: actions/checkout@v2.3.2
+      - name: Run image compression
+        id: calibre
+        uses: calibreapp/image-actions@master
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          compressOnly: ${{ github.event_name != 'pull_request' }}
+          jpegProgressive: true
+      - name: Create Pull Request
+        # If it's not a pull request then commit any changes as a new PR
+        if: |
+          github.event_name != 'pull_request' &&
+          steps.calibre.outputs.markdown != ''
+        id: cpr
+        uses: peter-evans/create-pull-request@v3.3.0
+        with:
+          title: Auto Compress Images
+          branch-suffix: timestamp
+          commit-message: Compress Images
+          body: ${{ steps.calibre.outputs.markdown }}
+          labels: performance
+      - name: Check outputs
+        run: echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"

--- a/.github/workflows/calibreapp-image-action.yml
+++ b/.github/workflows/calibreapp-image-action.yml
@@ -36,10 +36,13 @@ jobs:
   build:
     name: calibreapp/image-actions
     runs-on: ubuntu-latest
-    # Only run on main repo as PRs can't be updated on forks
-    if: github.repository == 'HTTPArchive/almanac.httparchive.org'
-    env:
-      COMPRESS_ONLY: false
+    # Only run on main repo on and PRs that match the main repo
+    if: |
+      (github.event_name != 'pull_request' &&
+       github.repository == 'HTTPArchive/almanac.httparchive.org')
+      ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2.3.2

--- a/.github/workflows/calibreapp-image-action.yml
+++ b/.github/workflows/calibreapp-image-action.yml
@@ -37,8 +37,10 @@ jobs:
     name: calibreapp/image-actions
     runs-on: ubuntu-latest
     # Only run on main repo on and PRs that match the main repo
-    if: github.repository == 'HTTPArchive/almanac.httparchive.org' &&
-      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    if: |
+      github.repository == 'HTTPArchive/almanac.httparchive.org' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2.3.2


### PR DESCRIPTION
The [Calibre-Image Github Action](https://github.com/calibreapp/image-actions) was not able to compress images on pull requests from forks, due to security restrictions in GitHub Actions themselves.

However they have recently merged a pull request (from yours truly!) that allows it to run in Compress Only mode and then open a new Pull Request (much like we do for our timestamp updates) for those image optimisations, meaning we no longer have to accept unoptimised images from PRs from forks and remember to optimise them ourselves.

I've also added the ability to run this on-demand, and also weekly just in case anything slips through, or they add any improvements.

This will be useful as the Analysts start to submit the images for the 2020 chapters which should start happening soon.