### PR TITLE
Add sheets_gid and sql_file to figure_link

### DIFF
--- a/src/templates/base/2019/base.html
+++ b/src/templates/base/2019/base.html
@@ -479,7 +479,16 @@
 {% endif %}
 
 {% macro figure_id(metadata, id) %}{{ metadata.chapter_number }}.{{ id }}{% endmacro %}
-{% macro figure_link(metadata, id, caption, ebook=false) %}
+
+{% macro figure_link(
+  metadata,
+  id,
+  caption, 
+  sheets_gid="",
+  sql_file="",
+  ebook=false
+  )
+%}
 {% if ebook %}
 <a href="#fig-{{ metadata.chapter_number }}-{{ id }}" class="anchor-link">{{ figure_text(metadata, id) }}</a> {{ caption|safe }}
 {% else %}


### PR DESCRIPTION
Adds the ability to add more meta data to table links, for future when we will add drop downs with more functions as described in #1138 .

Previously only allowed these to be specified for charts, images or big_figures but this adds it for tables.

Maybe should move to kwargs so don't need to specify input args but I find it handy to list them in all in macro definition.