### PR TITLE
Correction to HTTP/2 by site usage queries

### DIFF
--- a/sql/2020/22_HTTP_2/avg_percentage_of_resources_loaded_over_HTTP_by_version_per_site.sql
+++ b/sql/2020/22_HTTP_2/avg_percentage_of_resources_loaded_over_HTTP_by_version_per_site.sql
@@ -2,25 +2,34 @@
 # Average percentage of resources loaded over HTTP .9, 1, 1.1, 2, and QUIC per site
 SELECT
   client,
-  protocol,
-  AVG(num_requests / total_requests) AS avg_pct_requests_per_page
+  AVG(http09_pct) AS http09_pct,
+  AVG(http10_pct) AS http10_pct,
+  AVG(http11_pct) AS http11_pct,
+  AVG(http2_pct) AS http2_pct,
+  AVG(quic_pct) AS quic_pct,
+  AVG(http2quic46_pct) AS http2quic46_pct,
+  AVG(other_pct) AS other_pct,
+  AVG(null_pct) AS null_pct
 FROM (
-  SELECT 
+  SELECT
     client,
     page,
-    IF(JSON_EXTRACT_SCALAR(payload, '$._protocol') IN ('http/0.9', 'http/1.0', 'http/1.1', 'HTTP/2', 'QUIC', 'http/2+quic/46', 'HTTP/3'), JSON_EXTRACT_SCALAR(payload, '$._protocol'), 'other') AS protocol,
-    COUNT(0) AS num_requests,
-    SUM(COUNT(0)) OVER (PARTITION BY client, page) AS total_requests
+    COUNTIF(JSON_EXTRACT_SCALAR(payload, '$._protocol') = 'http/0.9') / COUNT(0) AS http09_pct,
+    COUNTIF(JSON_EXTRACT_SCALAR(payload, '$._protocol') = 'http/1.0') / COUNT(0) AS http10_pct,
+    COUNTIF(JSON_EXTRACT_SCALAR(payload, '$._protocol') = 'http/1.1') / COUNT(0) AS http11_pct,
+    COUNTIF(JSON_EXTRACT_SCALAR(payload, '$._protocol') = 'HTTP/2') / COUNT(0) AS http2_pct,
+    COUNTIF(JSON_EXTRACT_SCALAR(payload, '$._protocol') = 'QUIC') / COUNT(0) AS quic_pct,
+    COUNTIF(JSON_EXTRACT_SCALAR(payload, '$._protocol') = 'http/2+quic/46') / COUNT(0) AS http2quic46_pct,
+    COUNTIF(JSON_EXTRACT_SCALAR(payload, '$._protocol') NOT IN ('http/0.9', 'http/1.0', 'http/1.1', 'HTTP/2', 'QUIC', 'http/2+quic/46')) / COUNT(0) AS other_pct,
+    COUNTIF(JSON_EXTRACT_SCALAR(payload, '$._protocol') IS NULL) / COUNT(0) AS null_pct
   FROM 
     `httparchive.almanac.requests`
   WHERE
     date = '2020-08-01'
   GROUP BY
     client,
-    page,
-    protocol)
+    page)
 GROUP BY 
-  client,
-  protocol
+  client
 ORDER BY
-  avg_pct_requests_per_page DESC
+  client

--- a/sql/2020/22_HTTP_2/percentiles_of_resources_loaded_over_HTTP2_or_better_per_site.sql
+++ b/sql/2020/22_HTTP_2/percentiles_of_resources_loaded_over_HTTP2_or_better_per_site.sql
@@ -1,0 +1,25 @@
+# standardSQL
+# Percentiles of sites that load resources of HTTP/2 or above
+SELECT
+  client,
+  percentile,
+  APPROX_QUANTILES(ROUND(http2_pct, 2), 1000)[OFFSET(percentile * 10)] AS http2_or_above
+FROM (
+  SELECT
+    client,
+    page,
+    COUNTIF(JSON_EXTRACT_SCALAR(payload, '$._protocol') IN ('HTTP/2', 'QUIC', 'http/2+quic/46')) / COUNT(0) AS http2_pct
+  FROM 
+    `httparchive.almanac.requests`
+  WHERE
+    date = '2020-08-01'
+  GROUP BY
+    client,
+    page),
+  UNNEST([5, 6, 7, 8, 9, 10, 25, 50, 75, 90, 95, 100]) AS percentile
+GROUP BY 
+  client,
+  percentile
+ORDER BY
+  client,
+  percentile


### PR DESCRIPTION
Part of #921 

The current "avg_percentage_of_resources_loaded_over_HTTP_by_version_per_site" query calculates the percentages of each protocol per site, and then takes an average of these.

Unfortunately this does not work as when a site is not using a particular protocol, a row for that does not exist, and so is ignored from the average and so we end up with totals in excess of 100%.

For example with the below:

client | page | protocol | num_requests | total_requests | pct
-- | -- | -- | -- | -- | --
desktop_10k | site1 | HTTP/1.1 | 86 | 172 | 50%
desktop_10k | site1 | HTTP/2 | 86 | 172 | 50%
desktop_10k | site2 | HTTP/1.1 | 13 | 26 | 50%
desktop_10k | site2 | HTTP/2 | 13 | 26 | 50%
desktop_10k | site3 | HTTP/1.1 | 10 | 10 | 100%

HTTP/1.1 is (50% + 50% + 100%)/3 = 200%/3 = 66.666%
HTTP/2 however is (50% + 50%)/2 = 100%/2 = 50%
Total is therefore 116.666% which is not possible!
This is because the 0% usage of site 3 for HTTP/2 is not being counted as there are no rows.

The new version of the query instead gets a count by site of each known version in our data set, meaning the second calculation becomes:

HTTP/2 is (50% + 50% + 0%)/3 = 100%/3 = 33.3333% which therefore causes the total to make 100% as expected.

I've also included a percentile of sites using HTTP/2 or above which I think makes an interesting query.

