### PR TITLE
Add option to generate individual watchers and a watcher

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -70,6 +70,22 @@ If you have the server up you can test all the pages are being served correctly:
 npm run test
 ```
 
+You can also run single chapters:
+
+```
+npm run generate en/2019/css
+```
+
+Or event patterns (note patterns must be in quotes to prevent OS attempting to match to files):
+
+```
+npm run generate ".*/2019/css"
+npm run generate "en/.*/css"
+npm run generate ".*/2020/.*"
+```
+
+
+
 ## Generating Ebooks
 
 For generating PDFs of the ebook, you need to install Prince. Follow the instructions on [the Prince Website](https://www.princexml.com/) and pdftk.

--- a/src/README.md
+++ b/src/README.md
@@ -70,13 +70,13 @@ If you have the server up you can test all the pages are being served correctly:
 npm run test
 ```
 
-You can also run single chapters:
+You can also run single chapters, so you don't have to wait for the full run time:
 
 ```
 npm run generate en/2019/css
 ```
 
-Or event patterns (note patterns must be in quotes to prevent OS attempting to match to files):
+Or even patterns (note patterns must be in quotes to prevent OS attempting to match to files):
 
 ```
 npm run generate ".*/2019/css"
@@ -84,6 +84,10 @@ npm run generate "en/.*/css"
 npm run generate ".*/2020/.*"
 ```
 
+There is also a file watcher, which monitors the `content` directory and automatically regenerates a chapter when it sees it being modified:
+```
+npm run watch
+```
 
 
 ## Generating Ebooks

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -684,6 +684,12 @@
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
     },
+    "node-watch": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.0.tgz",
+      "integrity": "sha512-OOBiglke5SlRQT5WYfwXTmYqTfXjcTNBHpalyHLtLxDpQYVpVRkJqabcch1kmwJsjV/J4OZuzEafeb4soqtFZA==",
+      "dev": true
+    },
     "nwsapi": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",

--- a/src/package.json
+++ b/src/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "test": "node ./tools/test",
     "generate": "node ./tools/generate",
+    "watch": "node ./tools/generate/chapter_watcher",
     "ebooks": "node ./tools/generate/generate_ebook_pdfs",
     "deploy": "./tools/scripts/deploy.sh",
     "start": "run-script-os",
@@ -32,6 +33,7 @@
     "web-vitals": "0.2.4",
     "node-fetch": "2.6.1",
     "xml-js": "1.6.11",
-    "run-script-os": "1.1.3"
+    "run-script-os": "1.1.3",
+    "node-watch": "0.7.0"
   }
 }

--- a/src/tools/generate/chapter_watcher.js
+++ b/src/tools/generate/chapter_watcher.js
@@ -1,0 +1,23 @@
+var watch = require('node-watch');
+let { generate_chapters } = require('./generate_chapters');
+const { exec } = require("child_process");
+ 
+watch('content', { filter: /\.md$/, recursive: true }, async function(evt, name) {
+  console.log('File modified: %s', name);
+  if (evt != 'remove') {
+    await generate_chapters(name)
+      /*
+      const command = 'npm run generate ' + name;
+      exec (command, (err, stdout, stderr) => {
+        if (err) {
+          // some err occurred
+          console.error(err)
+        } else {
+          // the *entire* stdout and stderr (buffered)
+          console.log(`stdout: ${stdout}`);
+          console.log(`stderr: ${stderr}`);
+        }
+      });
+      */
+  }
+});

--- a/src/tools/generate/chapter_watcher.js
+++ b/src/tools/generate/chapter_watcher.js
@@ -6,18 +6,5 @@ watch('content', { filter: /\.md$/, recursive: true }, async function(evt, name)
   console.log('File modified: %s', name);
   if (evt != 'remove') {
     await generate_chapters(name)
-      /*
-      const command = 'npm run generate ' + name;
-      exec (command, (err, stdout, stderr) => {
-        if (err) {
-          // some err occurred
-          console.error(err)
-        } else {
-          // the *entire* stdout and stderr (buffered)
-          console.log(`stdout: ${stdout}`);
-          console.log(`stderr: ${stderr}`);
-        }
-      });
-      */
   }
 });

--- a/src/tools/generate/index.js
+++ b/src/tools/generate/index.js
@@ -5,5 +5,6 @@ let { generate_chapters } = require('./generate_chapters');
   // let { generate_last_updated } = require('./generate_last_updated');
   // await generate_last_updated();
 
-  await generate_chapters();
+  const first_arg = process.argv.slice(2)[0]
+  await generate_chapters(first_arg);
 })();


### PR DESCRIPTION
The Chapter generation with `npm run generate` can take a while to complete. This can be frustrating if you just want to one chapter generated (e.g. if you are writing or editing it).

This PR adds the ability to pass arguments to `npm run generate`, for example:
```
npm run generate en/2020/markup
```

Or even patterns (note patterns must be in quotes to prevent OS attempting to match to files):
```
npm run generate ".*/2019/css"
npm run generate "en/.*/css"
npm run generate ".*/2020/.*"
```

It also adds a file watcher, which monitors the `content` directory and automatically regenerates a chapter when it sees it being modified:
```
npm run watch
```
