### PR TITLE
Fix spacing differences between translation templates

### DIFF
--- a/src/templates/en/2019/accessibility_statement.html
+++ b/src/templates/en/2019/accessibility_statement.html
@@ -6,7 +6,6 @@
 
 {% block twitter_image_alt %}Web Almanac Accessibility Statement{% endblock %}
 
-
 {% block index %}
       <ul>
         <li><a href="#overview">Overview</a></li>

--- a/src/templates/en/2019/base_ebook.html
+++ b/src/templates/en/2019/base_ebook.html
@@ -2,7 +2,6 @@
 
 {% block title %}The {{ year }} Web Almanac by HTTP Archive{% endblock %}
 
-
 {% block intro_title %}<span class="intro-year">{{ year }}</span><br>Web Almanac{% endblock %}
 {% block intro_sub_title %}HTTP Archive's annual<br><b>state of the web</b> report{% endblock %}
 

--- a/src/templates/en/2019/contributors.html
+++ b/src/templates/en/2019/contributors.html
@@ -4,7 +4,6 @@
 
 {% block description %}The {{ config.contributors.items() | length }} people who contributed to the 2019 Web Almanac as Analysts, Authors, Brainstormers, Designers, Developers, Editors, Reviewers and Translators.{% endblock %}
 
-
 {% block filter_by_team %}Filter by team: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> of <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> contributors.{% endblock %}
 {% block filter_by %}Filter by{% endblock %}
 

--- a/src/templates/en/2019/index.html
+++ b/src/templates/en/2019/index.html
@@ -5,7 +5,5 @@
 
 {% block twitter_image_alt %}The {{ year }} Web Almanac{% endblock %}
 
-
 {% block intro_title %}Web Almanac{% endblock %}
 {% block intro_sub_title %}HTTP Archive's annual<br> <b>state of the web</b> report{% endblock %}
-

--- a/src/templates/en/2019/methodology.html
+++ b/src/templates/en/2019/methodology.html
@@ -6,7 +6,6 @@
 
 {% block twitter_image_alt %}{{ year }} Web Almanac methodology{% endblock %}
 
-
 {% block index %}
       <ul>
         <li><a href="#overview">Overview</a></li>

--- a/src/templates/en/2019/table_of_contents.html
+++ b/src/templates/en/2019/table_of_contents.html
@@ -5,4 +5,3 @@
 {% block description %}Table of Contents for the 2019 Web Almanac, listing each section: Page Contents, User Experience, Content Publishing, Content Distribution.{% endblock %}
 
 {% block twitter_image_alt %}{{ year }} Web Almanac methodology{% endblock %}
-

--- a/src/templates/en/2020/contributors.html
+++ b/src/templates/en/2020/contributors.html
@@ -4,7 +4,6 @@
 
 {% block description %}The {{ config.contributors.items() | length }} people who contributed to the {{ year }} Web Almanac as Analysts, Authors, Designers, Developers, Editors, Leaders, Reviewers and Translators.{% endblock %}
 
-
 {% block filter_by_team %}Filter by team: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> of <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> contributors.{% endblock %}
 {% block filter_by %}Filter by{% endblock %}
 

--- a/src/templates/en/2020/index.html
+++ b/src/templates/en/2020/index.html
@@ -5,7 +5,6 @@
 
 {% block twitter_image_alt %}The {{ year }} Web Almanac{% endblock %}
 
-
 {% block intro_title %}{{ self.coming_soon() }}{% endblock %}
 {% block intro_sub_title %}The {{ year }} <b>state of the web</b> report{% endblock %}
 

--- a/src/templates/en/2020/methodology.html
+++ b/src/templates/en/2020/methodology.html
@@ -6,7 +6,6 @@
 
 {% block twitter_image_alt %}{{ year }} Web Almanac methodology{% endblock %}
 
-
 {% block index %}
       <ul>
         <li><a href="#overview">Overview</a></li>
@@ -375,8 +374,7 @@
         <h4 id="parsel"><a href="#parsel" class="anchor-link">Parsel</a></h4>
 
         <p>
-            <a href="https://projects.verou.me/parsel/">Parsel</a> is a CSS selector parser and specificity calculator, originally written by <a href="{{ url_for('chapter', year=year, lang=lang, chapter='css') }}">CSS</a> chapter lead <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='LeaVerou') }}">Lea Verou</a> and open sourced as a separate library.
-            It is used extensively in all CSS metrics that relate to selectors and specificity.
+            <a href="https://projects.verou.me/parsel/">Parsel</a> is a CSS selector parser and specificity calculator, originally written by <a href="{{ url_for('chapter', year=year, lang=lang, chapter='css') }}">CSS</a> chapter lead <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='LeaVerou') }}">Lea Verou</a> and open sourced as a separate library. It is used extensively in all CSS metrics that relate to selectors and specificity.
         </p>
     </section>
 

