### PR TITLE
Fix prevnext for todo chapters

### DIFF
--- a/src/server/helpers.py
+++ b/src/server/helpers.py
@@ -101,7 +101,7 @@ def get_chapter_nextprev(config, chapter_slug):
             if found and 'todo' not in chapter:
                 next_chapter = chapter
                 break
-            elif chapter.get('slug') == chapter_slug and 'todo' not in chapter:
+            elif chapter.get('slug') == chapter_slug not in chapter:
                 found = True
             elif 'todo' not in chapter:
                 prev_chapter = chapter
@@ -109,7 +109,7 @@ def get_chapter_nextprev(config, chapter_slug):
             break
 
     if not found:
-        return None
+        return (None, None)
 
     return prev_chapter, next_chapter
 

--- a/src/server/tests/helpers_test.py
+++ b/src/server/tests/helpers_test.py
@@ -148,7 +148,9 @@ def test_get_chapter_nextprev_last_chapter():
 
 def test_get_chapter_nextprev_unknown_chapter():
     nextprev = get_chapter_nextprev(get_config('2019'), 'random')
-    assert nextprev is None
+    prev_slug = nextprev[0]
+    next_slug = nextprev[1]
+    assert prev_slug is None and next_slug is None
 
 
 def test_convert_old_image_path_http2():


### PR DESCRIPTION
A change when adding pylint tests mean that ToDo chapters cannot render properly. The change actually surfaced a previous bug that was already there so not technically the fault of that change but either way we need to fix ASAP so will merge this right away.