### PR TITLE
Add lang attribute when using fallback quote

### DIFF
--- a/src/templates/base/2019/featured_chapters.ejs.html
+++ b/src/templates/base/2019/featured_chapters.ejs.html
@@ -24,4 +24,4 @@
 <% } -%>
 {% endif %}
 
-{{ featuredChapter(featured_chapter, featured_chapter_quote, featured_chapter_stats) }}
+{{ featuredChapter(featured_chapter, featured_chapter_quote, featured_chapter_stats, "<%- language %>") }}

--- a/src/templates/base/2019/index.html
+++ b/src/templates/base/2019/index.html
@@ -76,38 +76,49 @@
         {{ featured_chapter_quote|safe }}
       </blockquote>
       {% endif %}
-      <div class="featured-chapter-content-data">
+      {% if quote_language != lang %}
+      <div lang="{{ quote_language }}" class="featured-chapter-content-data">
         {% if featured_chapter_stats.get('stat1') %}
         <div class="featured-chapter-content-data-item">
           <div>{{ featured_chapter_stats.get('stat1')|safe }}</div>
-          {% if quote_language != lang %}
-          <div lang="{{ quote_language }}">{{ featured_chapter_stats.get('label1')|safe }}</div>
-          {% else %}
           <div>{{ featured_chapter_stats.get('label1')|safe }}</div>
-          {% endif %}
         </div>
         {% endif %}
         {% if featured_chapter_stats.get('stat2') %}
         <div class="featured-chapter-content-data-item">
           <div>{{ featured_chapter_stats.get('stat2')|safe }}</div>
-          {% if quote_language != lang %}
-          <div lang="{{ quote_language }}">{{ featured_chapter_stats.get('label2')|safe }}</div>
-          {% else %}
           <div>{{ featured_chapter_stats.get('label2')|safe }}</div>
-          {% endif %}
         </div>
         {% endif %}
         {% if featured_chapter_stats.get('stat3') %}
         <div class="featured-chapter-content-data-item">
           <div>{{ featured_chapter_stats.get('stat3')|safe }}</div>
-          {% if quote_language != lang %}
-          <div lang="{{ quote_language }}">{{ featured_chapter_stats.get('label3')|safe }}</div>
-          {% else %}
           <div>{{ featured_chapter_stats.get('label3')|safe }}</div>
-          {% endif %}
         </div>
         {% endif %}
       </div>
+      {% else %}
+      <div class="featured-chapter-content-data">
+        {% if featured_chapter_stats.get('stat1') %}
+        <div class="featured-chapter-content-data-item">
+          <div>{{ featured_chapter_stats.get('stat1')|safe }}</div>
+          <div>{{ featured_chapter_stats.get('label1')|safe }}</div>
+        </div>
+        {% endif %}
+        {% if featured_chapter_stats.get('stat2') %}
+        <div class="featured-chapter-content-data-item">
+          <div>{{ featured_chapter_stats.get('stat2')|safe }}</div>
+          <div>{{ featured_chapter_stats.get('label2')|safe }}</div>
+        </div>
+        {% endif %}
+        {% if featured_chapter_stats.get('stat3') %}
+        <div class="featured-chapter-content-data-item">
+          <div>{{ featured_chapter_stats.get('stat3')|safe }}</div>
+          <div>{{ featured_chapter_stats.get('label3')|safe }}</div>
+        </div>
+        {% endif %}
+      </div>
+      {% endif %}
       {% if year_with_chapters %}
       <a href="{{ url_for('chapter', year=year, chapter=featured_chapter, lang=lang) }}" class="btn">
         {{ read_chapter(localizedChapterTitles[featured_chapter]) }}

--- a/src/templates/base/2019/index.html
+++ b/src/templates/base/2019/index.html
@@ -58,7 +58,7 @@
     </div>
   </section>
   {% block featured_chapter_section %}
-  {% macro featuredChapter(featured_chapter, featured_chapter_quote, featured_chapter_stats) %}
+  {% macro featuredChapter(featured_chapter, featured_chapter_quote, featured_chapter_stats, quote_language) %}
   <section id="featured-chapter" class="featured-chapter">
     <div class="featured-chapter-content">
       {% if year_with_chapters %}
@@ -67,26 +67,44 @@
       <h2 class="title title-center">{{ self.featured_chapter_last_year() }}</h2>
       {% endif %}
       <h3>{{ localizedChapterTitles[featured_chapter] }}</h3>
+      {% if quote_language != lang %}
+      <blockquote lang="{{ quote_language }}">
+        {{ featured_chapter_quote|safe }}
+      </blockquote>
+      {% else %}
       <blockquote>
         {{ featured_chapter_quote|safe }}
       </blockquote>
+      {% endif %}
       <div class="featured-chapter-content-data">
         {% if featured_chapter_stats.get('stat1') %}
         <div class="featured-chapter-content-data-item">
           <div>{{ featured_chapter_stats.get('stat1')|safe }}</div>
+          {% if quote_language != lang %}
+          <div lang="{{ quote_language }}">{{ featured_chapter_stats.get('label1')|safe }}</div>
+          {% else %}
           <div>{{ featured_chapter_stats.get('label1')|safe }}</div>
+          {% endif %}
         </div>
         {% endif %}
         {% if featured_chapter_stats.get('stat2') %}
         <div class="featured-chapter-content-data-item">
           <div>{{ featured_chapter_stats.get('stat2')|safe }}</div>
+          {% if quote_language != lang %}
+          <div lang="{{ quote_language }}">{{ featured_chapter_stats.get('label2')|safe }}</div>
+          {% else %}
           <div>{{ featured_chapter_stats.get('label2')|safe }}</div>
+          {% endif %}
         </div>
         {% endif %}
         {% if featured_chapter_stats.get('stat3') %}
         <div class="featured-chapter-content-data-item">
           <div>{{ featured_chapter_stats.get('stat3')|safe }}</div>
+          {% if quote_language != lang %}
+          <div lang="{{ quote_language }}">{{ featured_chapter_stats.get('label3')|safe }}</div>
+          {% else %}
           <div>{{ featured_chapter_stats.get('label3')|safe }}</div>
+          {% endif %}
         </div>
         {% endif %}
       </div>

--- a/src/tools/generate/generate_featured_chapters.js
+++ b/src/tools/generate/generate_featured_chapters.js
@@ -60,7 +60,7 @@ const write_template = async (language, year, featured_quotes) => {
   const path = `templates/${language}/${year}/featured_chapters.html`;
 
   if (fs.existsSync(template)) {
-    let html = await ejs.renderFile(template, { featured_quotes });
+    let html = await ejs.renderFile(template, { featured_quotes, language });
     await fs.outputFile(path, html, 'utf8');
     await size_of(path);
   }


### PR DESCRIPTION
We fallback to English featured quotes when we have no language-specific ones.

This affects 2020, but also 2019 for languages that have no chapters yet (Traditional Chinese and soon Hindi).

This PR adds `lang="en"` attributes to the parts of the Featured Quotes affected.