### PR TITLE
Pytest config.py

### DIFF
--- a/src/config/2020.json
+++ b/src/config/2020.json
@@ -215,7 +215,8 @@
       "name": "Abby Tsai",
       "teams": [
         "analysts",
-        "translators"
+        "translators",
+        "developers"
       ],
       "avatar_url": "https://avatars1.githubusercontent.com/u/44442451?v=4&s=200",
       "github": "AbbyTsai"

--- a/src/server/config.py
+++ b/src/server/config.py
@@ -100,5 +100,5 @@ def update_config():
                         contributor['avatar_url'] = DEFAULT_AVATAR_FOLDER_PATH + str(
                             hash(contributor_id) % AVATARS_NUMBER) + '.jpg'
 
-                     
+
 update_config()

--- a/src/server/config.py
+++ b/src/server/config.py
@@ -100,5 +100,5 @@ def update_config():
                         contributor['avatar_url'] = DEFAULT_AVATAR_FOLDER_PATH + str(
                             hash(contributor_id) % AVATARS_NUMBER) + '.jpg'
 
-                            
+                     
 update_config()

--- a/src/server/config.py
+++ b/src/server/config.py
@@ -99,14 +99,6 @@ def update_config():
 
                 for contributor_id, contributor in json_config['contributors'].items():
                     if 'avatar_url' not in contributor:
-                        if 'gravatar' in contributor:
-                            gravatar_url = 'https://www.gravatar.com/avatar/' + hashlib.md5(
-                                contributor['gravatar'].lower().encode()).hexdigest() + '.jpg?'
-                            gravatar_url += urllib.parse.urlencode({'d': 'mp', 's': str(AVATAR_SIZE)})
-                            contributor['avatar_url'] = gravatar_url
-                        else:
-                            contributor['avatar_url'] = DEFAULT_AVATAR_FOLDER_PATH + str(
-                                hash(contributor_id) % AVATARS_NUMBER) + '.jpg'
-
-
+                        contributor['avatar_url'] = DEFAULT_AVATAR_FOLDER_PATH + str(
+                            hash(contributor_id) % AVATARS_NUMBER) + '.jpg'
 update_config()

--- a/src/server/config.py
+++ b/src/server/config.py
@@ -1,6 +1,4 @@
-import hashlib
 import json
-import urllib.parse
 import os
 
 from .language import Language

--- a/src/server/config.py
+++ b/src/server/config.py
@@ -101,4 +101,6 @@ def update_config():
                     if 'avatar_url' not in contributor:
                         contributor['avatar_url'] = DEFAULT_AVATAR_FOLDER_PATH + str(
                             hash(contributor_id) % AVATARS_NUMBER) + '.jpg'
+
+                            
 update_config()

--- a/src/server/tests/config_test.py
+++ b/src/server/tests/config_test.py
@@ -45,6 +45,16 @@ def test_get_languages_good_and_bad():
     languages = [str(language) for language in get_languages(get_config('2019'))]
     assert 'English' in languages
     assert 'random' not in languages
-def test_get_live():
+def test_get_live_for_all_supported_years():
     for year in SUPPORTED_YEARS:
         assert get_live(get_config(year)) is True
+
+
+def test_get_live_for_known_years():
+    assert get_live(get_config('2019')) is True
+    assert get_live(get_config('2020')) is True
+
+
+def test_get_live_for_bad_year_raises_error():
+    with pytest.raises(TypeError):
+        get_live(get_config('2018'))

--- a/src/server/tests/config_test.py
+++ b/src/server/tests/config_test.py
@@ -27,6 +27,14 @@ def test_get_chapters_for_all_supported_chapters():
             assert chapter in SUPPORTED_CHAPTERS[year]
 
 
+def test_get_chapters_good_chapter():
+    assert 'javascript' in get_chapters(get_config('2019'))
+
+
+def test_get_chapters_bad_chapter():
+    assert 'random' not in get_chapters(get_config('2019'))
+
+
 def test_get_languages_in_supported_languages():
     for year in SUPPORTED_YEARS:
         for language in get_languages(get_config(year)):

