### PR TITLE
Add bkardell to 2020 Contributors

### DIFF
--- a/src/config/2020.json
+++ b/src/config/2020.json
@@ -362,6 +362,16 @@
       "github": "borisschapira",
       "twitter": "boostmarks"
     },
+    "bkardell": {
+      "name": "Brian Kardell",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "https://avatars1.githubusercontent.com/u/870501?v=4&s=200",
+      "website": "https://bkardell.com",
+      "github": "bkardell",
+      "twitter": "briankardell"
+    },
     "cqueern": {
       "name": "Caleb Queern",
       "teams": [


### PR DESCRIPTION
@bkardell is a reviewer on [Markup 2020 chapter](https://github.com/HTTPArchive/almanac.httparchive.org/issues/899) but is not rendering properly as not in 2020.json config.

Adding him based on 2019 data - @bkardell shout if you wanna change anything or approve if happy to go with same again.