### PR TITLE
Upgrade setup-node

### DIFF
--- a/.github/workflows/generate_chapters.yml
+++ b/.github/workflows/generate_chapters.yml
@@ -41,7 +41,7 @@ jobs:
         COMMIT_SHA: ${{ github.sha }}
       run: ./src/tools/scripts/update_timestamps_versions.sh
     - name: Setup Node.js for use with actions
-      uses: actions/setup-node@v1.4.2
+      uses: actions/setup-node@v1.4.4
       with:
         node-version: 12.x
     - name: Set up Python 3.8

--- a/.github/workflows/generate_ebooks.yml
+++ b/.github/workflows/generate_ebooks.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout branch
       uses: actions/checkout@v2.3.3
     - name: Setup Node.js for use with actions
-      uses: actions/setup-node@v1.4.2
+      uses: actions/setup-node@v1.4.4
       with:
         version:  12.x
     - name: Set up Python 3.8

--- a/.github/workflows/test-template-changes.yml
+++ b/.github/workflows/test-template-changes.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Setup Node.js for use with actions
-      uses: actions/setup-node@v1.4.2
+      uses: actions/setup-node@v1.4.4
       with:
         node-version: 12.x
     - name: Test Template Changes

--- a/.github/workflows/test_website.yml
+++ b/.github/workflows/test_website.yml
@@ -21,7 +21,7 @@ jobs:
         # Full git history is needed to get a proper list of changed files within `super-linter`
         fetch-depth: 0
     - name: Setup Node.js for use with actions
-      uses: actions/setup-node@v1.4.2
+      uses: actions/setup-node@v1.4.4
       with:
         node-version: 12.x
     - name: Set up Python 3.8


### PR DESCRIPTION
[GitHub have disabled the old, insecure, way of setting environment variables](https://github.blog/changelog/2020-11-09-github-actions-removing-set-env-and-add-path-commands-on-november-16/) from today.

Some of our action dependencies still use this and now fail:
- setup-node

Not sure why dependabot didn't offer to upgrade as they have new versions.