### PR TITLE
Add Analysis By byline

### DIFF
--- a/src/content/en/2019/accessibility.md
+++ b/src/content/en/2019/accessibility.md
@@ -5,6 +5,7 @@ title: Accessibility
 description: Accessibility chapter of the 2019 Web Almanac covering ease of reading, media, ease of navigation, and compatibility with assistive technologies.
 authors: [nektarios-paisios, obto, kleinab]
 reviewers: [ljme]
+analysts: [dougsillars, rviscomi, obto]
 translators: []
 discuss: 1764
 results: https://docs.google.com/spreadsheets/d/16JGy-ehf4taU0w4ABiKjsHGEXNDXxOlb__idY8ifUtQ/

--- a/src/content/en/2019/caching.md
+++ b/src/content/en/2019/caching.md
@@ -5,6 +5,7 @@ title: Caching
 description: Caching chapter of the 2019 Web Almanac covering cache-control, expires, TTLs, validitaty, vary, set-cookies, AppCache, Service Workers and opportunities.
 authors: [paulcalvano]
 reviewers: [obto, bkardell]
+analysts: [paulcalvano, obto]
 translators: []
 discuss: 1771
 results: https://docs.google.com/spreadsheets/d/1mnq03DqrRBwxfDV05uEFETK0_hPbYOynWxZkV3tFgNk/

--- a/src/content/en/2019/cdn.md
+++ b/src/content/en/2019/cdn.md
@@ -5,6 +5,7 @@ title: CDN
 description: CDN chapter of the 2019 Web Almanac covering CDN adoption and usage, RTT & TLS management, HTTP/2 adoption, caching and common library and content CDNs.
 authors: [andydavies, colinbendell]
 reviewers: [yoavweiss, paulcalvano, pmeenan, enygren]
+analysts: [raghuramakrishnan71, rviscomi]
 translators: []
 discuss: 1772
 results: https://docs.google.com/spreadsheets/d/1Y7kAxjxUl8puuTToe6rL3kqJLX1ftOb0nCcD8m3lZBw/

--- a/src/content/en/2019/cms.md
+++ b/src/content/en/2019/cms.md
@@ -5,6 +5,7 @@ title: CMS
 description: CMS chapter of the 2019 Web Almanac covering CMS adoption, how CMS suites are built, User experience of CMS powered websites, and CMS innovation.
 authors: [ernee, amedina]
 reviewers: [sirjonathan]
+analysts: [rviscomi]
 translators: []
 discuss: 1769
 results: https://docs.google.com/spreadsheets/d/1FDYe6QdoY3UtXodE2estTdwMsTG-hHNrOe9wEYLlwAw/

--- a/src/content/en/2019/compression.md
+++ b/src/content/en/2019/compression.md
@@ -5,6 +5,7 @@ title: Compression
 description: Compression chapter of the 2019 Web Almanac covering HTTP compression, algorithms, content types, 1st party and 3rd party compression and opportunities.
 authors: [paulcalvano]
 reviewers: [obto, yoavweiss]
+analysts: [paulcalvano]
 translators: []
 discuss: 1770
 results: https://docs.google.com/spreadsheets/d/1IK9kaScQr_sJUwZnWMiJcmHEYJV292C9DwCfXH6a50o/

--- a/src/content/en/2019/css.md
+++ b/src/content/en/2019/css.md
@@ -5,6 +5,7 @@ title: CSS
 description: CSS chapter of the 2019 Web Almanac covering color, units, selectors, layout, typography and fonts, spacing, decoration, animation, and media queries.
 authors: [una, argyleink]
 reviewers: [meyerweb, huijing]
+analysts: [rviscomi]
 translators: []
 discuss: 1757
 results: https://docs.google.com/spreadsheets/d/1uFlkuSRetjBNEhGKWpkrXo4eEIsgYelxY-qR9Pd7QpM/

--- a/src/content/en/2019/ecommerce.md
+++ b/src/content/en/2019/ecommerce.md
@@ -5,6 +5,7 @@ title: Ecommerce
 description: Ecommerce chapter of the 2019 Web Almanac covering ecommerce platforms, payloads, images, third-parties, performance, seo, and PWAs.
 authors: [samdutton, alankent]
 reviewers: [voltek62]
+analysts: [rviscomi]
 translators: []
 discuss: 1768
 results: https://docs.google.com/spreadsheets/d/1FUMHeOPYBgtVeMU5_pl2r33krZFzutt9vkOpphOSOss/

--- a/src/content/en/2019/fonts.md
+++ b/src/content/en/2019/fonts.md
@@ -5,6 +5,7 @@ title: Fonts
 description: Fonts chapter of the 2019 Web Almanac covering where fonts are loaded from, font formats, font loading performance, variable fonts and color fonts.
 authors: [zachleat]
 reviewers: [hyperpress, AymenLoukil]
+analysts: [tjmonsi, rviscomi]
 translators: []
 discuss: 1761
 results: https://docs.google.com/spreadsheets/d/108g6LXdC3YVsxmX1CCwrmpZ3-DmbB8G_wwgQHX5pn6Q/

--- a/src/content/en/2019/http2.md
+++ b/src/content/en/2019/http2.md
@@ -5,8 +5,8 @@ title: HTTP/2
 description: HTTP/2 chapter of the 2019 Web Almanac covering adoption and impact of HTTP/2, HTTP/2 Push, HTTP/2 Issues, and HTTP/3.
 authors: [bazzadp]
 reviewers: [bagder, rmarx, dotjs]
-translators: []
 analysts: [paulcalvano]
+translators: []
 discuss: 1775
 results: https://docs.google.com/spreadsheets/d/1z1gdS3YVpe8J9K3g2UdrtdSPhRywVQRBz5kgBeqCnbw/
 queries: 20_HTTP_2

--- a/src/content/en/2019/http2.md
+++ b/src/content/en/2019/http2.md
@@ -6,6 +6,7 @@ description: HTTP/2 chapter of the 2019 Web Almanac covering adoption and impact
 authors: [bazzadp]
 reviewers: [bagder, rmarx, dotjs]
 translators: []
+analysts: [paulcalvano]
 discuss: 1775
 results: https://docs.google.com/spreadsheets/d/1z1gdS3YVpe8J9K3g2UdrtdSPhRywVQRBz5kgBeqCnbw/
 queries: 20_HTTP_2

--- a/src/content/en/2019/javascript.md
+++ b/src/content/en/2019/javascript.md
@@ -5,6 +5,7 @@ title: JavaScript
 description: JavaScript chapter of the 2019 Web Almanac covering how much JavaScript we use on the web, compression, libraries and frameworks, loading, and source maps.
 authors: [housseindjirdeh]
 reviewers: [obto, paulcalvano, mathiasbynens]
