### PR TITLE
Add plaintext alt attributes where necessary

### DIFF
--- a/src/content/en/2019/caching.md
+++ b/src/content/en/2019/caching.md
@@ -83,6 +83,7 @@ The tool [RedBot.org](https://redbot.org/) allows you to input a URL and see a d
 
 {{ figure_markup(
   image="ch16_fig1_redbot_example.jpg",
+  alt="Cache-Control information from RedBot.",
   caption="<code>Cache-Control</code> information from RedBot.",
   description="Redbot example response showing detailed information about when the resource was changed, whether caches can store it, how long it can be considered fresh for and warnings.",
   width=600,
@@ -96,6 +97,7 @@ If no caching headers are present in a response, then the [client is permitted t
 
 {{ figure_markup(
   image="fig2.png",
+  alt="Presence of HTTP Cache-Control and Expires headers.",
   caption="Presence of HTTP <code>Cache-Control</code> and <code>Expires</code> headers.",
   description="Two identical bar charts for mobile and desktop showing 72% of requests use Cache-Control headers, 56% use Expires and the 27% use neither.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vT3GWCs19Wq0mu0zgIlKRc8zcXgmVEk2xFHuzZACiWVtqOv8FO5gfHwBxa0mhU6O9TBY8ODdN4Zjd_O/pubchart?oid=1611664016&format=interactive"
@@ -264,6 +266,7 @@ HTTP/1.1 introduced the `Cache-Control` header, and most modern clients support 
 
 {{ figure_markup(
   image="fig7.png",
+  alt="Usage of Cache-Control versus Expires headers.",
   caption="Usage of <code>Cache-Control</code> versus <code>Expires</code> headers.",
   description="A bar chart showing 53% of responses have a `Cache-Control: max-age`, 54%-55% use `Expires`, 41%-42% use both, and 34% use neither. The figures are given for both desktop and mobile but the figures are near identical with mobile having a percentage point higher in use of expires.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vT3GWCs19Wq0mu0zgIlKRc8zcXgmVEk2xFHuzZACiWVtqOv8FO5gfHwBxa0mhU6O9TBY8ODdN4Zjd_O/pubchart?oid=1909701542&format=interactive"
@@ -336,6 +339,7 @@ For example, `cache-control: public, max-age=43200` indicates that a cached entr
 
 {{ figure_markup(
   image="fig9.png",
+  alt="Usage of Cache-Control directives on mobile.",
   caption="Usage of <code>Cache-Control</code> directives on mobile.",
   description="A bar chart of 15 cache control directives and their usage ranging from 74.8% for max-age, 37.8% for public, 27.8% for no-cache, 18% for no-store, 14.3% for private, 3.4% for immutable, 3.3% for no-transform, 2.4% for stale-while-revalidate, 2.2% for pre-check, 2.2% for post-check, 1.9% for s-maxage, 1.6% for proxy-revalidate, 0.3% for set-cookie and 0.2% for stale-if-error. The stats are near identical for desktop and mobile.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vT3GWCs19Wq0mu0zgIlKRc8zcXgmVEk2xFHuzZACiWVtqOv8FO5gfHwBxa0mhU6O9TBY8ODdN4Zjd_O/pubchart?oid=1054108345&format=interactive",
@@ -476,6 +480,7 @@ Overall, 65% of responses are served with a `Last-Modified` header, 42% are serv
 
 {{ figure_markup(
   image="fig12.png",
+  alt="Adoption of validating freshness via Last-Modified and ETag headers for desktop websites.",
   caption="Adoption of validating freshness via <code>Last-Modified</code> and <code>ETag</code> headers for desktop websites.",
   description="A bar chart showing 64.4% of desktop requests have a last modified, 42.8% have an ETag, 37.9% have both and 30.7% have neither. The stats for mobile are almost identical at 65.3% for Last Modified, 42.8% for ETag, 38.0% for both and 29.9% for neither.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vT3GWCs19Wq0mu0zgIlKRc8zcXgmVEk2xFHuzZACiWVtqOv8FO5gfHwBxa0mhU6O9TBY8ODdN4Zjd_O/pubchart?oid=20297100&format=interactive"
@@ -577,6 +582,7 @@ One of the risks of caching responses with `Set-Cookie` is that the cookie value
 
 {{ figure_markup(
   image="ch16_fig16_cacheable_responses_set_cookie.jpg",
+  alt="Cacheable responses of Set-Cookie responses.",
   caption="Cacheable responses of <code>Set-Cookie</code> responses.",
   description="A bar chart showing 97% of responses do not use Set-Cookie, and 3% do. This 3% is zoomed into for another bar chart showing the split of 15.3% private, 84.7% public for desktop and similar for mobile at 18.4% public and 81.6% private.",
   width=600,

--- a/src/content/en/2019/cdn.md
+++ b/src/content/en/2019/cdn.md
@@ -1487,6 +1487,7 @@ Another useful tool is the use of the `Vary` HTTP header. This header instructs 
 
 {{ figure_markup(
   image="use_of_vary_on_cdn.png",
+  alt="Usage of Vary for HTML served from CDNs.",
   caption="Usage of <code>Vary</code> for HTML served from CDNs.",
   description="Treemap graph showing accept-encoding dominates vary usage with 73% of the chart taken up with that. Cookie (13%) and user-agent (8%) having some usage, then a complete mixed of other headers.",
   width=600,
@@ -1502,6 +1503,7 @@ In a similar way, `Vary: Cookie` usually indicates that content that will change
 
 {{ figure_markup(
   image="use_of_vary.png",
+  alt="Comparison of Vary usage for HTML and resources served from origin and CDN.",
   caption="Comparison of <code>Vary</code> usage for HTML and resources served from origin and CDN.",
   description="Set of four treemap graphs showing that for CDNs serving home pages the biggest use of Vary is for Cookie, followed by User-agent. For CDNs serving other resources it's origin, followed by accept, user-agent, x-origin and referrer. For Origins and home pages it's user-agent, followed by cookie. Finally for Origins and other resources it's primarily user-agent followed by origin, accept, then range and host."
   )
@@ -1525,6 +1527,7 @@ The `s-maxage` directive informs proxies for how long they may cache a response.
 
 {{ figure_markup(
   image="fig26.png",
+  alt="Adoption of s-maxage across CDN responses.",
   caption="Adoption of <code>s-maxage</code> across CDN responses.",
   description="Bar chart showing 82% of jsDelivr serves responses with s-maxage, 14% of Level 3, 6.3% of Amazon CloudFront, 3.3% of Akamai, 3.1% of Fastly, 3% of Highwinds, 2% of Cloudflare, 0.91% of ORIGIN, 0.75% of Edgecast, 0.07% of Google.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRzPn-1SGVa3rNCT0U9QeQNODE97fsmXyaJX1ZOoBNR8nPpclhC6fg8R_UpoodeiX6HkdHrp50WBQ5Q/pubchart?oid=1215102767&format=interactive"

--- a/src/content/en/2019/fonts.md
+++ b/src/content/en/2019/fonts.md
@@ -538,6 +538,7 @@ Let's have a look at what `font-display` values are popular:
 
 {{ figure_markup(
   image="fig11.png",
+  alt="Usage of font-display values.",
   caption="Usage of <code>font-display</code> values.",
   description="Bar chart showing the usage of the font-display style. 2.6% of mobile pages set this style to \"swap\", 1.5% to \"auto\", 0.7% to \"block\", 0.4% to \"fallback\", 0.2% to optional, and 0.1% to \"swap\" enclosed in quotes, which is invalid. The desktop distribution is similar except \"swap\" usage is lower by 0.4 percentage points and \"auto\" usage is higher by 0.1 percentage points.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vQDogXDb3BwZZHrBT39qccP_LJoCScD3QEi_FmjT_8VDPD_1Srpz-g7ZuuTUEb8pYXBpDmQzZ1hQh7q/pubchart?oid=1988783738&format=interactive"
@@ -641,6 +642,7 @@ Even at 1.8% this was higher than expected, although I am excited to see this ta
 
 {{ figure_markup(
   image="fig19.png",
+  alt="Usage of font-variation-settings axes.",
   caption="Usage of <code>font-variation-settings</code> axes.",
   description="Bar chart showing the usage of the font-variation-settings property. 42% of properties on desktop pages are set to the \"opsz\" value, 32% to \"wght\", 16% to \"wdth\", 2% or fewer to \"roun\", \"crsb\", \"slnt\", \"inln\", and more. The most notable differences between desktop and mobile pages are 26% usage of \"opsz\", 38% of \"wght\", and 23% of \"wdth\".",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vQDogXDb3BwZZHrBT39qccP_LJoCScD3QEi_FmjT_8VDPD_1Srpz-g7ZuuTUEb8pYXBpDmQzZ1hQh7q/pubchart?oid=699343351&format=interactive"

--- a/src/content/en/2019/javascript.md
+++ b/src/content/en/2019/javascript.md
@@ -69,6 +69,7 @@ Although this data shows how much longer it can take for a mobile device to proc
 
 {{ figure_markup(
   image="js-processing-reddit.png",
+  alt="JavaScript processing times for reddit.com.",
   caption='JavaScript processing times for reddit.com. From <a href="https://v8.dev/blog/cost-of-javascript-2019">The cost of JavaScript in 2019</a>.',
   description="Bar chart showing 3 different devices: at the top a Pixel 3 has small amount on both the main thread and the worker thread of less than 400ms. For a Moto G4 it is approximately 900 ms on main thread and a further 300 ms on worker thread. And the final bar is an Alcatel 1X 5059D with over 2,000 ms on the main thread and over 500 ms on worker thread.",
   width=600,
@@ -298,6 +299,7 @@ In the past number of years, the JavaScript ecosystem has seen a rise in open-so
 
 {{ figure_markup(
   image="fig12.png",
+  alt="Most frequently used frameworks on desktop.",
   caption="Most frequently used frameworks on desktop.",
   description="Bar chart showing 4.6% of sites use React, 2.0% AngularJS, 1.8% Backbone.js, 0.8% Vue.js, 0.4% Knockout.js, 0.3% Zone.js, 0.3% Angular, 0.1% AMP, 0.1% Ember.js.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTpzDb9HGbdVvin6YPTOmw11qBVGGysltxmH545fUfnqIThAq878F_b-KxUo65IuXaeFVSnlmJ5K1Dm/pubchart?oid=1699359221&format=interactive"
@@ -419,6 +421,7 @@ Although useful, there are a number of reasons why many sites may not want to in
 
 {{ figure_markup(
   image="fig18.png",
+  alt="Percentage of sites using source maps.",
   caption="Percentage of sites using source maps.",
   description="Bar chart showing 18% of desktop sites and 17% of mobile sites use source maps.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTpzDb9HGbdVvin6YPTOmw11qBVGGysltxmH545fUfnqIThAq878F_b-KxUo65IuXaeFVSnlmJ5K1Dm/pubchart?oid=906754154&format=interactive"

--- a/src/content/en/2019/media.md
+++ b/src/content/en/2019/media.md
@@ -233,6 +233,7 @@ The savings in this AB Lighthouse test is not just about potential byte savings,
 
  {{ figure_markup(
   image="fig13_project_perf_improvements_image_optimization.png",
+  alt="Projected page performance improvements from image optimization from Lighthouse.",
   caption="Projected page performance improvements from image optimization from Lighthouse.",
   description="Bar chart showing in the 10th percentile 0 ms could be sized, same in 25th percentile, in the 50th percentile 150 ms could be saved, in the 75th percentile 1,460 ms could be saved and in the 90th percentile 5,720 ms could be saved.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vSViHIntdF6-bHAI0cl1HelY_X8rR4lf0P3W2Y8I5SyVMxG-ptggTHfWA0qrrU47RvuAydLE6Zex6L3/pubchart?oid=167590779"
@@ -301,7 +302,8 @@ To enable Client Hints, the web page must signal to the browser using either an 
 
 {{ figure_markup(
   image="fig17_usage_of_accept-ch_http_v_html.png",
-  caption="Usage of the <code>Accept-CH</code> header versus the equivalent <code>&lt;meta></code> tag.",
+  alt="Usage of the Accept-CH header versus the equivalent meta tag.",
+  caption="Usage of the <code>Accept-CH</code> header versus the equivalent <code>&lt;meta&gt;</code> tag.",
   description="Bar chart showing 71% use the 'meta http-equiv', 30% use the 'Accept-CH' HTTP header and 1% use both.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vSViHIntdF6-bHAI0cl1HelY_X8rR4lf0P3W2Y8I5SyVMxG-ptggTHfWA0qrrU47RvuAydLE6Zex6L3/pubchart?oid=284657706&format=interactive"
   )
@@ -329,6 +331,7 @@ Earlier, in [Figure 4.5](#fig-5), we showed that the volume of image content at 
 
 {{ figure_markup(
   image="fig19_lighthouse_audit_offscreen.png",
+  alt="Lighthouse audit: Offscreen.",
   caption="Lighthouse audit: Offscreen.",
   description="A bar chart showing in the 10th percentile 0% of images are offscreen, in the 25th percentile 2% are offscreen, in the 50th percentile, 27% are offscreen, in the 75th percentile 64% are offscreen, and in the 90th percentile 84% of images are offscreen.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vSViHIntdF6-bHAI0cl1HelY_X8rR4lf0P3W2Y8I5SyVMxG-ptggTHfWA0qrrU47RvuAydLE6Zex6L3/pubchart?oid=2123391693&format=interactive"

--- a/src/content/en/2019/seo.md
+++ b/src/content/en/2019/seo.md
@@ -86,7 +86,7 @@ Meta tags allow us to give specific instructions and information to search engin
 #### Page titles
 
 {{ figure_markup(
-  caption="Percent of mobile pages that include a <code>&lt;title></code> tag.",
+  caption="Percent of mobile pages that include a <code>&lt;title&gt;</code> tag.",
   content="97%",
   classes="big-number"
 )

--- a/src/content/es/2019/fonts.md
+++ b/src/content/es/2019/fonts.md
@@ -538,6 +538,7 @@ Echemos un vistazo a los valores de `font-display` que son populares:
 
 {{ figure_markup(
   image="fig11.png",
+  alt="Uso de valores font-display.",
   caption="Uso de valores <code>font-display</code>.",
   description="Gráfico de barras que muestra el uso del estilo font-display. El 2,6% de las páginas móviles configuran este estilo en \"swap\", 1,5% en \"auto\", 0,7% en \"block\", 0,4% en \"fallback\", 0,2% en \"optional\" y 0,1% en \"swap\" entre comillas. que no es válido. La distribución de escritorio es similar, excepto que el uso de \"swap\" es menor en 0.4 puntos porcentuales y el uso \"auto\" es mayor en 0.1 puntos porcentuales.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vQDogXDb3BwZZHrBT39qccP_LJoCScD3QEi_FmjT_8VDPD_1Srpz-g7ZuuTUEb8pYXBpDmQzZ1hQh7q/pubchart?oid=1988783738&format=interactive"
@@ -641,6 +642,7 @@ Incluso con un 1.8%, esto fue más alto de lo esperado, aunque estoy emocionado 
 
 {{ figure_markup(
   image="fig19.png",
+  alt="Uso de los ejes font-variation-settings.",
   caption="Uso de los ejes <code>font-variation-settings</code>.",
   description="Gráfico de barras que muestra el uso de la propiedad font-variation-settings. El 42% de las propiedades en las páginas de escritorio se establecen en el valor \"opsz\", el 32% en \"wght\", el 16% en \"wdth\", el 2% o menos en \"roun\", \"crsb\", \"slnt\", \"inln\" , y más. Las diferencias más notables entre las páginas de escritorio y móviles son el 26% de uso de \"opsz\", el 38% de \"wght\" y el 23% de \"wdth\".",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vQDogXDb3BwZZHrBT39qccP_LJoCScD3QEi_FmjT_8VDPD_1Srpz-g7ZuuTUEb8pYXBpDmQzZ1hQh7q/pubchart?oid=699343351&format=interactive"

--- a/src/content/es/2019/javascript.md
+++ b/src/content/es/2019/javascript.md
@@ -69,6 +69,7 @@ Aunque estos datos muestran cuánto tiempo puede llevar un dispositivo móvil pr
 
 {{ figure_markup(
   image="js-processing-reddit.png",
+  alt="Tiempos de procesamiento de JavaScript para Reddit.com.",
   caption='Tiempos de procesamiento de JavaScript para Reddit.com. Tomado de <a href="https://v8.dev/blog/cost-of-javascript-2019\">El costo de JavaScript en 2019</a>.',
   description="Gráfico de barras que muestra 3 dispositivos diferentes: en la parte superior, un Pixel 3, que tiene un tiempo de procesamiento pequeño tanto en el hilo principal como en el hilo worker de menos de 400 ms. Para un Moto G4 es de aproximadamente 900 ms en el subproceso principal y otros 300 ms en el subproceso del worker. Y la barra final es un Alcatel 1X 5059D con más de 2.000 ms en el subproceso principal y más de 500 ms en el subproceso del worker.",
   width=600,
@@ -296,6 +297,7 @@ En los últimos años, el ecosistema de JavaScript ha visto un aumento en las bi
 
 {{ figure_markup(
   image="fig12.png",
+  alt="Los frameworks más utilizados en el escritorio.",
   caption="Los frameworks más utilizados en el escritorio.",
   description="Gráfico de barras que muestra que el 4,6% de los sitios usan React, 2,0% AngiularJS, 1,8% Backbone.js, 0,8% Vue.js, 0,4% Knockout.js, 0,3% Zone.js, 0,3% Angular, 0,1% AMP, 0,1% Ember. js.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTpzDb9HGbdVvin6YPTOmw11qBVGGysltxmH545fUfnqIThAq878F_b-KxUo65IuXaeFVSnlmJ5K1Dm/pubchart?oid=1699359221&format=interactive"
@@ -419,6 +421,7 @@ Aunque es útil, hay una serie de razones por las cuales muchos sitios pueden no
 
 {{ figure_markup(
   image="fig18.png",
+  alt="Porcentaje de sitios que usan mapas fuente.",
   caption="Porcentaje de sitios que usan mapas fuente.",
   description="Gráfico de barras que muestra el 18% de los sitios de escritorio y el 17% de los sitios móviles utilizan mapas fuente.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTpzDb9HGbdVvin6YPTOmw11qBVGGysltxmH545fUfnqIThAq878F_b-KxUo65IuXaeFVSnlmJ5K1Dm/pubchart?oid=906754154&format=interactive"

--- a/src/content/es/2019/media.md
+++ b/src/content/es/2019/media.md
@@ -233,6 +233,7 @@ La ventaja de este test AB <i lang="en">Lighthouse</i> no es solo la potencial r
 
  {{ figure_markup(
   image="fig13_project_perf_improvements_image_optimization.png",
+  alt="Estimación de la mejora del rendimiento de la página tras la optimización de imagen de Lighthouse.",
   caption='Estimación de la mejora del rendimiento de la página tras la optimización de imagen de <i lang="en">Lighthouse</i>.',
   description="Gráfico de barras que muestra  que en el percentil 10 0 ms pudieron ser medidos, lo mismo pasa en el percentil 25, en el percentil 50 se redujeron 150 ms, en el percentil 75 se redujeron 1.460 ms, y en el percentil 90 se redujeron 5.720 ms.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vSViHIntdF6-bHAI0cl1HelY_X8rR4lf0P3W2Y8I5SyVMxG-ptggTHfWA0qrrU47RvuAydLE6Zex6L3/pubchart?oid=167590779"
@@ -301,7 +302,8 @@ Para habilitar los <i lang="en">Client Hints</i>, la página web debe señalizá
 
 {{ figure_markup(
   image="fig17_usage_of_accept-ch_http_v_html.png",
-  caption="Uso del encabezado <code>Accept-CH</code> versus la etiqueta <code>&lt;meta></code> equivalente.",
+  alt="Uso del encabezado Accept-CH versus la etiqueta meta equivalente.",
+  caption="Uso del encabezado <code>Accept-CH</code> versus la etiqueta <code>&lt;meta&gt;</code> equivalente.",
   description="Gráfico de barras mostrando que un 71% usa el 'meta http-equiv', un 30% usa el encabezado 'Accept-CH' HTTP y un 1% usa ambos.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vSViHIntdF6-bHAI0cl1HelY_X8rR4lf0P3W2Y8I5SyVMxG-ptggTHfWA0qrrU47RvuAydLE6Zex6L3/pubchart?oid=284657706&format=interactive"
   )
@@ -329,6 +331,7 @@ Anteriormente, en la [Figura 4.5](#fig-5), mostramos como el volumen del conteni
 
 {{ figure_markup(
   image="fig19_lighthouse_audit_offscreen.png",
+  alt="Auditoría Lighthouse: Fuera de pantalla.",
   caption='Auditoría <i lang="en">Lighthouse</i>: Fuera de pantalla.',
   description="Un gráfico de barras que muestra que en el percentil 10 un 0% de las imágenes se encuentran fuera de pantalla, en el percentil 25 un 2% están fuera de pantalla, en el percentil 50 un 27% están fuera de pantalla, en el percentil 75 un 64% están fuera de pantalla, y en el percentil 90 un 84% de las imágenes están fuera de pantalla.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vSViHIntdF6-bHAI0cl1HelY_X8rR4lf0P3W2Y8I5SyVMxG-ptggTHfWA0qrrU47RvuAydLE6Zex6L3/pubchart?oid=2123391693&format=interactive"

--- a/src/content/fr/2019/caching.md
+++ b/src/content/fr/2019/caching.md
@@ -83,6 +83,7 @@ L'outil [RedBot.org](https://redbot.org/) vous permet d'entrer une URL et de voi
 
 {{ figure_markup(
   image="ch16_fig1_redbot_example.jpg",
+  alt="Informations de RedBot relatives au Cache-Control.",
   caption="Informations de RedBot relatives au <code>Cache-Control</code>.",
   description="Exemple de réponse Redbot montrant des informations détaillées sur le moment où la ressource a été modifiée ; si les caches peuvent la stocker ; pour combien de temps elle peut être considérée valide ; si nécessaire les avertissements.",
   width=600,
@@ -96,6 +97,7 @@ Si aucun en-tête de mise en cache n'est renseigné dans la réponse, alors [l'a
 
 {{ figure_markup(
   image="fig2.png",
+  alt="Présence des en-tête HTTP Cache-Control et Expires.",
   caption="Présence des en-tête HTTP <code>Cache-Control</code> et <code>Expires</code>.",
   description="Ces deux diagrammes à barres identiques pour le mobile et les ordinateurs de bureau montrent que 72&nbsp;% des requêtes utilisent des en-têtes Cache-Control et que 56&nbsp;% utilisent Expires et les 27&nbsp;% n'utilisent aucun des deux.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vT3GWCs19Wq0mu0zgIlKRc8zcXgmVEk2xFHuzZACiWVtqOv8FO5gfHwBxa0mhU6O9TBY8ODdN4Zjd_O/pubchart?oid=1611664016&format=interactive"
@@ -264,6 +266,7 @@ HTTP/1.1 a introduit l'en-tête `Cache-Control`, et la plupart des clients moder
 
 {{ figure_markup(
   image="fig7.png",
+  alt="Utilisation comparée des en-têtes Cache-Control et Expires.",
   caption="Utilisation comparée des en-têtes <code>Cache-Control</code> et <code>Expires</code>.",
   description="Un diagramme à barres montrant que 53&nbsp;% des réponses ont un `Cache-Control: max-age`, 54&nbsp;%-55&nbsp;% utilisent `Expire`, 41&nbsp;%-42&nbsp;% utilisent les deux, et 34&nbsp;% n'utilisent aucun des deux. Les chiffres sont donnés à la fois pour les ordinateurs de bureau et les mobiles, mais les chiffres sont presque identiques, les mobiles ayant un point de pourcentage d'utilisation des expirations plus élevé.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vT3GWCs19Wq0mu0zgIlKRc8zcXgmVEk2xFHuzZACiWVtqOv8FO5gfHwBxa0mhU6O9TBY8ODdN4Zjd_O/pubchart?oid=1909701542&format=interactive"
@@ -336,6 +339,7 @@ Par exemple, `cache-control:public, max-age=43200` indique qu'une entrée mise e
 
 {{ figure_markup(
   image="fig9.png",
+  alt="Utilisation de la directive Cache-Control sur mobile.",
   caption="Utilisation de la directive <code>Cache-Control</code> sur mobile.",
   description="Un diagramme à barres de 15 directives `Cache-Control` et leur utilisation allant de 74,8&nbsp;% pour max-age, 37,8&nbsp;% pour public, 27,8&nbsp;% pour no-cache, 18&nbsp;% pour no-store, 14,3&nbsp;% pour private, 3,4&nbsp;% pour l'immutable, 3.3. 3&nbsp;% pour no-transform, 2,4&nbsp;% pour le stale-while-revalidate, 2,2&nbsp;% pour pre-check, 2,2&nbsp;% pour post-check, 1,9&nbsp;% pour s-maxage, 1,6&nbsp;% pour proxy-revalidate, 0,3&nbsp;% pour le set-cookie et 0,2&nbsp;% pour le stale-if-error. Les statistiques sont presque identiques pour les ordinateurs de bureaux et les téléphones portables. ",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vT3GWCs19Wq0mu0zgIlKRc8zcXgmVEk2xFHuzZACiWVtqOv8FO5gfHwBxa0mhU6O9TBY8ODdN4Zjd_O/pubchart?oid=1054108345&format=interactive",
@@ -476,6 +480,7 @@ Dans l'ensemble, 65&nbsp;% des réponses sont servies avec un en-tête `Last-Mod
 
 {{ figure_markup(
   image="fig12.png",
+  alt="Adoption de la validation de la fraîcheur via les en-têtes Last-Modified et ETag pour sites sur ordinateurs de bureau.",
   caption="Adoption de la validation de la fraîcheur via les en-têtes <code>Last-Modified</code> et <code>ETag</code> pour sites sur ordinateurs de bureau.",
   description="Le diagramme à barres montre que 64,4&nbsp;% des requêtes sur ordinateurs de bureau ont un Last Modified, 42,8&nbsp;% ont un ETag, 37,9&nbsp;% ont les deux et 30,7&nbsp;% n'ont ni l'un ni l'autre. Les statistiques pour les mobiles sont presque identiques&nbsp;: 65,3&nbsp;% pour la dernière modification, 42,8&nbsp;% pour l'ETag, 38,0&nbsp;% pour les deux et 29,9&nbsp;% pour aucune des deux.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vT3GWCs19Wq0mu0zgIlKRc8zcXgmVEk2xFHuzZACiWVtqOv8FO5gfHwBxa0mhU6O9TBY8ODdN4Zjd_O/pubchart?oid=20297100&format=interactive"
@@ -577,6 +582,7 @@ L'un des risques de la mise en cache avec `Set-Cookie` est que les valeurs des c
 
 {{ figure_markup(
   image="ch16_fig16_cacheable_responses_set_cookie.jpg",
+  alt="Réponses pouvant être mises en cache avec Set-Cookie.",
   caption="Réponses pouvant être mises en cache avec <code>Set-Cookie</code>.",
   description="Le graphique à barres montre que 97&nbsp;% des réponses n'utilisent pas Set-Cookie alors que 3&nbsp;% le font. Ces 3&nbsp;% sont zoomés pour obtenir un autre diagramme à barres montrant la répartition entre 15,3&nbsp;% de réponses <code>private</code>, 84,7&nbsp;% de réponses <code>public</code> pour les ordinateurs de bureau et réciproquement pour les téléphones portables, 18,4&nbsp;% de réponses <code>public</code> et 81,6&nbsp;% de réponses <code>private</code>.",
   width=600,

--- a/src/content/fr/2019/javascript.md
+++ b/src/content/fr/2019/javascript.md
@@ -69,6 +69,7 @@ Bien que ces données montrent combien de temps il peut falloir à un appareil m
 
 {{ figure_markup(
   image="js-processing-reddit.png",
+  alt="Délais de traitement de JavaScript pour Reddit.com.",
   caption='Délais de traitement de JavaScript pour Reddit.com, issus de <a href="https://v8.dev/blog/cost-of-javascript-2019"><i lang="en">The cost of JavaScript in 2019</i> (en anglais)</a>.',
   description="Diagramme à barres montrant 3 appareils différents&nbsp;: en haut, un Pixel 3 présentant une petite portion à la fois sur le fil principal et le fil secondaire de moins de 400&nbsp;ms. Dans le cas du Moto G4, cela représente environ 900&nbsp;ms sur le fil principal et 300&nbsp;ms sur le fil secondaire. La dernière barre est celle d’un Alcatel 1X 5059D avec plus de 2&#8239;000&nbsp;ms sur le fil principal et plus de 500&nbsp;ms sur le fil secondaire.",
   width=600,
@@ -298,6 +299,7 @@ Au cours des dernières années, l’écosystème JavaScript a connu une augment
 
 {{ figure_markup(
   image="fig12.png",
+  alt="Frameworks les plus fréquemment utilisés sur ordinateurs de bureau.",
   caption='<span lang="en">Frameworks</span> les plus fréquemment utilisés sur ordinateurs de bureau.',
   description="Diagramme à barres montrant que 4,6&nbsp;% des sites utilisent React, 2,0&nbsp;% AngularJS, 1,8&nbsp;% Backbone.js, 0,8&nbsp;% Vue.js, 0,4&nbsp;% Knockout.js, 0,3&nbsp;% Zone.js, 0,3&nbsp;% Angular, 0,1&nbsp;% AMP, 0,1&nbsp;% Ember.js.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTpzDb9HGbdVvin6YPTOmw11qBVGGysltxmH545fUfnqIThAq878F_b-KxUo65IuXaeFVSnlmJ5K1Dm/pubchart?oid=1699359221&format=interactive"
@@ -419,6 +421,7 @@ Bien qu’utile, il existe un certain nombre de raisons pour lesquelles de nombr
 
 {{ figure_markup(
   image="fig18.png",
+  alt="Pourcentage de sites utilisant des source maps.",
   caption='Pourcentage de sites utilisant des <i lang="en">source maps</i>.',
   description='Diagramme à barres montrant que 18&nbsp;% des sites sur ordinateurs de bureau et 17&nbsp;% des sites sur mobiles utilisent des <i lang="en">source maps</i>.',
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTpzDb9HGbdVvin6YPTOmw11qBVGGysltxmH545fUfnqIThAq878F_b-KxUo65IuXaeFVSnlmJ5K1Dm/pubchart?oid=906754154&format=interactive"

--- a/src/content/ja/2019/caching.md
+++ b/src/content/ja/2019/caching.md
@@ -83,6 +83,7 @@ Webブラウザーがクライアントにレスポンスを送信するとき�
 
 {{ figure_markup(
   image="ch16_fig1_redbot_example.jpg",
+  alt="ロボットからのCache-Control情報",
   caption="ロボットからの <code>Cache-Control</code> 情報",
   description="リソースがいつ変更されたか、キャッシュがそれを保存できるかどうか、リソースが新鮮であると見なされる期間、および警告に関する詳細情報を示すRedbotの応答例。",
   width=600,
@@ -96,6 +97,7 @@ Webブラウザーがクライアントにレスポンスを送信するとき�
 
 {{ figure_markup(
   image="fig2.png",
+  alt="HTTP Cache-ControlおよびExpiresヘッダーの存在",
   caption="HTTP <code>Cache-Control</code> および <code>Expires</code> ヘッダーの存在",
   description="リクエストの72％がCache-Controlヘッダーを使用し、56％がExpiresを使用し、27％がどちらも使用しないことを示す、モバイルとデスクトップの棒グラフ。",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vT3GWCs19Wq0mu0zgIlKRc8zcXgmVEk2xFHuzZACiWVtqOv8FO5gfHwBxa0mhU6O9TBY8ODdN4Zjd_O/pubchart?oid=1611664016&format=interactive"
@@ -264,6 +266,7 @@ HTTPレスポンスの53％は、`max-age`ディレクティブを持つ`Cache-C
 
 {{ figure_markup(
   image="fig7.png",
+  alt="Cache-ControlとExpiresヘッダーの使用法。",
   caption="<code>Cache-Control</code> と <code>Expires</code> ヘッダーの使用法。",
   description="レスポンスの53％を示す棒グラフには、「Cache-Control：max-age」、54％-55％が「Expires」、41％-42％が両方を使用し、34％がどちらも使用していません。数字は、デスクトップとモバイルの両方について示されていますが、有効期限の使用率が高いモバイルとほぼ同じです。",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vT3GWCs19Wq0mu0zgIlKRc8zcXgmVEk2xFHuzZACiWVtqOv8FO5gfHwBxa0mhU6O9TBY8ODdN4Zjd_O/pubchart?oid=1909701542&format=interactive"
@@ -336,6 +339,7 @@ HTTP/1.1[仕様](https://tools.ietf.org/html/rfc7234#section-5.2.1)には、`Cac
 
 {{ figure_markup(
   image="fig9.png",
+  alt="モバイルでのCache-Controlディレクティブの使用。",
   caption="モバイルでの <code>Cache-Control</code> ディレクティブの使用。",
   description="15のcache-controlディレクティブとその使用量の棒グラフ。74.8％のmax-age、37.8％のpublic、27.8％のno-cache、18％のno-store、14.3％のprivate、3.4％のimmutable、3.3％のno-transform、2.4％のstale-while-revalidate、2.2％のpre-check、2.2％のpost-check、1.9％のs-maxage、1.6％のproxy-revalidate、0.3％set-cookieおよび0.2％のstale-if-error。統計は、デスクトップとモバイルでほぼ同じです。",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vT3GWCs19Wq0mu0zgIlKRc8zcXgmVEk2xFHuzZACiWVtqOv8FO5gfHwBxa0mhU6O9TBY8ODdN4Zjd_O/pubchart?oid=1054108345&format=interactive",
@@ -476,6 +480,7 @@ HTTP/1.1[仕様](https://tools.ietf.org/html/rfc7234#section-5.2.1)には、`Cac
 
 {{ figure_markup(
   image="fig12.png",
+  alt="デスクトップWebサイトのLast-ModifiedおよびETagヘッダーを介した鮮度の検証の採用。",
   caption="デスクトップWebサイトの <code>Last-Modified</code> および <code>ETag</code> ヘッダーを介した鮮度の検証の採用。",
   description="デスクトップリクエストの64.4％が最後に変更され、42.8％がETagを持ち、37.9％が両方を持ち、30.7％がどちらも持たないことを示す棒グラフ。モバイルの統計は、最終変更が65.3％、ETagが42.8％、両方が38.0％、どちらも29.9％というほぼ同じです。",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vT3GWCs19Wq0mu0zgIlKRc8zcXgmVEk2xFHuzZACiWVtqOv8FO5gfHwBxa0mhU6O9TBY8ODdN4Zjd_O/pubchart?oid=20297100&format=interactive"
@@ -577,6 +582,7 @@ Varyヘッダーは、1つ以上の要求ヘッダー値の値をキャッシュ
 
 {{ figure_markup(
   image="ch16_fig16_cacheable_responses_set_cookie.jpg",
+  alt="Set-Cookieレスポンスのキャッシュ可能なレスポンス。",
   caption="<code>Set-Cookie</code> レスポンスのキャッシュ可能なレスポンス。",
   description="レスポンスの97％を示す棒グラフはSet-Cookieを使用せず、3％が使用します。この3％の内、15.3％がプライベート、84.7％がデスクトップ、モバイルは18.4％がパブリック、81.6％がプライベートであるという別の棒グラフに拡大されています。",
   width=600,

--- a/src/content/ja/2019/cdn.md
+++ b/src/content/ja/2019/cdn.md
@@ -1487,6 +1487,7 @@ Webサイトは、さまざまなHTTPヘッダーを使用して、ブラウザ�
 
 {{ figure_markup(
   image="use_of_vary_on_cdn.png",
+  alt="CDNから提供されるHTMLのVaryの使用法。",
   caption="CDNから提供されるHTMLの <code>Vary</code> の使用法。",
   description="accept-encodingを示すツリーマップグラフは使用率が異なり、チャートの73％が使用されます。 Cookie（13％）とユーザーエージェント（8％）がある程度使用され、その後に他のヘッダーが完全に混在しています。",
   width=600,
@@ -1502,6 +1503,7 @@ HTMLページの場合、`Vary`の最も一般的な使用法は、`User-Agent`�
 
 {{ figure_markup(
   image="use_of_vary.png",
+  alt="HTMLとoriginとCDNから提供されるリソースのVary使用の比較。",
   caption="HTMLとoriginとCDNから提供されるリソースの <code>Vary</code> 使用の比較。",
   description="ホームページを提供するCDNの場合、Varyの最大の用途はCookieであり、その後にuser-agentが続くことを示す4つのツリーマップグラフのセット、他のリソースを提供するCDNの場合は、originであり、その後にaccept、user-agent、x-origin、およびreferrerが続きます。 originsとホームページの場合、それはuser-agentであり、その後にcookieが続きます。最後に、originsおよびその他のリソースについては、主にuser-agentであり、その後にorigin、accept、range、hostが続きます。"
   )
@@ -1525,6 +1527,7 @@ HTMLページの場合、`Vary`の最も一般的な使用法は、`User-Agent`�
 
 {{ figure_markup(
   image="fig26.png",
+  alt="CDN応答全体でのs-maxageの採用。",
   caption="CDN応答全体での <code>s-maxage</code> の採用。",
   description="jsDelivrの82％がs-maxage、レベル3の14％、Amazon CloudFrontの6.3％、Akamaiの3.3％、Fastlyの3.1％、Highwindsの3％、Cloudflareの2％、ORIGINの0.91％の応答を提供する棒グラフ、Edgecastの0.75％、Googleの0.07％。",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRzPn-1SGVa3rNCT0U9QeQNODE97fsmXyaJX1ZOoBNR8nPpclhC6fg8R_UpoodeiX6HkdHrp50WBQ5Q/pubchart?oid=1215102767&format=interactive"

--- a/src/content/ja/2019/fonts.md
+++ b/src/content/ja/2019/fonts.md
@@ -365,6 +365,7 @@ Google Fontsのドキュメントでは、Google Fonts CSSの`<link>`はペー�
 
 {{ figure_markup(
   image="fig8.png",
+  alt="@font-face宣言におけるフォントフォーマットの人気度。",
   caption="<code>@font-face</code> 宣言におけるフォントフォーマットの人気度。",
   description="フォントフェイス宣言で使用されるフォーマットの人気を示す棒グラフ。デスクトップページの@font-face宣言の 69%がWOFF2形式を指定しており、11%がWOFF、10%がTrueType、8%がSVG、2%がEOT、1%未満でOpenType、TTF、OTFを指定しています。モバイルページの分布も同様です。",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vQDogXDb3BwZZHrBT39qccP_LJoCScD3QEi_FmjT_8VDPD_1Srpz-g7ZuuTUEb8pYXBpDmQzZ1hQh7q/pubchart?oid=700778025&format=interactive"
@@ -538,6 +539,7 @@ Google Fontsを使っているなら、スニペットを更新しよう！　Go
 
 {{ figure_markup(
   image="fig11.png",
+  alt="font-displayの値の使用法。",
   caption="<code>font-display</code> の値の使用法。",
   description="フォント表示スタイルの利用状況を示す棒グラフ。モバイルページの2.6％がこのスタイルを「swap」、1.5％が「auto」、0.7％が「block」、0.4％が「fallback」、0.2％が「optional」、0.1％が引用符で囲んだ「swap」に設定しているが、これは無効である。デスクトップの分布は、「swap」の利用率が0.4％ポイント低く、「auto」の利用率が0.1％ポイント高くなっている以外は似ている。",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vQDogXDb3BwZZHrBT39qccP_LJoCScD3QEi_FmjT_8VDPD_1Srpz-g7ZuuTUEb8pYXBpDmQzZ1hQh7q/pubchart?oid=1988783738&format=interactive"
@@ -641,6 +643,7 @@ Google FontsはそのCSSのほとんど（すべてではないにしても）�
 
 {{ figure_markup(
   image="fig19.png",
+  alt="font-variation-settings軸の使用法。",
   caption="<code>font-variation-settings</code> 軸の使用法。",
   description="font-variation-settingsプロパティの使用状況を示す棒グラフ。デスクトップページのプロパティの42%が\"opsz\"の値に設定されており、32%が\"wght\"、16%が\"wdth\"、2%以下が\"roun\"、\"crsb\"、\"slnt\"、\"inln\"などに設定されています。デスクトップページとモバイルページで顕著な違いは、\"opsz\"の使用率が26％、\"wght\"の使用率が38％、\"wdth\"の使用率が23％となっており、\"wght\"の使用率は、\"wght\"の使用率と\"wght\"の使用率の差が大きい。",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vQDogXDb3BwZZHrBT39qccP_LJoCScD3QEi_FmjT_8VDPD_1Srpz-g7ZuuTUEb8pYXBpDmQzZ1hQh7q/pubchart?oid=699343351&format=interactive"

--- a/src/content/ja/2019/javascript.md
+++ b/src/content/ja/2019/javascript.md
@@ -69,6 +69,7 @@ V8のメインスレッドの処理時間を異なるパーセンタイルで分
 
 {{ figure_markup(
   image="js-processing-reddit.png",
+  alt="reddit.comのJavaScript処理時間。",
   caption='reddit.comのJavaScript処理時間。<a href="https://v8.dev/blog/cost-of-javascript-2019">2019年のJavaScriptのコスト</a>より。',
   description="3つの異なるデバイスを示す棒グラフ: 上部のPixel3は、メインスレッドとワーカースレッドの両方で400ms未満と量が少ないです。Moto G4の場合、メインスレッドで約900ms、ワーカースレッドでさらに300msです。そして最後のバーはAlcatel 1X 5059Dで、メインスレッドで2,000ms以上、ワーカースレッドで500ms以上となっています。",
   width=600,
@@ -298,6 +299,7 @@ JavaScriptのリソースを圧縮しているサイトはどれくらいある�
 
 {{ figure_markup(
   image="fig12.png",
+  alt="デスクトップで最もよく使われるフレームワーク",
   caption="デスクトップで最もよく使われるフレームワーク",
   description="Reactを使用しているサイトは4.6％、AngularJSを使用しているサイトは2.0％、Backbone.jsを使用しているサイトは1.8％、Vue.jsを使用しているサイトは0.8％、Knockout.jsを使用しているサイトは0.4％、Zone.jsを使用しているサイトは0.3％、Angularを使用しているサイトは0.3％、AMPを使用しているサイトは0.1％、Ember.jsを使用しているサイトは0.1％という棒グラフになっています。",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTpzDb9HGbdVvin6YPTOmw11qBVGGysltxmH545fUfnqIThAq878F_b-KxUo65IuXaeFVSnlmJ5K1Dm/pubchart?oid=1699359221&format=interactive"
@@ -419,6 +421,7 @@ Atomics(0.38％)とSharedArrayBuffer(0.20％)は、使用されているペー�
 
 {{ figure_markup(
   image="fig18.png",
+  alt="ソースマップを使用しているサイトの割合。",
   caption="ソースマップを使用しているサイトの割合。",
   description="デスクトップサイトの18％、モバイルサイトの17％がソースマップを使用していることを示す棒グラフ。",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTpzDb9HGbdVvin6YPTOmw11qBVGGysltxmH545fUfnqIThAq878F_b-KxUo65IuXaeFVSnlmJ5K1Dm/pubchart?oid=906754154&format=interactive"

--- a/src/content/ja/2019/media.md
+++ b/src/content/ja/2019/media.md
@@ -234,6 +234,7 @@ CSSピクセルと自然ピクセル量を見ると、中央値のウェブサ�
 
  {{ figure_markup(
   image="fig13_project_perf_improvements_image_optimization.png",
+  alt="Lighthouseからの画像最適化によるページパフォーマンスの向上を予測。",
   caption="Lighthouseからの画像最適化によるページパフォーマンスの向上を予測。",
   description="10パーセンタイルでは0ms、25パーセンタイルでも同じ、50パーセンタイルでは150ms、75パーセンタイルでは1,460ms、90パーセンタイルでは5,720msの保存が可能であることを示す棒グラフです。",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vSViHIntdF6-bHAI0cl1HelY_X8rR4lf0P3W2Y8I5SyVMxG-ptggTHfWA0qrrU47RvuAydLE6Zex6L3/pubchart?oid=167590779"
@@ -329,6 +330,7 @@ HTMLでクライアントヒントを呼び出すために`<meta>`タグを使�
 
 {{ figure_markup(
   image="fig19_lighthouse_audit_offscreen.png",
+  alt="Lighthouse監査：オフスクリーン。",
   caption="Lighthouse監査：オフスクリーン。",
   description="10パーセンタイルでは画像の0%が画面外、25パーセンタイルでは2%が画面外、50パーセンタイルでは27%が画面外、75パーセンタイルでは64%が画面外、90パーセンタイルでは 84%が画面外であることを示す棒グラフです。",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vSViHIntdF6-bHAI0cl1HelY_X8rR4lf0P3W2Y8I5SyVMxG-ptggTHfWA0qrrU47RvuAydLE6Zex6L3/pubchart?oid=2123391693&format=interactive"

--- a/src/content/pt/2019/javascript.md
+++ b/src/content/pt/2019/javascript.md
@@ -69,6 +69,7 @@ Embora esses dados mostrem quanto tempo pode levar para um dispositivo móvel pr
 
 {{ figure_markup(
   image="/static/images/2019/javascript/js-processing-reddit.png",
+  alt="Tempos de processamento de JavaScript para reddit.com.",
   caption='Tempos de processamento de JavaScript para reddit.com. De <a href="https://v8.dev/blog/cost-of-javascript-2019">O custo do JavaScript em 2019</a>.',
   description="Gráfico de barras mostrando 3 dispositivos diferentes: no topo, um Pixel 3 tem uma pequena quantidade no thread principal e no thread de trabalho de menos de 400ms. Para um Moto G4, é aproximadamente 900 ms no thread principal e mais 300 ms no thread de trabalho. E a barra final é um Alcatel 1X 5059D com mais de 2.000 ms no thread principal e mais de 500 ms no thread de trabalho.",
   width=600,
@@ -298,7 +299,8 @@ Nos últimos anos, o ecossistema JavaScript tem visto um aumento em bibliotecas 
 
 {{ figure_markup(
   image="/static/images/2019/javascript/fig12.png",
-  caption="Os frameworks mais usados ​​no desktop.",
+  alt="Os frameworks mais usados no desktop.",
+  caption="Os frameworks mais usados no desktop.",
   description="Gráfico de barras mostrando que 4,6% dos sites usam React, 2.0% AngularJS, 1.8% Backbone.js, 0.8% Vue.js, 0.4% Knockout.js, 0.3% Zone.js, 0.3% Angular, 0.1% AMP, 0.1% Ember.js.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTpzDb9HGbdVvin6YPTOmw11qBVGGysltxmH545fUfnqIThAq878F_b-KxUo65IuXaeFVSnlmJ5K1Dm/pubchart?oid=1699359221&format=interactive"
   )
@@ -419,6 +421,7 @@ Embora úteis, existem vários motivos pelos quais muitos sites podem não quere
 
 {{ figure_markup(
   image="/static/images/2019/javascript/fig18.png",
+  alt="Porcentagem de sites usando mapas de origem.",
   caption="Porcentagem de sites usando mapas de origem.",
   description="Gráfico de barras mostrando 18% dos sites para desktop e 17% dos sites para celular usam mapas de origem.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTpzDb9HGbdVvin6YPTOmw11qBVGGysltxmH545fUfnqIThAq878F_b-KxUo65IuXaeFVSnlmJ5K1Dm/pubchart?oid=906754154&format=interactive"


### PR DESCRIPTION
Further cleanup of the figures. Moving all `alt` attributes to plain text.

There's some dispute as to whether alt attributes can/should contain HTML elements but in our [figure wiki](https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Git-Guide) that they shouldn't and, since we don't use them for accessibility reasons and only really for SEO, they shouldn't have markup.

So let's clean them up!
