### PR TITLE
Lower HTML cache times to 10 mins for 2020 launch

### DIFF
--- a/src/server/__init__.py
+++ b/src/server/__init__.py
@@ -28,7 +28,7 @@ app = WebAlmanacServer(__name__, template_folder=TEMPLATES_DIR, static_folder=ST
 def add_header(response):
     # Make sure bad responses are not cached
     #
-    # Cache good responses for 3 hours if no other Cache-Control header set
+    # Cache good responses for 10 mins if no other Cache-Control header set
     # This is used for the dynamically generated files (e.g. the HTML)
     # (currently don't use unique filenames so cannot use long caches and
     # some say they are overrated anyway as caches smaller than we think).
@@ -40,7 +40,7 @@ def add_header(response):
             response.cache_control.max_age = 0
         if response.status_code == 200 or response.status_code == 304:
             response.cache_control.public = True
-            response.cache_control.max_age = 10800
+            response.cache_control.max_age = 600
     return response
 
 


### PR DESCRIPTION
Reduce the HTML cache times from 3 hours to 10 mins as we may be releasing a lot over next month and may not want to wait 3 hours for people to see updates.

Tested on [a staging link](https://20201113t101644-dot-webalmanac.uk.r.appspot.com/en/2019/) to ensure this is what App Engine uses and looks good.

Note I've left the static content at 3 hours - including images for figure fallback. I think that's OK as think 10 mins is a little short for that but let me know your thoughts. If we change CSS or JS then they should have a unique Hash so they shouldn't matter.

The first hit for uncached dynamic content is a little slower as App Engine starts up, which is why I went with the 3 hours in the first place. We should measure impact to our Core Web Vitals to see if we just stick with this year round or revert back after things die down a little.