### PR TITLE
Change percentiles for two HTTP/2 queries

### DIFF
--- a/sql/2020/22_HTTP_2/cdn_summary.sql
+++ b/sql/2020/22_HTTP_2/cdn_summary.sql
@@ -30,7 +30,7 @@ GROUP BY
   page,
   firstHTML,
   CDN),
-UNNEST([0, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 100]) AS percentile
+UNNEST(GENERATE_ARRAY(1, 100)) AS percentile
 GROUP BY
   percentile,
   client,

--- a/sql/2020/22_HTTP_2/http2_%_1st_party_vs_3rd_party.sql
+++ b/sql/2020/22_HTTP_2/http2_%_1st_party_vs_3rd_party.sql
@@ -30,7 +30,7 @@ GROUP BY
   client,
   page,
   is_third_party),
-UNNEST([5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 100]) AS percentile
+UNNEST(GENERATE_ARRAY(1, 100)) AS percentile
 GROUP BY
   percentile,
   client,


### PR DESCRIPTION
@dotjs switched two of the queries for all percentiles to allow drawing of smoother graphs:

![HTTP/2 usage by 1st and 3rd party](https://user-images.githubusercontent.com/10931297/99394727-42e02e80-28d7-11eb-8fde-87164a2b0255.png)

![HTTP/2 usage by CDN](https://user-images.githubusercontent.com/10931297/99394808-64411a80-28d7-11eb-98f7-f83043fd3af8.png)
