### PR TITLE
Modifications to Caching 2020 queries 

### DIFF
--- a/sql/2020/20_Caching/appcache_and_serviceworkers_2019.sql
+++ b/sql/2020/20_Caching/appcache_and_serviceworkers_2019.sql
@@ -1,0 +1,17 @@
+#standardSQL
+# Use of AppCache and ServiceWorkers
+SELECT
+  IF(STARTS_WITH(url, 'https'), 'https', 'http') AS http_type,
+  JSON_EXTRACT_SCALAR(report, "$.audits.appcache-manifest.score") AS using_appcache,
+  JSON_EXTRACT_SCALAR(report, "$.audits.service-worker.score") AS using_serviceworkers,
+  COUNT(0) AS occurrences,
+  SUM(COUNT(0)) OVER () AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER () AS pct
+FROM 
+  `httparchive.lighthouse.2019_07_01_mobile` 
+GROUP BY 
+  http_type, 
+  using_appcache, 
+  using_serviceworkers
+ORDER BY
+  pct DESC

--- a/sql/2020/20_Caching/cache_ttl_and_content_age_diff.sql
+++ b/sql/2020/20_Caching/cache_ttl_and_content_age_diff.sql
@@ -4,7 +4,7 @@ CREATE TEMPORARY FUNCTION toTimestamp(date_string STRING)
 RETURNS INT64 LANGUAGE js AS '''
   try {
     var timestamp = Math.round(new Date(date_string).getTime() / 1000);
-    return isNaN(timestamp) ? -1 : timestamp;
+    return isNaN(timestamp) || timestamp < 0 ? -1 : timestamp;
   } catch (e) {
     return -1;
   }
@@ -18,7 +18,7 @@ FROM
   (
     SELECT
       _TABLE_SUFFIX AS client,
-      ROUND((expAge - (startedDateTime - toTimestamp(resp_last_modified))) / 86400, 2)  AS diff_in_days
+      ROUND((expAge - (startedDateTime - toTimestamp(resp_last_modified))) / (60 * 60 * 24), 2)  AS diff_in_days
     FROM
       `httparchive.summary_requests.2020_08_01_*`
     WHERE

--- a/sql/2020/20_Caching/cache_ttl_and_content_age_diff.sql
+++ b/sql/2020/20_Caching/cache_ttl_and_content_age_diff.sql
@@ -6,7 +6,7 @@ RETURNS INT64 LANGUAGE js AS '''
     var timestamp = Math.round(new Date(date_string).getTime() / 1000);
     return isNaN(timestamp) || timestamp < 0 ? -1 : timestamp;
   } catch (e) {
-    return -1;
+    return null;
   }
 ''';
 

--- a/sql/2020/20_Caching/cache_ttl_lighthouse_score.sql
+++ b/sql/2020/20_Caching/cache_ttl_lighthouse_score.sql
@@ -1,0 +1,15 @@
+#standardSQL
+# Distribution of cache TTL Lighthouse scores
+SELECT 
+  _TABLE_SUFFIX AS client,
+  JSON_EXTRACT_SCALAR(report, "$.audits.uses-long-cache-ttl.score") AS caching_score,
+  COUNT(*) AS num_pages,
+  COUNT(0) * 100 / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct_pages
+FROM 
+  `httparchive.lighthouse.2020_08_01_*` 
+GROUP BY 
+  client,
+  caching_score
+ORDER BY 
+  client, 
+  caching_score ASC

--- a/sql/2020/20_Caching/cache_ttl_lighthouse_score.sql
+++ b/sql/2020/20_Caching/cache_ttl_lighthouse_score.sql
@@ -3,8 +3,9 @@
 SELECT 
   _TABLE_SUFFIX AS client,
   JSON_EXTRACT_SCALAR(report, "$.audits.uses-long-cache-ttl.score") AS caching_score,
-  COUNT(*) AS num_pages,
-  COUNT(0) * 100 / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct_pages
+  COUNT(0) AS num_pages,
+  SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS  total,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct_pages
 FROM 
   `httparchive.lighthouse.2020_08_01_*` 
 GROUP BY 

--- a/sql/2020/20_Caching/cache_ttl_lighthouse_score.sql
+++ b/sql/2020/20_Caching/cache_ttl_lighthouse_score.sql
@@ -4,7 +4,7 @@ SELECT
   _TABLE_SUFFIX AS client,
   JSON_EXTRACT_SCALAR(report, "$.audits.uses-long-cache-ttl.score") AS caching_score,
   COUNT(0) AS num_pages,
-  SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS  total,
+  SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS total,
   COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct_pages
 FROM 
   `httparchive.lighthouse.2020_08_01_*` 

--- a/sql/2020/20_Caching/cache_wastedbytes_lighthouse.sql
+++ b/sql/2020/20_Caching/cache_wastedbytes_lighthouse.sql
@@ -2,9 +2,10 @@
 # Distribution of bytes wasted (absence of adequate caching) from Lighthouse
 SELECT 
   _TABLE_SUFFIX AS client,
-  ROUND(CAST(JSON_EXTRACT_SCALAR(report, "$.audits.uses-long-cache-ttl.details.summary.wastedBytes")as numeric)/1024/1024) AS mbyte_savings,
-  COUNT(*) num_pages,
-  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct_pages       
+  ROUND(CAST(JSON_EXTRACT_SCALAR(report, "$.audits.uses-long-cache-ttl.details.summary.wastedBytes") AS NUMERIC) / 1024 / 1024) AS mbyte_savings,
+  COUNT(0) AS num_pages,
+  SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct_pages
 FROM 
   `httparchive.lighthouse.2020_08_01_*`
 WHERE

--- a/sql/2020/20_Caching/cache_wastedbytes_lighthouse.sql
+++ b/sql/2020/20_Caching/cache_wastedbytes_lighthouse.sql
@@ -2,7 +2,7 @@
 # Distribution of bytes wasted (absence of adequate caching) from Lighthouse
 SELECT 
   _TABLE_SUFFIX AS client,
-  ROUND(CAST(JSON_EXTRACT_SCALAR(report, "$.audits.uses-long-cache-ttl.details.summary.wastedBytes")as numeric)/1024/1024) mbyte_savings,
+  ROUND(CAST(JSON_EXTRACT_SCALAR(report, "$.audits.uses-long-cache-ttl.details.summary.wastedBytes")as numeric)/1024/1024) AS mbyte_savings,
   COUNT(*) num_pages,
   COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct_pages       
 FROM 

--- a/sql/2020/20_Caching/cache_wastedbytes_lighthouse.sql
+++ b/sql/2020/20_Caching/cache_wastedbytes_lighthouse.sql
@@ -1,0 +1,15 @@
+#standardSQL
+# Distribution of cache wasted bytes from Lighthouse
+SELECT 
+  _TABLE_SUFFIX AS client,
+  JSON_EXTRACT_SCALAR(report, "$.audits.uses-long-cache-ttl.score") AS caching_score,
+  COUNT(*) AS num_pages,
+  COUNT(0) * 100 / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct_pages
+FROM 
+  `httparchive.lighthouse.2020_08_01_*` 
+GROUP BY 
+  client,
+  caching_score
+ORDER BY 
+  client, 
+  caching_score ASC

--- a/sql/2020/20_Caching/content_age_older_than_ttl.sql
+++ b/sql/2020/20_Caching/content_age_older_than_ttl.sql
@@ -6,7 +6,7 @@ RETURNS INT64 LANGUAGE js AS '''
     var timestamp = Math.round(new Date(date_string).getTime() / 1000);
     return isNaN(timestamp) || timestamp < 0 ? -1 : timestamp;
   } catch (e) {
-    return -1;
+    return null;
   }
 ''';
 

--- a/sql/2020/20_Caching/content_age_older_than_ttl.sql
+++ b/sql/2020/20_Caching/content_age_older_than_ttl.sql
@@ -4,7 +4,7 @@ CREATE TEMPORARY FUNCTION toTimestamp(date_string STRING)
 RETURNS INT64 LANGUAGE js AS '''
   try {
     var timestamp = Math.round(new Date(date_string).getTime() / 1000);
-    return isNaN(timestamp) ? -1 : timestamp;
+    return isNaN(timestamp) || timestamp < 0 ? -1 : timestamp;
   } catch (e) {
     return -1;
   }

