### PR TITLE
Use todos for 2020 Table of Contents

### DIFF
--- a/src/config/2020.json
+++ b/src/config/2020.json
@@ -15,13 +15,15 @@
           "part": "I",
           "chapter": "1",
           "title": "CSS",
-          "slug": "css"
+          "slug": "css",
+          "todo": true
         },
         {
           "part": "I",
           "chapter": "2",
           "title": "JavaScript",
-          "slug": "javascript"
+          "slug": "javascript",
+          "todo": true
         },
         {
           "part": "I",
@@ -33,19 +35,22 @@
           "part": "I",
           "chapter": "4",
           "title": "Fonts",
-          "slug": "fonts"
+          "slug": "fonts",
+          "todo": true
         },
         {
           "part": "I",
           "chapter": "5",
           "title": "Media",
-          "slug": "media"
+          "slug": "media",
+          "todo": true
         },
         {
           "part": "I",
           "chapter": "6",
           "title": "Third Parties",
-          "slug": "third-parties"
+          "slug": "third-parties",
+          "todo": true
         }
       ]
     },
@@ -57,49 +62,57 @@
           "part": "II",
           "chapter": "7",
           "title": "SEO",
-          "slug": "seo"
+          "slug": "seo",
+          "todo": true
         },
         {
           "part": "II",
           "chapter": "8",
           "title": "Accessibility",
-          "slug": "accessibility"
+          "slug": "accessibility",
+          "todo": true
         },
         {
           "part": "II",
           "chapter": "9",
           "title": "Performance",
-          "slug": "performance"
+          "slug": "performance",
+          "todo": true
         },
         {
           "part": "II",
           "chapter": "10",
           "title": "Privacy",
-          "slug": "privacy"
+          "slug": "privacy",
+          "todo": true
         },
         {
           "part": "II",
           "chapter": "11",
           "title": "Security",
-          "slug": "security"
+          "slug": "security",
+          "todo": true
         },
         {
           "part": "II",
           "chapter": "12",
           "title": "Mobile Web",
-          "slug": "mobile-web"
+          "slug": "mobile-web",
+          "todo": true
         },
         {
           "part": "II",
           "chapter": "13",
           "title": "Capabilities",
-          "slug": "capabilities"
+          "slug": "capabilities",
+          "todo": true
         },
         {
           "part": "II",
           "chapter": "14",
           "title": "PWA",
-          "slug": "pwa"
+          "slug": "pwa",
+          "todo": true
         }
       ]
     },
@@ -111,19 +124,22 @@
           "part": "III",
           "chapter": "15",
           "title": "CMS",
-          "slug": "cms"
+          "slug": "cms",
+          "todo": true
         },
         {
           "part": "III",
           "chapter": "16",
           "title": "Ecommerce",
-          "slug": "ecommerce"
+          "slug": "ecommerce",
+          "todo": true
         },
         {
           "part": "III",
           "chapter": "17",
           "title": "Jamstack",
-          "slug": "jamstack"
+          "slug": "jamstack",
+          "todo": true
         }
       ]
     },
@@ -135,31 +151,36 @@
           "part": "IV",
           "chapter": "18",
           "title": "Page Weight",
-          "slug": "page-weight"
+          "slug": "page-weight",
+          "todo": true
         },
         {
           "part": "IV",
           "chapter": "19",
           "title": "Compression",
-          "slug": "compression"
+          "slug": "compression",
+          "todo": true
         },
         {
           "part": "IV",
           "chapter": "20",
           "title": "Caching",
-          "slug": "caching"
+          "slug": "caching",
+          "todo": true
         },
         {
           "part": "IV",
           "chapter": "21",
           "title": "Resource Hints",
-          "slug": "resource-hints"
+          "slug": "resource-hints",
+          "todo": true
         },
         {
           "part": "IV",
           "chapter": "22",
           "title": "HTTP/2",
-          "slug": "http2"
+          "slug": "http2",
+          "todo": true
         }
       ]
     }

--- a/src/content/en/2020/markup.md
+++ b/src/content/en/2020/markup.md
@@ -22,6 +22,7 @@ featured_stat_3: 25.24 KB
 featured_stat_label_3: Weight of the median document
 published: 2020-11-01T00:00:00.000Z
 last_updated: 2020-11-06T00:00:00.000Z
+unedited: true
 ---
 
 ## Introduction

--- a/src/templates/base/2019/table_of_contents.html
+++ b/src/templates/base/2019/table_of_contents.html
@@ -112,11 +112,8 @@
           <div class="chapters">
             {% for chapter_config in part_config.chapters %}
               <div class="chapter">
-                {% if year > "2019" %}
-                <span class="todo">{{ self.chapter() }} {{ chapter_config.chapter }}: {{ localizedChapterTitles[chapter_config.slug] if localizedChapterTitles[chapter_config.slug]|length else chapter_config.title }} - {{ self.coming_soon() }}</span>
-                {% else %}
                   {% if chapter_config.todo %}
-                  <span class="todo">{{ self.chapter() }} {{ chapter_config.chapter }}: {{ localizedChapterTitles[chapter_config.slug] if localizedChapterTitles[chapter_config.slug]|length else chapter_config.title }}</span>
+                  <span class="todo">{{ self.chapter() }} {{ chapter_config.chapter }}: {{ localizedChapterTitles[chapter_config.slug] if localizedChapterTitles[chapter_config.slug]|length else chapter_config.title }} - {{ self.coming_soon() }}</span>
                   {% else %}
                     {% if chapter_lang_exists(lang, year, chapter_config.slug) %}
                     <a href="{{ url_for('chapter', year=year, lang=lang, chapter=chapter_config.slug) }}">
@@ -128,7 +125,6 @@
                     </a>
                     {% endif %}
                   {% endif %}
-                {% endif %}
               </div>
             {% endfor %}
           </div>


### PR DESCRIPTION
Changes to using the todo config for 2020 Table of Contents so we can turn on chapters as they are ready.

Also adds the `unedited` flag to 2020 Markup chapter until #1435 is finished, reviewed and merged.