### PR TITLE
Add a min height to intro section on mobile

### DIFF
--- a/src/static/css/index.css
+++ b/src/static/css/index.css
@@ -504,6 +504,7 @@ p {
     justify-items: center;
     justify-content: center;
     overflow: hidden;
+    min-height: 1100px;
   }
 
   .intro {


### PR DESCRIPTION
Fixes #1467 

Current versus new:

![image](https://user-images.githubusercontent.com/10931297/98693982-dad69900-2368-11eb-99f0-ceea0e881adf.png) ![image](https://user-images.githubusercontent.com/10931297/98693692-86cbb480-2368-11eb-9dff-1c4f3fade085.png)

Also gives English a bit more breathing space too!:

![image](https://user-images.githubusercontent.com/10931297/98694177-0fe2eb80-2369-11eb-8ee1-4de7b5b7b316.png) ![image](https://user-images.githubusercontent.com/10931297/98694252-21c48e80-2369-11eb-925d-b64b6f198522.png)

