### PR TITLE
Methodology html fixes

### DIFF
--- a/src/templates/en/2020/methodology.html
+++ b/src/templates/en/2020/methodology.html
@@ -407,22 +407,24 @@
 
       <p>
         To that end, this year we've made systematic changes to the way that we seek and select authors:
+      </p>
 
-        <ul>
-          <li>
-            Previous authors were specifically discouraged from writing again to make room for different perspectives.
-          </li>
-          <li>
-            Everyone endorsing 2020 authors were asked to be especially conscious not to nominate people who all look or think alike.
-          </li>
-          <li>
-            Many 2019 authors were Google employees and this year we tried to get a greater balance of perspectives from the broader web community. We believe that the voices in the Web Almanac should be a reflection of the community itself, and not skewed towards any specific company to avoid creating echo chambers.
-          </li>
-          <li>
-            The project leads reviewed all of the author nominations and made an effort to select authors who will bring new perspectives and amplify the voices of underrepresented groups in the community.
-          </li>
-        </ul>
+      <ul>
+        <li>
+          Previous authors were specifically discouraged from writing again to make room for different perspectives.
+        </li>
+        <li>
+          Everyone endorsing 2020 authors were asked to be especially conscious not to nominate people who all look or think alike.
+        </li>
+        <li>
+          Many 2019 authors were Google employees and this year we tried to get a greater balance of perspectives from the broader web community. We believe that the voices in the Web Almanac should be a reflection of the community itself, and not skewed towards any specific company to avoid creating echo chambers.
+        </li>
+        <li>
+          The project leads reviewed all of the author nominations and made an effort to select authors who will bring new perspectives and amplify the voices of underrepresented groups in the community.
+        </li>
+      </ul>
 
+      <p>
         We hope to iterate on this process in the future to ensure that the Web Almanac is a more diverse and inclusive project with contributors from all backgrounds.
       </p>
 

--- a/src/templates/fr/2020/methodology.html
+++ b/src/templates/fr/2020/methodology.html
@@ -424,7 +424,7 @@
         </li>
       </ul>
     
-      <p
+      <p></p>
         Nous espérons réitérer ce processus à l’avenir afin de garantir que le Web Almanac soit un projet plus diversifié et inclusif avec des contributeurs et contributrices de tous horizons.
       </p>
 

--- a/src/templates/fr/2020/methodology.html
+++ b/src/templates/fr/2020/methodology.html
@@ -424,7 +424,7 @@
         </li>
       </ul>
     
-      <p></p>
+      <p>
         Nous espérons réitérer ce processus à l’avenir afin de garantir que le Web Almanac soit un projet plus diversifié et inclusif avec des contributeurs et contributrices de tous horizons.
       </p>
 

--- a/src/templates/fr/2020/methodology.html
+++ b/src/templates/fr/2020/methodology.html
@@ -407,22 +407,24 @@
 
       <p>
         Dans cette optique, nous avons apporté cette année des changements structurels à la manière dont nous recherchons et sélectionnons les auteurs et autrices&nbsp;:
+      </p>
 
-        <ul>
-          <li>
-            Les auteurs et autrices précédentes ont été spécifiquement dissuadés d’écrire à nouveau afin de faire place à des perspectives différentes.
-          </li>
-          <li>
-            Il a été demandé à tous ceux qui soutiennent les auteurs de 2020 d’être particulièrement attentifs à ne pas nommer des personnes qui se ressemblent toutes ou qui pensent de la même façon.
-          </li>
-          <li>
-            De nombreux auteurs de 2019 étaient des personnes employées de Google et cette année, nous avons essayé d’obtenir un meilleur équilibre des perspectives de la communauté du web au sens large. Nous pensons que les voix dans le Web Almanac doivent être le reflet de la communauté elle-même, et non pas être biaisées vers une entreprise spécifique pour éviter de créer des chambres d’écho.
-          </li>
-          <li>
-            Les responsables du projet ont examiné toutes les nominations d’auteurs et d’autrices et se sont efforcés de sélectionner des personnes qui apportent de nouvelles perspectives et amplifient les voix des groupes sous-représentés dans la communauté.
-          </li>
-        </ul>
-
+      <ul>
+        <li>
+          Les auteurs et autrices précédentes ont été spécifiquement dissuadés d’écrire à nouveau afin de faire place à des perspectives différentes.
+        </li>
+        <li>
+          Il a été demandé à tous ceux qui soutiennent les auteurs de 2020 d’être particulièrement attentifs à ne pas nommer des personnes qui se ressemblent toutes ou qui pensent de la même façon.
+        </li>
+        <li>
+          De nombreux auteurs de 2019 étaient des personnes employées de Google et cette année, nous avons essayé d’obtenir un meilleur équilibre des perspectives de la communauté du web au sens large. Nous pensons que les voix dans le Web Almanac doivent être le reflet de la communauté elle-même, et non pas être biaisées vers une entreprise spécifique pour éviter de créer des chambres d’écho.
+        </li>
+        <li>
+          Les responsables du projet ont examiné toutes les nominations d’auteurs et d’autrices et se sont efforcés de sélectionner des personnes qui apportent de nouvelles perspectives et amplifient les voix des groupes sous-représentés dans la communauté.
+        </li>
+      </ul>
+    
+      <p
         Nous espérons réitérer ce processus à l’avenir afin de garantir que le Web Almanac soit un projet plus diversifié et inclusif avec des contributeurs et contributrices de tous horizons.
       </p>
 


### PR DESCRIPTION
As discussed in https://github.com/HTTPArchive/almanac.httparchive.org/pull/1489#discussion_r521919285 we have [technically invalid HTML in the Methodology page](https://validator.w3.org/nu/?doc=https%3A%2F%2Falmanac.httparchive.org%2Fen%2F2020%2Fmethodology)

Great spot @nico3333fr !