### PR TITLE
Support closed issues in progress tracker

### DIFF
--- a/.github/workflows/progress-tracker.yml
+++ b/.github/workflows/progress-tracker.yml
@@ -153,7 +153,8 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               direction: 'asc',
-              labels: filterLabel
+              labels: filterLabel,
+              state: 'all'
             })
 
             let chapters = []


### PR DESCRIPTION
As chapters are completed and their issues are closed, we still want to include them in the [progress tracker](https://github.com/HTTPArchive/almanac.httparchive.org/issues/989).