### PR TITLE
Move virtual env folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 env/
+.venv/
 *.log
 *.pyc
 **/.DS_Store

--- a/src/.gcloudignore
+++ b/src/.gcloudignore
@@ -32,6 +32,8 @@ __pycache__/*
 
 env/
 env/*
+.venv/
+.venv/*
 node_modules/
 node_modules/*
 static/html

--- a/src/README.md
+++ b/src/README.md
@@ -25,15 +25,15 @@ py -m pip install --user virtualenv
 2. Create an isolated Python environment, and install dependencies:
 
 ```
-virtualenv --python python3 env
-source env/bin/activate
+virtualenv --python python3 .venv
+source .venv/bin/activate
 ```
 
 Or for those on Windows:
 
 ```
-virtualenv --python python3 env
-env\Scripts\activate.bat
+virtualenv --python python3 .venv
+.venv\Scripts\activate.bat
 ```
 
 3. Install generate and run the website:


### PR DESCRIPTION
Currently we install our Virtual Env folder to the `src/env` folder.

The GitHub Super-linter ignores the `.venv` folder but not the `env` one. It's a bit of a generic name to be fair to ask them to add to there.

I'd like to move to `.venv` folder by default, but we'll keep supporting `env` (e.g. in .gitignore) for those that want to continue using this.

Doesn't really affect anything as these are just manually run commands when first setting up your environment.