### PR TITLE
Support h5 and h6 in chapters

### DIFF
--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -366,6 +366,30 @@ h6,
   line-height: 1.2em;
 }
 
+h1 {
+  font-size: 2em;
+}
+
+h2 {
+  font-size: 1.5em;
+}
+
+h3 {
+  font-size: 1.2em;
+}
+
+h4 {
+  font-size: 1.15em;
+}
+
+h5 {
+  font-size: 1.075em;
+}
+
+h6 {
+  font-size: 1em;
+}
+
 b {
   font-weight: bold;
 }

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -130,6 +130,17 @@
 
 .index li li li a {
   padding-left: 48px;
+  padding-left: 3rem;
+}
+
+.index li li li li a {
+  padding-left: 64px;
+  padding-left: 4rem;
+}
+
+.index li li li li li a {
+  padding-left: 80px;
+  padding-left: 5rem;
 }
 
 .index li::before {


### PR DESCRIPTION
We currently only really support h1-h4 in our chapters as h5 and h6 has two issues:
1. Not intended any more than h4 in Table of Contents
2. Appears really small compared to text in main content

This PR fixes both of these issues as more levels may be wanted by some chapters (e.g. SEO).

It does make a slight alteration from the default User Agent style:

Heading | Chrome, Firefox and Safari Default Style | New Style | Comment
---------|-------------|-----------|-----
h1 | 2em | 2em | No change
h2 | 1.5em | 1.5em | No change
h3 | 1.17em | 1.2em | Slight increase in size to better space out smaller sizes below
h4 | 1.0625em | 1.15em | Slight increase as wasn't setting this so picking up `.main` default, but now are explicitly setting this to a slightly bigger size to better space out smaller sizes below
h5 | 0.83em | 1.075em | Bigger but shouldn't matter as not currently used and increasing it is the point of this change
h6  | 0.67.em | 1em | Bigger but shouldn't matter as not currently used and increasing it is the point of this change