### PR TITLE
Support Markdown in Table of Contents titles

### DIFF
--- a/src/templates/base/2019/chapter.ejs.html
+++ b/src/templates/base/2019/chapter.ejs.html
@@ -13,7 +13,7 @@
 {% set metadata = <%- JSON.stringify(metadata) %> %}
 
 {% block index %}
-  <%- include('toc.html', { headings: toc }) %>
+  <%- include('toc.ejs.html', { headings: toc }) %>
 {% endblock %}
 
 {% block main_content %}

--- a/src/templates/base/2019/toc.ejs.html
+++ b/src/templates/base/2019/toc.ejs.html
@@ -1,9 +1,9 @@
 <ul>
   <% for (let heading of headings ) { %>
     <li>
-        <a href="#<%= heading.id %>"><%= heading.title %></a>
+        <a href="#<%= heading.id %>"><%- heading.title %></a>
         <% if (heading.children && heading.children.length) { %>
-            <%- include('toc.html', { headings: heading.children }) %>
+            <%- include('toc.ejs.html', { headings: heading.children }) %>
         <% } %>
     </li>
   <% } %>   

--- a/src/tools/generate/generate_table_of_contents.js
+++ b/src/tools/generate/generate_table_of_contents.js
@@ -20,7 +20,8 @@ const nest_headings = (source, current_level = 1) => {
     // Pull the first item off of the source list.
     const element = source.shift();
     const id = element.id;
-    const title = element.textContent;
+    // Every title should be in an Anchor element, but let's check to be sure
+    const title = element.firstChild && element.firstChild.nodeName === 'A' ? element.firstChild.innerHTML : element.textContent;
     const level = get_level(element);
 
     const heading = {

--- a/src/tools/scripts/set_lighthouse_urls.sh
+++ b/src/tools/scripts/set_lighthouse_urls.sh
@@ -61,7 +61,7 @@ elif [ "${RUN_TYPE}" == "pull_request" ] && [ "${COMMIT_SHA}" != "" ]; then
     git pull --quiet
     git checkout main
     # Then get the changes
-    CHANGED_FILES=$(git diff --name-only "main...${COMMIT_SHA}" --diff-filter=d content templates | grep -v base.html | grep -v ejs | grep -v base_ | grep -v toc.html | grep -v sitemap | grep -v error.html)
+    CHANGED_FILES=$(git diff --name-only "main...${COMMIT_SHA}" --diff-filter=d content templates | grep -v base.html | grep -v ejs | grep -v base_ | grep -v sitemap | grep -v error.html)
     # Then back to the pull request changes
     git checkout --progress --force "${COMMIT_SHA}"
 


### PR DESCRIPTION
Fixes #1445 

![Table of Content Headings with formatting](https://user-images.githubusercontent.com/10931297/98577306-a8b72f80-22b3-11eb-9290-2078ac0dcf47.png)

This also renames `toc.html` to `toc.ejs.html` in line with our other EJS templates to differentiate them from Jinja Templates.