--- a/sql/2020/20_Caching/content_age_older_than_ttl.sql
+++ b/sql/2020/20_Caching/content_age_older_than_ttl.sql
@@ -28,3 +28,5 @@ FROM
   )
 GROUP BY
   client
+ORDER BY
+  client                

--- a/sql/2020/20_Caching/content_age_older_than_ttl_by_party.sql
+++ b/sql/2020/20_Caching/content_age_older_than_ttl_by_party.sql
@@ -6,7 +6,7 @@ RETURNS INT64 LANGUAGE js AS '''
     var timestamp = Math.round(new Date(date_string).getTime() / 1000);
     return isNaN(timestamp) || timestamp < 0 ? -1 : timestamp;
   } catch (e) {
-    return -1;
+    return null;
   }
 ''';
 

--- a/sql/2020/20_Caching/content_age_older_than_ttl_by_party.sql
+++ b/sql/2020/20_Caching/content_age_older_than_ttl_by_party.sql
@@ -4,7 +4,7 @@ CREATE TEMPORARY FUNCTION toTimestamp(date_string STRING)
 RETURNS INT64 LANGUAGE js AS '''
   try {
     var timestamp = Math.round(new Date(date_string).getTime() / 1000);
-    return isNaN(timestamp) ? -1 : timestamp;
+    return isNaN(timestamp) || timestamp < 0 ? -1 : timestamp;
   } catch (e) {
     return -1;
   }
@@ -20,28 +20,24 @@ FROM
    (
      SELECT
        "desktop" AS client,
-       IF(STRPOS(NET.HOST(requests.url), REGEXP_EXTRACT(NET.HOST(pages.url), r'([\w-]+)'))>0, 1, 3) AS party,
+       IF(NET.HOST(url) IN (
+         SELECT domain FROM `httparchive.almanac.third_parties` WHERE date = '2020-08-01' AND category != 'hosting'
+       ), 'third party', 'first party') AS party,
        requests.expAge - (requests.startedDateTime - toTimestamp(requests.resp_last_modified)) AS diff
      FROM
        `httparchive.summary_requests.2020_08_01_desktop` requests
-     JOIN
-       `httparchive.summary_pages.2020_08_01_desktop` pages
-     ON
-       pages.pageid = requests.pageid 
      WHERE
        TRIM(requests.resp_last_modified) <> "" AND
        expAge > 0
      UNION ALL
      SELECT
        "mobile" AS client,
-       IF(STRPOS(NET.HOST(requests.url), REGEXP_EXTRACT(NET.HOST(pages.url), r'([\w-]+)'))>0, 1, 3) AS party,
+       IF(NET.HOST(url) IN (
+         SELECT domain FROM `httparchive.almanac.third_parties` WHERE date = '2020-08-01' AND category != 'hosting'
+       ), 'third party', 'first party') AS party,
        requests.expAge - (requests.startedDateTime - toTimestamp(requests.resp_last_modified)) AS diff
      FROM
        `httparchive.summary_requests.2020_08_01_mobile` requests
-     JOIN
-       `httparchive.summary_pages.2020_08_01_mobile` pages
-     ON
-       pages.pageid = requests.pageid 
      WHERE
        TRIM(requests.resp_last_modified) <> "" AND
        expAge > 0

--- a/sql/2020/20_Caching/last_modified_and_etag_2019.sql
+++ b/sql/2020/20_Caching/last_modified_and_etag_2019.sql
@@ -1,0 +1,35 @@
+#standardSQL
+# Presence of Last-Modified and ETag header, statistics on weak, strong, and invalid ETag.
+SELECT
+  client,
+  COUNT(0) AS total_requests,
+  COUNTIF(uses_no_etag) AS total_using_no_etag,
+  COUNTIF(uses_etag) AS total_using_etag,
+  COUNTIF(uses_weak_etag) AS total_using_weak_etag,
+  COUNTIF(uses_strong_etag) AS total_using_strong_etag,
+  COUNTIF(NOT uses_weak_etag AND NOT uses_strong_etag AND uses_etag) AS total_using_invalid_etag,
+  COUNTIF(uses_last_modified) AS total_using_last_modified,
+  COUNTIF(uses_etag AND uses_last_modified) AS total_using_both,
+  COUNTIF(NOT uses_etag AND NOT uses_last_modified) AS total_using_neither,
+  COUNTIF(uses_no_etag) / COUNT(0) AS pct_using_no_etag,
+  COUNTIF(uses_etag) / COUNT(0) AS pct_using_etag,
+  COUNTIF(uses_weak_etag) / COUNT(0) AS pct_using_weak_etag,
+  COUNTIF(uses_strong_etag) / COUNT(0) AS pct_using_strong_etag,
+  COUNTIF(NOT uses_weak_etag AND NOT uses_strong_etag AND uses_etag) / COUNT(0) AS pct_using_invalid_etag,
+  COUNTIF(uses_last_modified) / COUNT(0) AS pct_using_last_modified,
+  COUNTIF(uses_etag AND uses_last_modified) / COUNT(0) AS pct_using_both,
+  COUNTIF(NOT uses_etag AND NOT uses_last_modified) / COUNT(0) AS pct_using_neither
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    TRIM(resp_etag) = "" AS uses_no_etag,
+    TRIM(resp_etag) != "" AS uses_etag,
+    TRIM(resp_last_modified) != "" AS uses_last_modified,
+    REGEXP_CONTAINS(TRIM(resp_etag), '^W/\".*\"') AS uses_weak_etag,
+    REGEXP_CONTAINS(TRIM(resp_etag), '^\".*\"') AS uses_strong_etag
+  FROM
+    `httparchive.summary_requests.2019_07_01_*`
+)
+GROUP BY
+  client
+  

--- a/sql/2020/20_Caching/resource_age_party_and_type_wise.sql
+++ b/sql/2020/20_Caching/resource_age_party_and_type_wise.sql
@@ -3,7 +3,7 @@
 CREATE TEMPORARY FUNCTION toTimestamp(date_string STRING)
 RETURNS INT64 LANGUAGE js AS '''
   try {
-    var timestamp = Math.round(new Date(date_string).getTime());
+    var timestamp = Math.round(new Date(date_string).getTime() / 1000);
     return isNaN(timestamp) || timestamp < 0 ? null : timestamp;
   } catch (e) {
     return null;
@@ -17,7 +17,7 @@ SELECT
     SELECT domain FROM `httparchive.almanac.third_parties` WHERE date = '2020-08-01' AND category != 'hosting'
   ), 'third party', 'first party') AS party,
   type AS resource_type,
