### PR TITLE
ToC drop down clean ups

### DIFF
--- a/src/templates/base/2019/base.html
+++ b/src/templates/base/2019/base.html
@@ -115,11 +115,16 @@
 {% set current_title = metadata.get('title') if metadata else None %}
 <div class="table-of-contents-switcher">
   <label for="table-of-contents-switcher-{{switcher_name}}" class="visually-hidden">
-    {{ self.table_of_contents_title() }}
+    {{ self.table_of_contents_switcher() }}
   </label>
   <select id="table-of-contents-switcher-{{switcher_name}}">
-    <option value="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</option>
-    <option value="{{ url_for('table_of_contents', year=year, lang=lang) }}#forward">{{ self.foreword_title() }}</option>
+    {% if request.path.endswith("table-of-contents") %}
+      <option selected disabled value="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</option>
+      <option disabled value="{{ url_for('table_of_contents', year=year, lang=lang) }}#foreword">{{ self.foreword_title() }}</option>
+    {% else %}
+      <option value="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</option>
+      <option value="{{ url_for('table_of_contents', year=year, lang=lang) }}#foreword">{{ self.foreword_title() }}</option>
+    {% endif %}
     {% for part_config in config.outline %}
     {% for chapter_config in part_config.chapters %}
       {% set title = localizedChapterTitles[chapter_config.slug] if localizedChapterTitles[chapter_config.slug]|length else chapter_config.title %}
@@ -188,7 +193,11 @@
   <ul class="nav-dropdown-list hidden {{switcher_name}}-list">
     
     <li class="nav-dropdown-list-part foreword">
+      {% if request.path.endswith("table-of-contents") %}
+      <span class="nav-dropdown-list-current">{{ self.foreword_title() }}</span>
+      {% else %}
       <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.foreword_title() }}</a>
+      {% endif %}
     </li>
 
     {% for part_config in config.outline %}

--- a/src/templates/base/2019/table_of_contents.html
+++ b/src/templates/base/2019/table_of_contents.html
@@ -100,7 +100,7 @@
 
   <section>
     {% if year < "2020" %}
-    <h2 id="forward"><a href="#forward" class="anchor-link">{{ self.foreword_title() }}</a></h2>
+    <h2 id="foreword"><a href="#foreword" class="anchor-link">{{ self.foreword_title() }}</a></h2>
     {{ self.foreword() }}
     {% endif %}
   </section>

--- a/src/templates/en/2019/base.html
+++ b/src/templates/en/2019/base.html
@@ -31,6 +31,7 @@ Our mission is to combine the raw stats and trends of the HTTP Archive with the 
 {% block translation_not_available %}English - not available in English{% endblock %}
 {% block language_switcher %}Language Switcher{% endblock %}
 {% block year_switcher %}Year Switcher{% endblock %}
+{% block table_of_contents_switcher %}Table of Contents Switcher{% endblock %}
 
 {% block home %}Home{% endblock %}
 {% block table_of_contents_title %}Table of Contents{% endblock %}

--- a/src/templates/es/2019/base.html
+++ b/src/templates/es/2019/base.html
@@ -31,6 +31,7 @@ Nuestra misión es combinar las estadísticas y tendencias sin procesar del HTTP
 {% block translation_not_available %}en inglés - no disponible en español{% endblock %}
 {% block language_switcher %}Selector de idioma{% endblock %}
 {% block year_switcher %}Selector de año{% endblock %}
+{% block table_of_contents_switcher %}Selector de Tabla de Contenidos{% endblock %}
 
 {% block home %}Página de inicio{% endblock %}
 {% block table_of_contents_title %}Tabla de Contenidos{% endblock %}

--- a/src/templates/fr/2019/base.html
+++ b/src/templates/fr/2019/base.html
@@ -31,6 +31,7 @@ Notre mission est de combiner les statistiques brutes et les tendances de HTTP A
 {% block translation_not_available %}en anglais - non disponible en français{% endblock %}
 {% block language_switcher %}Sélecteur de langue{% endblock %}
 {% block year_switcher %}Sélecteur d’année{% endblock %}
+{% block table_of_contents_switcher %}Sélecteur de table des matières{% endblock %}
 
 {% block home %}Accueil{% endblock %}
 {% block table_of_contents_title %}Table des matières{% endblock %}

--- a/src/templates/hi/2019/base.html
+++ b/src/templates/hi/2019/base.html
@@ -31,6 +31,7 @@
 {% block translation_not_available %}अंग्रेजी - हिन्दी में उपलब्ध नहीं है{% endblock %}
 {% block language_switcher %}भाषा परिवर्तन करें{% endblock %}
 {% block year_switcher %}वर्ष परिवर्तन करें{% endblock %}
+{% block table_of_contents_switcher %}विषय सूची परिवर्तन करें{% endblock %}
 
 {% block home %}होम{% endblock %}
 {% block table_of_contents_title %}विषय सूची{% endblock %}

--- a/src/templates/ja/2019/base.html
+++ b/src/templates/ja/2019/base.html
@@ -31,6 +31,7 @@
 {% block translation_not_available %}英語-日本語では使用できません{% endblock %}
 {% block language_switcher %}言語ピッカー{% endblock %}
 {% block year_switcher %}年ピッカー{% endblock %}
+{% block table_of_contents_switcher %}年ピッカー{% endblock %}
 
 {% block home %}ホームページ{% endblock %}
 {% block table_of_contents_title %}目次{% endblock %}

--- a/src/templates/pt/2019/base.html
+++ b/src/templates/pt/2019/base.html
@@ -31,6 +31,7 @@ Nossa missão é combinar as estatísticas brutas e as tendências do HTTP Archi
 {% block translation_not_available %}Inglês - não disponível em Português{% endblock %}
 {% block language_switcher %}Selecione o Idioma{% endblock %}
 {% block year_switcher %}Selecione o Ano{% endblock %}
+{% block table_of_contents_switcher %}Selecione o Tabela de Conteúdos{% endblock %}
 
 {% block home %}Início{% endblock %}
 {% block table_of_contents_title %}Tabela de Conteúdos{% endblock %}

--- a/src/templates/zh-CHT/2019/base.html
+++ b/src/templates/zh-CHT/2019/base.html
@@ -31,6 +31,7 @@
 {% block translation_not_available %}英文 - 中文不能使用{% endblock %}
 {% block language_switcher %}選擇語言{% endblock %}
 {% block year_switcher %}選擇年度{% endblock %}
+{% block table_of_contents_switcher %}選擇目錄{% endblock %}
 
 {% block home %}主頁{% endblock %}
 {% block table_of_contents_title %}目錄{% endblock %}

--- a/src/templates/zh-CN/2019/base.html
+++ b/src/templates/zh-CN/2019/base.html
@@ -31,6 +31,7 @@
 {% block translation_not_available %}英语-中文不能使用{% endblock %}
 {% block language_switcher %}语言切换{% endblock %}
 {% block year_switcher %}年份切换{% endblock %}
+{% block table_of_contents_switcher %}目录切换{% endblock %}
 
 {% block home %}主页{% endblock %}
 {% block table_of_contents_title %}目录{% endblock %}


### PR DESCRIPTION
A couple of small clean ups to the ToC drop down menu added in #1393 (FYI @MSakamaki )

- Noticed the anchor link has always been forward instead of foreword (not part of #1393)
- Add "Table of Contents Switcher" label to differentiate from "Table of Contents" entry.
- Disable ToC entries when on ToC page.
