### PR TITLE
Update headers with code or English language

### DIFF
--- a/src/content/en/2019/caching.md
+++ b/src/content/en/2019/caching.md
@@ -258,7 +258,7 @@ The same data for mobile is shown below. As can be seen, the cacheability of con
 }}
 
 
-## Cache-Control vs Expires
+## `Cache-Control` vs `Expires`
 
 In HTTP/1.0, the `Expires` header was used to indicate the date/time after which the response is considered stale. Its value is a date timestamp, such as:
 
@@ -282,7 +282,7 @@ HTTP/1.1 introduced the `Cache-Control` header, and most modern clients support 
   )
 }}
 
-## Cache-Control directives
+## `Cache-Control` directives
 
 The HTTP/1.1 [specification](https://tools.ietf.org/html/rfc7234#section-5.2.1) includes multiple directives that can be used in the `Cache-Control` response header and are detailed below. Note that multiple can be used in a single response.
 
@@ -369,7 +369,7 @@ Another interesting set of directives to show up in this list are `pre-check` an
 
 In the long tail, there are more than 1,500 erroneous directives in use across 0.28% of responses. These are ignored by clients, and include misspellings such as "nocache", "s-max-age", "smax-age", and "maxage". There are also numerous non-existent directives such as "max-stale", "proxy-public", "surrogate-control", etc. 
 
-## Cache-Control: no-store, no-cache and max-age=0
+## `Cache-Control`: `no-store`, `no-cache` and `max-age=0`
 
 When a response is not cacheable, the `Cache-Control` `no-store` directive should be used. If this directive is not used, then the response is cacheable.
 
@@ -542,7 +542,7 @@ Examples of some of the invalid uses of the `Expires` header are:
 
 The largest source of invalid `Expires` headers is from assets served from a popular third-party, in which a date/time uses the EST time zone, for example `Expires: Tue, 27 Apr 1971 19:44:06 EST`.
 
-## Vary header
+## `Vary` header
 
 One of the most important steps in caching is determining if the resource being requested is cached or not. While this may seem simple, many times the URL alone is not enough to determine this. For example, requests with the same URL could vary in what [compression](./compression) they used (gzip, brotli, etc.) or be modified and tailored for mobile visitors.
 

--- a/src/content/es/2019/media.md
+++ b/src/content/es/2019/media.md
@@ -250,7 +250,7 @@ La ventaja de este test AB <i lang="en">Lighthouse</i> no es solo la potencial r
   )
 }}
 
-### Imágenes adaptables (responsive)
+### Imágenes adaptables (<i lang="en">responsive</i>) {imágenes-adaptables-responsive}
 
 Otra forma de mejorar el rendimiento de la página es usar imágenes <i lang="en">responsive</i>. Esta técnica se basa en la reducción de bytes por imagen, mediante la reducción de aquellos pixeles de más que no estarán visibles debido al encogimiento de la imagen. Al comenzar este capítulo, viste cómo la página web media, en escritorio, usaba un MP de marcadores de imagen aunque transfiere 2,1 MP de volumen de pixel. Dado que esto era un test de 1x DPR, 1,1 MP de píxeles fueron transferidos por la red, pero no mostrados. Para reducir esta carga, podemos usar cualquiera de estas dos (posiblemente tres) técnicas:
 
