### PR TITLE
Update home page to reference 2020 chapters now we have some ready

### DIFF
--- a/src/templates/base/2019/index.html
+++ b/src/templates/base/2019/index.html
@@ -4,11 +4,7 @@
 {% block image_height %}562{% endblock %}
 {% block image_width %}715{% endblock %}
 
-{% if featured_chapters_exists(lang, year) or featured_chapters_exists('en', year) %}
-{% set year_with_chapters = true %}
-{% else %}
-{% set year_with_chapters = false %}
-{% endif %}
+{% set year_with_chapters = featured_chapters_exists(lang, year) or featured_chapters_exists('en', year) %}
 
 {% block breadcrumb %}
 <script type="application/ld+json">

--- a/src/templates/base/2019/index.html
+++ b/src/templates/base/2019/index.html
@@ -32,7 +32,7 @@
       <h1 class="title title-lg title-alt">{{ self.intro_title() }}</h1>
       <h2>{{ self.intro_sub_title() }}</h2>
       {{ self.mission() }}
-      {% if year < "2020" %}
+      {% if year < "2021" %}
       <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}" class="btn">
         {{ self.start_exploring() }}
       </a>
@@ -84,16 +84,16 @@
         </div>
         {% endif %}
       </div>
-      <a href="{{ url_for('chapter', year=2019, chapter=featured_chapter, lang=lang) }}" class="btn">
+      <a href="{{ url_for('chapter', year=year, chapter=featured_chapter, lang=lang) }}" class="btn">
         {{ read_chapter(localizedChapterTitles[featured_chapter]) }}
       </a>
     </div>
   </section>
   {% endmacro %}
-  {% if featured_chapters_exists(lang, 2019) %}
-  {% include "%s/2019/featured_chapters.html" % lang %}
-  {% elif featured_chapters_exists('en', 2019) %}
-  {% include "en/2019/featured_chapters.html" %}
+  {% if featured_chapters_exists(lang, year) %}
+  {% include "%s/%s/featured_chapters.html" % (lang, year) %}
+  {% elif featured_chapters_exists('en', year) %}
+  {% include "en/%s/featured_chapters.html" % year %}
   {% endif %}
   {% endblock %}
   <section id="contributors" class="contributors-container alt-bg">

--- a/src/templates/base/2019/index.html
+++ b/src/templates/base/2019/index.html
@@ -4,6 +4,12 @@
 {% block image_height %}562{% endblock %}
 {% block image_width %}715{% endblock %}
 
+{% if featured_chapters_exists(lang, year) or featured_chapters_exists('en', year) %}
+{% set year_with_chapters = true %}
+{% else %}
+{% set year_with_chapters = false %}
+{% endif %}
+
 {% block breadcrumb %}
 <script type="application/ld+json">
   {
@@ -32,12 +38,12 @@
       <h1 class="title title-lg title-alt">{{ self.intro_title() }}</h1>
       <h2>{{ self.intro_sub_title() }}</h2>
       {{ self.mission() }}
-      {% if year < "2021" %}
+      {% if year_with_chapters %}
       <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}" class="btn">
         {{ self.start_exploring() }}
       </a>
       {% else %}
-      <a href="{{ url_for('table_of_contents', year=2019, lang=lang) }}" class="btn">
+      <a href="{{ url_for('table_of_contents', year=year|int -1, lang=lang) }}" class="btn">
         {{ self.read_last_years_almanac() }}
       </a>
       {% endif %}
@@ -59,7 +65,11 @@
   {% macro featuredChapter(featured_chapter, featured_chapter_quote, featured_chapter_stats) %}
   <section id="featured-chapter" class="featured-chapter">
     <div class="featured-chapter-content">
+      {% if year_with_chapters %}
       <h2 class="title title-center">{{ self.featured_chapter() }}</h2>
+      {% else %}
+      <h2 class="title title-center">{{ self.featured_chapter_last_year() }}</h2>
+      {% endif %}
       <h3>{{ localizedChapterTitles[featured_chapter] }}</h3>
       <blockquote>
         {{ featured_chapter_quote|safe }}