--- a/src/templates/en/2020/table_of_contents.html
+++ b/src/templates/en/2020/table_of_contents.html
@@ -5,4 +5,3 @@
 {% block description %}Table of Contents for the 2020 Web Almanac, listing each section: Page Contents, User Experience, Content Publishing, Content Distribution.{% endblock %}
 
 {% block twitter_image_alt %}{{ year }} Web Almanac methodology{% endblock %}
-

--- a/src/templates/es/2019/base.html
+++ b/src/templates/es/2019/base.html
@@ -96,7 +96,6 @@ Nuestra misión es combinar las estadísticas y tendencias sin procesar del HTTP
 {% macro read_last_years_chapter(chapter) %}Lea el {{ year|int -1 }} Capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 
-
 {% block contributors_description %}
 Web Almanac ha sido posible gracias al arduo trabajo de la comunidad web. {{ self.contributors() }} personas han ofrecido incontables horas en las fases de planificación, investigación, redacción y producción.
 {% endblock %}

--- a/src/templates/es/2019/contributors.html
+++ b/src/templates/es/2019/contributors.html
@@ -4,7 +4,6 @@
 
 {% block description %}El {{ config.contributors.items() | length }} personas que contribuyeron al 2019 Web Almanac commo Analistas, Autores, Pensadores, Diseñadores, Desarrolladores, Editores, Revisores y Traductores.{% endblock %}
 
-
 {% block filter_by_team %}Filtrar por equipo: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> de <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> contributors.{% endblock %}
 {% block filter_by %}Filtrar por{% endblock %}
 

--- a/src/templates/es/2019/error.html
+++ b/src/templates/es/2019/error.html
@@ -1,6 +1,5 @@
 {% extends "base/2019/error.html" %}
 
-
 {% block unknown_error %}Error Desconocido{% endblock %}
 
 {% 

--- a/src/templates/es/2019/index.html
+++ b/src/templates/es/2019/index.html
@@ -5,6 +5,5 @@
 
 {% block twitter_image_alt %}Web Almanac {{ year }}{% endblock %}
 
-
 {% block intro_title %}Web Almanac{% endblock %}
 {% block intro_sub_title %}HTTP Archive informe del<br><b>estado de la web</b> anual{% endblock %}

--- a/src/templates/es/2019/table_of_contents.html
+++ b/src/templates/es/2019/table_of_contents.html
@@ -5,4 +5,3 @@
 {% block description %}Tabla de contenidos del Web Almanac 2019 de HTTP Archive, que enumera cada sección: contenido de la página, experiencia del usuario, publicación de contenido, distribución de contenido{% endblock %}
 
 {% block twitter_image_alt %}{{ year }} Web Almanac methodology{% endblock %}
-

--- a/src/templates/es/2020/contributors.html
+++ b/src/templates/es/2020/contributors.html
@@ -4,7 +4,6 @@
 
 {% block description %}El {{ config.contributors.items() | length }} personas que contribuyeron al {{ year }} Web Almanac commo Analistas, Autores, Diseñadores, Desarrolladores, Editores, Revisores y Traductores.{% endblock %}
 
-
 {% block filter_by_team %}Filtrar por equipo: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> de <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> contributors.{% endblock %}
 {% block filter_by %}Filtrar por{% endblock %}
 

--- a/src/templates/es/2020/index.html
+++ b/src/templates/es/2020/index.html
@@ -5,7 +5,6 @@
 
 {% block twitter_image_alt %}Web Almanac {{ year }}{% endblock %}
 
-
 {% block intro_title %}{{ self.coming_soon() }}{% endblock %}
 {% block intro_sub_title %}El informe del <b>estado de la Web</b> de {{ year }}{% endblock %}
 

--- a/src/templates/es/2020/table_of_contents.html
+++ b/src/templates/es/2020/table_of_contents.html
@@ -5,4 +5,3 @@
 {% block description %}Tabla de contenidos del Web Almanac 2020 de HTTP Archive, que enumera cada sección: contenido de la página, experiencia del usuario, publicación de contenido, distribución de contenido{% endblock %}
 
 {% block twitter_image_alt %}{{ year }} Web Almanac methodology{% endblock %}
-

--- a/src/templates/fr/2019/accessibility_statement.html
+++ b/src/templates/fr/2019/accessibility_statement.html
@@ -6,7 +6,6 @@
 
 {% block twitter_image_alt %}Déclaration d’accessibilité du Web Almanac{% endblock %}
 
-
 {% block index %}
       <ul>
         <li><a href="#apercu">Aperçu</a></li>

--- a/src/templates/fr/2019/base.html
+++ b/src/templates/fr/2019/base.html
@@ -58,7 +58,6 @@ Notre mission est de combiner les statistiques brutes et les tendances de HTTP A
 {% block open %}Ouvrez{% endblock %}
 {% block close %}Fermez{% endblock %}
 
-
 {% macro figure_text(metadata, id) %}Figure {{ figure_id(metadata, id) }}.{% endmacro %}
 {% macro show_description(metadata, id) %}Afficher la description de la figure {{ figure_id(metadata, id) }}{% endmacro %}
 {% macro hide_description(metadata, id) %}Masquer la description de la figure  {{ figure_id(metadata, id) }}{% endmacro %}

--- a/src/templates/fr/2019/contributors.html
+++ b/src/templates/fr/2019/contributors.html
@@ -4,9 +4,6 @@
 
 {% block description %}Les {{ config.contributors.items() | length }} personnes ayant contribué au Web Almanac 2019 par leurs analyses, leurs écrits, leurs réflexions, leurs participations au design, leur code, leurs éditions, leurs relectures, ou leurs traductions.{% endblock %}
 
-{% block twitter_image_alt %}Méthodologie du Web Almanac {{ year }}{% endblock %}
-
-
 {% block filter_by_team %}Filtrer par équipe&nbsp;: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> sur <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> contributeurs et contributrices.{% endblock %}
 {% block filter_by %}Filtrer par{% endblock %}
 

--- a/src/templates/fr/2019/error.html
+++ b/src/templates/fr/2019/error.html
@@ -1,6 +1,5 @@
 {% extends "base/2019/error.html" %}
 
-
 {% block unknown_error %}Erreur inconnue{% endblock %}
 
 {% 
@@ -20,7 +19,6 @@
     "Not Found": "L'URL demandée est introuvable sur le serveur. Si vous avez entré l'URL manuellement, vérifiez l'orthographe et réessayez."
   }
 %}
