### PR TITLE
Fix chapter hero image metadata URLs

### DIFF
--- a/src/templates/base/2019/base_chapter.html
+++ b/src/templates/base/2019/base_chapter.html
@@ -5,7 +5,7 @@
 {% block date_published %}{{ metadata.published }}{% endblock %}
 {% block date_modified %}{{ metadata.last_updated }}{% endblock %}
 
-{% block image_url %}https://almanac.httparchive.org/images/2019/{{ metadata.chapter }}/hero_lg.jpg{% endblock %}
+{% block image_url %}https://almanac.httparchive.org/static/images/2019/{{ metadata.chapter }}/hero_lg.jpg{% endblock %}
 {% block image_height %}433{% endblock %}
 {% block image_width %}866{% endblock %}
 

--- a/src/templates/en/2019/base_chapter.html
+++ b/src/templates/en/2019/base_chapter.html
@@ -1,6 +1,6 @@
 {% extends "base/2019/base_chapter.html" %}
 
-{% block title %}{{ metadata.get('title') }} | 2019 | The Web Almanac by HTTP Archive{% endblock %}
+{% block title %}{{ metadata.get('title') }} | {{ year }} | The Web Almanac by HTTP Archive{% endblock %}
 
 {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac probing into the use of ' + metadata.get('description',metadata.get('title')) + ' on the web.') }}{% endblock %}
 

--- a/src/templates/es/2019/base_chapter.html
+++ b/src/templates/es/2019/base_chapter.html
@@ -1,6 +1,6 @@
 {% extends "base/2019/base_chapter.html" %}
 
-{% block title %}{{ metadata.get('title') }} | 2019 | Web Almanac por HTTP Archive{% endblock %}
+{% block title %}{{ metadata.get('title') }} | {{ year }} | Web Almanac por HTTP Archive{% endblock %}
 
 {% block description %}{{ metadata.get('description','Capítulo' + metadata.get('title') + ' del Web Almanac '+ year + " explorando el uso de " + metadata.get('description',metadata.get('title')) + ' en la web.') }}{% endblock %}
 

--- a/src/templates/fr/2019/base_chapter.html
+++ b/src/templates/fr/2019/base_chapter.html
@@ -1,6 +1,6 @@
 {% extends "base/2019/base_chapter.html" %}
 
-{% block title %}{{ metadata.get('title') }} | 2019 | Le Web Almanac par HTTP Archive{% endblock %}
+{% block title %}{{ metadata.get('title') }} | {{ year }} | Le Web Almanac par HTTP Archive{% endblock %}
 
 {% block description %}{{ metadata.get('description','Chapitre' + metadata.get('title') + ' du Web Almanac'+ year + " explorant l’utilisation des " + metadata.get('description',metadata.get('title')) + ' sur le web.') }}{% endblock %}
 

--- a/src/templates/ja/2019/base_chapter.html
+++ b/src/templates/ja/2019/base_chapter.html
@@ -1,6 +1,6 @@
 {% extends "base/2019/base_chapter.html" %}
 
-{% block title %}{{ metadata.get('title') }} | 2019 | HTTP ArchiveによるWeb Almanac{% endblock %}
+{% block title %}{{ metadata.get('title') }} | {{ year }} | HTTP ArchiveによるWeb Almanac{% endblock %}
 
 {% block description %}{{ metadata.get('description',metadata.get('title') + ' の章 ' + year + ' Web Almanacの使用状況を調べる ' + metadata.get('description',metadata.get('title')) + ' をウェブ上で公開しています。') }}{% endblock %}
 

--- a/src/templates/pt/2019/base_chapter.html
+++ b/src/templates/pt/2019/base_chapter.html
@@ -1,6 +1,6 @@
 {% extends "base/2019/base_chapter.html" %}
 
-{% block title %}{{ metadata.get('title') }} | 2019 | Web Almanac por HTTP Archive{% endblock %}
+{% block title %}{{ metadata.get('title') }} | {{ year }} | Web Almanac por HTTP Archive{% endblock %}
 
 {% block description %}{{ metadata.get('description',metadata.get('title') + ' capítulo do ' + year + ' Web Almanac sondando o uso de ' + metadata.get('description',metadata.get('title')) + ' na web.') }}{% endblock %}
 

--- a/src/templates/zh-CHT/2019/base_chapter.html
+++ b/src/templates/zh-CHT/2019/base_chapter.html
@@ -1,6 +1,6 @@
 {% extends "base/2019/base_chapter.html" %}
 
-{% block title %}{{ metadata.get('title') }} | 2019 | Web Almanac 精粹自 HTTP Archive{% endblock %}
+{% block title %}{{ metadata.get('title') }} | {{ year }} | Web Almanac 精粹自 HTTP Archive{% endblock %}
 
 {% block description %}{{ metadata.get('description',metadata.get('title') + ' 章節 ' + year + ' Web Almanac 探索使用狀況 ' + metadata.get('description',metadata.get('title')) + ' 在網路中。') }}{% endblock %}
 

--- a/src/templates/zh-CN/2019/base_chapter.html
+++ b/src/templates/zh-CN/2019/base_chapter.html
@@ -1,6 +1,6 @@
 {% extends "base/2019/base_chapter.html" %}
 
-{% block title %}{{ metadata.get('title') }} | 2019 | Web Almanac 源于 HTTP Archive{% endblock %}
+{% block title %}{{ metadata.get('title') }} | {{ year }} | Web Almanac 源于 HTTP Archive{% endblock %}
 
 {% block description %}{{ metadata.get('description',metadata.get('title') + ' 章节 ' + year + ' 调查Web Almanac的使用状况 ' + metadata.get('description',metadata.get('title')) + ' 在 web中。') }}{% endblock %}
 


### PR DESCRIPTION
Progress on #1468 

Image URL paths must start with `/static`