--- a/src/server/tests/config_test.py
+++ b/src/server/tests/config_test.py
@@ -1,8 +1,11 @@
-from server.config import get_config, get_chapters, get_languages, get_live, SUPPORTED_YEARS, SUPPORTED_CHAPTERS, SUPPORTED_LANGUAGES
+from server.config import get_config, get_chapters, get_languages, get_live, \
+    SUPPORTED_YEARS, SUPPORTED_CHAPTERS, SUPPORTED_LANGUAGES
+
 
 def test_get_config_in_suppoted_year():
     for year in SUPPORTED_YEARS:
         assert get_config(year) is not None
+
 
 def test_get_chapters_in_supported_chapters():
     for year in SUPPORTED_YEARS:
@@ -18,4 +21,4 @@ def test_get_languages_in_supported_languages():
 
 def test_get_live():
     for year in SUPPORTED_YEARS:
-        assert get_live(get_config(year)) == True
+        assert get_live(get_config(year)) is True

--- a/src/server/tests/config_test.py
+++ b/src/server/tests/config_test.py
@@ -1,6 +1,6 @@
 from server.config import get_config, get_chapters, get_languages, get_live, \
     SUPPORTED_YEARS, SUPPORTED_CHAPTERS, SUPPORTED_LANGUAGES
-
+import pytest
 
 def test_get_config_year():
     assert get_config('2020') is not None

--- a/src/server/tests/config_test.py
+++ b/src/server/tests/config_test.py
@@ -35,7 +35,7 @@ def test_get_chapters_bad_chapter():
     assert 'random' not in get_chapters(get_config('2019'))
 
 
-def test_get_languages_in_supported_languages():
+def test_get_languages_for_all_supported_languages():
     for year in SUPPORTED_YEARS:
         for language in get_languages(get_config(year)):
             assert language in SUPPORTED_LANGUAGES[year]

--- a/src/server/tests/config_test.py
+++ b/src/server/tests/config_test.py
@@ -9,6 +9,7 @@ def test_get_config_year():
 
 
 def test_static_avatar():
+    # For this test we use an existing contributor with no avatar as they should be assigned one on initial load
     for contributor in get_config('2020'):
         if contributor == 'michelleoconnor':
             static_url = contributor['avatar_url']

--- a/src/server/tests/config_test.py
+++ b/src/server/tests/config_test.py
@@ -2,6 +2,7 @@ from server.config import get_config, get_chapters, get_languages, get_live, \
     SUPPORTED_YEARS, SUPPORTED_CHAPTERS, SUPPORTED_LANGUAGES
 import pytest
 
+
 def test_get_config_year():
     assert get_config('2020') is not None
     assert get_config('2019') is not None
@@ -45,6 +46,8 @@ def test_get_languages_good_and_bad():
     languages = [str(language) for language in get_languages(get_config('2019'))]
     assert 'English' in languages
     assert 'random' not in languages
+
+
 def test_get_live_for_all_supported_years():
     for year in SUPPORTED_YEARS:
         assert get_live(get_config(year)) is True

--- a/src/server/tests/config_test.py
+++ b/src/server/tests/config_test.py
@@ -1,0 +1,21 @@
+from server.config import get_config, get_chapters, get_languages, get_live, SUPPORTED_YEARS, SUPPORTED_CHAPTERS, SUPPORTED_LANGUAGES
+
+def test_get_config_in_suppoted_year():
+    for year in SUPPORTED_YEARS:
+        assert get_config(year) is not None
+
+def test_get_chapters_in_supported_chapters():
+    for year in SUPPORTED_YEARS:
+        for chapter in get_chapters(get_config(year)):
+            assert chapter in SUPPORTED_CHAPTERS[year]
+
+
+def test_get_languages_in_supported_languages():
+    for year in SUPPORTED_YEARS:
+        for language in get_languages(get_config(year)):
+            assert language in SUPPORTED_LANGUAGES[year]
+
+
+def test_get_live():
+    for year in SUPPORTED_YEARS:
+        assert get_live(get_config(year)) == True

--- a/src/server/tests/config_test.py
+++ b/src/server/tests/config_test.py
@@ -16,7 +16,7 @@ def test_static_avatar():
             assert static_url is not None and static_url.startswith('/static')
 
 