-
 {% macro expandedErrorMessage(errorCode, errorDescription, errorMessage) %}
 {{ errorCode }} <i lang="en">{{ errorDescription }}</i>&nbsp;: {{ errorMessage }}
 {% endmacro %}

--- a/src/templates/fr/2019/index.html
+++ b/src/templates/fr/2019/index.html
@@ -5,6 +5,5 @@
 
 {% block twitter_image_alt %}Web Almanac {{ year }}{% endblock %}
 
-
 {% block intro_title %}Web Almanac{% endblock %}
 {% block intro_sub_title %}Rapport annuel<br>de HTTP Archive sur<br><b>l’état du Web</b>{% endblock %}

--- a/src/templates/fr/2019/methodology.html
+++ b/src/templates/fr/2019/methodology.html
@@ -6,7 +6,6 @@
 
 {% block twitter_image_alt %}Méthodologie du Web Almanac {{ year }}{% endblock %}
 
-
 {% block index %}
       <ul>
         <li><a href="#overview">Vue d’ensemble</a></li>

--- a/src/templates/fr/2019/table_of_contents.html
+++ b/src/templates/fr/2019/table_of_contents.html
@@ -5,4 +5,3 @@
 {% block description %}Table des matières du Web Almanac 2019, listant chaque section : Contenu des pages, Expérience utilisateur, Publication du contenu, Diffusion du contenu.{% endblock %}
 
 {% block twitter_image_alt %}Méthodologie du Web Almanac {{ year }}{% endblock %}
-

--- a/src/templates/fr/2020/contributors.html
+++ b/src/templates/fr/2020/contributors.html
@@ -4,9 +4,6 @@
 
 {% block description %}Les {{ config.contributors.items() | length }} personnes ayant contribué au Web Almanac {{ year }} par leurs analyses, leurs écrits, leurs participations au design, leur code, leurs éditions, leurs relectures, ou leurs traductions.{% endblock %}
 
-{% block twitter_image_alt %}Méthodologie du Web Almanac {{ year }}{% endblock %}
-
-
 {% block filter_by_team %}Filtrer par équipe&nbsp;: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> sur <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> contributeurs et contributrices.{% endblock %}
 {% block filter_by %}Filtrer par{% endblock %}
 

--- a/src/templates/fr/2020/index.html
+++ b/src/templates/fr/2020/index.html
@@ -5,7 +5,6 @@
 
 {% block twitter_image_alt %}Web Almanac {{ year }}{% endblock %}
 
-
 {% block intro_title %}{{ self.coming_soon() }}{% endblock %}
 {% block intro_sub_title %}Le rapport {{ year }} sur <b>l’état du Web</b>{% endblock %}
 

--- a/src/templates/fr/2020/methodology.html
+++ b/src/templates/fr/2020/methodology.html
@@ -6,7 +6,6 @@
 
 {% block twitter_image_alt %}Méthodologie du Web Almanac {{ year }}{% endblock %}
 
-
 {% block index %}
       <ul>
         <li><a href="#overview">Vue d’ensemble</a></li>
@@ -375,8 +374,7 @@
         <h4 id="parsel"><a href="#parsel" lang="en" class="anchor-link">Parsel</a></h4>
 
         <p>
