### PR TITLE
Misc fixes for ToC dropdown

### DIFF
--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -1414,8 +1414,8 @@ div.js-show,
   flex-direction: column;
 }
 
-.nav-dropdown-list-chapter.ebook small {
-  padding: 0 0 24px 20px;
+.nav-dropdown-list-chapter.ebook {
+  padding: 0 0 24px 24px;
 }
 
 .nav-dropdown-list-todo,

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -972,6 +972,10 @@ p.copyright a {
   display: none;
 }
 
+button.js-unhide {
+  display: none;
+}
+
 #skiptocontent a {
   padding: 6px;
   position: absolute;

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -659,13 +659,6 @@ header .cta {
   transform: rotate(135deg);
 }
 
-.js-switcher-menu::after {
-  height: 0;
-  width: 0;
-  margin-top: 0;
-  border: 0;
-}
-
 .table-of-contents-switcher select,
 .language-switcher select,
 .year-switcher select {
@@ -979,8 +972,7 @@ p.copyright a {
   display: none;
 }
 
-button.js-unhide,
-select.js-unhide {
+div.js-show {
   display: none;
 }
 

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -1431,7 +1431,9 @@ div.js-show,
 }
 
 @media (prefers-reduced-motion: reduce) {
-  *, ::before, ::after {
+  *,
+  ::before,
+  ::after {
     animation-delay: -1ms !important;
     animation-duration: 1ms !important;
     animation-iteration-count: 1 !important;

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -1291,7 +1291,8 @@ div.js-show,
   outline: revert;
 }
 
-.nav-dropdown-btn::after {
+.nav-dropdown-btn::after,
+.nav-dropdown-list-current::after {
   content: "";
   position: absolute;
   pointer-events: none;
@@ -1309,10 +1310,26 @@ div.js-show,
   transition: all 200ms linear;
 }
 
-.nav-dropdown-btn.dropdown-open::after {
+.nav-dropdown-btn.dropdown-open::after,
+.nav-dropdown-list-current::after {
   width: 17px;
   right: 16px;
   margin-top: -9px;
+}
+
+.table-of-contents .nav-dropdown-btn.dropdown-open::after {
+  height: 7px;
+  width: 7px;
+  margin-top: -2px;
+  right: 23px;
+  -webkit-transform: rotate(-45deg);
+  -ms-transform: rotate(-45deg);
+  transform: rotate(-45deg);
+}
+
+.nav-dropdown-list-current {
+  position: relative;
+  color: #f7f779;
 }
 
 .nav-dropdown-list {
@@ -1403,7 +1420,7 @@ div.js-show,
 
 .nav-dropdown-list-todo,
 .nav-dropdown-list-current {
-  opacity: 0.3;
+  opacity: 0.5;
 }
 
 .nav-dropdown-list .help-translate {

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -979,10 +979,6 @@ p.copyright a {
   cursor: unset;
 }
 
-.nav-dropdown-btn.js-hide::after {
-  border: 0;
-}
-
 #skiptocontent a {
   padding: 6px;
   position: absolute;

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -968,10 +968,7 @@ p.copyright a {
   white-space: nowrap; /* added line */
 }
 
-.hidden {
-  display: none;
-}
-
+.hidden,
 div.js-show,
 #menu.js-show {
   display: none;

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -659,6 +659,13 @@ header .cta {
   transform: rotate(135deg);
 }
 
+.js-switcher-menu::after {
+  height: 0;
+  width: 0;
+  margin-top: 0;
+  border: 0
+}
+
 .table-of-contents-switcher select,
 .language-switcher select,
 .year-switcher select {
@@ -972,7 +979,8 @@ p.copyright a {
   display: none;
 }
 
-button.js-unhide {
+button.js-unhide,
+select.js-unhide {
   display: none;
 }
 

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -1432,3 +1432,15 @@ div.js-show,
   border-bottom: 1px dashed #bdbdbd;
   border-top: none;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *, ::before, ::after {
+    animation-delay: -1ms !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    background-attachment: initial !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+  }
+}

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -968,9 +968,19 @@ p.copyright a {
   white-space: nowrap; /* added line */
 }
 
-.hidden,
-.js-show {
-  display: none;
+.hidden {
+  display: none !important;
+}
+
+.nav-dropdown-btn.js-enable,
+.nav-dropdown-btn.js-enable:hover {
+  opacity: 0.5;
+  color: unset;
+  cursor: unset;
+}
+
+.nav-dropdown-btn.js-hide:after {
+  border: 0;
 }
 
 #skiptocontent a {

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -979,7 +979,7 @@ p.copyright a {
   cursor: unset;
 }
 
-.nav-dropdown-btn.js-hide:after {
+.nav-dropdown-btn.js-hide::after {
   border: 0;
 }
 

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -972,7 +972,8 @@ p.copyright a {
   display: none;
 }
 
-div.js-show {
+div.js-show,
+#menu.js-show {
   display: none;
 }
 

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -663,7 +663,7 @@ header .cta {
   height: 0;
   width: 0;
   margin-top: 0;
-  border: 0
+  border: 0;
 }
 
 .table-of-contents-switcher select,

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -1412,9 +1412,6 @@ div.js-show,
 .nav-dropdown-list-chapter.ebook {
   display: flex;
   flex-direction: column;
-}
-
-.nav-dropdown-list-chapter.ebook {
   padding: 0 0 24px 24px;
 }
 

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -969,8 +969,7 @@ p.copyright a {
 }
 
 .hidden,
-div.js-show,
-#menu.js-show {
+.js-show {
   display: none;
 }
 

--- a/src/templates/base/2019/base.html
+++ b/src/templates/base/2019/base.html
@@ -113,12 +113,12 @@
 
 {% macro native_table_of_contents_dropdown(switcher_name) %}
 {% set current_title = metadata.get('title') if metadata else None %}
-<div class="table-of-contents-switcher js-switcher-menu">
+<a class="js-hide" href="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</a>
+<div class="table-of-contents-switcher js-show">
   <label for="table-of-contents-switcher-{{switcher_name}}" class="visually-hidden">
     {{ self.table_of_contents_switcher() }}
   </label>
-  <a class="js-hide" href="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</a>
-  <select id="table-of-contents-switcher-{{switcher_name}}" class="js-unhide">
+  <select id="table-of-contents-switcher-{{switcher_name}}">
     {% if request.path.endswith("table-of-contents") %}
       <option selected disabled value="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</option>
       <option disabled value="{{ url_for('table_of_contents', year=year, lang=lang) }}#foreword">{{ self.foreword_title() }}</option>
@@ -187,9 +187,9 @@
 
 {% macro styled_table_of_contents_dropdown(switcher_name) %}
 {% set current_title = metadata.get('title') if metadata else None %}
-<div class="nav-dropdown {{switcher_name}} table-of-contents">
-  <a class="js-hide" href="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</a>
-  <button class="nav-dropdown-btn js-unhide" aria-expanded="false" aria-label="{{ self.table_of_contents_title() }}" >
+<a class="js-hide" href="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</a>
+<div class="nav-dropdown {{switcher_name}} table-of-contents js-show">
+  <button class="nav-dropdown-btn" aria-expanded="false" aria-label="{{ self.table_of_contents_title() }}" >
     {{ self.table_of_contents_title() }}
   </button>
   <ul class="nav-dropdown-list hidden {{switcher_name}}-list">
@@ -444,11 +444,8 @@
         document.querySelectorAll('.js-hide').forEach(element => {
           element.classList.add('hidden');
         });
-        document.querySelectorAll('.js-unhide').forEach(element => {
-          element.classList.remove('js-unhide');
-        });
-        document.querySelectorAll('.js-switcher-menu').forEach(element => {
-          element.classList.remove('js-switcher-menu');
+        document.querySelectorAll('.js-show').forEach(element => {
+          element.classList.remove('js-show');
         });
 
         // Language and Year switching
@@ -594,7 +591,7 @@
 {% endmacro %}
 
 {% macro native_lang_dropdown(switcher_name) %}
-  <div class="language-switcher js-switcher-menu">
+  <div class="language-switcher js-show">
     <label for="language-switcher-{{switcher_name}}" class="visually-hidden">{{ self.language_switcher() }}</label>
     <select id="language-switcher-{{switcher_name}}">
       {% for l in supported_languages | sort(attribute='_local_name') %}
@@ -619,7 +616,7 @@
 {% endmacro %}
 
 {% macro styled_lang_dropdown(switcher_name) %}
-  <div class="nav-dropdown {{switcher_name}}">
+  <div class="nav-dropdown {{switcher_name}} js-show">
     <button class="nav-dropdown-btn" aria-expanded="false" aria-label="{{ self.language_switcher() }}" >{{ language }}</button>
     <ul class="nav-dropdown-list hidden {{switcher_name}}-list">
       {% for l in supported_languages | sort(attribute='_local_name') %}
@@ -734,7 +731,7 @@
 {%- endmacro %}
 
 {% macro native_year_dropdown(switcher_name)%}
-  <div class="year-switcher js-switcher-menu">
+  <div class="year-switcher js-show">
     <label for="year-switcher-{{switcher_name}}" class="visually-hidden">{{ self.year_switcher() }}</label>
     <select id="year-switcher-{{switcher_name}}">
       {% for y in supported_years | sort %}
@@ -766,7 +763,7 @@
 {% endmacro %}
 
 {% macro styled_year_dropdown(switcher_name)%}
-  <div class="nav-dropdown {{switcher_name}}">
+  <div class="nav-dropdown {{switcher_name}} js-show">
     <button class="nav-dropdown-btn" aria-expanded="false" aria-label="{{ self.year_switcher() }}">{{ year }}</button>
     <ul class="nav-dropdown-list hidden {{switcher_name}}-list">
       {% for y in supported_years | sort %}

--- a/src/templates/base/2019/base.html
+++ b/src/templates/base/2019/base.html
@@ -114,7 +114,7 @@
 {% macro native_table_of_contents_dropdown(switcher_name) %}
 {% set current_title = metadata.get('title') if metadata else None %}
 <a class="js-hide" href="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</a>
-<div class="table-of-contents-switcher js-show">
+<div class="table-of-contents-switcher js-enable hidden" disabled>
   <label for="table-of-contents-switcher-{{switcher_name}}" class="visually-hidden">
     {{ self.table_of_contents_switcher() }}
   </label>
@@ -189,8 +189,8 @@
 
 {% macro styled_table_of_contents_dropdown(switcher_name) %}
 {% set current_title = metadata.get('title') if metadata else None %}
-<a class="js-hide" href="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</a>
-<div class="nav-dropdown {{switcher_name}} table-of-contents js-show">
+<a class="nav-dropdown-btn js-hide" href="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</a>
+<div class="nav-dropdown {{switcher_name}} table-of-contents js-enable hidden" disabled>
   <button class="nav-dropdown-btn" aria-expanded="false" aria-label="{{ self.table_of_contents_title() }}" >
     {{ self.table_of_contents_title() }}
   </button>
@@ -305,8 +305,13 @@
             </li>
           </ul>
         </nav>
-        <nav aria-label="{{ self.menu_title() }}" id="menu" aria-labelledby="menu-btn" class="js-show">
-          <button type="button" class="menu-btn" id="menu-btn" aria-label="{{ self.open_the_menu() }}" aria-expanded="false" data-open-text="{{ self.open_the_menu() }}" data-close-text="{{ self.close_the_menu() }}">
+        <nav id="menu" aria-labelledby="menu-btn">
+          <a href="#footer" class="menu-btn js-hide" aria-label="{{ self.menu_title() }}">
+            <span class="menu-btn__bar"></span>
+            <span class="menu-btn__bar"></span>
+            <span class="menu-btn__bar"></span>
+          </a>
+          <button type="button" class="menu-btn js-enable hidden" disabled id="menu-btn" aria-label="{{ self.open_the_menu() }}" aria-expanded="false" data-open-text="{{ self.open_the_menu() }}" data-close-text="{{ self.close_the_menu() }}">
             <span class="menu-btn__bar"></span>
             <span class="menu-btn__bar"></span>
             <span class="menu-btn__bar"></span>
@@ -467,10 +472,14 @@
     <script nonce="{{ csp_nonce() }}">
       (function() {
         document.querySelectorAll('.js-hide').forEach(element => {
-          element.classList.add('hidden');
+          // Don't just hide it - delete it completely to avoid any specifity issues
+          element.parentNode.removeChild(element);
         });
-        document.querySelectorAll('.js-show').forEach(element => {
-          element.classList.remove('js-show');
+        document.querySelectorAll('.js-enable').forEach(element => {
+          element.classList.remove('js-enable');
+          element.classList.remove('hidden');
+          element.disabled = false;
+          element.hidden = false;
         });
 
         // Language and Year switching
@@ -641,8 +650,8 @@
 {% endmacro %}
 
 {% macro styled_lang_dropdown(switcher_name) %}
-  <div class="nav-dropdown {{switcher_name}} js-show">
-    <button class="nav-dropdown-btn" aria-expanded="false" aria-label="{{ self.language_switcher() }}" >{{ language }}</button>
+  <div class="nav-dropdown {{switcher_name}}">
+    <button class="nav-dropdown-btn js-enable" disabled aria-expanded="false" aria-label="{{ self.language_switcher() }}" >{{ language }}</button>
     <ul class="nav-dropdown-list hidden {{switcher_name}}-list">
       {% for l in supported_languages | sort(attribute='_local_name') %}
         {% if l != language %}
@@ -788,8 +797,8 @@
 {% endmacro %}
 
 {% macro styled_year_dropdown(switcher_name)%}
-  <div class="nav-dropdown {{switcher_name}} js-show">
-    <button class="nav-dropdown-btn" aria-expanded="false" aria-label="{{ self.year_switcher() }}">{{ year }}</button>
+  <div class="nav-dropdown {{switcher_name}}">
+    <button class="nav-dropdown-btn js-enable" disabled aria-expanded="false" aria-label="{{ self.year_switcher() }}">{{ year }}</button>
     <ul class="nav-dropdown-list hidden {{switcher_name}}-list">
       {% for y in supported_years | sort %}
         {% if y != year %}

--- a/src/templates/base/2019/base.html
+++ b/src/templates/base/2019/base.html
@@ -280,7 +280,7 @@
             </li>
           </ul>
         </nav>
-        <nav aria-label="{{ self.menu_title() }}" id="menu" aria-labelledby="menu-btn">
+        <nav aria-label="{{ self.menu_title() }}" id="menu" aria-labelledby="menu-btn" class="js-show">
           <button type="button" class="menu-btn" id="menu-btn" aria-label="{{ self.open_the_menu() }}" aria-expanded="false" data-open-text="{{ self.open_the_menu() }}" data-close-text="{{ self.close_the_menu() }}">
             <span class="menu-btn__bar"></span>
             <span class="menu-btn__bar"></span>

--- a/src/templates/base/2019/base.html
+++ b/src/templates/base/2019/base.html
@@ -188,7 +188,7 @@
 {% set current_title = metadata.get('title') if metadata else None %}
 <div class="nav-dropdown {{switcher_name}} table-of-contents">
   <a class="js-hide" href="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</a>
-  <button class="nav-dropdown-btn hidden js-unhide" aria-expanded="false" aria-label="{{ self.table_of_contents_title() }}" >
+  <button class="nav-dropdown-btn js-unhide" aria-expanded="false" aria-label="{{ self.table_of_contents_title() }}" >
     {{ self.table_of_contents_title() }}
   </button>
   <ul class="nav-dropdown-list hidden {{switcher_name}}-list">

--- a/src/templates/base/2019/base.html
+++ b/src/templates/base/2019/base.html
@@ -113,11 +113,12 @@
 
 {% macro native_table_of_contents_dropdown(switcher_name) %}
 {% set current_title = metadata.get('title') if metadata else None %}
-<div class="table-of-contents-switcher">
+<div class="table-of-contents-switcher js-switcher-menu">
   <label for="table-of-contents-switcher-{{switcher_name}}" class="visually-hidden">
     {{ self.table_of_contents_switcher() }}
   </label>
-  <select id="table-of-contents-switcher-{{switcher_name}}">
+  <a class="js-hide" href="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</a>
+  <select id="table-of-contents-switcher-{{switcher_name}}" class="js-unhide">
     {% if request.path.endswith("table-of-contents") %}
       <option selected disabled value="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</option>
       <option disabled value="{{ url_for('table_of_contents', year=year, lang=lang) }}#foreword">{{ self.foreword_title() }}</option>
@@ -446,6 +447,9 @@
         document.querySelectorAll('.js-unhide').forEach(element => {
           element.classList.remove('js-unhide');
         });
+        document.querySelectorAll('.js-switcher-menu').forEach(element => {
+          element.classList.remove('js-switcher-menu');
+        });
 
         // Language and Year switching
         var languageYearSwitchers = document.querySelectorAll('.language-switcher select, .year-switcher select, .table-of-contents-switcher select');
@@ -590,7 +594,7 @@
 {% endmacro %}
 
 {% macro native_lang_dropdown(switcher_name) %}
-  <div class="language-switcher">
+  <div class="language-switcher js-switcher-menu">
     <label for="language-switcher-{{switcher_name}}" class="visually-hidden">{{ self.language_switcher() }}</label>
     <select id="language-switcher-{{switcher_name}}">
       {% for l in supported_languages | sort(attribute='_local_name') %}
@@ -730,7 +734,7 @@
 {%- endmacro %}
 
 {% macro native_year_dropdown(switcher_name)%}
-  <div class="year-switcher">
+  <div class="year-switcher js-switcher-menu">
     <label for="year-switcher-{{switcher_name}}" class="visually-hidden">{{ self.year_switcher() }}</label>
     <select id="year-switcher-{{switcher_name}}">
       {% for y in supported_years | sort %}

--- a/src/templates/base/2019/base.html
+++ b/src/templates/base/2019/base.html
@@ -194,13 +194,15 @@
   </button>
   <ul class="nav-dropdown-list hidden {{switcher_name}}-list">
     
-    <li class="nav-dropdown-list-part foreword">
-      {% if request.path.endswith("table-of-contents") %}
-      <span class="nav-dropdown-list-current">{{ self.foreword_title() }}</span>
-      {% else %}
-      <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.foreword_title() }}</a>
-      {% endif %}
+    {% if request.path.endswith('table-of-contents') %}
+    <li class="nav-dropdown-list-part foreword nav-dropdown-list-current">
+      <span>{{ self.foreword_title() }}</span>
     </li>
+    {% else %}
+    <li class="nav-dropdown-list-part foreword">
+      <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.foreword_title() }}</a>
+    </li>
+    {% endif %}
 
     {% for part_config in config.outline %}
     <li class="nav-dropdown-list-part">
@@ -208,53 +210,63 @@
     </li>
     {% for chapter_config in part_config.chapters %}
     {% set title = localizedChapterTitles[chapter_config.slug] if localizedChapterTitles[chapter_config.slug]|length else chapter_config.title %}
-    <li class="nav-dropdown-list-chapter {% if current_title == title %}nav-dropdown-list-current{% endif %}">
+    {% if current_title == title %}
+    <li class="nav-dropdown-list-chapter nav-dropdown-list-current">
       {% if chapter_config.todo %}
       <span class="nav-dropdown-list-todo">{{ self.chapter() }} {{ chapter_config.chapter }}: {{ title }}</span>
       {% else %}
-        {% if current_title == title %}
           {% if chapter_lang_exists(lang, year, chapter_config.slug) %}
-          <span class="nav-dropdown-list-current">
+          <span>
             {{ self.chapter() }} {{ chapter_config.chapter }}: {{ title }}
           </span>
           {% else %}
-          <span class="nav-dropdown-list-current">
+          <span>
             {{ self.chapter() }} {{ chapter_config.chapter }}: {{ title }} <span class="not-translated">({{ self.translation_not_available() }})</span>
           </span>
           {% endif %}
+      {% endif %}
+    </li>
+    {% else %}
+    <li class="nav-dropdown-list-chapter">
+      {% if chapter_config.todo %}
+      <span class="nav-dropdown-list-todo">{{ self.chapter() }} {{ chapter_config.chapter }}: {{ title }}</span>
+      {% else %}
+        {% if chapter_lang_exists(lang, year, chapter_config.slug) %}
+        <a href="{{ url_for('chapter', year=year, lang=lang, chapter=chapter_config.slug) }}">
+          {{ self.chapter() }} {{ chapter_config.chapter }}: {{ title }}
+        </a>
         {% else %}
-          {% if chapter_lang_exists(lang, year, chapter_config.slug) %}
-          <a href="{{ url_for('chapter', year=year, lang=lang, chapter=chapter_config.slug) }}">
-            {{ self.chapter() }} {{ chapter_config.chapter }}: {{ title }}
-          </a>
-          {% else %}
-          <a href="{{ url_for('chapter', year=year, lang='en', chapter=chapter_config.slug) }}">
-            {{ self.chapter() }} {{ chapter_config.chapter }}: {{ title }} <span class="not-translated">({{ self.translation_not_available() }})</span>
-          </a>
-          {% endif %}
+        <a href="{{ url_for('chapter', year=year, lang='en', chapter=chapter_config.slug) }}">
+          {{ self.chapter() }} {{ chapter_config.chapter }}: {{ title }} <span class="not-translated">({{ self.translation_not_available() }})</span>
+        </a>
         {% endif %}
       {% endif %}
     </li>
+    {% endif %}
     {% endfor %}
     {% endfor %}
 
     <li class="nav-dropdown-list-part">
       <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}#appendices">{{ self.appendices() }}</a>
     </li>
+    {% if request.path.endswith("methodology") %}
+    <li class="nav-dropdown-list-chapter nav-dropdown-list-current">
+      <span>{{ self.methodology_title() }}</span>
+    </li>
+    {% else %}
     <li class="nav-dropdown-list-chapter">
-      {% if request.path.endswith("methodology") %}
-      <span class="nav-dropdown-list-current">{{ self.methodology_title() }}</span>
-      {% else %}
       <a href="{{ url_for('methodology', year=year, lang=lang) }}">{{ self.methodology_title() }}</a>
-      {% endif %}
     </li>
+    {% endif %}
+    {% if request.path.endswith("contributors") %}
+    <li class="nav-dropdown-list-chapter nav-dropdown-list-current">
+      <span>{{ self.contributors_title() }}</span>
+    </li>
+    {% else %}
     <li class="nav-dropdown-list-chapter">
-      {% if request.path.endswith("contributors") %}
-      <span class="nav-dropdown-list-current">{{ self.contributors_title() }}</span>
-      {% else %}
       <a href="{{ url_for('contributors', year=year, lang=lang) }}">{{ self.contributors_title() }}</a>
-      {% endif %}
     </li>
+    {% endif %}
 
     {% if ebook_size_in_mb and ebook_size_in_mb > 0 %}
     <li class="nav-dropdown-list-part">

--- a/src/templates/base/2019/base.html
+++ b/src/templates/base/2019/base.html
@@ -187,8 +187,9 @@
 {% macro styled_table_of_contents_dropdown(switcher_name) %}
 {% set current_title = metadata.get('title') if metadata else None %}
 <div class="nav-dropdown {{switcher_name}} table-of-contents">
-  <button class="nav-dropdown-btn enable-script" aria-expanded="false" aria-label="{{ self.table_of_contents_title() }}" >
-    <a class="js-enable-script-remove-tag" href="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</a>
+  <a class="js-hide" href="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</a>
+  <button class="nav-dropdown-btn hidden js-unhide" aria-expanded="false" aria-label="{{ self.table_of_contents_title() }}" >
+    {{ self.table_of_contents_title() }}
   </button>
   <ul class="nav-dropdown-list hidden {{switcher_name}}-list">
     
@@ -439,11 +440,11 @@
   {% block scripts %}
     <script nonce="{{ csp_nonce() }}">
       (function() {
-        document.querySelectorAll('.js-enable-script-remove-tag').forEach(element => {
-          var text = element.textContent;
-          var parentEl = element.parentElement;
-          parentEl.removeChild(element);
-          parentEl.innerText = text;
+        document.querySelectorAll('.js-hide').forEach(element => {
+          element.classList.add('hidden');
+        });
+        document.querySelectorAll('.js-unhide').forEach(element => {
+          element.classList.remove('js-unhide');
         });
 
         // Language and Year switching

--- a/src/templates/base/2019/base.html
+++ b/src/templates/base/2019/base.html
@@ -178,9 +178,11 @@
     </option>
     {% endif %}
 
+    {% if ebook_size_in_mb and ebook_size_in_mb > 0 %}
     <option value="/static/pdfs/web_almanac_{{ year }}_{{ lang }}.pdf">
-      {{ self.ebook_title() }}
+      {{ self.ebook_download_short() }}
     </option>
+    {% endif %}
   </select>
 </div>
 {% endmacro %}
@@ -273,8 +275,7 @@
       <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}#ebook">{{ self.ebook_title() }}</a>
     </li>
     <li class="nav-dropdown-list-chapter ebook">
-      <a href="/static/pdfs/web_almanac_{{ year }}_{{ lang }}.pdf">{{ self.ebook_download() }}</a>
-      <small>{{ self.ebook_download_note() }}</small>
+      <a href="/static/pdfs/web_almanac_{{ year }}_{{ lang }}.pdf">{{ self.ebook_download_short() }}</a>
     </li>
     {% endif %}
   </ul>

--- a/src/templates/base/2019/base.html
+++ b/src/templates/base/2019/base.html
@@ -212,14 +212,26 @@
       {% if chapter_config.todo %}
       <span class="nav-dropdown-list-todo">{{ self.chapter() }} {{ chapter_config.chapter }}: {{ title }}</span>
       {% else %}
-        {% if chapter_lang_exists(lang, year, chapter_config.slug) %}
-        <a href="{{ url_for('chapter', year=year, lang=lang, chapter=chapter_config.slug) }}">
-          {{ self.chapter() }} {{ chapter_config.chapter }}: {{ title }}
-        </a>
+        {% if current_title == title %}
+          {% if chapter_lang_exists(lang, year, chapter_config.slug) %}
+          <span class="nav-dropdown-list-current">
+            {{ self.chapter() }} {{ chapter_config.chapter }}: {{ title }}
+          </span>
+          {% else %}
+          <span class="nav-dropdown-list-current">
+            {{ self.chapter() }} {{ chapter_config.chapter }}: {{ title }} <span class="not-translated">({{ self.translation_not_available() }})</span>
+          </span>
+          {% endif %}
         {% else %}
-        <a href="{{ url_for('chapter', year=year, lang='en', chapter=chapter_config.slug) }}">
-          {{ self.chapter() }} {{ chapter_config.chapter }}: {{ title }} <span class="not-translated">({{ self.translation_not_available() }})</span>
-        </a>
+          {% if chapter_lang_exists(lang, year, chapter_config.slug) %}
+          <a href="{{ url_for('chapter', year=year, lang=lang, chapter=chapter_config.slug) }}">
+            {{ self.chapter() }} {{ chapter_config.chapter }}: {{ title }}
+          </a>
+          {% else %}
+          <a href="{{ url_for('chapter', year=year, lang='en', chapter=chapter_config.slug) }}">
+            {{ self.chapter() }} {{ chapter_config.chapter }}: {{ title }} <span class="not-translated">({{ self.translation_not_available() }})</span>
+          </a>
+          {% endif %}
         {% endif %}
       {% endif %}
     </li>

--- a/src/templates/en/2019/base.html
+++ b/src/templates/en/2019/base.html
@@ -140,6 +140,7 @@ Unless otherwise noted, the metrics in all of the 20 chapters of the Web Almanac
 {% block appendices %}Appendices{% endblock %}
 
 {% block ebook_title %}Ebook{% endblock %}
+{% block ebook_download_short %}Ebook PDF ({{ ebook_size_in_mb }}MB){% endblock %}
 {% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format ({{ ebook_size_in_mb }}MB){% endblock %}
 {% block ebook_download_note %}(generated with <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 

--- a/src/templates/es/2019/base.html
+++ b/src/templates/es/2019/base.html
@@ -141,6 +141,7 @@ A menos que se indique lo contrario, las métricas en los 20 capítulos del Web 
 {% block appendices %}Apéndices{% endblock %}
 
 {% block ebook_title %}Libro electronico{% endblock %}
+{% block ebook_download_short %}Libro electronico PDF ({{ ebook_size_in_mb }}MB){% endblock %}
 {% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format ({{ ebook_size_in_mb }}MB){% endblock %}
 {% block ebook_download_note %}(generated with <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 

--- a/src/templates/fr/2019/base.html
+++ b/src/templates/fr/2019/base.html
@@ -141,6 +141,7 @@ Sauf indication contraire, les statistiques des 20 chapitres du Web Almanac prov
 {% block appendices %}Annexes{% endblock %}
 
 {% block ebook_title %}Ebook{% endblock %}
+{% block ebook_download_short %}Ebook PDF ({{ ebook_size_in_mb }}MB){% endblock %}
 {% block ebook_download %}Download the entire {{ year }} Web Almanac in PDF format ({{ ebook_size_in_mb }}MB){% endblock %}
 {% block ebook_download_note %}(generated with <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 

--- a/src/templates/hi/2019/base.html
+++ b/src/templates/hi/2019/base.html
@@ -140,6 +140,7 @@ Web Almanac वेब समुदाय की मेहनत से संभ
 {% block appendices %}परिशिष्ट{% endblock %}
 
 {% block ebook_title %}ईबुक{% endblock %}
+{% block ebook_download_short %}ईबुक पीडीएफ ({{ ebook_size_in_mb }}MB){% endblock %}
 {% block ebook_download %}पीडीएफ प्रारूप में पूरे {{ year }} Web Almanac को डाउनलोड करें ({{ ebook_size_in_mb }}MB){% endblock %}
 {% block ebook_download_note %}(generated with <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 

--- a/src/templates/ja/2019/base.html
+++ b/src/templates/ja/2019/base.html
@@ -141,6 +141,7 @@ Web Almanacは、ウェブ・コミュニティの努力によって実現して
 {% block appendices %}付属資料{% endblock %}
 
 {% block ebook_title %}電子ブック{% endblock %}
+{% block ebook_download_short %}電子ブックPDF ({{ ebook_size_in_mb }}MB){% endblock %}
 {% block ebook_download %} {{ year }} Web AlmanacのPDFファイルをダウンロードする ({{ ebook_size_in_mb }}MB){% endblock %}
 {% block ebook_download_note %}(generated with <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 

--- a/src/templates/pt/2019/base.html
+++ b/src/templates/pt/2019/base.html
@@ -140,6 +140,7 @@ Salvo indicação em contrário, as métricas em todos os 20 capítulos do Web A
 {% block appendices %}Apêndices{% endblock %}
 
 {% block ebook_title %}Ebook{% endblock %}
+{% block ebook_download_short %}Ebook PDF ({{ ebook_size_in_mb }}MB){% endblock %}
 {% block ebook_download %}Faça o download do Web Almanac {{ year }} completo em formato PDF ({{ ebook_size_in_mb }}MB){% endblock %}
 {% block ebook_download_note %}(gerado em <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 

--- a/src/templates/zh-CHT/2019/base.html
+++ b/src/templates/zh-CHT/2019/base.html
@@ -140,6 +140,7 @@ Web Almanac 網路年鑑是被熱情的網路社群擁抱而茁壯。 {{ self.co
 {% block appendices %}附錄{% endblock %}
 
 {% block ebook_title %}電子書{% endblock %}
+{% block ebook_download_short %}電子書PDF ({{ ebook_size_in_mb }}MB){% endblock %}
 {% block ebook_download %}下載 {{ year }} Web Almanac 網路年鑑： PDF 格式 ({{ ebook_size_in_mb }}MB){% endblock %}
 {% block ebook_download_note %}(使用 <a href="https://www.princexml.com/">www.princexml.com</a>){% endblock %}
 

--- a/src/templates/zh-CN/2019/base.html
+++ b/src/templates/zh-CN/2019/base.html
@@ -140,6 +140,7 @@
 {% block appendices %}附录{% endblock %}
 
 {% block ebook_title %}Ebook{% endblock %}
+{% block ebook_download_short %}Ebook PDF ({{ ebook_size_in_mb }}MB){% endblock %}
 {% block ebook_download %}下载 {{ year }} Web Almanac网络年鉴 ：PDF 格式 ({{ ebook_size_in_mb }}MB){% endblock %}
 {% block ebook_download_note %}(使用 <a href="https://www.princexml.com/">www.princexml.com</a>生成){% endblock %}
 


### PR DESCRIPTION
Misc fixes from ToC drop don added in #1393 for #985

I was running the pages through an HTML validator for another issue and it was complaining about some invalid HTML as we are using an `<a>` element inside of a `<button>` which is not allowed. I've pulled it out as a separate element and use JS to show/hide whichever as appropriate. Wish the HTML linter found these :-(

I've also hidden the dropdown arrows until JS kicks in, and done same for mobile menu.

I also fixed some of the issues discussed in https://github.com/HTTPArchive/almanac.httparchive.org/issues/985#issuecomment-727235918:
- Open ToC menu changes from tick to up arrow
- Current chapter should not be clickable
- Highlight current page with tick and yellow colouring
- Opacity change as was too light.