@@ -84,16 +94,30 @@
         </div>
         {% endif %}
       </div>
+      {% if year_with_chapters %}
       <a href="{{ url_for('chapter', year=year, chapter=featured_chapter, lang=lang) }}" class="btn">
         {{ read_chapter(localizedChapterTitles[featured_chapter]) }}
       </a>
+      {% else %}
+      <a href="{{ url_for('chapter', year=year|int -1, chapter=featured_chapter, lang=lang) }}" class="btn">
+        {{ read_last_years_chapter(localizedChapterTitles[featured_chapter]) }}
+      </a>
+      {% endif %}
     </div>
   </section>
   {% endmacro %}
-  {% if featured_chapters_exists(lang, year) %}
-  {% include "%s/%s/featured_chapters.html" % (lang, year) %}
-  {% elif featured_chapters_exists('en', year) %}
-  {% include "en/%s/featured_chapters.html" % year %}
+  {% if year_with_chapters %}
+    {% if featured_chapters_exists(lang, year) %}
+    {% include "%s/%s/featured_chapters.html" % (lang, year) %}
+    {% elif featured_chapters_exists('en', year) %}
+    {% include "en/%s/featured_chapters.html" % year %}
+    {% endif %}
+  {% else %}
+    {% if featured_chapters_exists(lang, year|int -1) %}
+    {% include "%s/%s/featured_chapters.html" % (lang, year|int -1) %}
+    {% elif featured_chapters_exists('en', year|int -1) %}
+    {% include "en/%s/featured_chapters.html" % (year|int -1) %}
+    {% endif %}
   {% endif %}
   {% endblock %}
   <section id="contributors" class="contributors-container alt-bg">
@@ -137,9 +161,11 @@
       <p class="methodology-info">
         {{ self.methodology_description() }}
       </p>
+      {% if year_with_chapters %}
       <a href="{{ url_for('methodology', year=year, lang=lang) }}" class="alt btn">
         {{ self.methodology_link() }}
       </a>
+      {% endif %}
       <img class="methodology-characters" src="/static/images/methodology-characters.png" alt="" width="984" height="354" loading="lazy" />
     </div>
   </section>

--- a/src/templates/en/2019/base.html
+++ b/src/templates/en/2019/base.html
@@ -85,10 +85,14 @@ Our mission is to combine the raw stats and trends of the HTTP Archive with the 
 {% block accessibility_statement %}Accessibility Statement{% endblock %}
 
 {% block featured_chapter %}Featured Chapter{% endblock %}