@@ -304,7 +304,7 @@ La utilidad de `srcset` normalmente depende de la precisión de la media query `
   )
 }}
 
-### Client Hints
+### <i lang="en">Client Hints</i> {client-hints}
 
 Los <i lang="en">[Client Hints](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints)</i> permiten a los creadores de contenido cambiar el redimensionamiento de imágenes por la negociación de contenido HTTP. De este modo, el HTML no necesita de `<img srcset>` adicionales para reordenar el marcado, y en su lugar depende de un servidor o [imagen CDN para elegir la imagen óptima](https://cloudinary.com/blog/client_hints_and_responsive_images_what_changed_in_chrome_67) en cada contexto. Esto permite simplificar el HTML y habilita a los servidores de origen para adaptar y desconectar el contenido y las capas de presentación.
 
@@ -333,7 +333,7 @@ De los <i lang="en">Client Hints</i> solicitados, la mayoría de las páginas lo
 
 Los <i lang="en">Client Hints</i> relacionados con la red, `downlink`, `rtt`, y `ect`, solamente están disponibles en Android Chrome.
 
-### Lazy loading
+### <i lang="en">Lazy loading</i> {lazy-loading}
 
 Mejorar el rendimiento de una página web puede ser parcialmente descrito como un juego de ilusiones; moviendo las cosas más lentas fuera de banda y lejos de la vista del usuario. De este modo, el <i lang="en">lazy loading</i> de imágenes es una de esas ilusiones donde la imagen y el contenido multimedia solamente se cargan cuando el usuario se desplaza por la página. Esto mejora el rendimiento que se percibe, incluso en conexiones lentas, y evita al usuario la descarga de bytes que no van a estar visibles.
 

--- a/src/content/fr/2019/accessibility.md
+++ b/src/content/fr/2019/accessibility.md
@@ -266,7 +266,7 @@ Actuellement, 46,91&nbsp;% des pages utilisent au moins un attribut de rôle ARI
 
 En examinant les résultats de la figure 9.9, nous avons trouvé deux informations intéressantes&nbsp;: la mise à jour des <i lang="en">frameworks</i> d’interface pourrait avoir un impact profond sur l’accessibilité sur le web, et le nombre impressionnant de sites tentant de rendre les modales accessibles.
 
-##### Mettre à jour les <i lang="en">frameworks</i> d’interface pourrait être la voie à suivre pour l’accessibilité du web
+##### Mettre à jour les <i lang="en">frameworks</i> d’interface pourrait être la voie à suivre pour l’accessibilité du web {mettre-à-jour-les-frameworks-d’interface-pourrait-être-la-voie-à-suivre-pour-l’accessibilité-du-web}
 
 Les 5 premiers rôles, tous apparaissant sur 11&nbsp;% des pages ou plus, sont des rôles de type <i lang="en">landmark</i>. Ils sont utilisés pour faciliter la navigation, pas pour décrire les fonctionnalités d’un widget, comme une zone de liste déroulante. C’est un résultat surprenant, car le principal facteur de motivation du développement d’ARIA était justement de donner aux développeurs et développeuses web la possibilité de décrire la fonctionnalité de widgets constitués d’éléments HTML génériques (comme un `<div>`).
 

--- a/src/content/fr/2019/caching.md
+++ b/src/content/fr/2019/caching.md
@@ -113,7 +113,7 @@ Si aucun en-tête de mise en cache n'est renseigné dans la réponse, alors [l'a
   )
 }}
 
-## Quel type de contenu met-on en cache&nbsp;?
+## Quel type de contenu met-on en cache&nbsp;? {quel-type-de-contenu-met-on-en-cache}
 
 Une ressource mise en cache est stockée par le client pendant un certain temps et peut être réutilisée ultérieurement. Pour les requêtes HTTP, 80&nbsp;% des réponses peuvent certainement être mises en cache, ce qui signifie qu'un système de cache peut les stocker. En dehors de ça,
 
@@ -258,7 +258,7 @@ Les mêmes données pour le mobile sont présentées ci-dessous. Comme on peut l
 }}
 
 
-## Cache-Control vs Expires
+## `Cache-Control` vs `Expires`
 
 Dans HTTP/1.0, l'en-tête `Expires` était utilisé pour indiquer la date/heure après laquelle la réponse était considérée comme périmée. Sa valeur est un horodatage, par exemple&nbsp;:
 
@@ -282,7 +282,7 @@ HTTP/1.1 a introduit l'en-tête `Cache-Control`, et la plupart des clients moder
   )
 }}
 
-## Directives Cache-Control
+## Directives `Cache-Control`
 
 La [specification](https://tools.ietf.org/html/rfc7234#section-5.2.1)  HTTP/1.1 inclut de multiples directives qui peuvent être utilisées dans l'en-tête de réponse `Cache-Control` et sont détaillées ci-dessous. Notez que plusieurs directives peuvent être utilisées dans une seule réponse.
 
@@ -369,7 +369,7 @@ Un autre ensemble intéressant de directives à faire apparaître dans cette lis
 
 Il y a plus de 1&nbsp;500 directives erronées utilisées dans 0,28&nbsp;% des réponses. Ces directives sont ignorées par les clients, comprennent des erreurs d'orthographe telles que `nocache`, `s-max-age`, `smax-age` et `maxage`. Il y a aussi de nombreuses directives inexistantes comme `max-stale`, `proxy-public`, `subsrogate-control`, etc.
 
-## Cache-Control&nbsp;: no-store, no-cache et max-age=0
+## `Cache-Control`&nbsp;: `no-store`, `no-cache` et `max-age=0` {cache-control-no-store-no-cache-et-max-age0}
 
 Lorsqu'une réponse ne doit pas être mise en cache, la directive `Cache-Control` `no-store` doit être utilisée. Si cette directive n'est pas utilisée, alors la réponse peut être mise en cache.
 
@@ -386,7 +386,7 @@ Plus de 3 millions de réponses comprennent la combinaison de `no-store`, `no-ca
 
 La directive `max-age=0` est présente sur 1,1&nbsp;% des réponses (plus de quatre millions de réponses) où `no-store` n'est pas présent. Ces ressources seront mises en cache dans le navigateur mais devront être revalidées car elles sont immédiatement expirées.
 
