### PR TITLE
Start website in full in Docker

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -23,4 +23,4 @@ RUN     pip install -r requirements.txt
 RUN     npm install
 COPY    . ./
 
-CMD     ["python", "main.py"]
+CMD     ["npm", "run", "start"]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -23,4 +23,4 @@ RUN     pip install -r requirements.txt
 RUN     npm install
 COPY    . ./
 
-CMD     ["npm", "run", "start"]
+CMD     ["./tools/scripts/run_and_test_website.sh", "-d"]

--- a/src/README.md
+++ b/src/README.md
@@ -269,7 +269,7 @@ root@[CID]:/app# exit
 6. To customize the image use `PYVER`, `NODEVER`, and `SKIPGC` build arguments to control which versions of Python and Node are used and whether Google Cloud SDK is installed.
 
 ```
-docker image build --build-arg PYVER=3.7 --build-arg NODEVER=14.x --build-arg SKIPGC=false -t webalmanac:custom .
+docker image build --build-arg PYVER=3.8 --build-arg NODEVER=14.x --build-arg SKIPGC=false -t webalmanac:custom .
 ```
 
 7. If you want to run the GitHub Super-Linter without `npm` being installed you need to call the command directly as given in `package.json`.
@@ -277,11 +277,11 @@ docker image build --build-arg PYVER=3.7 --build-arg NODEVER=14.x --build-arg SK
 This will depend on your operating system but for MacOS/Linux this would be:
 
 ```
-docker container run -it --rm -v "$PWD/..":/app -w /app/src --entrypoint=./tools/scripts/run_linter_locally.sh github/super-linter
+docker container run -it --rm -v /app/node_modules -v "$PWD/..":/app -w /app/src --entrypoint=./tools/scripts/run_linter_locally.sh github/super-linter
 ```
 
 And for Windows:
 
 ```
-docker container run --rm -v %cd%\\..:/app -w /app/src --entrypoint=./tools/scripts/run_linter_locally.sh github/super-linter
+docker container run --rm -v /app/node_modules -v %cd%\\..:/app -w /app/src --entrypoint=./tools/scripts/run_linter_locally.sh github/super-linter
 ```

--- a/src/tools/scripts/run_and_test_website.sh
+++ b/src/tools/scripts/run_and_test_website.sh
@@ -48,19 +48,17 @@ fi
 
 if [ "$(pgrep -f 'python main.py')" ]; then
   echo "Killing existing server to run a fresh version"
-  pkill -9 python main.py
+  pkill -9 -f "python main.py"
+fi
+
+if [ "$(pgrep -f 'node ./tools/generate/chapter_watcher')" ]; then
+  echo "Killing existing watcher to run a fresh version"
+  pkill -9 -f "node ./tools/generate/chapter_watcher"
 fi
 
 echo "Installing and testing python environment"
 python -m pip install --upgrade pip
 pip install -r requirements.txt
-pytest
-
-echo "Installing node modules"
-npm install
-
-echo "Building website"
-npm run generate
 
 echo "Starting website in background mode for tests"
 python main.py background &
@@ -68,6 +66,15 @@ python main.py background &
 sleep 2
 # Check website is running as won't have got feedback as backgrounded
 pgrep -f "python main.py"
+
+# Run pytests
+pytest
+
+echo "Installing node modules"
+npm install
+
+echo "Building website"
+npm run generate
 
 echo "Testing website"
 npm run test
@@ -84,7 +91,7 @@ if [ "${debug}" == "1" ]; then
 
   if [ "$(pgrep -f 'python main.py')" ]; then
     echo "Killing server to run a fresh version in debug mode"
-    pkill -9 python main.py
+    pkill -9 -f "python main.py"
   fi
 
   echo "Starting website in foreground mode so it reloads on file changes"

--- a/src/tools/scripts/stop_website.sh
+++ b/src/tools/scripts/stop_website.sh
@@ -9,5 +9,7 @@
 # It is useful as sometimes these are backgrounded so this offers a quick way of stopping them.
 #
 
-pkill -9 python main.py
-pkill -9 node ./tools/generate/chapter_watcher
+pkill -9 -f "python main.py"
+pkill -9 -f "./tools/generate/chapter_watcher"
+
+exit 0


### PR DESCRIPTION
We recently added the `npm run start` command in #1436 which does a full clean install, generates the chapters, runs the website tests and has a file watcher (added in #1437 and #1457 ) to regenerate chapters as they are saved.

This brings the same functionality to our Dockerfile.

I also moved the start of the website to earlier (before the tests and `npm run generate`) so you don't have to wait for them to complete to have old website up.

Note the `pkill` command on MacOS accepts files without quote, but not on linux so had to change slightly.