### PR TITLE
Remove use of set-env as being deprecated by GitHub Actions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -27,10 +27,10 @@ jobs:
       - name: Set VALIDATE_ALL_CODEBASE variable to false
         # Only run the full workflow for manual runs or if upgrading the super linter
         if: |
-            github.event_name != 'workflow' &&
+            github.event_name != 'workflow_dispatch' &&
             startsWith(github.event.pull_request.title,'Bump github/super-linter') != true
         run: |
-          echo "::set-env name=VALIDATE_ALL_CODEBASE::false"
+          echo "VALIDATE_ALL_CODEBASE=false" >> $GITHUB_ENV
       - name: Lint Code Base
         uses: github/super-linter@v3.13.1
         env:

--- a/.github/workflows/test-template-changes.yml
+++ b/.github/workflows/test-template-changes.yml
@@ -37,7 +37,6 @@ jobs:
       with:
         node-version: 12.x
     - name: Test Template Changes
-      id: test-template-changes
       run: ./src/tools/scripts/test_template_changes.sh
     - name: 'Comment PR'
       uses: actions/github-script@0.3.0

--- a/.github/workflows/test-template-changes.yml
+++ b/.github/workflows/test-template-changes.yml
@@ -41,11 +41,11 @@ jobs:
       run: ./src/tools/scripts/test_template_changes.sh
     - name: 'Comment PR'
       uses: actions/github-script@0.3.0
-      if: github.event_name == 'pull_request' && steps.test-template-changes.outputs.PR_COMMENT != ''
+      if: github.event_name == 'pull_request' && env.PR_COMMENT != ''
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
           // Unescape any escaped comments so code blocks appear correctly
-          const pr_comment = steps.test-template-changes.outputs.PR_COMMENT.replace(/%0A/g,'\n').replace(/%0D/g,'\r').replace(/%25/g,'%');
+          const pr_comment = process.env.PR_COMMENT.replace(/%0A/g,'\n').replace(/%0D/g,'\r').replace(/%27/g,"'").replace(/%22/g,'"').replace(/%25/g,'%');
           github.issues.createComment({ issue_number, owner, repo, body: pr_comment });

--- a/.github/workflows/test-template-changes.yml
+++ b/.github/workflows/test-template-changes.yml
@@ -41,11 +41,11 @@ jobs:
       run: ./src/tools/scripts/test_template_changes.sh
     - name: 'Comment PR'
       uses: actions/github-script@0.3.0
-      if: github.event_name == 'pull_request' && env.PR_COMMENT != ''
+      if: github.event_name == 'pull_request' && steps.test-template-changes.outputs.PR_COMMENT != ''
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
           // Unescape any escaped comments so code blocks appear correctly
-          const pr_comment = process.env.PR_COMMENT.replace(/%0A/g,'\n').replace(/%0D/g,'\r').replace(/%25/g,'%');
+          const pr_comment = steps.test-template-changes.outputs.PR_COMMENT.replace(/%0A/g,'\n').replace(/%0D/g,'\r').replace(/%25/g,'%');
           github.issues.createComment({ issue_number, owner, repo, body: pr_comment });

--- a/src/tools/scripts/test_template_changes.sh
+++ b/src/tools/scripts/test_template_changes.sh
@@ -59,9 +59,9 @@ cat "${DIFF_FILENAME}"
 NUM_DIFFS=$(wc -l < "${DIFF_FILENAME}")
 if [ "${NUM_DIFFS}" -ne "0" ]; then
   # Weird syntax is to make is Mac compatible: https://stackoverflow.com/a/1252191/2144578
-  ESCAPED_OUTPUT=$(sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/%0A/g' -e 's/\r/%0D/g' -e 's/\%/%25/g' "${DIFF_FILENAME}")
+  ESCAPED_OUTPUT=$(sed -e ':a' -e 'N' -e '$!ba' -e 's/\%/%25/g' -e 's/\n/%0A/g' -e 's/\r/%0D/g' -e "s/'/%27/g" -e 's/"/%22/g' "${DIFF_FILENAME}")
   PR_COMMENT="Please note, that the following diffs happen in the templates on this branch compared to main:%0A\`\`\`%0A${ESCAPED_OUTPUT}%0A\`\`\`%0A"
-  echo "::set-output name=PR_COMMENT::${PR_COMMENT}"
+  echo "PR_COMMENT=${PR_COMMENT}" >> "$GITHUB_ENV"
 fi
 
 echo "Removing templates backup"

--- a/src/tools/scripts/test_template_changes.sh
+++ b/src/tools/scripts/test_template_changes.sh
@@ -61,7 +61,7 @@ if [ "${NUM_DIFFS}" -ne "0" ]; then
   # Weird syntax is to make is Mac compatible: https://stackoverflow.com/a/1252191/2144578
   ESCAPED_OUTPUT=$(sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/%0A/g' -e 's/\r/%0D/g' -e 's/\%/%25/g' "${DIFF_FILENAME}")
   PR_COMMENT="Please note, that the following diffs happen in the templates on this branch compared to main:%0A\`\`\`%0A${ESCAPED_OUTPUT}%0A\`\`\`%0A"
-  echo "::set-env name=PR_COMMENT::${PR_COMMENT}"
+  echo "::set-output name=PR_COMMENT::${PR_COMMENT}"
 fi
 
 echo "Removing templates backup"


### PR DESCRIPTION
GitHub are [deprecating the `set-env` command](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) and started noticing warnings in our Action logs.

This PR makes some changes so they aren't used anymore.