### PR TITLE
Pytest tests for helpers.py

### DIFF
--- a/.github/linters/.flake8
+++ b/.github/linters/.flake8
@@ -3,4 +3,4 @@ max-line-length = 120
 per-file-ignores =
     # The __init__.py file imports the routes and errors file at bottom
     /github/workspace/src/server/__init__.py:E402,F401
-    /github/workspace/server/__init__.py:E402,F401
+    /tmp/lint/server/__init__.py:E402,F401

--- a/src/package.json
+++ b/src/package.json
@@ -22,7 +22,7 @@
     "lint": "run-script-os",
     "lint:darwin:linux": "docker container run -it --rm -v \"$PWD/..\":/app -w /app/src --entrypoint=./tools/scripts/run_linter_locally.sh github/super-linter",
     "lint:win32": "docker container run --rm -v \"%cd%\\..\":/app -w /app/src --entrypoint=./tools/scripts/run_linter_locally.sh github/super-linter",
-    "pytest": "pytest --cov server --cov-fail-under=65 --cov-report=term-missing -s",
+    "pytest": "pytest --cov server --cov-fail-under=85 --cov-report=term-missing -s",
     "stage": "./tools/scripts/deploy.sh -n",
     "start": "run-script-os",
     "start:darwin:linux": "./tools/scripts/run_and_test_website.sh -d",

--- a/src/server/helpers.py
+++ b/src/server/helpers.py
@@ -108,7 +108,7 @@ def get_chapter_nextprev(config, chapter_slug):
         if found and next_chapter:
             break
 
-    if found is False:
+    if not found:
         return None
 
     return prev_chapter, next_chapter

--- a/src/server/helpers.py
+++ b/src/server/helpers.py
@@ -71,12 +71,9 @@ def render_error_template(error, status_code):
     if lang not in supported_langs:
         lang = DEFAULT_LANGUAGE.lang_code
 
-    if not (os.path.isfile(TEMPLATES_DIR + '/%s/%s/error.html' % (lang, year))):
-        if os.path.isfile(TEMPLATES_DIR + '/%s/%s/error.html' % (lang, DEFAULT_YEAR)):
-            year = DEFAULT_YEAR
-        elif os.path.isfile(TEMPLATES_DIR + '/%s/%s/error.html' % (DEFAULT_LANGUAGE.lang_code, DEFAULT_YEAR)):
+    if not (os.path.isfile(TEMPLATES_DIR + '/%s/error.html' % (lang))):
+        if os.path.isfile(TEMPLATES_DIR + '/%s/error.html' % (DEFAULT_LANGUAGE.lang_code)):
             lang = DEFAULT_LANGUAGE.lang_code
-            year = DEFAULT_YEAR
     return render_template('%s/error.html' % lang, lang=lang, year=year, error=error), status_code
 
 
@@ -111,6 +108,9 @@ def get_chapter_nextprev(config, chapter_slug):
         if found and next_chapter:
             break
 
+    if found is False:
+        return None
+
     return prev_chapter, next_chapter
 
 
@@ -138,9 +138,13 @@ def convert_old_image_path(folder):
 # anyway, so I think this is the cleanest.
 def get_ebook_methodology(lang, year):
     methodology_template = render_template('%s/%s/methodology.html' % (lang, year))
+    if not isinstance(methodology_template, str):
+        return False
     methodology_maincontent = re.search('<article id="maincontent" class="content">(.+?)</article>',
                                         methodology_template, re.DOTALL | re.MULTILINE)
-    if not methodology_maincontent:
+
+    # Can't test this as should never end up here unless bad template to 'pragma no cover' it is
+    if not methodology_maincontent:  # pragma no cover
         return False
 
     methodology_maincontent = methodology_maincontent.group(1)

--- a/src/server/tests/helpers_test.py
+++ b/src/server/tests/helpers_test.py
@@ -1,19 +1,245 @@
-from server.helpers import get_file_date_info, get_versioned_filename, get_ebook_size_in_mb
-from server.config import get_config, SUPPORTED_YEARS, get_entries_from_json
+from server.helpers import get_file_date_info, get_versioned_filename, get_ebook_size_in_mb, \
+    chapter_lang_exists, featured_chapters_exists, get_chapter_nextprev, convert_old_image_path, \
+    add_footnote_links, year_live, strip_accents, accentless_sort, render_template, render_error_template, \
+    get_ebook_methodology
+from server.config import get_config, SUPPORTED_LANGUAGES, SUPPORTED_YEARS, get_entries_from_json
+from server.language import _Language
+from server import app
+from flask import request
 import re
 import pytest
 
 
 MIN_DATE = "2019-11-01T00:00:00.000Z"
+
+# Get all configured ebooks across all years - used to test all ebook sizes are correct later
 all_ebooks = []
