### PR TITLE
Highlight H4, H5 and H6 in table of contents as well

### DIFF
--- a/src/static/js/chapter.js
+++ b/src/static/js/chapter.js
@@ -351,7 +351,7 @@ function indexHighlighter() {
   }, options);
 
   // Add an intersection observer to each heading
-  var all_headings = document.querySelectorAll('article h1, article h2, article h3');
+  var all_headings = document.querySelectorAll('article h1, article h2, article h3, article h4, article h5, article h6');
   for (var index = 0; index < all_headings.length; ++index) {
     var heading = all_headings[index];
     observer.observe(heading);


### PR DESCRIPTION
Adds 'article h4' also in selectors to be marked for IntersectionObserver API. This will highlight individual H4s as well. If we want to avoid doing that, then we can check if the Intersection node is a h4 and activate the parent h3 node instead of itself. Let me know which seems more desireable.

Fixes #1363 