### PR TITLE
Add author bios to 2020 Markup chapter

### DIFF
--- a/src/content/en/2020/markup.md
+++ b/src/content/en/2020/markup.md
@@ -5,8 +5,8 @@ title: Markup
 description: Markup chapter of the 2020 Web Almanac covering general observations, the use of elements and attributes, as well as trivia and trends.
 authors: [j9t, catalinred, iandevlin]
 j9t_bio: Jens Oliver Meiert is a web developer and author (<a href="https://leanpub.com/css-optimization-basics"><cite>CSS Optimization Basics</cite></a>, <a href="https://leanpub.com/web-development-glossary"><cite>The Web Development Glossary</cite></a>), who works as an engineering manager at <a href="https://www.jimdo.com/">Jimdo</a>. He’s an expert on web development where he specializes in HTML and CSS optimization. Jens contributes to technical standards and regularly writes about his work and research, particularly on his website, <a href="https://meiert.com/en/">meiert.com</a>.
-# catalinred_bio: @@
-# iandevlin_bio: @@
+catalinred_bio: Catalin Rosu is a front-end developer at <a href="https://www.caphyon.com/">Caphyon</a> and currently works on <a href="https://www.wattspeed.com/">Wattspeed</a>. He has a passion for web standards and a keen eye for great UX & UI, things he <a href="https://twitter.com/catalinred">tweets</a> and writes about on <a href="https://catalin.red/">his website</a>.
+iandevlin_bio: Ian Devlin is a web developer who advocates for good, semantic HTML, as well as accessibility. He once wrote a book about <a href="https://www.peachpit.com/store/html5-multimedia-develop-and-design-9780321793935">HTML5 Multimedia</a>, and sporadically writes on <a href="https://iandevlin.com/">his website</a> about the Web and other things. He currently works as a Senior Frontend Engineer at <a href="https://www.real-digital.de/">real.digital</a> in Germany.
 reviewers: [zcorpan, matuzo, bkardell]
 analysts: [Tiggerito]
 translators: []


### PR DESCRIPTION
Progress on #899 and #1432 
Related #1435 

This adds the missing author bios to get the unedited version of this chapter ready for launch.