-
-
-# Get all configured ebooks across all years
 for year in SUPPORTED_YEARS:
     ebook_languages = get_entries_from_json(get_config(year), 'settings', 'ebook_languages')[0]
     for ebook_language in ebook_languages:
         year_lang = [ebook_language, year]
         all_ebooks.append(year_lang)
+
+
+def test_render_template_success():
+    with app.test_request_context():
+        render_call = render_template('en/2019/index.html', lang='en', year='2019')
+        # Check it's a decent size with 'Web Almanac' somewhere in there
+        assert len(render_call) > 3000 and 'Web Almanac' in render_call
+
+
+def test_render_template_no_chapter():
+    # Note normally this would be caught by validate before render_template is called
+    with app.test_request_context():
+        request.full_path = '/en/2019/random'
+        render_call = render_template(template='en/2019/chapters/random.html', lang='en', year='2019')
+        assert render_call.status_code == 302 and render_call.headers['Location'] == '/en/2019/'
+
+
+def test_render_template_translation_valid_chapter():
+    with app.test_request_context():
+        request.full_path = '/es/2019/css'
+        render_call = render_template(template='es/2019/chapters/css.html', lang='es', year='2019')
+        assert len(render_call) > 3000 and '<html lang="es"' in render_call
+
+
+def test_render_template_no_translation_valid_chapter():
+    with app.test_request_context():
+        request.full_path = '/es/2019/css'
+        # Use a fake template that won't ever be found by overriding lang to 99
+        render_call = render_template(template='99/2019/chapters/css.html', lang='es', year='2019')
+        assert render_call.status_code == 302 and render_call.headers['Location'] == '/en/2019/css'
+
+
+def test_render_template_no_translation_invalid_chapter():
+    with app.test_request_context():
+        request.full_path = '/es/2019/random'
+        render_call = render_template(template='es/2019/chapters/random.html', lang='es', year='2019')
+        assert render_call.status_code == 302 and render_call.headers['Location'] == '/es/2019/'
+
+
+def test_render_error_template_404():
+    with app.test_request_context():
+        render_call = render_error_template(error='Not Found', status_code=404)
+        assert render_call[1] == 404
+
+
+def test_render_error_template_404_es():
+    with app.test_request_context():
+        request.view_args = {'lang': 'es', 'year': '2019'}
+        render_call = render_error_template(error='Not Found', status_code=404)
+        assert render_call[1] == 404 and '<html lang="es"' in render_call[0]
+
+
+def test_render_error_template_404_bad_lang():
+    with app.test_request_context():
+        request.view_args = {'lang': '12', 'year': '2019'}
+        render_call = render_error_template(error='Not Found', status_code=404)
+        assert render_call[1] == 404 and '<html lang="en"' in render_call[0]
+
+
+def test_render_error_template_404_bad_year():
+    with app.test_request_context():
+        request.view_args = {'lang': 'en', 'year': '2018'}
+        render_call = render_error_template(error='Not Found', status_code=404)
+        assert render_call[1] == 404 and '<html lang="en"' in render_call[0]
+
+
+def test_render_error_template_404_bad_lang_and_year():
+    with app.test_request_context():
+        request.view_args = {'lang': '12', 'year': '2018'}
+        render_call = render_error_template(error='Not Found', status_code=404)
+        assert render_call[1] == 404 and '<html lang="en"' in render_call[0]
+
+
+def test_render_error_template_404_no_error_template():
+    with app.test_request_context():
+        # As all languages should have an error template we fake a new "valid" language called random
+        request.view_args = {'lang': 'random', 'year': '2020'}
+
+        class Language(object):
+            EN = _Language('English', 'en')
+            RANDOM = _Language('Random', 'random')
+
+        Languages = []
+        Languages.append(getattr(Language, 'EN'))
+        Languages.append(getattr(Language, 'RANDOM'))
+        SUPPORTED_LANGUAGES.update({'2020': Languages})
+        render_call = render_error_template(error='Not Found', status_code=404)
+        assert render_call[1] == 404 and '<html lang="en"' in render_call[0]
+
+
+def test_chapter_lang_exists():
+    assert chapter_lang_exists('en', '2019', 'css') is True
+
+
+def test_chapter_lang_not_exists():
+    assert chapter_lang_exists('en', '2019', 'random') is False
+
+
+def test_featured_chapters_exists():
+    assert featured_chapters_exists('en', '2019') is True
+
+
+def test_featured_chapters_not_exists():
+    assert featured_chapters_exists('random', '2019') is False
+
+
+def test_get_chapter_nextprev_1st_chapter():
+    nextprev = get_chapter_nextprev(get_config('2019'), 'javascript')
+    prev_slug = nextprev[0]
+    next_slug = nextprev[1]['slug']
+    assert next_slug == 'css' and prev_slug is None
+
+
+def test_get_chapter_nextprev_mid_chapter():
+    nextprev = get_chapter_nextprev(get_config('2019'), 'css')
+    prev_slug = nextprev[0]['slug']
+    next_slug = nextprev[1]['slug']
+    assert next_slug == 'markup' and prev_slug == 'javascript'
+
+
+def test_get_chapter_nextprev_last_chapter():
+    nextprev = get_chapter_nextprev(get_config('2019'), 'http2')
+    prev_slug = nextprev[0]['slug']
+    next_slug = nextprev[1]
+    assert next_slug is None and prev_slug == 'resource-hints'
+
+
+def test_get_chapter_nextprev_unknown_chapter():
+    nextprev = get_chapter_nextprev(get_config('2019'), 'random')
+    assert nextprev is None
+
+
+def test_convert_old_image_path_http2():
+    new_folder = convert_old_image_path('20_HTTP_2')
+    assert new_folder == 'http2'
+
+
+def test_convert_old_image_path_fake_css():
+    new_folder = convert_old_image_path('99_CSS')
+    assert new_folder == 'css'
+
+
+def test_convert_old_image_path_random():
+    new_folder = convert_old_image_path('99_RANDOM')
+    assert new_folder == 'random'
+
+
+def test_render_methodology():
+    with app.test_request_context():
+        render_call = get_ebook_methodology('en', '2019')
+        # Check it's a decent size with 'Web Almanac' somewhere in there
+        assert len(render_call) > 3000 and 'Web Almanac' in render_call
+
+
+def test_render_methodology_bad_year():
+    with app.test_request_context():
+        render_call = get_ebook_methodology('en', '2018')
+        assert render_call is False
+
+
+def test_render_methodology_bad_lang():
+    with app.test_request_context():
+        render_call = get_ebook_methodology('random', '2019')
+        assert render_call is False
+
+
+def test_render_methodology_bad_year_lang():
+    with app.test_request_context():
+        render_call = get_ebook_methodology('random', '2018')
+        assert render_call is False
+
+
+def test_add_footnote_links():
+    footnote_html = add_footnote_links('<a href="http://example.com">linktext</a>')
+    assert footnote_html == '<a href="http://example.com">linktext</a><span class="fn">http://example.com</span>'
+
+
+def test_year_live_2018():
+    assert year_live('2018') is False
+
+
+def test_year_live_2019():
+    assert year_live('2019') is True
+
+
+def test_year_live_2020():
+    assert year_live('2020') is True
+
+
+def test_strip_accents_fr_edition():
+    assert strip_accents('Édition') == 'Edition'
+
+
+def test_strip_accents_en_edition():
+    assert strip_accents('Edition') == 'Edition'
+
+
+def test_accentless_sort():
+    unsorted_french_teams_dict = {
+        "analysts": "Analyse",
+        "authors": "Rédaction",
+        "brainstormers": "Réflexion",
+        "designers": "Design",
+        "developers": "Développement",
+        "editors": "Édition",
+        "leads": "Gestion de projet",
+        "reviewers": "Relecture",
+        "translators": "Traduction"
+    }
+    sorted_french_teams_list = [
+        ("analysts", "Analyse"),
+        ("designers", "Design"),
+        ("developers", "Développement"),
+        ("editors", "Édition"),
+        ("leads", "Gestion de projet"),
+        ("authors", "Rédaction"),
+        ("brainstormers", "Réflexion"),
+        ("reviewers", "Relecture"),
+        ("translators", "Traduction")
+    ]
+    assert accentless_sort(unsorted_french_teams_dict.items()) == sorted_french_teams_list
 
 
 def test_date_published_is_returned_and_correct_format():