-## Comment les TTL de cache se comparent-ils à l'âge des ressources&nbsp;?
+## Comment les TTL de cache se comparent-ils à l'âge des ressources&nbsp;? {comment-les-ttl-de-cache-se-comparent-ils-à-lâge-des-ressources}
 
 Jusqu'à présent, nous avons parlé de la façon dont les serveurs Web indiquent à un client ce qui peut être mis en cache, et pendant combien de temps. Lors de la conception des règles de mise en cache, il est également important de comprendre l'âge du contenu que vous servez.
 
@@ -542,7 +542,7 @@ Voici des exemples d'utilisations incorrectes de l'en-tête `Expires`&nbsp;:
 
 La plus grande source d'en-têtes `Expires` invalides provient de ressources servies par une tierce partie , dans lesquels un horodatage utilise le fuseau horaire EST, par exemple `Expires: Tue, 27 Apr 1971 19:44:06 EST`.
 
-## En-tête Vary
+## En-tête `Vary`
 
 L'une des étapes les plus importantes de la mise en cache est de déterminer si la ressource demandée est mise en cache ou non. Bien que cela puisse paraître simple, il arrive souvent que l'URL seule ne suffise pas à le déterminer. Par exemple, les requêtes ayant la même URL peuvent varier en fonction de la [compression](./compression) utilisée (gzip, brotli, etc.) ou être modifiées et adaptées aux visiteurs mobiles.
 