+{% block featured_chapter_last_year %}Featured Chapter<br/>from the {{ year|int -1 }} Web Almanac{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}Read the <span class="featured-chapter-name">{{ chapter }}</span> Chapter{% endmacro %}
+{% endif %}
+{% if not read_last_years_chapter %}
+{% macro read_last_years_chapter(chapter) %}Read the {{ year|int-1 }} <span class="featured-chapter-name">{{ chapter }}</span> Chapter{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/en/2020/base.html
+++ b/src/templates/en/2020/base.html
@@ -1,8 +1,5 @@
 {% extends "%s/2019/base.html" % lang %}
 
-{% block featured_chapter %}Featured Chapter<br/>from the 2019 Web Almanac{% endblock %}
-{% macro read_chapter(chapter) %}Read the 2019 <span class="featured-chapter-name">{{ chapter }}</span> Chapter{% endmacro %}
-
 {% block methodology_stat_1 %}7.5M{% endblock %}
 {% block methodology_stat_2 %}31.3 TB{% endblock %}
 {% block methodology_description %}

--- a/src/templates/es/2019/base.html
+++ b/src/templates/es/2019/base.html
@@ -85,11 +85,16 @@ Nuestra misión es combinar las estadísticas y tendencias sin procesar del HTTP
 {% block accessibility_statement %}Declaración de accesibilidad{% endblock %}
 
 {% block featured_chapter %}Capítulo Destacado{% endblock %}
+{% block featured_chapter_last_year %}Capítulo Destacado<br/>del Web Almanac {{ year|int -1 }}{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}Lea el Capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
+{% if not read_last_years_chapter %}
+{% macro read_last_years_chapter(chapter) %}Lea el {{ year|int -1 }} Capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
+{% endif %}
+
 
 {% block contributors_description %}
 Web Almanac ha sido posible gracias al arduo trabajo de la comunidad web. {{ self.contributors() }} personas han ofrecido incontables horas en las fases de planificación, investigación, redacción y producción.

--- a/src/templates/es/2020/base.html
+++ b/src/templates/es/2020/base.html
@@ -1,8 +1,5 @@
 {% extends "%s/2019/base.html" % lang %}
 
-{% block featured_chapter %}Capítulo Destacadobr <br/>del Web Almanac 2019{% endblock %}
-{% macro read_chapter(chapter) %}Lea el 2019 Capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
-
 {% block methodology_stat_1 %}7.5M{% endblock %}
 {% block methodology_stat_2 %}31.3 TB{% endblock %}
 {% block methodology_description %}

--- a/src/templates/fr/2019/base.html
+++ b/src/templates/fr/2019/base.html
@@ -86,10 +86,14 @@ Notre mission est de combiner les statistiques brutes et les tendances de HTTP A
 {% block accessibility_statement %}Déclaration d’accessibilité{% endblock %}
 
 {% block featured_chapter %}Focus sur le chapitre…{% endblock %}
+{% block featured_chapter_last_year %}Focus sur le chapitre<br />de le {{ year|int-1 }} Web Almanac{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}Lire le chapitre&nbsp;: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
+{% endif %}
+{% if not read_last_years_chapter %}
+{% macro read_last_years_chapter(chapter) %}Lire le {{ year|int-1 }} chapitre&nbsp;: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/fr/2020/base.html
+++ b/src/templates/fr/2020/base.html
@@ -1,8 +1,5 @@
 {% extends "%s/2019/base.html" % lang %}
 
-{% block featured_chapter %}Focus sur le chapitre<br />de le 2019 Web Almanac{% endblock %}
-{% macro read_chapter(chapter) %}Lire le 2019 chapitre&nbsp;: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
-
 {% block methodology_stat_1 %}7.5&nbsp;M{% endblock %}
 {% block methodology_stat_2 %}31.3&nbsp;TB{% endblock %}
 {% block methodology_description %}

--- a/src/templates/ja/2019/base.html
+++ b/src/templates/ja/2019/base.html
@@ -85,11 +85,15 @@
 {% block copyright %}© Web Almanac. Licensed under <a href="https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/LICENSE">Apache 2.0</a>.{% endblock %}
 {% block accessibility_statement %}アクセシビリティに関する声明{% endblock %}
 
-{% block featured_chapter%}注目の章{% endblock %}
+{% block featured_chapter %}注目の章{% endblock %}
+{% block featured_chapter_last_year %}{{ year|int -1 }} Web Alamanc<br />注目の章{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}<span class="featured-chapter-name">{{ chapter }}</span>の章を読む{% endmacro %}
+{% endif %}
+{% if not read_last_years_chapter %}
+{% macro read_last_years_chapter(chapter) %}<span class="featured-chapter-name">{{ chapter }}</span>の章を読む{{ year|int -1 }}{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/ja/2020/base.html
+++ b/src/templates/ja/2020/base.html
@@ -1,8 +1,5 @@
 {% extends "%s/2019/base.html" % lang %}
 
-{% block featured_chapter%}2019 Web Alamanc<br />注目の章{% endblock %}
-{% macro read_chapter(chapter) %}<span class="featured-chapter-name">{{ chapter }}</span>の章を読む2019{% endmacro %}
-
 {% block methodology_stat_1 %}7.5M{% endblock %}
 {% block methodology_stat_2 %}31.3 TB{% endblock %}
 {% block methodology_description %}

--- a/src/templates/pt/2019/base.html
+++ b/src/templates/pt/2019/base.html
@@ -85,10 +85,14 @@ Nossa missão é combinar as estatísticas brutas e as tendências do HTTP Archi
 {% block accessibility_statement %}Declaração de acessibilidade{% endblock %}
 
 {% block featured_chapter %}Capítulo em Destaque{% endblock %}
+{% block featured_chapter_last_year %}Capítulo em Destaque<br />do Web Almanac {{ year|int -1 }}{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}Leia o Capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
+{% endif %}
+{% if not read_last_years_chapter %}
+{% macro read_last_years_chapter(chapter) %}Leia o {{ year|int -1 }} Capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/pt/2020/base.html
+++ b/src/templates/pt/2020/base.html
@@ -1,8 +1,5 @@
 {% extends "%s/2019/base.html" % lang %}
 
-{% block featured_chapter %}Capítulo em Destaque<br />do Web Almanac 2019{% endblock %}
-{% macro read_chapter(chapter) %}Leia o 2019 Capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
-
 {% block methodology_stat_1 %}7.5M{% endblock %}
 {% block methodology_stat_2 %}31.3 TB{% endblock %}
 {% block methodology_description %}

--- a/src/templates/zh-CHT/2019/base.html
+++ b/src/templates/zh-CHT/2019/base.html
@@ -85,10 +85,14 @@
 {% block accessibility_statement %}無障礙網頁聲明{% endblock %}
 
 {% block featured_chapter %}章節精選{% endblock %}
+{% block featured_chapter_last_year %}精選章節<br/>從 {{ year|int -1 }} Web Almanac{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}閱讀 <span class="featured-chapter-name">{{ chapter }}</span> 章節{% endmacro %}
+{% endif %}
+{% if not read_last_years_chapter %}
+{% macro read_last_years_chapter(chapter) %}閱讀 {{ year|int -1 }} <span class="featured-chapter-name">{{ chapter }}</span> 章節{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/zh-CHT/2020/base.html
+++ b/src/templates/zh-CHT/2020/base.html
@@ -1,8 +1,5 @@
 {% extends "%s/2019/base.html" % lang %}
 
-{% block featured_chapter %}精選章節<br/>從 2019 Web Almanac{% endblock %}
-{% macro read_chapter(chapter) %}閱讀 2019 <span class="featured-chapter-name">{{ chapter }}</span> 章節{% endmacro %}
-
 {% block methodology_stat_1 %}7.5百萬{% endblock %}
 {% block methodology_stat_2 %}31.3 兆位元組{% endblock %}
 {% block methodology_description %}

--- a/src/templates/zh-CN/2019/base.html
+++ b/src/templates/zh-CN/2019/base.html
@@ -84,11 +84,15 @@
 {% block copyright %}© Web Almanac.的许可是基于 <a href="https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/LICENSE">Apache 2.0</a>.{% endblock %}
 {% block accessibility_statement %}无障碍可访问声明{% endblock %}
 
-{% block featured_chapter%}章节精选{% endblock %}
+{% block featured_chapter %}章节精选{% endblock %}
+{% block featured_chapter_last_year %}{{ year|int -1 }} Web Alamanc<br />章节精选{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}阅读 <span class="featured-chapter-name">{{ chapter }}</span> 章节{% endmacro %}
+{% endif %}
+{% if not read_last_years_chapter %}
+{% macro read_last_years_chapter(chapter) %}阅读 {{ year|int -1 }} <span class="featured-chapter-name">{{ chapter }}</span> 章节{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/zh-CN/2020/base.html
+++ b/src/templates/zh-CN/2020/base.html
@@ -1,8 +1,5 @@
 {% extends "%s/2019/base.html" % lang %}
 
-{% block featured_chapter%}2019 Web Almanac章节精选{% endblock %}
-{% macro read_chapter(chapter) %}阅读 2019 <span class="featured-chapter-name">{{ chapter }}</span> 章节{% endmacro %}
-
 {% block methodology_stat_1 %}7.5M{% endblock %}
 {% block methodology_stat_2 %}31.3 TB{% endblock %}
 {% block methodology_description %}


### PR DESCRIPTION
Closes #1405 

Now we have some chapters we can stop referring to the 2019 edition in the 2020 home page.

Only slight issue is that we will see English Featured Quotes in translations until at least one chapter is Translated. Alternative is to drop back to 2019 featured quote for now?