-            <a href="https://projects.verou.me/parsel/" lang="en">Parsel</a> est un analyseur de sélecteur CSS et un calculateur de spécificité, écrit à l’origine par la responsable du chapitre <a href="{{ url_for('chapter', year=year, lang=lang, chapter='css') }}">CSS</a>, <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='LeaVerou') }}" lang="en">Lea Verou</a>, et dont elle a ouvert le code source dans une bibliothèque distincte.
-            Il est largement utilisé pour tous les indicateurs du CSS qui concernent les sélecteurs et la spécificité.
+            <a href="https://projects.verou.me/parsel/" lang="en">Parsel</a> est un analyseur de sélecteur CSS et un calculateur de spécificité, écrit à l’origine par la responsable du chapitre <a href="{{ url_for('chapter', year=year, lang=lang, chapter='css') }}">CSS</a>, <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='LeaVerou') }}" lang="en">Lea Verou</a>, et dont elle a ouvert le code source dans une bibliothèque distincte. Il est largement utilisé pour tous les indicateurs du CSS qui concernent les sélecteurs et la spécificité.
         </p>
     </section>
 

--- a/src/templates/fr/2020/table_of_contents.html
+++ b/src/templates/fr/2020/table_of_contents.html
@@ -5,4 +5,3 @@
 {% block description %}Table des matières du Web Almanac 2020, listant chaque section : Contenu des pages, Expérience utilisateur, Publication du contenu, Diffusion du contenu.{% endblock %}
 
 {% block twitter_image_alt %}Méthodologie du Web Almanac {{ year }}{% endblock %}
-

--- a/src/templates/hi/2019/accessibility_statement.html
+++ b/src/templates/hi/2019/accessibility_statement.html
@@ -6,7 +6,6 @@
 
 {% block twitter_image_alt %}Web Almanac की अभिगम्यता का विवरण{% endblock %}
 
-
 {% block index %}
       <ul>
         <li><a href="#overview">अवलोकन</a></li>

--- a/src/templates/hi/2019/contributors.html
+++ b/src/templates/hi/2019/contributors.html
@@ -4,7 +4,6 @@
 
 {% block description %}{{ config.contributors.items() | length }} लोग जिन्होंने 2019 Web Almanac में विश्लेषक, लेखक, डिजाइनर, डेवलपर्स, संपादक, लीडर, समीक्षक और अनुवादक के रूप में योगदान दिया।{% endblock %}
 
-
 {% block filter_by_team %}टीम द्वारा फ़िल्टर करें: <span id="contributors-total">{{ config.contributors.items() | length }}</span><span id="contributors-total-text" class="hidden"> में से <span id="filtered-contributors">{{ self.contributors() }}</span></span> योगदानकर्ता।{% endblock %}
 {% block filter_by %}Filter by{% endblock %}
 

--- a/src/templates/hi/2019/error.html
+++ b/src/templates/hi/2019/error.html
@@ -1,6 +1,5 @@
 {% extends "base/2019/error.html" %}
 
