### PR TITLE
Fix src/README.md npm installation 

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -39,7 +39,7 @@ env\Scripts\activate.bat
 3. Install generate and run the website:
 
 ```
-npm run install
+npm install
 npm run start
 ```
 


### PR DESCRIPTION
Hello everyone :)

I found a micro typo in the src/README.md file. 
To use the command `npm run install` you should have a install script in package.json.

I suggest `npm install` instead

