### PR TITLE
Fix colour contrast issues with 2020 Table of Contents

### DIFF
--- a/src/templates/base/2019/table_of_contents.html
+++ b/src/templates/base/2019/table_of_contents.html
@@ -46,7 +46,8 @@
 }
 
 .chapter .todo {
-  opacity: 0.3;
+  opacity: 0.65;
+  font-style: italic;
 }
 .chapter a {
   text-decoration: none;


### PR DESCRIPTION
The colour contrast to the todos is way too low:

![Production Table of Contents with low colour contrast](https://user-images.githubusercontent.com/10931297/98443729-2c7ee980-2105-11eb-9ef0-8407d9b54fd1.png)

Picked up when I ran our all new [Lighthouse production monitor job](https://github.com/HTTPArchive/almanac.httparchive.org/actions/runs/351001128) - from now this will be picked up at commit time, but this change was committed before the Lighthouse tests were added in #1415 

I've made the opacity less and also added and italic slant to help differentiate it further:

![New Table of Contents with better colour contrast](https://user-images.githubusercontent.com/10931297/98443746-50dac600-2105-11eb-8b3d-31c9f3028e10.png)
