### PR TITLE
Add CodeQL GitHub Action

### DIFF
--- a/.github/workflows/code-static-analysis.yml
+++ b/.github/workflows/code-static-analysis.yml
@@ -1,0 +1,77 @@
+# Runs the CodeQL static code analysis
+
+name: "Static Code Analysis"
+
+on:
+  push:
+    paths:
+      - '**.js'
+      - '**.py'
+      - '**.html'
+  pull_request:
+    paths:
+      - '**.js'
+      - '**.py'
+      - '**.html'
+  schedule:
+    #        ┌───────────── minute (0 - 59)
+    #        │ ┌───────────── hour (0 - 23)
+    #        │ │ ┌───────────── day of the month (1 - 31)
+    #        │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+    #        │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #        │ │ │ │ │
+    #        │ │ │ │ │
+    #        │ │ │ │ │
+    #        * * * * *
+    - cron: '30 1 * * 0'
+  workflow_dispatch:
+
+jobs:
+  CodeQL-Build:
+    # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest
+    runs-on: ubuntu-latest
+    # Skip duplicate job for local branches
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          # Must fetch at least the immediate parents so that if this is
+          # a pull request then we can checkout the head of the pull request.
+          # Only include this option if you are running this workflow on pull requests.
+          fetch-depth: 2
+
+      # If this run was triggered by a pull request event then checkout
+      # the head of the pull request instead of the merge commit.
+      # Only include this step if you are running this workflow on pull requests.
+      - run: git checkout HEAD^2
+        if: ${{ github.event_name == 'pull_request' }}
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          queries: +security-and-quality
+        # Override language selection by uncommenting this and choosing your languages
+        # with:
+        #   languages: go, javascript, csharp, python, cpp, java
+
+      # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below).
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
+
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
+
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following
+      #    three lines and modify them (or add more) to build your code if your
+      #    project uses a compiled language
+
+      #- run: |
+      #   make bootstrap
+      #   make release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/code-static-analysis.yml
+++ b/.github/workflows/code-static-analysis.yml
@@ -31,7 +31,7 @@ jobs:
     # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest
     runs-on: ubuntu-latest
     # Skip duplicate job for local branches
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
 
     steps:
       - name: Checkout repository

