### PR TITLE
Switch LH weighting to AVG

### DIFF
--- a/sql/2020/14_PWA/lighthouse_pwa_audits.sql
+++ b/sql/2020/14_PWA/lighthouse_pwa_audits.sql
@@ -26,7 +26,7 @@ SELECT
   COUNTIF(audits.score > 0) AS num_pages,
   COUNT(0) AS total,
   COUNTIF(audits.score > 0) / COUNT(0) AS pct,
-  MAX(audits.weight) AS weight,
+  AVG(audits.weight) AS weight,
   MAX(audits.audit_group) AS audit_group,
   MAX(audits.description) AS description
 FROM


### PR DESCRIPTION
Just missed you merging this @rviscomi so missed this last update.

MAX was a bad call on weighting as means a single lighthouse run on different versions throws it off. Is fine for PWA but noticed it weirdly adding other audits on occasion in the other categories.

Have changed to AVG - Mode or Median would be best but seems no native functions for that so AVG will do.