### PR DESCRIPTION
Makes progress on #1229 

Moves pytest coverage of [helpers.py](https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/src/server/helpers.py) from 31% to 100% and overall pytest coverage from 67% to 87%

Mostly the code itself is untouched, but did identify a couple of edge cases that weren't handled the best. Fixed one in #1575 as could cause issues in prod if new language added, but rest are edge cases I left for this PR.

```
Name                            Stmts   Miss  Cover   Missing
-------------------------------------------------------------
server/__init__.py                 39     12    69%   19-21, 37-45
server/config.py                   75      3    96%   103-106
server/csp.py                       1      0   100%
server/errors.py                   23      8    65%   11, 16-17, 22, 27-28, 33-34
server/feature_policy.py            1      0   100%
server/helpers.py                 126      0   100%
server/language.py                 33      1    97%   10
server/routes.py                   72     30    58%   12, 18, 24-26, 32, 38-42, 48, 58-61, 78-82, 90-92, 98, 103, 109-112, 118
server/tests/__init__.py            0      0   100%
server/tests/helpers_test.py      182      0   100%
server/tests/validate_test.py      52      0   100%
server/validate.py                 79     33    58%   25-53, 59-72, 81-82, 104, 108-109
-------------------------------------------------------------
TOTAL                             683     87    87%
```

@SaptakS since you reviewed my last Python change could you have a look over this?
And would gladly take any other feedback from anyone else with Python experience.