### PR TITLE
Better heading sizes

### DIFF
--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -375,19 +375,20 @@ h2 {
 }
 
 h3 {
-  font-size: 1.2em;
+  font-size: 1.17em;
 }
 
 h4 {
-  font-size: 1.15em;
+  font-size: 1.0625em;
 }
 
 h5 {
-  font-size: 1.075em;
+  font-size: 1em;
 }
 
 h6 {
   font-size: 1em;
+  font-weight: normal;
 }
 
 b {


### PR DESCRIPTION
Revert some of the changes from #1603 to have bigger differences between `<h3>` and `<h4>`


Heading | Original (Chrome, Firefox and Safari Default Style) | New Style | New New Style | Comment
---------|---------------------------------------------------|-----------|-----------------|-----
h1 | 2em | 2em | 2em | No change
h2 | 1.5em | 1.5em | 1.5em | No change
h3 | 1.17em | 1.2em | 1.17em | Reverted back
h4 | 1.0625em | 1.15em | 1.0625em | Reverted back
h5 | 0.83em | 1.075em | 1em | Made smaller to allow `h4` to revert
h6  | 0.67.em | 1em | 1em no bold | Shouldn't be used much (currently no chapters used this)
