### PR TITLE
Stop over linting

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -24,6 +24,9 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2.3.3
+        with:
+          # Fetch all commits so super-linter can compare branches fully
+          fetch-depth: 0
       - name: Set VALIDATE_ALL_CODEBASE variable to false
         # Only run the full workflow for manual runs or if upgrading the super linter
         if: |

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2.3.3
         with:
-          # Fetch all commits so super-linter can compare branches fully
+          # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
       - name: Set VALIDATE_ALL_CODEBASE variable to false
         # Only run the full workflow for manual runs or if upgrading the super linter

--- a/.github/workflows/test_website.yml
+++ b/.github/workflows/test_website.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Checkout branch
       uses: actions/checkout@v2.3.3
       with:
-        # Fetch all commits so super-linter can compare branches fully
+        # Full git history is needed to get a proper list of changed files within `super-linter`
         fetch-depth: 0
     - name: Setup Node.js for use with actions
       uses: actions/setup-node@v1.4.2

--- a/.github/workflows/test_website.yml
+++ b/.github/workflows/test_website.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
     - name: Checkout branch
       uses: actions/checkout@v2.3.3
+      with:
+        # Fetch all commits so super-linter can compare branches fully
+        fetch-depth: 0
     - name: Setup Node.js for use with actions
       uses: actions/setup-node@v1.4.2
       with:


### PR DESCRIPTION
As per https://github.com/github/super-linter/issues/671#issuecomment-706131556 adding a small bit of config so we only lint the actual changes in a branch, and not the full differences between two branches if main goes ahead of a branch.