### PR TITLE
Add a comment fallback for when comments fail to load

### DIFF
--- a/src/templates/base/2019/base_chapter.html
+++ b/src/templates/base/2019/base_chapter.html
@@ -66,7 +66,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
       <title>{{ self.discuss_this_chapter() }}</title>
       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#comment"></use>
     </svg>    
-    <span id="num_comments">{{ self.comments() }}</span> <span data-translation id="comment-singular">{{ self.comment() }}</span>
+    <span id="num_comments">{{ self.comments_fallback() }}</span> <span data-translation id="comment-singular">{{ self.comment() }}</span>
     <span data-translation id="comment-plural">{{ self.comments() }}</span>
   </a>
   <a class="alt btn" href="{{ metadata.get('results') }}/">

--- a/src/templates/base/2019/base_chapter.html
+++ b/src/templates/base/2019/base_chapter.html
@@ -66,7 +66,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
       <title>{{ self.discuss_this_chapter() }}</title>
       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#comment"></use>
     </svg>    
-    <span id="num_comments"></span> <span data-translation id="comment-singular">{{ self.comment() }}</span>
+    <span id="num_comments">{{ self.comments() }}</span> <span data-translation id="comment-singular">{{ self.comment() }}</span>
     <span data-translation id="comment-plural">{{ self.comments() }}</span>
   </a>
   <a class="alt btn" href="{{ metadata.get('results') }}/">

--- a/src/templates/en/2019/base_chapter.html
+++ b/src/templates/en/2019/base_chapter.html
@@ -13,6 +13,7 @@
 {% block discuss_this_chapter %}Discuss this chapter{% endblock %}
 {% block comment %}comment{% endblock %}
 {% block comments %}comments{% endblock %}
+{% block comments_fallback %}Comments{% endblock %}
 {% block queries %}View queries{% endblock %}
 {% block results %}View results{% endblock %}
 

--- a/src/templates/es/2019/base_chapter.html
+++ b/src/templates/es/2019/base_chapter.html
@@ -13,6 +13,7 @@
 {% block discuss_this_chapter %}Comenta este capítulo{% endblock %}
 {% block comment %}comentar{% endblock %}
 {% block comments %}comentarios{% endblock %}
+{% block comments_fallback %}Comentarios{% endblock %}
 {% block queries %}Ver consultas{% endblock %}
 {% block results %}Ver resultados{% endblock %}
 

--- a/src/templates/fr/2019/base_chapter.html
+++ b/src/templates/fr/2019/base_chapter.html
@@ -13,6 +13,7 @@
 {% block discuss_this_chapter %}Discuter de ce chapitre{% endblock %}
 {% block comment %}commentaire{% endblock %}
 {% block comments %}commentaires{% endblock %}
+{% block comments_fallback %}Commentaires{% endblock %}
 {% block queries %}Afficher les requêtes{% endblock %}
 {% block results %}Voir les résultats{% endblock %}
 

--- a/src/templates/ja/2019/base_chapter.html
+++ b/src/templates/ja/2019/base_chapter.html
@@ -13,6 +13,7 @@
 {% block discuss_this_chapter %}この章について話し合う{% endblock %}
 {% block comment %}コメント{% endblock %}
 {% block comments %}コメント{% endblock %}
+{% block comments_fallback %}コメント{% endblock %}
 {% block queries %}クエリを表示{% endblock %}
 {% block results %}結果を表示{% endblock %}
 

--- a/src/templates/pt/2019/base_chapter.html
+++ b/src/templates/pt/2019/base_chapter.html
@@ -11,8 +11,9 @@
 {% block prev_next_title %}Navegação do capítulo anterior e seguinte{% endblock %}
 
 {% block discuss_this_chapter %}Discuta este capítulo{% endblock %}
-{% block comment %}Comente{% endblock %}
+{% block comment %}comente{% endblock %}
 {% block comments %}comentários{% endblock %}
+{% block comments_fallback %}Comentários{% endblock %}
 {% block queries %}Ver consultas{% endblock %}
 {% block results %}Ver resultados{% endblock %}
 

--- a/src/templates/zh-CHT/2019/base_chapter.html
+++ b/src/templates/zh-CHT/2019/base_chapter.html
@@ -13,6 +13,7 @@
 {% block discuss_this_chapter %}討論本章節{% endblock %}
 {% block comment %}評論{% endblock %}
 {% block comments %}評論{% endblock %}
+{% block comments_fallback %}評論{% endblock %}
 {% block queries %}查看查詢{% endblock %}
 {% block results %}查看結果{% endblock %}
 

--- a/src/templates/zh-CN/2019/base_chapter.html
+++ b/src/templates/zh-CN/2019/base_chapter.html
@@ -13,6 +13,7 @@
 {% block discuss_this_chapter %}讨论本章节{% endblock %}
 {% block comment %}评论{% endblock %}
 {% block comments %}评论{% endblock %}
+{% block comments_fallback %}评论{% endblock %}
 {% block queries %}查看请求{% endblock %}
 {% block results %}查看结果{% endblock %}
 


### PR DESCRIPTION
Nicer for user and also should avoid Lighthouse errors if comments fail to load for some reason.

Now shows "Comments" (without number) when it fails to load which still links to the Discussion thread:

![Fallback Comments](https://user-images.githubusercontent.com/10931297/98463366-aa4cfe80-21b2-11eb-9d07-9035569c6d14.png)
