### PR TITLE
Remove incorrect disabled attributes from divs

### DIFF
--- a/src/templates/base/2019/base.html
+++ b/src/templates/base/2019/base.html
@@ -114,7 +114,7 @@
 {% macro native_table_of_contents_dropdown(switcher_name) %}
 {% set current_title = metadata.get('title') if metadata else None %}
 <a class="js-hide" href="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</a>
-<div class="table-of-contents-switcher js-enable hidden" disabled>
+<div class="table-of-contents-switcher js-enable hidden">
   <label for="table-of-contents-switcher-{{switcher_name}}" class="visually-hidden">
     {{ self.table_of_contents_switcher() }}
   </label>
@@ -190,7 +190,7 @@
 {% macro styled_table_of_contents_dropdown(switcher_name) %}
 {% set current_title = metadata.get('title') if metadata else None %}
 <a class="nav-dropdown-btn js-hide" href="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</a>
-<div class="nav-dropdown {{switcher_name}} table-of-contents js-enable hidden" disabled>
+<div class="nav-dropdown {{switcher_name}} table-of-contents js-enable hidden">
   <button class="nav-dropdown-btn" aria-expanded="false" aria-label="{{ self.table_of_contents_title() }}" >
     {{ self.table_of_contents_title() }}
   </button>


### PR DESCRIPTION
Went overboard on the disabled attributes in #1512 - you can't apply them to `<divs>` only interactive components.