+analysts: [rviscomi]
 translators: []
 discuss: 1756
 results: https://docs.google.com/spreadsheets/d/1kBTglETN_V9UjKqK_EFmFjRexJnQOmLLr-I2Tkotvic/

--- a/src/content/en/2019/markup.md
+++ b/src/content/en/2019/markup.md
@@ -5,6 +5,7 @@ title: Markup
 description: Markup chapter of the 2019 Web Almanac covering elements used, custom elements, value, products, and common use cases.
 authors: [bkardell]
 reviewers: [zcorpan, tomhodgins, matthewp]
+analysts: [rviscomi]
 translators: []
 discuss: 1758
 results: https://docs.google.com/spreadsheets/d/1WnDKLar_0Btlt9UgT53Giy2229bpV4IM2D_v6OM_WzA/

--- a/src/content/en/2019/media.md
+++ b/src/content/en/2019/media.md
@@ -5,6 +5,7 @@ title: Media
 description: Media chapter of the 2019 Web Almanac covering image file sizes and formats, responsive images, client hints, lazy loading, accessibility and video.
 authors: [colinbendell, dougsillars]
 reviewers: [ahmadawais, eeeps]
+analysts: [dougsillars, rviscomi]
 translators: []
 discuss: 1759
 results: https://docs.google.com/spreadsheets/d/1hj9bY6JJZfV9yrXHsoCRYuG8t8bR-CHuuD98zXV7BBQ/

--- a/src/content/en/2019/mobile-web.md
+++ b/src/content/en/2019/mobile-web.md
@@ -5,6 +5,7 @@ title: Mobile Web
 description: Mobile Web chapter of the 2019 Web Almanac covering page loading, textual content, zooming and scaling, buttons and links, and ease of filling out forms.
 authors: [obto]
 reviewers: [AymenLoukil, hyperpress]
+analysts: [ymschaap, rviscomi]
 translators: []
 discuss: 1767
 results: https://docs.google.com/spreadsheets/d/1dPBDeHigqx9FVaqzfq7CYTz4KjllkMTkfq4DG4utE_g/

--- a/src/content/en/2019/page-weight.md
+++ b/src/content/en/2019/page-weight.md
@@ -5,6 +5,7 @@ title: Page Weight
 description: Page Weight chapter of the 2019 Web Almanac covering why page weight matters, bandwidth, complex pages, page weight over time, page requests, and file formats.
 authors: [tammyeverts, khempenius]
 reviewers: [paulcalvano]
+analysts: [khempenius]
 translators: []
 discuss: 1773
 results: https://docs.google.com/spreadsheets/d/1nWOo8efqDgzmA0wt1ipplziKhlReAxnVCW1HkjuFAxU/

--- a/src/content/en/2019/performance.md
+++ b/src/content/en/2019/performance.md
@@ -5,6 +5,7 @@ title: Performance
 description: Performance chapter of the 2019 Web Almanac covering First Contentful Paint (FCP), Time to First Byte (TTFB), and First Input Delay (FID).
 authors: [rviscomi]
 reviewers: [JMPerez,obto,sergeychernyshev,zeman]
+analysts: [rviscomi, raghuramakrishnan71]
 translators: []
 discuss: 1762
 results: https://docs.google.com/spreadsheets/d/1zWzFSQ_ygb-gGr1H1BsJCfB7Z89zSIf7GX0UayVEte4/

--- a/src/content/en/2019/pwa.md
+++ b/src/content/en/2019/pwa.md
@@ -5,6 +5,7 @@ title: PWA
 description: PWA chapter of the 2019 Web Almanac covering service workers (registations, installability, events and filesizes), Web App Manifests properties, and Workbox.
 authors: [tomayac, jeffposnick]
 reviewers: [hyperpress, ahmadawais]
+analysts: [jrharalson]
 translators: []
 discuss: 1766
 results: https://docs.google.com/spreadsheets/d/19BI3RQc_vR9bUPPZfVsF_4gpFWLNT6P0pLcAdL-A56c/

--- a/src/content/en/2019/resource-hints.md
+++ b/src/content/en/2019/resource-hints.md
@@ -5,6 +5,7 @@ title: Resource Hints
 description: Resource Hints chapter of the 2019 Web Almanac covering usage of dns-prefetch, preconnect, preload, prefetch, priority hints, and native lazy loading.
 authors: [khempenius]
 reviewers: [andydavies, bazzadp, yoavweiss]
+analysts: [rviscomi]
 translators: []
 discuss: 1774
 results: https://docs.google.com/spreadsheets/d/14QBP8XGkMRfWRBbWsoHm6oDVPkYhAIIpfxRn4iOkbUU/

