### PR TITLE
Fixes made as the data was being gathered.

### DIFF
--- a/sql/2020/03_Markup/pages_almanac_by_device_and_attribute_name_frequency.sql
+++ b/sql/2020/03_Markup/pages_almanac_by_device_and_attribute_name_frequency.sql
@@ -34,7 +34,7 @@ GROUP BY
   client,
   almanac_attribute_info.name
 ORDER BY
-  client,
-  pct_m400 DESC
+  freq DESC,
+  client
 LIMIT
   1000

--- a/sql/2020/03_Markup/pages_almanac_by_device_and_data_attribute_name_frequency.sql
+++ b/sql/2020/03_Markup/pages_almanac_by_device_and_data_attribute_name_frequency.sql
@@ -34,7 +34,7 @@ GROUP BY
   client,
   almanac_attribute_info.name
 ORDER BY
-  client,
-  pct_m402 DESC
+  freq DESC,
+  client
 LIMIT
   1000

--- a/sql/2020/03_Markup/pages_almanac_by_device_and_favicon_image_type.sql
+++ b/sql/2020/03_Markup/pages_almanac_by_device_and_favicon_image_type.sql
@@ -16,7 +16,7 @@ try {
 
     if (Array.isArray(almanac) || typeof almanac != 'object') return result;
 
-    if (almanac["link-nodes"] && almanac["link-nodes"].nodes) {
+    if (almanac["link-nodes"] && almanac["link-nodes"].nodes && almanac["link-nodes"].nodes.find) {
       var faviconNode = almanac["link-nodes"].nodes.find(n => n.rel && n.rel.split(' ').find(r => r.trim().toLowerCase() == 'icon'));
 
       if (faviconNode) {
@@ -30,7 +30,7 @@ try {
           if (temp.includes('.')) {
             temp = temp.substring(temp.lastIndexOf('.')+1);
 
-            result.image_type_extension = temp;
+            result.image_type_extension = temp.toLowerCase().trim();
           }
           else {
             result.image_type_extension = "NO_EXTENSION";
@@ -47,7 +47,7 @@ try {
       result.image_type_extension = "NO_DATA";
     }
 
-} catch (e) {result.image_type_extension = "ERROR: "+e.message;}
+} catch (e) {result.image_type_extension = "NO_DATA";}
 return result;
 ''';
 

--- a/sql/2020/03_Markup/pages_almanac_by_device_and_html_lang.sql
+++ b/sql/2020/03_Markup/pages_almanac_by_device_and_html_lang.sql
@@ -40,5 +40,6 @@ SELECT
 GROUP BY
   client,
   html_lang
-ORDER BY freq DESC
+ORDER BY 
+  freq DESC
   

--- a/sql/2020/03_Markup/pages_element_count_by_device_and_element_type_frequency.sql
+++ b/sql/2020/03_Markup/pages_element_count_by_device_and_element_type_frequency.sql
@@ -33,8 +33,8 @@ FROM
 GROUP BY
   client,
   element_type_info.name
-ORDER BY
-  client,
-  pct_m202 DESC
+ORDER BY 
+  freq_m201 DESC,
+  client
 LIMIT
   1000

--- a/sql/2020/03_Markup/pages_markup_by_device_and_button_types.sql
+++ b/sql/2020/03_Markup/pages_markup_by_device_and_button_types.sql
@@ -28,7 +28,7 @@ return result;
 
 SELECT
   _TABLE_SUFFIX AS client,
-  button_type_info.name AS button_type,
+  LOWER(TRIM(button_type_info.name)) AS button_type,
   COUNTIF(button_type_info.freq > 0) AS freq_page_with_button, 
   AS_PERCENT(COUNTIF(button_type_info.freq > 0), total) AS pct_page_with_button,
   SUM(button_type_info.freq) AS freq_button, 
@@ -43,5 +43,8 @@ FROM
     UNNEST(get_markup_buttons_info(JSON_EXTRACT_SCALAR(payload, '$._markup'))) AS button_type_info
 GROUP BY
   client,
-  button_type
+  button_type,
+  total
+ORDER BY 
+  freq_page_with_button DESC
 LIMIT 1000

--- a/sql/2020/03_Markup/pages_wpt_bodies_by_device_and_percentile.sql
+++ b/sql/2020/03_Markup/pages_wpt_bodies_by_device_and_percentile.sql
@@ -41,7 +41,7 @@ SELECT
 
   # Comments per page
   APPROX_QUANTILES(wpt_bodies_info.comment_count, 1000)[OFFSET(percentile * 10)] AS comment_count_m103,
-  APPROX_QUANTILES(wpt_bodies_info.conditional_comment_count, 1000)[OFFSET(percentile * 10)] AS conditional_comment_count_m104,
+  APPROX_QUANTILES(wpt_bodies_info.conditional_comment_count, 1000)[OFFSET(percentile * 10)] AS conditional_comment_count_m105,
 
   # size of the head section in characters
   APPROX_QUANTILES(wpt_bodies_info.head_size, 1000)[OFFSET(percentile * 10)] AS head_size_m234

--- a/sql/2020/03_Markup/pages_wpt_bodies_by_device_and_protocol.sql
+++ b/sql/2020/03_Markup/pages_wpt_bodies_by_device_and_protocol.sql
@@ -1,5 +1,6 @@
 #standardSQL
 # page wpt_bodies metrics grouped by device
+# M235
 
 # helper to create percent fields
 CREATE TEMP FUNCTION AS_PERCENT (freq FLOAT64, total FLOAT64) RETURNS FLOAT64 AS (
@@ -43,4 +44,6 @@ GROUP BY
   client,
   total,
   protocol
+ORDER BY 
+  pages DESC
 LIMIT 1000


### PR DESCRIPTION
Having client first in the ORDER BY in combination of a LIMIT can cause the mobile devices data to cut out.

Some text normalisation to clean up the results.