-  APPROX_QUANTILES(ROUND((startedDateTime - toTimestamp(resp_last_modified)) / (1000 * 60 * 60 * 24 * 7)), 1000 IGNORE NULLS)[OFFSET(percentile * 10)] AS age_weeks
+  APPROX_QUANTILES(ROUND((startedDateTime - toTimestamp(resp_last_modified)) / (60 * 60 * 24 * 7)), 1000 IGNORE NULLS)[OFFSET(percentile * 10)] AS age_weeks
 FROM 
   `httparchive.summary_requests.2020_08_01_*`,
   UNNEST([10, 25, 50, 75, 90]) AS percentile

--- a/sql/2020/20_Caching/resource_age_party_and_type_wise.sql
+++ b/sql/2020/20_Caching/resource_age_party_and_type_wise.sql
@@ -1,0 +1,33 @@
+#standardSQL
+# Age of resources party, type wise.
+CREATE TEMPORARY FUNCTION toTimestamp(date_string STRING)
+RETURNS INT64 LANGUAGE js AS '''
+  try {
+    var timestamp = Math.round(new Date(date_string).getTime() / 1000);
+    return isNaN(timestamp) ? -1 : timestamp;
+  } catch (e) {
+    return -1;
+  }
+''';
+
+SELECT 
+  IF (STRPOS(NET.HOST(requests.url), REGEXP_EXTRACT(NET.REG_DOMAIN(pages.url), r'([\w-]+)')) > 0, 1, 3) AS party,
+  requests.type AS resource_type,
+  ROUND((requests.startedDateTime - toTimestamp(requests.resp_last_modified)) / (86400 * 7)) AS age_weeks,
+  COUNT(0) AS total_requests,
+FROM 
+  `httparchive.summary_requests.2020_08_01_desktop` requests
+JOIN 
+  `httparchive.summary_pages.2020_08_01_desktop` pages
+ON 
+  requests.pageid = pages.pageid
+WHERE 
+  TRIM(requests.resp_last_modified) <> ""
+GROUP BY 
+  party, 
+  resource_type,
+  age_weeks
+ORDER BY
+  resource_type, 
+  party, 
+  age_weeks

