### PR TITLE
Accessibility 2020 queries: Find the pages with the longest alts

### DIFF
--- a/sql/2020/08_Accessibility/README.md
+++ b/sql/2020/08_Accessibility/README.md
@@ -1,5 +1,5 @@
 ## Files and their purpose
 
-### pages_with_longest_alts.sql
+### [pages_with_longest_alts.sql](./pages_with_longest_alts.sql)
 
 This SQL file finds the specific pages (their url) with longest alt tags so we can physicially see them for ourselves and verify the crawler isn't broken

--- a/sql/2020/08_Accessibility/README.md
+++ b/sql/2020/08_Accessibility/README.md
@@ -1,0 +1,5 @@
+## Files and their purpose
+
+### pages_with_longest_alts.sql
+
+This SQL file finds the specific pages (their url) with longest alt tags so we can physicially see them for ourselves and verify the crawler isn't broken

--- a/sql/2020/08_Accessibility/pages_with_longest_alts.sql
+++ b/sql/2020/08_Accessibility/pages_with_longest_alts.sql
@@ -1,0 +1,26 @@
+#standardSQL
+
+SELECT
+  client,
+  url,
+  largest_alt,
+  alt_rank
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    url,
+    MAX(SAFE_CAST(alt_length_string AS INT64)) AS largest_alt,
+    ROW_NUMBER() OVER (PARTITION BY _TABLE_SUFFIX ORDER BY MAX(SAFE_CAST(alt_length_string AS INT64)) DESC) AS alt_rank
+  FROM
+    `httparchive.pages.2020_08_01_*`,
+    UNNEST(
+      JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._almanac'), '$.images.alt_lengths')
+    ) AS alt_length_string
+  GROUP BY
+    client,
+    url
+)
+WHERE
+  alt_rank <= 100
+ORDER BY
+  alt_rank ASC


### PR DESCRIPTION
Find the pages with the longest alt tags so we can verify the crawler isn't broken and see them for ourselves

Progress on #907 