--- a/src/content/en/2019/security.md
+++ b/src/content/en/2019/security.md
@@ -5,6 +5,7 @@ title: Security
 description: Security chapter of the 2019 Web Almanac covering Transport Layer Security (TLS(), mixed content, security headers, cookies, and Subresource Integrity.
 authors: [ScottHelme, arturjanc]
 reviewers: [bazzadp, ghedo, paulcalvano]
+analysts: [dotjs, jrharalson]
 translators: []
 discuss: 1763
 results: https://docs.google.com/spreadsheets/d/1Zq2tQhPE06YZUcbzryRrBE6rdZgHHlqEp2XcgS37cm8/

--- a/src/content/en/2019/seo.md
+++ b/src/content/en/2019/seo.md
@@ -5,6 +5,7 @@ title: SEO
 description: SEO chapter of the 2019 Web Almanac covering content, meta tags, indexability, linking, speed, structured data, internationalization, SPAs, AMP and security.
 authors: [ymschaap, rachellcostello, AVGP]
 reviewers: [clarkeclark, andylimn, AymenLoukil, catalinred, mattludwig]
+analysts: [ymschaap]
 translators: []
 discuss: 1765
 results: https://docs.google.com/spreadsheets/d/1uARtBWwz9nJOKqKPFinAMbtoDgu5aBtOhsBNmsCoTaA/

--- a/src/content/en/2019/third-parties.md
+++ b/src/content/en/2019/third-parties.md
@@ -5,6 +5,7 @@ title: Third Parties
 description: Third Parties chapter of the 2019 Web Almanac covering data of what third parties are used, what they are used for, performance impacts and privacy impacts.
 authors: [patrickhulce]
 reviewers: [zcorpan, obto, jasti]
+analysts: [patrickhulce]
 translators: []
 discuss: 1760
 results: https://docs.google.com/spreadsheets/d/1iC4WkdadDdkqkrTY32g7hHKhXs9iHrr3Bva8CuPjVrQ/

--- a/src/content/es/2019/css.md
+++ b/src/content/es/2019/css.md
@@ -5,6 +5,7 @@ title: CSS
 description: Capítulo CSS del 2019 Web Almanac que cubre el color, las unidades, los selectores, el diseño, la tipografía y las fuentes, el espaciado, la decoración, la animación y las consultas de medios.
 authors: [una, argyleink]
 reviewers: [meyerweb, huijing]
+analysts: [rviscomi]
 translators: [c-torres]
 discuss: 1757
 results: https://docs.google.com/spreadsheets/d/1uFlkuSRetjBNEhGKWpkrXo4eEIsgYelxY-qR9Pd7QpM/

--- a/src/content/es/2019/ecommerce.md
+++ b/src/content/es/2019/ecommerce.md
@@ -5,6 +5,7 @@ title: Ecommerce
 description: Capítulo sobre comercio electrónico del Almanaque Web de 2019 que cubre plataformas de comercio electrónico, payloads, imágenes, third-parties, rendimiento, seo y PWAs.
 authors: [samdutton, alankent]
 reviewers: [voltek62]
+analysts: [rviscomi]
 translators: [JMPerez]
 discuss: 1768
 results: https://docs.google.com/spreadsheets/d/1FUMHeOPYBgtVeMU5_pl2r33krZFzutt9vkOpphOSOss/

--- a/src/content/es/2019/fonts.md
+++ b/src/content/es/2019/fonts.md
@@ -5,6 +5,7 @@ title: Fuentes
 description: Capítulo Fuentes del Almanaque Web de 2019 que cubre desde dónde se cargan las fuentes, formatos de fuente, rendimiento de carga de fuentes, fuentes variables y fuentes de color.
 authors: [zachleat]
 reviewers: [hyperpress, AymenLoukil]
+analysts: [tjmonsi, rviscomi]
 translators: [c-torres]
 discuss: 1761
 results: https://docs.google.com/spreadsheets/d/108g6LXdC3YVsxmX1CCwrmpZ3-DmbB8G_wwgQHX5pn6Q/

--- a/src/content/es/2019/javascript.md
+++ b/src/content/es/2019/javascript.md
@@ -5,6 +5,7 @@ title: JavaScript
 description: JavaScript chapter of the 2019 Web Almanac covering how much JavaScript we use on the web, compression, libraries and frameworks, loading, and source maps.
 authors: [housseindjirdeh]
 reviewers: [obto, paulcalvano, mathiasbynens]
+analysts: [rviscomi]
 translators: [c-torres]
 discuss: 1756
 results: https://docs.google.com/spreadsheets/d/1kBTglETN_V9UjKqK_EFmFjRexJnQOmLLr-I2Tkotvic/

--- a/src/content/es/2019/markup.md
+++ b/src/content/es/2019/markup.md
@@ -5,6 +5,7 @@ title: Markup
 description: Capítulo sobre marcado del Web Almanac de 2019 que cubre elementos utilizados, elementos personalizados, valor, productos y casos de uso comunes.
 authors: [bkardell]
 reviewers: [zcorpan, tomhodgins, matthewp]
+analysts: [rviscomi]
 translators: [c-torres]
 discuss: 1758
 results: https://docs.google.com/spreadsheets/d/1WnDKLar_0Btlt9UgT53Giy2229bpV4IM2D_v6OM_WzA/

--- a/src/content/es/2019/media.md
+++ b/src/content/es/2019/media.md
@@ -5,6 +5,7 @@ title: Media
 description: Capítulo Multimedia del 2019 Web Almanac que cubre los tamaños y formatos de archivo de imagen, las imágenes adaptables (responsive), los client hints, el lazy loading, la accesibilidad y los vídeos.
 authors: [colinbendell, dougsillars]
 reviewers: [ahmadawais, eeeps]
+analysts: [dougsillars, rviscomi]
 translators: [garcaplay]
 discuss: 1759
 results: https://docs.google.com/spreadsheets/d/1hj9bY6JJZfV9yrXHsoCRYuG8t8bR-CHuuD98zXV7BBQ/

--- a/src/content/es/2019/performance.md
+++ b/src/content/es/2019/performance.md
@@ -5,6 +5,7 @@ title: Rendimiento
 description: Capítulo sobre rendimiento del Web Almanac de 2019 que explica First Contentful Paint (FCP), Time to First Byte (TTFB) y First Input Delay (FID) 
 authors: [rviscomi]
 reviewers: [JMPerez,obto,sergeychernyshev,zeman]
+analysts: [rviscomi, raghuramakrishnan71]
 translators: [JMPerez]
 discuss: 1762
 results: https://docs.google.com/spreadsheets/d/1zWzFSQ_ygb-gGr1H1BsJCfB7Z89zSIf7GX0UayVEte4/

--- a/src/content/fr/2019/accessibility.md
+++ b/src/content/fr/2019/accessibility.md
@@ -5,6 +5,7 @@ title: Accessibilité
 description: Chapitre Accessibilité du web Almanac 2019, couvrant la facilité de lecture, les medias, l’aisance de navigation et la compatibilité avec les technologies d’assistance.
 authors: [nektarios-paisios, obto, kleinab]
 reviewers: [ljme]
+analysts: [dougsillars, rviscomi, obto]
 translators: [nico3333fr]
 discuss: 1764
 results: https://docs.google.com/spreadsheets/d/16JGy-ehf4taU0w4ABiKjsHGEXNDXxOlb__idY8ifUtQ/

--- a/src/content/fr/2019/caching.md
+++ b/src/content/fr/2019/caching.md
@@ -5,6 +5,7 @@ title: Mise en cache
 description: Le chapitre sur la mise en cache de Web Almanac couvre la gestion de la mise en cache, sa validité, les TTLs, les headers Vary, les cookies, l'AppCache, les service workers et d'autres possibilités.
 authors: [paulcalvano]
 reviewers: [obto, bkardell]
+analysts: [paulcalvano, obto]
 translators: [allemas]
 discuss: 1771
 results: https://docs.google.com/spreadsheets/d/1mnq03DqrRBwxfDV05uEFETK0_hPbYOynWxZkV3tFgNk/

--- a/src/content/fr/2019/cms.md
+++ b/src/content/fr/2019/cms.md
@@ -5,6 +5,7 @@ title: CMS
 description: Chapitre CMS de l'Almanach Web 2019 couvrant l'adoption des CMS, la façon dont les solutions CMS sont construites, l'expérience utilisateur des sites web propulsés par les CMS et l'innovation des CMS.
 authors: [ernee, amedina]
 reviewers: [sirjonathan]
+analysts: [rviscomi]
 translators: [JustinyAhin]
 discuss: 1769
 results: https://docs.google.com/spreadsheets/d/1FDYe6QdoY3UtXodE2estTdwMsTG-hHNrOe9wEYLlwAw/

--- a/src/content/fr/2019/compression.md
+++ b/src/content/fr/2019/compression.md
@@ -5,6 +5,7 @@ title: Compression
 description: Chapitre sur la compression par Web Almanac 2019, les algorithmes, les types de contenu, la compression 1ere partie et tierce partie et les possibilités.
 authors: [paulcalvano]
 reviewers: [obto, yoavweiss]
+analysts: [paulcalvano]
 translators: [allemas]
 discuss: 1770
 results: https://docs.google.com/spreadsheets/d/1IK9kaScQr_sJUwZnWMiJcmHEYJV292C9DwCfXH6a50o/

--- a/src/content/fr/2019/javascript.md
+++ b/src/content/fr/2019/javascript.md
@@ -5,6 +5,7 @@ title: JavaScript
 description: Chapitre JavaScript du Web Almanac 2019 couvrant la quantité de JavaScript que nous utilisons sur le web, la compression, les bibliothèques et les frameworks, le chargement et les cartographies de code source (source maps).
 authors: [housseindjirdeh]
 reviewers: [obto, paulcalvano, mathiasbynens]
+analysts: [rviscomi]
 translators: [borisschapira]
 discuss: 1756
 results: https://docs.google.com/spreadsheets/d/1kBTglETN_V9UjKqK_EFmFjRexJnQOmLLr-I2Tkotvic/

--- a/src/content/fr/2019/markup.md
+++ b/src/content/fr/2019/markup.md
@@ -5,6 +5,7 @@ title: Balisage Web
 description: Chapitre sur le balisage web du rapport Web Almanac 2019. Découvrez des statistiques sur  l’usage des balises, leurs valeurs, les solutions et des cas d’utilisation courants.
 authors: [bkardell]
 reviewers: [zcorpan, tomhodgins, matthewp]
+analysts: [rviscomi]
 translators: [borisschapira, SilentJMA]
 discuss: 1758
 results: https://docs.google.com/spreadsheets/d/1WnDKLar_0Btlt9UgT53Giy2229bpV4IM2D_v6OM_WzA/

--- a/src/content/fr/2019/mobile-web.md
+++ b/src/content/fr/2019/mobile-web.md
@@ -5,6 +5,7 @@ title: Web Mobile
 description: Chapitre sur les web mobile du Web Almanac 2019, couvrant le chargement des pages, du contenu textuel, du zoom et de la mise à l’échelle, des boutons et des liens, ainsi que de la facilité à remplir les formulaires.
 authors: [obto]
 reviewers: [AymenLoukil, hyperpress]
+analysts: [ymschaap, rviscomi]
 translators: [borisschapira]
 discuss: 1767
 results: https://docs.google.com/spreadsheets/d/1dPBDeHigqx9FVaqzfq7CYTz4KjllkMTkfq4DG4utE_g/

--- a/src/content/fr/2019/resource-hints.md
+++ b/src/content/fr/2019/resource-hints.md
@@ -5,6 +5,7 @@ title: Indices de Ressources
 description: Chapitre sur les indices de ressources du Web Almanac 2019, couvrant les usages de dns-prefetch, preconnect, preload, prefetch, les indices de priorités et le lazy loading natif.
 authors: [khempenius]
 reviewers: [andydavies, bazzadp, yoavweiss]
+analysts: [rviscomi]
 translators: [borisschapira]
 discuss: 1774
 results: https://docs.google.com/spreadsheets/d/14QBP8XGkMRfWRBbWsoHm6oDVPkYhAIIpfxRn4iOkbUU/

--- a/src/content/fr/2019/third-parties.md
+++ b/src/content/fr/2019/third-parties.md
@@ -5,6 +5,7 @@ title: Tierces Parties
 description: Le chapitre sur les ressources tierces du Web Almanac 2019, qui aborde les tierces parties utilisées, pourquoi elles le sont et les répercussions de leur usage sur le rendu et la confidentialité.
 authors: [patrickhulce]
 reviewers: [zcorpan, obto, jasti]
+analysts: [patrickhulce]
 translators: [borisschapira]
 discuss: 1760
 results: https://docs.google.com/spreadsheets/d/1iC4WkdadDdkqkrTY32g7hHKhXs9iHrr3Bva8CuPjVrQ/

--- a/src/content/ja/2019/accessibility.md
+++ b/src/content/ja/2019/accessibility.md
@@ -5,6 +5,7 @@ title: アクセシビリティ
 description: 読みやすさ、メディア、操作性の容易さ、および支援技術とその互換性をカバーする2019 Web Almanacアクセシビリティの章。
 authors: [nektarios-paisios, obto, kleinab]
 reviewers: [ljme]
+analysts: [dougsillars, rviscomi, obto]
 translators: [MSakamaki]
 discuss: 1764
 results: https://docs.google.com/spreadsheets/d/16JGy-ehf4taU0w4ABiKjsHGEXNDXxOlb__idY8ifUtQ/

--- a/src/content/ja/2019/caching.md
+++ b/src/content/ja/2019/caching.md
@@ -5,6 +5,7 @@ title: キャッシング
 description: 2019 Web Almanacのキャッシュの章は、キャッシュコントロール、有効期限、TTL、有効性、変化、Cookieの設定、アプリケーションキャッシュ、Service Worker、および機会について説明します。
 authors: [paulcalvano]
 reviewers: [obto, bkardell]
+analysts: [paulcalvano, obto]
 translators: [ksakae]
 discuss: 1771
 results: https://docs.google.com/spreadsheets/d/1mnq03DqrRBwxfDV05uEFETK0_hPbYOynWxZkV3tFgNk/

--- a/src/content/ja/2019/cdn.md
+++ b/src/content/ja/2019/cdn.md
@@ -5,6 +5,7 @@ title: CDN
 description: CDNの採用と使用法、RTTとTLSの管理、HTTP/2の採用、キャッシング、および共通ライブラリとコンテンツCDNをカバーする2019 Web AlmanacのCDNの章。
 authors: [andydavies, colinbendell]
 reviewers: [yoavweiss, paulcalvano, pmeenan, enygren]
+analysts: [raghuramakrishnan71, rviscomi]
 translators: [ksakae]
 discuss: 1772
 results: https://docs.google.com/spreadsheets/d/1Y7kAxjxUl8puuTToe6rL3kqJLX1ftOb0nCcD8m3lZBw/

--- a/src/content/ja/2019/cms.md
+++ b/src/content/ja/2019/cms.md
@@ -5,6 +5,7 @@ title: CMS
 description: 2019年版Web AlmanacCMS章では、CMSの採用、CMS組み合わせの構築方法、CMSを搭載したWebサイトのユーザーエクスペリエンス、CMSのイノベーションを取り上げています。
 authors: [ernee, amedina]
 reviewers: [sirjonathan]
+analysts: [rviscomi]
 translators: [ksakae]
 discuss: 1769
 results: https://docs.google.com/spreadsheets/d/1FDYe6QdoY3UtXodE2estTdwMsTG-hHNrOe9wEYLlwAw/

--- a/src/content/ja/2019/compression.md
+++ b/src/content/ja/2019/compression.md
@@ -5,6 +5,7 @@ title: 圧縮
 description: HTTP圧縮、アルゴリズム、コンテンツタイプ、ファーストパーティとサードパーティの圧縮および機会をカバーする2019 Web Almanacの圧縮の章。
 authors: [paulcalvano]
 reviewers: [obto, yoavweiss]
+analysts: [paulcalvano]
 translators: [ksakae]
 discuss: 1770
 results: https://docs.google.com/spreadsheets/d/1IK9kaScQr_sJUwZnWMiJcmHEYJV292C9DwCfXH6a50o/

--- a/src/content/ja/2019/css.md
+++ b/src/content/ja/2019/css.md
@@ -5,6 +5,7 @@ title: CSS
 description: 色、単位、セレクター、レイアウト、タイポグラフィとフォント、間隔、装飾、アニメーション、およびメディアクエリをカバーする2019 Web AlmanacのCSS章。
 authors: [una, argyleink]
 reviewers: [meyerweb, huijing]
+analysts: [rviscomi]
 translators: [ksakae]
 discuss: 1757
 results: https://docs.google.com/spreadsheets/d/1uFlkuSRetjBNEhGKWpkrXo4eEIsgYelxY-qR9Pd7QpM/

--- a/src/content/ja/2019/ecommerce.md
+++ b/src/content/ja/2019/ecommerce.md
@@ -5,6 +5,7 @@ title: Eコマース
 description: 2019年Web AlmanacのEコマースの章では、Eコマースのプラットフォーム、ペイロード、画像、サードパーティ、パフォーマンス、SEO、PWAをカバーしています。
 authors: [samdutton, alankent]
 reviewers: [voltek62]
+analysts: [rviscomi]
 translators: [ksakae]
 discuss: 1768
 results: https://docs.google.com/spreadsheets/d/1FUMHeOPYBgtVeMU5_pl2r33krZFzutt9vkOpphOSOss/

--- a/src/content/ja/2019/fonts.md
+++ b/src/content/ja/2019/fonts.md
@@ -5,6 +5,7 @@ title: フォント
 description: フォントがどこから読み込まれるか、フォントのフォーマット、フォントの読み込み性能、可変フォント、カラーフォントを網羅した2019年Web AlmanacのFontsの章。
 authors: [zachleat]
 reviewers: [hyperpress, AymenLoukil]
+analysts: [tjmonsi, rviscomi]
 translators: [ksakae]
 discuss: 1761
 results: https://docs.google.com/spreadsheets/d/108g6LXdC3YVsxmX1CCwrmpZ3-DmbB8G_wwgQHX5pn6Q/

--- a/src/content/ja/2019/http2.md
+++ b/src/content/ja/2019/http2.md
@@ -5,6 +5,7 @@ title: HTTP/2
 description: HTTP/2、HTTP/2プッシュ、HTTP/2の問題、およびHTTP/3の採用と影響をカバーするWeb Almanac 2019のHTTP/2章
 authors: [bazzadp]
 reviewers: [bagder, rmarx, dotjs]
+analysts: [paulcalvano]
 translators: [ksakae]
 discuss: 1775
 results: https://docs.google.com/spreadsheets/d/1z1gdS3YVpe8J9K3g2UdrtdSPhRywVQRBz5kgBeqCnbw/

--- a/src/content/ja/2019/javascript.md
+++ b/src/content/ja/2019/javascript.md
@@ -5,6 +5,7 @@ title: JavaScript
 description: 2019年のWeb AlmanacのJavaScriptの章では、Web上でどれだけJavaScriptを使用しているか、圧縮、ライブラリとフレームワーク、読み込み、ソースマップを網羅しています。
 authors: [housseindjirdeh]
 reviewers: [obto, paulcalvano, mathiasbynens]
+analysts: [rviscomi]
 translators: [ksakae]
 discuss: 1756
 results: https://docs.google.com/spreadsheets/d/1kBTglETN_V9UjKqK_EFmFjRexJnQOmLLr-I2Tkotvic/

--- a/src/content/ja/2019/markup.md
+++ b/src/content/ja/2019/markup.md
@@ -5,6 +5,7 @@ title: マークアップ
 description: 使われている要素、カスタム要素、価値、製品、及び一般的なユースケースについて抑えてある 2019 Web Almanac マークアップの章
 authors: [bkardell]
 reviewers: [zcorpan, tomhodgins, matthewp]
+analysts: [rviscomi]
 translators: [MSakamaki]
 discuss: 1758
 results: https://docs.google.com/spreadsheets/d/1WnDKLar_0Btlt9UgT53Giy2229bpV4IM2D_v6OM_WzA/

--- a/src/content/ja/2019/media.md
+++ b/src/content/ja/2019/media.md
@@ -5,6 +5,7 @@ title: メディア
 description: 2019年版Web Almanacのメディアの章では、画像ファイルのサイズとフォーマット、レスポンシブ画像、クライアントのヒント、遅延読み込み、アクセシビリティ、動画を取り上げています。
 authors: [colinbendell, dougsillars]
 reviewers: [ahmadawais, eeeps]
+analysts: [dougsillars, rviscomi]
 translators: [ksakae]
 discuss: 1759
 results: https://docs.google.com/spreadsheets/d/1hj9bY6JJZfV9yrXHsoCRYuG8t8bR-CHuuD98zXV7BBQ/

--- a/src/content/ja/2019/mobile-web.md
+++ b/src/content/ja/2019/mobile-web.md
@@ -5,6 +5,7 @@ title: モバイルウェブ
 description: 2019年Web AlmanacのモバイルWebの章では、ページの読み込み、テキストコンテンツ、拡大縮小、ボタンやリンク、フォームへの記入のしやすさなどをカバーしています。
 authors: [obto]
 reviewers: [AymenLoukil, hyperpress]
+analysts: [ymschaap, rviscomi]
 translators: [ksakae]
 discuss: 1767
 results: https://docs.google.com/spreadsheets/d/1dPBDeHigqx9FVaqzfq7CYTz4KjllkMTkfq4DG4utE_g/

--- a/src/content/ja/2019/page-weight.md
+++ b/src/content/ja/2019/page-weight.md
@@ -5,6 +5,7 @@ title: Page Weight
 description: ページの重さが重要な理由、帯域幅、複雑なページ、経時的なページの重み、ページ要求、およびファイル形式をカバーする2019 Web Almanacのページの重さの章。
 authors: [tammyeverts, khempenius]
 reviewers: [paulcalvano]
+analysts: [khempenius]
 translators: [ksakae]
 discuss: 1773
 results: https://docs.google.com/spreadsheets/d/1nWOo8efqDgzmA0wt1ipplziKhlReAxnVCW1HkjuFAxU/

--- a/src/content/ja/2019/performance.md
+++ b/src/content/ja/2019/performance.md
@@ -5,6 +5,7 @@ title: パフォーマンス
 description: コンテンツの初回ペイント（FCP）、最初のバイトまでの時間（TTFB）、初回入力遅延（FID）を取り扱う2019 Web Almanac パフォーマンスの章。
 authors: [rviscomi]
 reviewers: [JMPerez,obto,sergeychernyshev,zeman]
+analysts: [rviscomi, raghuramakrishnan71]
 translators: [MSakamaki]
 discuss: 1762
 results: https://docs.google.com/spreadsheets/d/1zWzFSQ_ygb-gGr1H1BsJCfB7Z89zSIf7GX0UayVEte4/

--- a/src/content/ja/2019/pwa.md
+++ b/src/content/ja/2019/pwa.md
@@ -5,6 +5,7 @@ title: PWA
 description: Service Worker（登録、インストール可能性、イベント、およびファイルサイズ）、Webアプリマニフェストプロパティ、およびWorkboxを対象とする2019 Web AlmanacのPWAの章。
 authors: [tomayac, jeffposnick]
 reviewers: [hyperpress, ahmadawais]
+analysts: [jrharalson]
 translators: [ksakae]
 discuss: 1766
 results: https://docs.google.com/spreadsheets/d/19BI3RQc_vR9bUPPZfVsF_4gpFWLNT6P0pLcAdL-A56c/

--- a/src/content/ja/2019/resource-hints.md
+++ b/src/content/ja/2019/resource-hints.md
@@ -5,6 +5,7 @@ title: リソースヒント
 description: 2019年のWeb Almanacのリソースヒントの章では、dns-prefetch、preconnect、preload、prefetch、priority hints、ネイティブの遅延ローディングの使用法をカバーしています。
 authors: [khempenius]
 reviewers: [andydavies, bazzadp, yoavweiss]
+analysts: [rviscomi]
 translators: [ksakae]
 discuss: 1774
 results: https://docs.google.com/spreadsheets/d/14QBP8XGkMRfWRBbWsoHm6oDVPkYhAIIpfxRn4iOkbUU/

--- a/src/content/ja/2019/security.md
+++ b/src/content/ja/2019/security.md
@@ -5,6 +5,7 @@ title: セキュリティ
 description: トランスポート・レイヤー・セキュリティ(TLS()、混合コンテンツ、セキュリティヘッダ、Cookie、サブリソース完全性を網羅した2019年版Web Almanacのセキュリティの章。
 authors: [ScottHelme, arturjanc]
 reviewers: [bazzadp, ghedo, paulcalvano]
+analysts: [dotjs, jrharalson]
 translators: [ksakae]
 discuss: 1763
 results: https://docs.google.com/spreadsheets/d/1Zq2tQhPE06YZUcbzryRrBE6rdZgHHlqEp2XcgS37cm8/

--- a/src/content/ja/2019/seo.md
+++ b/src/content/ja/2019/seo.md
@@ -5,6 +5,7 @@ title: SEO
 description: コンテンツ、メタタグ、インデクサビリティ、リンク、速度、構造化データ、国際化、SPA、AMP、セキュリティをカバーする2019 Web AlmanacのSEOの章。
 authors: [ymschaap, rachellcostello, AVGP]
 reviewers: [clarkeclark, andylimn, AymenLoukil, catalinred, mattludwig]
+analysts: [ymschaap]
 translators: [MSakamaki]
 discuss: 1765
 results: https://docs.google.com/spreadsheets/d/1uARtBWwz9nJOKqKPFinAMbtoDgu5aBtOhsBNmsCoTaA/

--- a/src/content/ja/2019/third-parties.md
+++ b/src/content/ja/2019/third-parties.md
@@ -5,6 +5,7 @@ title: サードパーティ
 description: 2019 Web Almanacのサードパーティの章。サードパーティの使用目的、パフォーマンスへの影響、プライバシーへの影響について説明しています。
 authors: [patrickhulce]
 reviewers: [zcorpan, obto, jasti]
+analysts: [patrickhulce]
 translators: [ksakae]
 discuss: 1760
 results: https://docs.google.com/spreadsheets/d/1iC4WkdadDdkqkrTY32g7hHKhXs9iHrr3Bva8CuPjVrQ/

--- a/src/content/pt/2019/javascript.md
+++ b/src/content/pt/2019/javascript.md
@@ -5,6 +5,7 @@ title: JavaScript
 description: Capítulo de JavaScript de 2019 Web Almanac que cobre quanto JavaScript usamos na web, compressão, bibliotecas e estruturas, carregamento e mapas de origem.
 authors: [housseindjirdeh]
 reviewers: [obto, paulcalvano, mathiasbynens]
+analysts: [rviscomi]
 translators: [HakaCode]
 discuss: 1756
 results: https://docs.google.com/spreadsheets/d/1kBTglETN_V9UjKqK_EFmFjRexJnQOmLLr-I2Tkotvic/

--- a/src/content/zh-CN/2019/accessibility.md
+++ b/src/content/zh-CN/2019/accessibility.md
@@ -5,6 +5,7 @@ title: 无障碍可访问性
 description: 2019 Web Almanac 网络年鉴的无障碍易访问性章节，涵盖易阅读、媒体、易于导航和与辅助技术的兼容性。
 authors: [nektarios-paisios, obto, kleinab]
 reviewers: [ljme]
+analysts: [dougsillars, rviscomi, obto]
 translators: [chengxicn]
 discuss: 1764
 results: https://docs.google.com/spreadsheets/d/16JGy-ehf4taU0w4ABiKjsHGEXNDXxOlb__idY8ifUtQ/

--- a/src/content/zh-CN/2019/performance.md
+++ b/src/content/zh-CN/2019/performance.md
@@ -5,6 +5,7 @@ title: 性能
 description: 2019 Web Almanac网络年鉴的性能章节，包括 首次有内容的绘制 (FCP), 首包字节 (TTFB), 以及首次输入延迟 (FID)。
 authors: [rviscomi]
 reviewers: [JMPerez,obto,sergeychernyshev,zeman]
+analysts: [rviscomi, raghuramakrishnan71]
 translators: [chengxicn]
 discuss: 1762
 results: https://docs.google.com/spreadsheets/d/1zWzFSQ_ygb-gGr1H1BsJCfB7Z89zSIf7GX0UayVEte4/

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -191,7 +191,8 @@
 }
 
 .byline.reviewers,
-.byline.translators {
+.byline.translators,
+.byline.analysts {
   font-weight: normal;
 }
 

--- a/src/templates/base/2019/base_chapter.html
+++ b/src/templates/base/2019/base_chapter.html
@@ -99,21 +99,21 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
   {% endfor %}{{ self.reviewed_by_after() }}
   </div>
 
-  {% if metadata.get('translators') | length >= 1 %}
-  <div class="byline translators">{{ self.translated_by_before() }}
-  {% for translator in metadata.get('translators') %}
-    <a class="translator" href="{{ url_for('contributors', year=year, lang=lang, _anchor=translator) }}">{{ config.contributors[translator].name if translator in config.contributors else translator }}</a>{{ self.comma() if not loop.last and loop.length > 2 }}
-    {% if loop.index == loop.length - 1 %}{{ self.and() }}{% endif %}
-  {% endfor %}{{ self.translated_by_after() }}
-  </div>
-  {% endif %}
-
   {% if metadata.get('analysts') and metadata.get('analysts') | length >= 1 %}
   <div class="byline analysts">{{ self.analysis_by_before() }}
   {% for analyst in metadata.get('analysts') %}
     <a class="analyst" href="{{ url_for('contributors', year=year, lang=lang, _anchor=analyst) }}">{{ config.contributors[analyst].name if analyst in config.contributors else analyst }}</a>{{ self.comma() if not loop.last and loop.length > 2 }}
     {% if loop.index == loop.length - 1 %}{{ self.and() }}{% endif %}
   {% endfor %}{{ self.analysis_by_after() }}
+  </div>
+  {% endif %}
+
+  {% if metadata.get('translators') | length >= 1 %}
+  <div class="byline translators">{{ self.translated_by_before() }}
+  {% for translator in metadata.get('translators') %}
+    <a class="translator" href="{{ url_for('contributors', year=year, lang=lang, _anchor=translator) }}">{{ config.contributors[translator].name if translator in config.contributors else translator }}</a>{{ self.comma() if not loop.last and loop.length > 2 }}
+    {% if loop.index == loop.length - 1 %}{{ self.and() }}{% endif %}
+  {% endfor %}{{ self.translated_by_after() }}
   </div>
   {% endif %}
 {% endmacro %}

--- a/src/templates/base/2019/base_chapter.html
+++ b/src/templates/base/2019/base_chapter.html
@@ -107,6 +107,15 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
   {% endfor %}{{ self.translated_by_after() }}
   </div>
   {% endif %}
+
+  {% if metadata.get('analysts') and metadata.get('analysts') | length >= 1 %}
+  <div class="byline analysts">{{ self.analysis_by_before() }}
+  {% for analyst in metadata.get('analysts') %}
+    <a class="analyst" href="{{ url_for('contributors', year=year, lang=lang, _anchor=analyst) }}">{{ config.contributors[analyst].name if analyst in config.contributors else analyst }}</a>{{ self.comma() if not loop.last and loop.length > 2 }}
+    {% if loop.index == loop.length - 1 %}{{ self.and() }}{% endif %}
+  {% endfor %}{{ self.analysis_by_after() }}
+  </div>
+  {% endif %}
 {% endmacro %}
 
 {% macro render_authors() %}

--- a/src/templates/base/2019/ebook.ejs.html
+++ b/src/templates/base/2019/ebook.ejs.html
@@ -47,21 +47,21 @@
                 {% endfor %}{{ self.reviewed_by_after() }}
             </div>
             
-            {% if metadata.get('translators') | length >= 1 %}
-            <div class="byline translators">{{ self.translated_by_before() }}
-                {% for translator in metadata.get('translators') %}
-                <a class="translator" href="#contributors-{{ translator }}">{{ config.contributors[translator].name if translator in config.contributors else translator }}</a>{{ self.comma() if not loop.last and loop.length > 2 }}
-                {% if loop.index == loop.length - 1 %}{{ self.and() }}{% endif %}
-                {% endfor %}{{ self.translated_by_after() }}
-            </div>
-            {% endif %}
-            
             {% if metadata.get('analysts') and metadata.get('analysts') | length >= 1 %}
             <div class="byline analysts">{{ self.analysis_by_before() }}
                 {% for analyst in metadata.get('analysts') %}
                 <a class="analyst" href="#contributors-{{ analyst }}">{{ config.contributors[analyst].name if analyst in config.contributors else analyst }}</a>{{ self.comma() if not loop.last and loop.length > 2 }}
                 {% if loop.index == loop.length - 1 %}{{ self.and() }}{% endif %}
                 {% endfor %}{{ self.analysis_by_after() }}
+            </div>
+            {% endif %}
+            
+            {% if metadata.get('translators') | length >= 1 %}
+            <div class="byline translators">{{ self.translated_by_before() }}
+                {% for translator in metadata.get('translators') %}
+                <a class="translator" href="#contributors-{{ translator }}">{{ config.contributors[translator].name if translator in config.contributors else translator }}</a>{{ self.comma() if not loop.last and loop.length > 2 }}
+                {% if loop.index == loop.length - 1 %}{{ self.and() }}{% endif %}
+                {% endfor %}{{ self.translated_by_after() }}
             </div>
             {% endif %}
             <%- chapter.body %>

--- a/src/templates/base/2019/ebook.ejs.html
+++ b/src/templates/base/2019/ebook.ejs.html
@@ -55,6 +55,15 @@
                 {% endfor %}{{ self.translated_by_after() }}
             </div>
             {% endif %}
+            
+            {% if metadata.get('analysts') and metadata.get('analysts') | length >= 1 %}
+            <div class="byline analysts">{{ self.analysis_by_before() }}
+                {% for analyst in metadata.get('analysts') %}
+                <a class="analyst" href="#contributors-{{ analyst }}">{{ config.contributors[analyst].name if analyst in config.contributors else analyst }}</a>{{ self.comma() if not loop.last and loop.length > 2 }}
+                {% if loop.index == loop.length - 1 %}{{ self.and() }}{% endif %}
+                {% endfor %}{{ self.analysis_by_after() }}
+            </div>
+            {% endif %}
             <%- chapter.body %>
         </div>
 

--- a/src/templates/en/2019/base.html
+++ b/src/templates/en/2019/base.html
@@ -60,9 +60,11 @@ Our mission is to combine the raw stats and trends of the HTTP Archive with the 
 {% block written_by_before %}Written by{% endblock %}
 {% block reviewed_by_before %}Reviewed by{% endblock %}
 {% block translated_by_before %}Translated by{% endblock %}
+{% block analysis_by_before %}Analysis by{% endblock %}
 {% block written_by_after %}{% endblock %}
 {% block reviewed_by_after %}{% endblock %}
 {% block translated_by_after %}{% endblock %}
+{% block analysis_by_after %}{% endblock %}
 
 {% block author %}Author{% endblock %}
 {% block authors %}Authors{% endblock %}

--- a/src/templates/es/2019/base.html
+++ b/src/templates/es/2019/base.html
@@ -60,9 +60,11 @@ Nuestra misión es combinar las estadísticas y tendencias sin procesar del HTTP
 {% block written_by_before %}Escrito por{% endblock %}
 {% block reviewed_by_before %}Revisado por{% endblock %}
 {% block translated_by_before %}Traducido por{% endblock %}
+{% block analysis_by_before %}Análisis por{% endblock %}
 {% block written_by_after %}{% endblock %}
 {% block reviewed_by_after %}{% endblock %}
 {% block translated_by_after %}{% endblock %}
+{% block analysis_by_after %}{% endblock %}
 
 {% block author %}Autor(a){% endblock %}
 {% block authors %}Autores{% endblock %}

--- a/src/templates/fr/2019/base.html
+++ b/src/templates/fr/2019/base.html
@@ -61,9 +61,11 @@ Notre mission est de combiner les statistiques brutes et les tendances de HTTP A
 {% block written_by_before %}Écrit par{% endblock %}
 {% block reviewed_by_before %}Relu par{% endblock %}
 {% block translated_by_before %}Traduit par{% endblock %}
+{% block analysis_by_before %}Analyse par{% endblock %}
 {% block written_by_after %}{% endblock %}
 {% block reviewed_by_after %}{% endblock %}
 {% block translated_by_after %}{% endblock %}
+{% block analysis_by_after %}{% endblock %}
 
 {% block author %}Auteur·ice{% endblock %}
 {% block authors %}Auteur·ice·s{% endblock %}

--- a/src/templates/fr/2019/base.html
+++ b/src/templates/fr/2019/base.html
@@ -61,7 +61,7 @@ Notre mission est de combiner les statistiques brutes et les tendances de HTTP A
 {% block written_by_before %}Écrit par{% endblock %}
 {% block reviewed_by_before %}Relu par{% endblock %}
 {% block translated_by_before %}Traduit par{% endblock %}
-{% block analysis_by_before %}Analyse par{% endblock %}
+{% block analysis_by_before %}Analysé par{% endblock %}
 {% block written_by_after %}{% endblock %}
 {% block reviewed_by_after %}{% endblock %}
 {% block translated_by_after %}{% endblock %}

--- a/src/templates/ja/2019/base.html
+++ b/src/templates/ja/2019/base.html
@@ -56,9 +56,11 @@
 {% block written_by_before %}{% endblock %}
 {% block reviewed_by_before %}{% endblock %}
 {% block translated_by_before %}{% endblock %}
+{% block analysis_by_before %}{% endblock %}
 {% block written_by_after %}によって書かれた。{% endblock %}
 {% block reviewed_by_after %}によってレビュ。{% endblock %}
 {% block translated_by_after %}によって翻訳された。{% endblock %}
+{% block analysis_by_after %}による分析{% endblock %}
 
 {% block author %}著者{% endblock %}
 {% block authors %}著者{% endblock %}

--- a/src/templates/pt/2019/base.html
+++ b/src/templates/pt/2019/base.html
@@ -60,9 +60,11 @@ Nossa missão é combinar as estatísticas brutas e as tendências do HTTP Archi
 {% block written_by_before %}Escrito por{% endblock %}
 {% block reviewed_by_before %}Revisado por{% endblock %}
 {% block translated_by_before %}Traduzido por{% endblock %}
+{% block analysis_by_before %}Análise por{% endblock %}
 {% block written_by_after %}{% endblock %}
 {% block reviewed_by_after %}{% endblock %}
 {% block translated_by_after %}{% endblock %}
+{% block analysis_by_after %}{% endblock %}
 
 {% block author %}Autor(a){% endblock %}
 {% block authors %}Autores{% endblock %}

--- a/src/templates/zh-CN/2019/base.html
+++ b/src/templates/zh-CN/2019/base.html
@@ -60,9 +60,11 @@
 {% block written_by_before %}作者： {% endblock %}
 {% block reviewed_by_before %}审稿者： {% endblock %}
 {% block translated_by_before %}翻译者： {% endblock %}
+{% block analysis_by_before %}分析员: {% endblock %}
 {% block written_by_after %}{% endblock %}
 {% block reviewed_by_after %}{% endblock %}
 {% block translated_by_after %}{% endblock %}
+{% block analysis_by_after %}{% endblock %}
 
 {% block author %}作者{% endblock %}
 {% block authors %}作者{% endblock %}

--- a/src/templates/zh-CN/2019/base.html
+++ b/src/templates/zh-CN/2019/base.html
@@ -60,7 +60,7 @@
 {% block written_by_before %}作者： {% endblock %}
 {% block reviewed_by_before %}审稿者： {% endblock %}
 {% block translated_by_before %}翻译者： {% endblock %}
-{% block analysis_by_before %}分析员: {% endblock %}
+{% block analysis_by_before %}分析者: {% endblock %}
 {% block written_by_after %}{% endblock %}
 {% block reviewed_by_after %}{% endblock %}
 {% block translated_by_after %}{% endblock %}

--- a/src/tools/generate/generate_chapters.js
+++ b/src/tools/generate/generate_chapters.js
@@ -81,6 +81,10 @@ const parse_file = async (markdown,chapter) => {
   if (m.translators) {
     translators = parse_array(m.translators);
   }
+  let analysts;
+  if (m.analysts) {
+    analysts = parse_array(m.analysts);
+  }
 
   const metadata = {
     ...m,
@@ -88,7 +92,8 @@ const parse_file = async (markdown,chapter) => {
     chapter,
     authors,
     reviewers,
-    translators
+    translators,
+    analysts
   };
 
   return { metadata, body, toc };


### PR DESCRIPTION
@rviscomi I can't find it now, but think we said we'd give the Analysts a byline this year in the chapters?

![Analysis By Byline](https://user-images.githubusercontent.com/10931297/94838608-be604c00-040d-11eb-8705-ead31aea5c01.png)

It appears before the Translator if any exists:

![Analysis By Byline before Translated by](https://user-images.githubusercontent.com/10931297/94838557-b0123000-040d-11eb-8a26-5c46017f690f.png)

Will add the rest of the 2019 analysts [from the 2019 PM spreadsheet](https://docs.google.com/spreadsheets/d/1LR29JpI2XJSjan_z6uP1YpRy4EYYivYZPqCIG-9sfFY/edit#gid=2048624140) once this PR is reviewed.