-def test_get_config_in_supported_year():
+def test_get_config_for_all_supported_years():
     for year in SUPPORTED_YEARS:
         assert get_config(year) is not None
 

--- a/src/server/tests/config_test.py
+++ b/src/server/tests/config_test.py
@@ -2,7 +2,23 @@ from server.config import get_config, get_chapters, get_languages, get_live, \
     SUPPORTED_YEARS, SUPPORTED_CHAPTERS, SUPPORTED_LANGUAGES
 
 
-def test_get_config_in_suppoted_year():
+test_year = ['2020', '2019', '2018']
+
+
+def test_get_config_year():
+    assert get_config(test_year[0]) is not None
+    assert get_config(test_year[1]) is not None
+    assert get_config(test_year[2]) is None
+
+
+def test_static_avatar():
+    for contributor in get_config('2020'):
+        if contributor == 'michelleoconnor':
+            static_url = contributor['avatar_url']
+            assert static_url is not None and static_url.startswith('/static')
+
+
+def test_get_config_in_supported_year():
     for year in SUPPORTED_YEARS:
         assert get_config(year) is not None
 

--- a/src/server/tests/config_test.py
+++ b/src/server/tests/config_test.py
@@ -21,7 +21,7 @@ def test_get_config_for_all_supported_years():
         assert get_config(year) is not None
 
 
-def test_get_chapters_in_supported_chapters():
+def test_get_chapters_for_all_supported_chapters():
     for year in SUPPORTED_YEARS:
         for chapter in get_chapters(get_config(year)):
             assert chapter in SUPPORTED_CHAPTERS[year]

--- a/src/server/tests/config_test.py
+++ b/src/server/tests/config_test.py
@@ -2,13 +2,10 @@ from server.config import get_config, get_chapters, get_languages, get_live, \
     SUPPORTED_YEARS, SUPPORTED_CHAPTERS, SUPPORTED_LANGUAGES
 
 
-test_year = ['2020', '2019', '2018']
-
-
 def test_get_config_year():
-    assert get_config(test_year[0]) is not None
-    assert get_config(test_year[1]) is not None
-    assert get_config(test_year[2]) is None
+    assert get_config('2020') is not None
+    assert get_config('2019') is not None
+    assert get_config('2018') is None
 
 
 def test_static_avatar():

--- a/src/server/tests/config_test.py
+++ b/src/server/tests/config_test.py
@@ -41,6 +41,10 @@ def test_get_languages_for_all_supported_languages():
             assert language in SUPPORTED_LANGUAGES[year]
 
 
+def test_get_languages_good_and_bad():
+    languages = [str(language) for language in get_languages(get_config('2019'))]
+    assert 'English' in languages
+    assert 'random' not in languages
 def test_get_live():
     for year in SUPPORTED_YEARS:
         assert get_live(get_config(year)) is True


### PR DESCRIPTION
Pytest coverage for config.py. Makes progress on #1229 

```
----------- coverage: platform win32, python 3.7.4-final-0 -----------
Name                            Stmts   Miss  Cover   Missing
-------------------------------------------------------------
server\__init__.py                 38     12    68%   19-21, 37-45
server\config.py                   69      0   100%
server\csp.py                       1      0   100%
server\errors.py                   18      8    56%   11, 16-17, 22, 27-28, 33-34
server\feature_policy.py            1      0   100%
server\helpers.py                 126      0   100%
server\language.py                 31      1    97%   10
server\routes.py                   59     30    49%   12, 18, 24-26, 32, 38-42, 48, 58-61, 78-82, 90-92, 98, 103, 109-112, 118
server\tests\__init__.py            0      0   100%
server\tests\config_test.py        25      2    92%   17-18
server\tests\helpers_test.py      183      0   100%
server\tests\validate_test.py      52      0   100%
server\validate.py                 78     33    58%   25-53, 59-72, 81-82, 104, 108-109
-------------------------------------------------------------
TOTAL                             681     86    87%
Required test coverage of 85% reached. Total coverage: 87.37%.
```

Note after discussion with @bazzadp we removed Gravatar support as not used and doesn't even work when we tested it!