### PR TITLE
Bug with error template since template reorg

### DIFF
--- a/src/server/helpers.py
+++ b/src/server/helpers.py
@@ -71,12 +71,9 @@ def render_error_template(error, status_code):
     if lang not in supported_langs:
         lang = DEFAULT_LANGUAGE.lang_code
 
-    if not (os.path.isfile(TEMPLATES_DIR + '/%s/%s/error.html' % (lang, year))):
-        if os.path.isfile(TEMPLATES_DIR + '/%s/%s/error.html' % (lang, DEFAULT_YEAR)):
-            year = DEFAULT_YEAR
-        elif os.path.isfile(TEMPLATES_DIR + '/%s/%s/error.html' % (DEFAULT_LANGUAGE.lang_code, DEFAULT_YEAR)):
+    if not (os.path.isfile(TEMPLATES_DIR + '/%s/error.html' % lang)):
+        if os.path.isfile(TEMPLATES_DIR + '/%s/error.html' % DEFAULT_LANGUAGE.lang_code):
             lang = DEFAULT_LANGUAGE.lang_code
-            year = DEFAULT_YEAR
     return render_template('%s/error.html' % lang, lang=lang, year=year, error=error), status_code
 
 


### PR DESCRIPTION
Noticed a small bug with error templates still referencing old location.

Will only affect if a language is added without an error template (and all of them have them at the moment), hence why wasn't noticed before but should fix as fix is small (and actually cleaner code anyway!)