### PR TITLE
Check if audit is applicable

### DIFF
--- a/sql/2020/08_Accessibility/lighthouse_a11y_audits.sql
+++ b/sql/2020/08_Accessibility/lighthouse_a11y_audits.sql
@@ -25,6 +25,7 @@ return results;
 SELECT
   audits.id AS id,
   COUNTIF(audits.score > 0) AS num_pages,
+  COUNT(0) AS total,
   COUNTIF(audits.score IS NOT NULL) AS total_applicable,
   SAFE_DIVIDE(COUNTIF(audits.score > 0), COUNTIF(audits.score IS NOT NULL)) AS pct,
   APPROX_QUANTILES(audits.weight, 100)[OFFSET(50)] AS median_weight,

--- a/sql/2020/14_PWA/lighthouse_pwa_audits.sql
+++ b/sql/2020/14_PWA/lighthouse_pwa_audits.sql
@@ -24,7 +24,7 @@ return results;
 SELECT
   audits.id AS id,
   COUNTIF(audits.score > 0) AS num_pages,
-  count(0) AS total,
+  COUNT(0) AS total,
   COUNTIF(audits.score IS NOT NULL) AS total_applicable,
   SAFE_DIVIDE(COUNTIF(audits.score > 0), COUNTIF(audits.score IS NOT NULL)) AS pct,
   APPROX_QUANTILES(audits.weight, 100)[OFFSET(50)] AS median_weight,

--- a/sql/2020/14_PWA/lighthouse_pwa_audits.sql
+++ b/sql/2020/14_PWA/lighthouse_pwa_audits.sql
@@ -24,8 +24,8 @@ return results;
 SELECT
   audits.id AS id,
   COUNTIF(audits.score > 0) AS num_pages,
-  COUNT(0) AS total,
-  COUNTIF(audits.score > 0) / COUNT(0) AS pct,
+  COUNTIF(audits.score IS NOT NULL) AS total_applicable,
+  SAFE_DIVIDE(COUNTIF(audits.score > 0), COUNTIF(audits.score IS NOT NULL)) AS pct,
   APPROX_QUANTILES(audits.weight, 100)[OFFSET(50)] AS median_weight,
   MAX(audits.audit_group) AS audit_group,
   MAX(audits.description) AS description

--- a/sql/2020/14_PWA/lighthouse_pwa_audits.sql
+++ b/sql/2020/14_PWA/lighthouse_pwa_audits.sql
@@ -24,6 +24,7 @@ return results;
 SELECT
   audits.id AS id,
   COUNTIF(audits.score > 0) AS num_pages,
+  count(0) AS total,
   COUNTIF(audits.score IS NOT NULL) AS total_applicable,
   SAFE_DIVIDE(COUNTIF(audits.score > 0), COUNTIF(audits.score IS NOT NULL)) AS pct,
   APPROX_QUANTILES(audits.weight, 100)[OFFSET(50)] AS median_weight,


### PR DESCRIPTION
Quick update to the LH metric to check if the audit was applicable to a site or not. Only applicable sites should be counted towards the total, or you end up with incorrect %'s of sites meeting each audit.