### PR TITLE
Make Footer spacing consistent with header and fix spacing issue

### DIFF
--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -821,7 +821,6 @@ footer .nav-items > ul > li:last-child > * {
   margin-right: 0;
 }
 
-
 footer .language-switcher {
   grid-area: language-switcher;
 }

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -814,8 +814,13 @@ footer .ha-logo {
 }
 
 footer .nav-items > ul > li > * {
-  margin-left: 2vw;
+  margin-right: 2vw;
 }
+
+footer .nav-items > ul > li:last-child > * {
+  margin-right: 0;
+}
+
 
 footer .language-switcher {
   grid-area: language-switcher;


### PR DESCRIPTION
Just noticed the French footer looks like this:

![French Footer](https://user-images.githubusercontent.com/10931297/99554892-9cb82580-29b7-11eb-8ee8-9d373d1b6138.png)

But header is fine:

![French Header](https://user-images.githubusercontent.com/10931297/99554970-b3f71300-29b7-11eb-9f0b-e69cbd984a48.png)

Turns out Footer uses `margin-left` (so last item has no right margin), but means first item has margin to left.
The Header uses `header-right` with a `last-child` override.

Let's consolidate - which fixes the issue.