--- a/src/content/fr/2019/javascript.md
+++ b/src/content/fr/2019/javascript.md
@@ -30,7 +30,7 @@ La spécification du langage elle-même, ainsi que les nombreuses bibliothèques
 
 [HTTP Archive](https://httparchive.org/) parcourt [des millions de pages](https://httparchive.org/reports/state-of-the-web#numUrls) chaque mois et les soumet à une instance privée de [WebPageTest](https://webpagetest.org/) pour stocker les informations clés de chaque page (vous pouvez en savoir plus à ce sujet dans notre [méthodologie](./methodology)). Dans le contexte de JavaScript, HTTP Archive fournit des informations détaillées sur l’utilisation du langage pour l’ensemble du web. Ce chapitre regroupe et analyse un grand nombre de ces tendances.
 
-## Combien de JavaScript utilisons-nous&nbsp;?
+## Combien de JavaScript utilisons-nous&nbsp;? {combien-de-javascript-utilisons-nous}
 
 JavaScript est la ressource la plus consommatrice que nous envoyons aux navigateurs&nbsp;: il doit être téléchargé, analysé, compilé et enfin exécuté. Bien que les navigateurs aient considérablement réduit le temps nécessaire pour analyser et compiler les scripts, [le téléchargement et l’exécution sont devenus les étapes les plus coûteuses](https://v8.dev/blog/cost-of-javascript-2019) lorsque JavaScript est traité par une page web.
 
@@ -420,7 +420,7 @@ Atomics (0,38&nbsp;%) et SharedArrayBuffer (0,20&nbsp;%) sont à peine visibles 
 
 Il est important de noter que les chiffres indiqués ici sont des approximations et qu’ils ne s’appuient pas sur [UseCounter](https://chromium.googlesource.com/chromium/src.git/+/master/docs/use_counter_wiki.md) pour mesurer l’utilisation des fonctionnalités.
 
-## Cartographies de code source (source maps)
+## Cartographies de code source (<i lang="en">source maps</i>) {cartographies-de-code-source-source-maps}
 
 Dans de nombreux moteurs de compilation, les fichiers JavaScript subissent une minification afin de minimiser leur taille et une transpilation pour les nouvelles fonctionnalités du langage qui ne sont pas encore prises en charge par de nombreux navigateurs. Par ailleurs, les surensembles de langage comme [TypeScript](https://www.typescriptlang.org/) se compilent en un résultat qui peut être sensiblement différent du code source original. Pour toutes ces raisons, le code final servi au navigateur peut être illisible et difficile à déchiffrer.
 

--- a/src/content/fr/2019/media.md
+++ b/src/content/fr/2019/media.md
@@ -332,7 +332,7 @@ En observant la manière dont les Indications Client sont énoncées, on peut vo
 
 Les Indications Client liés au réseau, `downlink`, `rtt`, et `ect`, ne sont disponibles que sur Chrome pour Android.
 
-### Lazy loading
+### <i lang="en">Lazy loading</i> {lazy-loading}
 
 L’amélioration des performances des pages web peut être partiellement caractérisée comme un jeu de miroirs&nbsp;: sans les supprimer, on décale les éléments les plus lents en dehors de la zone d’usage de l’utilisateur. Par exemple, le <span lang="en">lazy loading</span> d’images est une de ces illusions où les images et les contenus médias ne sont chargés que lorsque l’utilisateur fait défiler la page. Cela améliore les performances perçues, même sur des réseaux lents, et évite à l’utilisateur de télécharger des octets qui ne sont pas visualisés autrement.
 

--- a/src/content/fr/2019/resource-hints.md
+++ b/src/content/fr/2019/resource-hints.md
@@ -261,7 +261,7 @@ Les indices de priorités sont [mis en œuvre](https://www.chromestatus.com/feat
 
 85 % de l'utilisation des indices de priorités se fait avec les balises `<img>`. Les indices de priorités sont surtout utilisés pour déprioriser des ressources : 72&nbsp;% de l'utilisation est `importance="low"` ; 28&nbsp;% de l'utilisation est `importance="high"`.
 
-### Le lazy loading natif
+### Le <i lang="en">lazy loading</i> natif {le-lazy-loading-natif}
 
 Le [<i lang="en">lazy loading</i> natif](https://web.dev/native-lazy-loading) est une API native permettant de différer le chargement des images et des iframes situées hors écran. Cela permet de libérer des ressources lors du chargement initial de la page et d'éviter de charger des ressources qui ne sont jamais utilisées. Auparavant, cette technique ne pouvait être réalisée qu'à l'aide de bibliothèques [JavaScript](./javascript) tierces.
 

--- a/src/content/fr/2019/seo.md
+++ b/src/content/fr/2019/seo.md
@@ -413,7 +413,7 @@ Alors que 38,40 % des sites de bureau (33,79 % sur mobile) ont l'attribut HTML
 
 L'analyse n'a pas vérifié la bonne mise en œuvre, par exemple si les différentes versions linguistiques se lient correctement les unes aux autres. Cependant, en examinant la faible adoption d'une version x-default (seulement 3,77 % sur ordinateur et 1,30 % sur mobile), [comme cela est recommandé](https://support.google.com/webmasters/answer/189077?hl=fr), c'est un indicateur que cet élément est complexe et pas toujours facile à bien faire.
 
-### Exploration des SPA (Single Page Application)
+### Exploration des SPA (<i lang="en">Single Page Application</i>) {exploration-des-spa-single-page-application}
 
 Les applications monopages (SPA) construites avec des frameworks comme React et Vue.js ont leur propre complexité SEO. Les sites web utilisant une navigation basée sur le hachage, rendent particulièrement difficile pour les moteurs de recherche de les explorer et de les indexer correctement. Par exemple, Google avait une solution de contournement "AJAX crawling scheme" qui s'est avérée complexe pour les moteurs de recherche ainsi que pour les développeurs, elle a donc été [déconseillée en 2015](https://webmasters.googleblog.com/2015/10/deprecating-notre-ajax-crawling-scheme.html).
 

--- a/src/content/ja/2019/caching.md
+++ b/src/content/ja/2019/caching.md
@@ -258,7 +258,7 @@ TTLの中央値のほとんどは高いですが、低いパーセンタイル�
 }}
 
 
-## Cache-ControlとExpires
+## `Cache-Control`と`Expires`
 
 HTTP/1.0では、`Expires`ヘッダーは、レスポンスが古くなったと見なされる日時を示すために使用されました。その値は、次のような日付のタイムスタンプです。
 
@@ -282,7 +282,7 @@ HTTPレスポンスの53％は、`max-age`ディレクティブを持つ`Cache-C
   )
 }}
 
-## Cache-Controlディレクティブ
+## `Cache-Control`ディレクティブ
 
 HTTP/1.1[仕様](https://tools.ietf.org/html/rfc7234#section-5.2.1)には、`Cache-Control`レスポンスヘッダーで使用できる複数のディレクティブが含まれており、以下で詳しく説明します。1つのレスポンスで複数を使用できることに注意してください。
 
@@ -369,7 +369,7 @@ HTTP/1.1[仕様](https://tools.ietf.org/html/rfc7234#section-5.2.1)には、`Cac
 
 ロングテールでは、レスポンスの0.28％で1,500を超える間違ったディレクティブが使用されています。これらはクライアントによって無視され、「nocache」「s-max-age」「smax-age」「maxage」などのスペルミスが含まれます。「max-stale」「proxy-public」「surrogate-control」など存在しないディレクティブも多数あります。
 
-## Cache-Control: no-store, no-cache and max-age=0
+## `Cache-Control`: `no-store`, `no-cache` and `max-age=0`
 
 レスポンスがキャッシュ可能でない場合、`Cache-Control` `no-store`ディレクティブを使用する必要があります。このディレクティブを使用しない場合、レスポンスはキャッシュ可能です。
 

--- a/src/tools/generate/generate_chapters.js
+++ b/src/tools/generate/generate_chapters.js
@@ -20,6 +20,7 @@ converter.setFlavor('github');
 converter.setOption('simpleLineBreaks', false);
 converter.setOption('tablesHeaderId', false);
 converter.setOption('ghMentions', false);
+converter.setOption('customizedHeaderId', true);
 
 const generate_chapters = async (chapter_match) => {
 


### PR DESCRIPTION
Fixes #656 as raised a long time ago by @borisschapira 

With the addition of Markdown support in Headings (#1445) in pull request #1461 I wanted to have another look at this old issue complaining about weird ids when using HTML in headers - particularly `<i lang="en">...</i>` for accessible translations.

As a reminder of the issue:

While Showdown does support (and correctly remove) markdown in headings to create the ids, it will not do this for HTML.

So this:
```
### Le <i lang="en">lazy loading</i> natif {le-lazy-loading-natif}
```
Gets an id of: `le-i-langenlazy-loadingi-natif`. It's still a valid id (it's correctly stripped the `<` and `>` symbols which would make this invalid) but looks very messy.

However there is another option (`customizedHeaderId`) which when turned on, allows you to optionally specify the header id after the header like this:

```
### Le <i lang="en">lazy loading</i> natif {le-lazy-loading-natif}
```

The risks of this are low: if it is not used the auto generated id will be used as normal, and duplicate ids are checked for during HTML linting. In fact we already have one chapter (French Accessibility) that's already using this incorrectly so we're already getting this wrong. This just offers a way of doing it right.

So I think we should enable this as an option for translators, which this PR does as well as updating the headings I could find from a quick look - also set code headings for caching chapter in all languages.

Let me know your thoughts.