--- a/src/static/js/chapter.js
+++ b/src/static/js/chapter.js
@@ -139,13 +139,13 @@ function googleSheetsPixelNotLoaded() {
   this.parentElement.removeChild(this);
 
   var all_fig_imgs = document.querySelectorAll('figure .fig-mobile');
-  for (index = 0; index < all_fig_imgs.length; ++index) {
+  for (var index = 0; index < all_fig_imgs.length; ++index) {
     var fig_img = all_fig_imgs[index];
     fig_img.classList.remove("fig-mobile");
   }
 
   var all_fig_iframes = document.querySelectorAll('figure .fig-iframe');
-  for (index = 0; index < all_fig_iframes.length; ++index) {
+  for (var index = 0; index < all_fig_iframes.length; ++index) {
     var fig_iframe = all_fig_iframes[index];
     fig_iframe.parentElement.removeChild(fig_iframe);
   }
@@ -166,7 +166,7 @@ function upgradeInteractiveFigures() {
       //Find each image and create the iframe
       var all_fig_imgs = document.querySelectorAll('figure img');
 
-      for (index = 0; index < all_fig_imgs.length; ++index) {
+      for (var index = 0; index < all_fig_imgs.length; ++index) {
         var fig_img = all_fig_imgs[index];
 
         if (fig_img.getAttribute('data-iframe')) {
@@ -289,7 +289,7 @@ function indexHighlighter() {
   // Check if 'position:sticky' is supported (as this is not great UX when not so don't bother)
   // Add the sticky class (which sets 'position:sticky') and then test if that stuck :-)
   // Also use endsWith to support vendor prefixes (Safari v12 needs this)
-  chapterIndex && chapterIndex.classList.add('sticky');
+  chapterIndex.classList.add('sticky');
   var chapterIndexStyles = getComputedStyle(chapterIndex);
   if (!chapterIndexStyles || !chapterIndexStyles.position || !chapterIndexStyles.position.endsWith('sticky')) {
     gtag('event', 'index-highlighter', { 'event_category': 'user', 'event_label': 'not-enabled', 'value': 0 });
@@ -341,7 +341,7 @@ function indexHighlighter() {
     threshold: null
   };
   var observer = new IntersectionObserver(function(entries) {
-    for (index = 0; index < entries.length; ++index) {
+    for (var index = 0; index < entries.length; ++index) {
       var entry = entries[index];
 
       if (entry.isIntersecting && entry.target && entry.target.id) {
@@ -352,7 +352,7 @@ function indexHighlighter() {
 
   // Add an intersection observer to each heading
   var all_headings = document.querySelectorAll('article h1, article h2, article h3');
-  for (index = 0; index < all_headings.length; ++index) {
+  for (var index = 0; index < all_headings.length; ++index) {
     var heading = all_headings[index];
     observer.observe(heading);
   };
@@ -362,16 +362,16 @@ function indexHighlighter() {
 }
 
 function toggleDescription(event) {
-  event_button = event.target;
+  var event_button = event.target;
   if (!event_button) {
     return;
   }
-  description_id = event_button.getAttribute('aria-controls');
+  var description_id = event_button.getAttribute('aria-controls');
   if (!description_id) {
     return;
   }
 
-  description = document.querySelector('#' + description_id);
+  var description = document.querySelector('#' + description_id);
   if (!description) {
     return;
   }
@@ -385,11 +385,11 @@ function toggleDescription(event) {
 function addShowDescription() {
   var all_desc_buttons = document.querySelectorAll('.fig-description-button');
 
-  for (index = 0; index < all_desc_buttons.length; ++index) {
+  for (var index = 0; index < all_desc_buttons.length; ++index) {
     var desc_button = all_desc_buttons[index];
     desc_button.addEventListener('click', toggleDescription);
     desc_button.hidden = false;
-    description = document.querySelector('#' + desc_button.getAttribute('aria-controls'));
+    var description = document.querySelector('#' + desc_button.getAttribute('aria-controls'));
     if(description) {
       description.classList.remove('visually-hidden');
       description.classList.add('fig-description');

--- a/src/templates/base/2019/base_ebook.html
+++ b/src/templates/base/2019/base_ebook.html
@@ -421,7 +421,7 @@
 
       <div class="ha-logo-wrapper">
         <svg role="img">
-          <title id="ha-logo">HTTP Archive home</title>
+          <title id="ha-logo-front-cover">HTTP Archive home</title>
           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ha"></use>
         </svg>
       </div>
@@ -446,7 +446,7 @@
 
       <div class="ha-logo-wrapper">
         <svg role="img">
-          <title id="ha-logo">HTTP Archive home</title>
+          <title id="ha-logo-spine">HTTP Archive home</title>
           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ha"></use>
         </svg>
       </div>
@@ -488,7 +488,7 @@
 
       <div class="ha-logo-wrapper">
         <svg role="img">
-          <title id="ha-logo">HTTP Archive home</title>
+          <title id="ha-logo-back-cover">HTTP Archive home</title>
           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#ha"></use>
         </svg>
       </div>

--- a/src/templates/base/2019/contributors.html
+++ b/src/templates/base/2019/contributors.html
@@ -453,14 +453,14 @@
                 contributors.classList.add.apply(contributors.classList,filterTeams);
             }
 
-            for (index = 0; index < buttons.length; ++index) {
+            for (var index = 0; index < buttons.length; ++index) {
               var button = buttons[index];
               button.setAttribute('aria-pressed', hash.includes(button.className));
             }
 
         } else {
             contributors.classList.add.apply(contributors.classList,teams);
-            for (index = 0; index < buttons.length; ++index) {
+            for (var index = 0; index < buttons.length; ++index) {
               var button = buttons[index];
               button.setAttribute('aria-pressed',false);
             }

--- a/src/tools/generate/generate_chapters.js
+++ b/src/tools/generate/generate_chapters.js
@@ -29,7 +29,7 @@ const generate_chapters = async () => {
   
   configs = await get_yearly_configs();
   for (const year in configs) {  
-    sitemap_languages[year] = configs[year].settings[0].supported_languages
+    sitemap_languages[year] = configs[year].settings[0].supported_languages;
   }
 
   for (const file of await find_markdown_files()) {

--- a/src/tools/test/test_status_codes.js
+++ b/src/tools/test/test_status_codes.js
@@ -39,7 +39,7 @@ const test_status_code = async (page, status, location) => {
     // Don't follow redirects
     const options = {
       redirect: 'manual'
-    }
+    };
 
     const response = await fetch(base_url + page, options);
 


### PR DESCRIPTION
GiHub have recently launched [Code Scanning via CodeQL](https://github.blog/2020-09-30-code-scanning-is-now-available/) which scans source code for Security Vulnerabilities, which is an additional step that our linters may not cover.

Now, as a static site, we hopefully don't have too much to worry about on the security front, but we still wouldn't want our server, or our users client side code compromised so I think we should add it.

It has already identified a few minor things that linting didn't pick up (I'm running it with both security and quality checks btw). I've included most of those fixes in this PR and also marked a couple as "won't fix" - the tool makes this very easy.

@rviscomi it's also identified a few issues in the CSS utils that I'll leave you to consider whether to fix or close off: https://github.com/HTTPArchive/almanac.httparchive.org/security/code-scanning?query=ref%3Arefs%2Fheads%2Fcodeql

Results will normally appear in the Pull Request but also in the Security tab of GitHub.