--- a/sql/2020/20_Caching/resource_age_party_and_type_wise.sql
+++ b/sql/2020/20_Caching/resource_age_party_and_type_wise.sql
@@ -12,15 +12,16 @@ RETURNS INT64 LANGUAGE js AS '''
 
 SELECT
   percentile,
-  client,
-  IF(NET.HOST(url) = NET.HOST(page), 'first party', 'third party') AS party,
+  _TABLE_SUFFIX AS client,
+  IF(NET.HOST(url) IN (
+    SELECT domain FROM `httparchive.almanac.third_parties` WHERE date = '2020-08-01' AND category != 'hosting'
+  ), 'third party', 'first party') AS party,
   type AS resource_type,
   APPROX_QUANTILES(ROUND((startedDateTime - toTimestamp(resp_last_modified)) / (1000 * 60 * 60 * 24 * 7)), 1000 IGNORE NULLS)[OFFSET(percentile * 10)] AS age_weeks
 FROM 
-  `httparchive.almanac.requests`,
+  `httparchive.summary_requests.2020_08_01_*`,
   UNNEST([10, 25, 50, 75, 90]) AS percentile
 WHERE
-  date = '2020-08-01' AND
   TRIM(resp_last_modified) <> ""
 GROUP BY
   percentile,

--- a/sql/2020/20_Caching/top_domains_using_immutable.sql
+++ b/sql/2020/20_Caching/top_domains_using_immutable.sql
@@ -1,0 +1,19 @@
+#standardSQL
+# The top domains to use immutable Cache-Control directive.
+SELECT 
+  _TABLE_SUFFIX AS client,
+  NET.HOST(url) AS domain, 
+  COUNT(DISTINCT pageid) AS pages, 
+  COUNT(0) AS requests,
+  SUM(COUNT(DISTINCT pageid)) OVER () AS total_pages,
+  SUM(COUNT(0)) OVER() AS total_requests 
+FROM 
+  `httparchive.summary_requests.2020_08_01_*`
+WHERE
+  REGEXP_CONTAINS(resp_cache_control, r'(?i)immutable')
+GROUP BY 
+  client,
+  domain
+ORDER BY 
+  client,
+  requests DESC


### PR DESCRIPTION
Progress on #917 
Carried forward from previous PR (https://github.com/HTTPArchive/almanac.httparchive.org/pull/1318)

**Todo query list**

- [x] Resource age distribution by content type,
- [x] Distribution of Lighthouse scores for the "uses-long-cache-ttl" audit for mobile web pages.
- [x] Distribution of potential byte savings from the Lighthouse caching audit.
- [x] Top domains using immutable in Cache-Control directive.
- [x] Feedback comments on PR being addressed in three similar queries
- [ ] Reworking one query (percentile as per PR review or age wise groups?)
- [ ] Spare slot (for any missing query, none as of now)

**Todo document list**

- [x] Service workers
- [x] How do cache TTLs compare to resource age (graph)?
- [x] Identifying caching opportunities? 