-
 {% block unknown_error %}अज्ञात त्रुटि{% endblock %}
 
 {% 

--- a/src/templates/hi/2019/index.html
+++ b/src/templates/hi/2019/index.html
@@ -5,6 +5,5 @@
 
 {% block twitter_image_alt %}{{ year }} Web Almanac{% endblock %}
 
-
 {% block intro_title %}Web Almanac{% endblock %}
 {% block intro_sub_title %}HTTP Archive के वार्षिक<br> <b>वेब की स्थिति</b> की रिपोर्ट{% endblock %}

--- a/src/templates/hi/2019/table_of_contents.html
+++ b/src/templates/hi/2019/table_of_contents.html
@@ -5,4 +5,3 @@
 {% block description %}2019 Web Almanac के लिए सामग्री की तालिका के, प्रत्येक अनुभाग सूचीबद्ध है: पृष्ठ सामग्री, उपयोगकर्ता अनुभव, सामग्री प्रकाशन, सामग्री वितरण।{% endblock %}
 
 {% block twitter_image_alt %}{{ year }} Web Almanac की कार्यप्रणाली{% endblock %}
-

--- a/src/templates/hi/2020/contributors.html
+++ b/src/templates/hi/2020/contributors.html
@@ -4,7 +4,6 @@
 
 {% block description %}{{ config.contributors.items() | length }} लोग जिन्होंने {{ year }} Web Almanac में विश्लेषक, लेखक, डिजाइनर, डेवलपर्स, संपादक, लीडर, समीक्षक और अनुवादक के रूप में योगदान दिया।{% endblock %}
 
-
 {% block filter_by_team %}टीम द्वारा फ़िल्टर करें: <span id="contributors-total">{{ config.contributors.items() | length }}</span><span id="contributors-total-text" class="hidden"> में से <span id="filtered-contributors">{{ self.contributors() }}</span></span> योगदानकर्ता।{% endblock %}
 {% block filter_by %}फ़िल्टर करें{% endblock %}
 

--- a/src/templates/hi/2020/index.html
+++ b/src/templates/hi/2020/index.html
@@ -5,7 +5,6 @@
 
 {% block twitter_image_alt %}{{ year }} Web Almanac{% endblock %}
 
-
 {% block intro_title %}{{ self.coming_soon() }}{% endblock %}
 {% block intro_sub_title %}{{ year }} <b>वेब की स्थिति</b> की रिपोर्ट{% endblock %}
 

--- a/src/templates/hi/2020/table_of_contents.html
+++ b/src/templates/hi/2020/table_of_contents.html
@@ -5,4 +5,3 @@
 {% block description %}2020 Web Almanac के लिए सामग्री की तालिका के, प्रत्येक अनुभाग सूचीबद्ध है: पृष्ठ सामग्री, उपयोगकर्ता अनुभव, सामग्री प्रकाशन, सामग्री वितरण।{% endblock %}
 
 {% block twitter_image_alt %}{{ year }} Web Almanac की कार्यप्रणाली{% endblock %}
-

--- a/src/templates/ja/2019/accessibility_statement.html
+++ b/src/templates/ja/2019/accessibility_statement.html
@@ -6,7 +6,6 @@
 
 {% block twitter_image_alt %}Web Almanacのアクセシビリティに関する声明{% endblock %}
 
-
 {% block index %}
       <ul>
         <li><a href="#overview">概要</a></li>

--- a/src/templates/ja/2019/base.html
+++ b/src/templates/ja/2019/base.html
@@ -9,11 +9,11 @@
 {% block organization %}HTTP ArchiveによるWeb Almanac{% endblock %}
 {% block web_almanac_logo %}
   <span class="ha line-group">HTTP Archive</span>
+
   <span class="pre">による</span>
   <span class="wa">Web Almanac</span>
+  
 {% endblock %}
-
-
 
 {% block mission %}
 <p>
@@ -69,7 +69,6 @@
 
 {% block author %}著者{% endblock %}
 {% block authors %}著者{% endblock %}
-
 
 {% macro figure_text(metadata, id) %}図{{ figure_id(metadata, id) }}.{% endmacro %}
 {% macro show_description(metadata, id) %}図{{ figure_id(metadata, id) }}の説明を表示{% endmacro %}

--- a/src/templates/ja/2019/base_ebook.html
+++ b/src/templates/ja/2019/base_ebook.html
@@ -2,7 +2,6 @@
 
 {% block title %}{{ year }} HTTP ArchiveによるWeb Almanac{% endblock %}
 
-
 {% block intro_title %}<span class="intro-year">{{ year }}</span><br>Web Almanac{% endblock %}
 {% block intro_sub_title %}HTTP Archiveの年次報告書<br><b>ウェブの状態</b>レポート{% endblock %}
 

--- a/src/templates/ja/2019/contributors.html
+++ b/src/templates/ja/2019/contributors.html
@@ -4,7 +4,6 @@
 
 {% block description %}{{ config.contributors.items() | length }} アナリスト、著者、ブレインストーマー、デザイナー、開発者、編集者、レビュアー、翻訳者として2019年のWeb Almanacに貢献した人々。{% endblock %}
 
-
 {% block filter_by_team %}チームでフィルタリング： <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> の <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> 貢献者。{% endblock %}
 {% block filter_by %}フィルタリング{% endblock %}
 

--- a/src/templates/ja/2019/error.html
+++ b/src/templates/ja/2019/error.html
@@ -1,6 +1,5 @@
 {% extends "base/2019/error.html" %}
 
-
 {% block unknown_error %}不明なエラー{% endblock %}
 
 {% 

--- a/src/templates/ja/2019/index.html
+++ b/src/templates/ja/2019/index.html
@@ -5,6 +5,5 @@
 
 {% block twitter_image_alt %}{{ year }} Web Almanac{% endblock %}
 
-
 {% block intro_title %}Web Almanac{% endblock %}
 {% block intro_sub_title %}HTTP Archiveの年次報告書<br> <b>ウェブの状態</b>レポート{% endblock %}

--- a/src/templates/ja/2019/methodology.html
+++ b/src/templates/ja/2019/methodology.html
@@ -6,7 +6,6 @@
 
 {% block twitter_image_alt %}{{ year }} Web Almanac方法論{% endblock %}
 
-
 {% block index %}
       <ul>
         <li><a href="#overview">概要</a></li>

--- a/src/templates/ja/2019/table_of_contents.html
+++ b/src/templates/ja/2019/table_of_contents.html
@@ -5,4 +5,3 @@
 {% block description %}2019年版Web Almanacの目次、各セクションを一覧表示しています。ページコンテンツ、ユーザー体験、コンテンツ公開、コンテンツ配信。{% endblock %}
 
 {% block twitter_image_alt %}{{ year }} Web Almanac方法論{% endblock %}
-

--- a/src/templates/ja/2020/contributors.html
+++ b/src/templates/ja/2020/contributors.html
@@ -4,7 +4,6 @@
 
 {% block description %}{{ config.contributors.items() | length }} アナリスト、著者、デザイナー、開発者、編集者、レビュアー、翻訳者として{ year }}年のWeb Almanacに貢献した人々。{% endblock %}
 
-
 {% block filter_by_team %}チームでフィルタリング： <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> の <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> 貢献者。{% endblock %}
 {% block filter_by %}フィルタリング{% endblock %}
 

--- a/src/templates/ja/2020/index.html
+++ b/src/templates/ja/2020/index.html
@@ -5,7 +5,6 @@
 
 {% block twitter_image_alt %}{{ year }} Web Almanac{% endblock %}
 
-
 {% block intro_title %}{{ self.coming_soon() }}{% endblock %}
 {% block intro_sub_title %}{{ year }}の<b>web状況</b>報告{% endblock %}
 

--- a/src/templates/ja/2020/methodology.html
+++ b/src/templates/ja/2020/methodology.html
@@ -6,7 +6,6 @@
 
 {% block twitter_image_alt %}{{ year }} Web Almanac方法論{% endblock %}
 
-
 {% block index %}
       <ul>
         <li><a href="#overview">概要</a></li>
@@ -375,8 +374,7 @@
         <h4 id="parsel"><a href="#parsel" class="anchor-link">Parsel</a></h4>
 
         <p>
-            <a href="https://projects.verou.me/parsel/">Parsel</a>はCSSセレクターの構文解析と詳細度の計算ツールで、元々は<a href="{{ url_for('chapter', year=year, lang=lang, chapter='css') }}">CSS</a>の章をリードする<a href="{{ url_for('contributors', year=year, lang=lang, _anchor='LeaVerou') }}">Lea Verou</a>によって書かれたものであり、個別のライブラリとしてオープンソース化されています。
-            これは、セレクターと詳細度に関連するすべてのCSSの分析で広く使われています。
+            <a href="https://projects.verou.me/parsel/">Parsel</a>はCSSセレクターの構文解析と詳細度の計算ツールで、元々は<a href="{{ url_for('chapter', year=year, lang=lang, chapter='css') }}">CSS</a>の章をリードする<a href="{{ url_for('contributors', year=year, lang=lang, _anchor='LeaVerou') }}">Lea Verou</a>によって書かれたものであり、個別のライブラリとしてオープンソース化されています。これは、セレクターと詳細度に関連するすべてのCSSの分析で広く使われています。
         </p>
     </section>
 

--- a/src/templates/ja/2020/table_of_contents.html
+++ b/src/templates/ja/2020/table_of_contents.html
@@ -5,4 +5,3 @@
 {% block description %}2020年版Web Almanacの目次、各セクションを一覧表示しています。ページコンテンツ、ユーザー体験、コンテンツ公開、コンテンツ配信。{% endblock %}
 
 {% block twitter_image_alt %}{{ year }} Web Almanac方法論{% endblock %}
-

--- a/src/templates/pt/2019/contributors.html
+++ b/src/templates/pt/2019/contributors.html
@@ -4,7 +4,6 @@
 
 {% block description %}O {{ config.contributors.items() | length }} pessoas que contribuíram para o Web Almanac 2019 como analistas, autores, pensadores, designers, desenvolvedores, editores, revisores e tradutores.{% endblock %}
 
-
 {% block filter_by_team %}Filtrar por equipe: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> de <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> contribuidores.{% endblock %}
 {% block filter_by %}Filtrar por{% endblock %}
 

--- a/src/templates/pt/2019/error.html
+++ b/src/templates/pt/2019/error.html
@@ -1,6 +1,5 @@
 {% extends "base/2019/error.html" %}
 
-
 {% block unknown_error %}Erro desconhecido{% endblock %}
 
 {% 

--- a/src/templates/pt/2019/index.html
+++ b/src/templates/pt/2019/index.html
@@ -5,7 +5,5 @@
 
 {% block twitter_image_alt %}Web Almanac {{ year }} {% endblock %}
 
-
 {% block intro_title %}Web Almanac{% endblock %}
 {% block intro_sub_title %}HTTP Archive relatório annual do <br> <b>estado da web</b>{% endblock %}
-

--- a/src/templates/pt/2019/table_of_contents.html
+++ b/src/templates/pt/2019/table_of_contents.html
@@ -5,4 +5,3 @@
 {% block description %}Tabela de Conteúdos de Web Almanac de 2019 , listando cada seção: Conteúdo da página, Experiência do usuário, Publicação de conteúdo, Distribuição de conteúdo.{% endblock %}
 
 {% block twitter_image_alt %}Web Almanac metodologia {{ year }}{% endblock %}
-

--- a/src/templates/pt/2020/contributors.html
+++ b/src/templates/pt/2020/contributors.html
@@ -4,7 +4,6 @@
 
 {% block description %}O {{ config.contributors.items() | length }} pessoas que contribuíram para o Web Almanac {{ year }} como analistas, autores, pensadores, designers, desenvolvedores, editores, revisores e tradutores.{% endblock %}
 
-
 {% block filter_by_team %}Filtrar por equipe: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> de <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> contribuidores.{% endblock %}
 {% block filter_by %}Filtrar por{% endblock %}
 

--- a/src/templates/pt/2020/index.html
+++ b/src/templates/pt/2020/index.html
@@ -5,7 +5,6 @@
 
 {% block twitter_image_alt %}Web Almanac {{ year }} {% endblock %}
 
-
 {% block intro_title %}{{ self.coming_soon() }}{% endblock %}
 {% block intro_sub_title %}O relatório do <b>estado da web</b> de {{ year }}{% endblock %}
 

--- a/src/templates/pt/2020/table_of_contents.html
+++ b/src/templates/pt/2020/table_of_contents.html
@@ -5,4 +5,3 @@
 {% block description %}Tabela de Conteúdos de Web Almanac de 2020 , listando cada seção: Conteúdo da página, Experiência do usuário, Publicação de conteúdo, Distribuição de conteúdo.{% endblock %}
 
 {% block twitter_image_alt %}Web Almanac metodologia {{ year }}{% endblock %}
-

--- a/src/templates/zh-CN/2019/accessibility_statement.html
+++ b/src/templates/zh-CN/2019/accessibility_statement.html
@@ -6,7 +6,6 @@
 
 {% block twitter_image_alt %}Web Almanac 无障碍访问声明{% endblock %}
 
-
 {% block index %}
       <ul>
         <li><a href="#overview">概览</a></li>

--- a/src/templates/zh-CN/2019/base_ebook.html
+++ b/src/templates/zh-CN/2019/base_ebook.html
@@ -2,7 +2,6 @@
 
 {% block title %}{{ year }} Web Almanac 源于 HTTP Archive{% endblock %}
 
-
 {% block intro_title %}<span class="intro-year">{{ year }}</span><br>Web Almanac{% endblock %}
 {% block intro_sub_title %}HTTP Archive 的<br><b>web状态</b>报告{% endblock %}
 

--- a/src/templates/zh-CN/2019/contributors.html
+++ b/src/templates/zh-CN/2019/contributors.html
@@ -4,7 +4,6 @@
 
 {% block description %}{{ config.contributors.items() | length }} 为 2019 Web Almanac 贡献的人员，包括分析者, 作者, 头脑风暴者, 设计者, 开发者, 编辑者, 审稿者和翻译者。{% endblock %}
 
-
 {% block filter_by_team %}按组过滤: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> 的 <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> 贡献者.{% endblock %}
 {% block filter_by %}过滤{% endblock %}
 

--- a/src/templates/zh-CN/2019/error.html
+++ b/src/templates/zh-CN/2019/error.html
@@ -1,6 +1,5 @@
 {% extends "base/2019/error.html" %}
 
-
 {% block unknown_error %}未知错误{% endblock %}
 
 {% 

--- a/src/templates/zh-CN/2019/index.html
+++ b/src/templates/zh-CN/2019/index.html
@@ -5,7 +5,5 @@
 
 {% block twitter_image_alt %}{{ year }} Web Almanac网络年鉴{% endblock %}
 
-
 {% block intro_title %}Web Almanac{% endblock %}
 {% block intro_sub_title %}HTTP Archive的年度报告<br> <b>网络状态</b>报告{% endblock %}
-

--- a/src/templates/zh-CN/2019/methodology.html
+++ b/src/templates/zh-CN/2019/methodology.html
@@ -6,7 +6,6 @@
 
 {% block twitter_image_alt %}{{ year }} Web Almanac 方法论{% endblock %}
 
-
 {% block index %}
       <ul>
         <li><a href="#overview">概述</a></li>

--- a/src/templates/zh-CN/2019/table_of_contents.html
+++ b/src/templates/zh-CN/2019/table_of_contents.html
@@ -4,6 +4,4 @@
 
 {% block description %}2019 Web Almanac 表单内容, 列出以下部分: 页面内容、用户体验、内容发布、内容分发。{% endblock %}
 
-
 {% block twitter_image_alt %}{{ year }} Web Almanac 方法论{% endblock %}
-

--- a/src/templates/zh-CN/2020/contributors.html
+++ b/src/templates/zh-CN/2020/contributors.html
@@ -4,7 +4,6 @@
 
 {% block description %}The {{ config.contributors.items() | length }} 为 {{ year }} Web Almanac 贡献的人员，包括分析者, 作者, 设计者, 开发者, 编辑者, 领导者，审稿者和翻译者。{% endblock %}
 
-
 {% block filter_by_team %}按组过滤: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> of <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> contributors.{% endblock %}
 {% block filter_by %}过滤{% endblock %}
 

--- a/src/templates/zh-CN/2020/index.html
+++ b/src/templates/zh-CN/2020/index.html
@@ -5,7 +5,6 @@
 
 {% block twitter_image_alt %}{{ year }} Web Almanac网络年鉴{% endblock %}
 
-
 {% block intro_title %}{{ self.coming_soon() }}{% endblock %}
 {% block intro_sub_title %}{{ year }} <b>网络状态</b> 报告{% endblock %}
 

--- a/src/templates/zh-CN/2020/table_of_contents.html
+++ b/src/templates/zh-CN/2020/table_of_contents.html
@@ -5,4 +5,3 @@
 {% block description %}2020 Web Almanac 表单内容, 列出以下部分: 页面内容、用户体验、内容发布、内容分发。{% endblock %}
 
 {% block twitter_image_alt %}{{ year }} Web Almanac 方法论{% endblock %}
-

--- a/src/templates/zh-TW/2019/base_ebook.html
+++ b/src/templates/zh-TW/2019/base_ebook.html
@@ -2,7 +2,6 @@
 
 {% block title %} {{ year }} Web Almanac 精粹自 HTTP Archive{% endblock %}
 
-
 {% block intro_title %}<span class="intro-year">{{ year }}</span><br>Web Almanac{% endblock %}
 {% block intro_sub_title %}HTTP Archive 的年度<br><b>網路狀態</b> 報告{% endblock %}
 

--- a/src/templates/zh-TW/2019/contributors.html
+++ b/src/templates/zh-TW/2019/contributors.html
@@ -4,7 +4,6 @@
 
 {% block description %} {{ config.contributors.items() | length }} Web Almanac 2019年的貢獻團隊有分析者、作者、腦力激盪者、設計者、開發者、編輯者、審稿者和翻譯者。{% endblock %}
 
-
 {% block filter_by_team %}按類組篩選： <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> 的 <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> 貢獻者。{% endblock %}
 {% block filter_by %}篩選{% endblock %}
 

--- a/src/templates/zh-TW/2019/error.html
+++ b/src/templates/zh-TW/2019/error.html
@@ -1,6 +1,5 @@
 {% extends "base/2019/error.html" %}
 
-
 {% block unknown_error %}未知錯誤{% endblock %}
 
 {% 

--- a/src/templates/zh-TW/2019/index.html
+++ b/src/templates/zh-TW/2019/index.html
@@ -5,6 +5,5 @@
 
 {% block twitter_image_alt %} {{ year }} Web Almanac{% endblock %}
 
-
 {% block intro_title %}Web Almanac{% endblock %}
 {% block intro_sub_title %}HTTP Archive 的年度<br> <b>網路狀態</b> 報告{% endblock %}

--- a/src/templates/zh-TW/2019/table_of_contents.html
+++ b/src/templates/zh-TW/2019/table_of_contents.html
@@ -5,4 +5,3 @@
 {% block description %}Web Almanac 網路年鑑2019年列出以下章節：頁面內容、使用者體驗、內容發布、內容傳遞。{% endblock %}
 
 {% block twitter_image_alt %}{{ year }} Web Almanac 網路年鑑的統計方法{% endblock %}
-

--- a/src/templates/zh-TW/2020/contributors.html
+++ b/src/templates/zh-TW/2020/contributors.html
@@ -4,7 +4,6 @@
 
 {% block description %} {{ config.contributors.items() | length }} 位團隊成員貢獻 {{ year }} Web Almanac 有分析者、作者、腦力激盪者、設計者、開發者、編輯者、審稿者和翻譯者。{% endblock %}
 
-
 {% block filter_by_team %}按類組篩選： <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> 的 <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> 貢獻者。{% endblock %}
 {% block filter_by %}篩選{% endblock %}
 

--- a/src/templates/zh-TW/2020/index.html
+++ b/src/templates/zh-TW/2020/index.html
@@ -5,7 +5,6 @@
 
 {% block twitter_image_alt %} {{ year }} Web Almanac{% endblock %}
 
-
 {% block intro_title %}{{ self.coming_soon() }}{% endblock %}
 {% block intro_sub_title %} {{ year }} <b>網路年鑑</b> 報告{% endblock %}
 

--- a/src/templates/zh-TW/2020/table_of_contents.html
+++ b/src/templates/zh-TW/2020/table_of_contents.html
@@ -5,4 +5,3 @@
 {% block description %}Web Almanac 網路年鑑2020年列出以下章節：頁面內容、使用者體驗、內容發布、內容傳遞。{% endblock %}
 
 {% block twitter_image_alt %}{{ year }} Web Almanac 網路年鑑的統計方法{% endblock %}
-


### PR DESCRIPTION
Noticed differences in lines numbers when reviewing the Russian translation. This makes it difficult to see real differences.