### PR TITLE
README and Deployment udpates

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -8,10 +8,18 @@ Make sure you run the following commands from within the `src` directory by exec
 
 [Source](https://cloud.google.com/appengine/docs/flexible/python/quickstart)
 
+Make sure Python (3.8 or above) and NodeJS (v12) are installed on your machine.
+
 1. If you don't have virtualenv, install it using pip.
 
 ```
 sudo pip install virtualenv
+```
+
+Or for Windows
+
+```
+py -m pip install --user virtualenv
 ```
 
 2. Create an isolated Python environment, and install dependencies:
@@ -21,6 +29,15 @@ virtualenv --python python3 env
 source env/bin/activate
 pip install -r requirements.txt
 ```
+
+Or for those on Windows:
+
+```
+virtualenv --python python3 env
+env\Scripts\activate.bat
+pip install -r requirements.txt
+```
+
 
 3. Run the application:
 

--- a/src/tools/scripts/deploy.sh
+++ b/src/tools/scripts/deploy.sh
@@ -92,8 +92,9 @@ if [ "$(pgrep -f 'python main.py')" ]; then
 fi
 
 #Remove generated chapters (in case new one from other branch in there)
+# Or with "true" to prevent failure if files don't exist
 echo "Removing Generated Chapters"
-rm -f ./templates/*/*/chapters/* | true
+rm -f ./templates/*/*/chapters/* || true
 
 echo "Run and test website"
 ./tools/scripts/run_and_test_website.sh

--- a/src/tools/scripts/deploy.sh
+++ b/src/tools/scripts/deploy.sh
@@ -91,6 +91,10 @@ if [ "$(pgrep -f 'python main.py')" ]; then
   pkill -9 python main.py
 fi
 
+#Remove generated chapters (in case new one from other branch in there)
+echo "Removing Generated Chapters"
+rm -f ./templates/*/*/chapters/* | true
+
 echo "Run and test website"
 ./tools/scripts/run_and_test_website.sh
 


### PR DESCRIPTION
Includes the following two changes:
1. Updates to the README to explain to Windows users how to run the site.
2. A clear down job for the deploy script so any old generated chapters you have lingering around your local machine (e.g. from other branches) are not accidentally released since they are not removed when switching branches as generated files are not tracked in git.