### PR TITLE
Add exterkamp to 2020 contributors

### DIFF
--- a/src/config/2020.json
+++ b/src/config/2020.json
@@ -1281,6 +1281,15 @@
       "github": "sergeychernyshev",
       "twitter": "sergeyche"
     },
+    "exterkamp": {
+      "name": "Shane Exterkamp",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "https://avatars2.githubusercontent.com/u/6392995?v=4&s=200",
+      "github": "exterkamp",
+      "twitter": "Shane_Exterkamp"
+    },
     "spanicker": {
       "name": "Shubhie Panicker",
       "teams": [


### PR DESCRIPTION
I've contributed to the [Third-Party](https://github.com/HTTPArchive/almanac.httparchive.org/issues/901) and [Performance](https://github.com/HTTPArchive/almanac.httparchive.org/issues/905) chapters as a reviewer. And Rick said to add myself to the [contrib.json](https://github.com/HTTPArchive/almanac.httparchive.org/issues/905#issuecomment-734958409).