### PR TITLE
Freeze GitHub super-linter due to buggy release

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           echo "VALIDATE_ALL_CODEBASE=false" >> $GITHUB_ENV
       - name: Lint Code Base
-        uses: github/super-linter@v3.13.2
+        uses: docker://github/super-linter:v3.13.1
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_website.yml
+++ b/.github/workflows/test_website.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Remove node modules to avoid linting errors
       run: rm -rf src/node_modules
     - name: Lint Generated HTML
-      uses: github/super-linter@v3.13.2
+      uses: docker://github/super-linter:v3.13.1
       env:
         DEFAULT_BRANCH: main
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_website.yml
+++ b/.github/workflows/test_website.yml
@@ -36,5 +36,6 @@ jobs:
       uses: docker://github/super-linter:v3.13.1
       env:
         DEFAULT_BRANCH: main
+        FILTER_REGEX_INCLUDE: src/static/html/.*
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         VALIDATE_HTML: true


### PR DESCRIPTION
The GitHub super linter has [another buggy release](https://github.com/github/super-linter/issues/938) so freezing back to the last good version on docker, especially as US election day so not sure if/when it will be fixed.

Also included a small perf tweak to limit the linting in the test website action.

Forks and branches will need to merge with main to pick up this workaround.