### PR TITLE
Fixes for printing chapters

### DIFF
--- a/src/static/css/print.css
+++ b/src/static/css/print.css
@@ -3,10 +3,12 @@
 .discuss,
 #chapter-navigation,
 footer .navigation-logo,
+footer #mobile-footer-nav-items,
 footer .nav-items,
 footer .table-of-contents,
 footer .language-switcher,
 footer .social-media,
+footer .accessibility-statement,
 footer hr {
   display: none;
 }
@@ -30,6 +32,10 @@ p.copyright a {
 
 p.copyright {
   margin: 0 auto;
+}
+
+footer .ha-logo {
+  color: #62718b;
 }
 
 figure iframe {

--- a/src/templates/base/2019/base.html
+++ b/src/templates/base/2019/base.html
@@ -439,7 +439,7 @@
         <p class="copyright">
           <span>{{ self.copyright() }}</span>
           <br>
-          <a href="{{ url_for('accessibility_statement', lang=lang) }}">{{ self.accessibility_statement() }}</a>
+          <a class="accessibility-statement" href="{{ url_for('accessibility_statement', lang=lang) }}">{{ self.accessibility_statement() }}</a>
         </p>
         <a class="ha-logo not-mobile" href="https://httparchive.org/" aria-labelledby="ha-logo-footer">
           <svg width="70" height="35" role="img">


### PR DESCRIPTION
Noticed that there's some extra junk at the bottom when printing chapters:

![Print chapter screenshot](https://user-images.githubusercontent.com/10931297/99295865-d533f400-283d-11eb-8f5e-e303551c6639.png)

This whole print stylesheet could do with a bit of a clean up (and removing `print.css` to be honest and merging into `2019.css`) but let's go with this for now.