### PR TITLE
Set min-width for translation text to avoid menu errors

### DIFF
--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -1350,6 +1350,7 @@ p.copyright a {
 
 .nav-dropdown-list .help-translate {
   border-top: 1px dashed #bdbdbd;
+  min-width: 10rem;
 }
 
 .footer .nav-dropdown-list .help-translate {

--- a/src/templates/base/2019/base.html
+++ b/src/templates/base/2019/base.html
@@ -329,7 +329,6 @@
             var btnBoundingRect = dropdownBtn.getBoundingClientRect();
             var listBoundingRect = list.getBoundingClientRect();
             if (listBoundingRect.width <= btnBoundingRect.width) {
-              list.style.minWidth = btnBoundingRect.width + "px";
               list.classList.add("align-center");
             } else if (btnBoundingRect.left + listBoundingRect.width > window.innerWidth) {
               list.classList.add("align-right");


### PR DESCRIPTION
Fixes #1466 

The easiest solution here was to set a min-width on the `help-translate` class so this didn't interfere with the year drop down. I use `rem` so it works even on font-zoom.

I also removed an inline style added by JavaScript for these drops downs since it will be ignored thanks to out CSP so wasn't doing anything anyway.