### PR TITLE
Contributors(authors, analysts and reviewers) cleanup

### DIFF
--- a/src/config/2019.json
+++ b/src/config/2019.json
@@ -425,9 +425,8 @@
     "colinbendell": {
       "name": "Colin Bendell",
       "teams": [
-        "brainstormers",
         "authors",
-        "analysts"
+        "brainstormers"
       ],
       "avatar_url": "https://avatars0.githubusercontent.com/u/1622597?v=4&s=200",
       "github": "colinbendell",
@@ -722,14 +721,6 @@
       "github": "MSakamaki",
       "twitter": "msakamaki2"
     },
-    "hakimelek": {
-      "name": "Malek Hakim",
-      "teams": [
-        "reviewers"
-      ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/1974993?v=4&s=200",
-      "github": "hakimelek"
-    },
     "mnot": {
       "name": "Mark Nottingham",
       "teams": [
@@ -807,12 +798,6 @@
       "website": "http://mor10.com/",
       "github": "mor10",
       "twitter": "mor10"
-    },
-    "natasha-kosoglov": {
-      "name": "Natasha Kosoglov",
-      "teams": [
-        "reviewers"
-      ]
     },
     "nektarios-paisios": {
       "name": "Nektarios Paisios",

--- a/src/config/2020.json
+++ b/src/config/2020.json
@@ -245,10 +245,9 @@
       "github": "AAgar",
       "twitter": "AAgar"
     },
-     "adityapandey1998": {
+    "adityapandey1998": {
       "name": "Aditya Pandey",
       "teams": [
-        "analysts",
         "developers"
       ],
       "avatar_url": "https://avatars1.githubusercontent.com/u/31750960?v=4&s=200",
@@ -339,33 +338,6 @@
       "avatar_url": "https://avatars1.githubusercontent.com/u/6231516?v=4&s=200",
       "github": "denar90",
       "twitter": "denar90_"
-    },
-    "ashleyish": {
-      "name": "ashleyish",
-      "teams": [
-        "reviewers"
-      ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/35119235?v=4&s=200",
-      "github": "ashleyish"
-    },
-    "ashrith-kulai": {
-      "name": "Ashrith Kulai",
-      "teams": [
-        "reviewers"
-      ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/1382793?v=4&s=200",
-      "github": "ashrith-kulai",
-      "twitter": "ashrith_kulai"
-    },
-    "aysunakarsu": {
-      "name": "Aysun Akarsu",
-      "teams": [
-        "reviewers"
-      ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/29519919?v=4&s=200",
-      "website": "https://www.searchdatalogy.com/blog/",
-      "github": "aysunakarsu",
-      "twitter": "aysunakarsu"
     },
     "bazzadp": {
       "name": "Barry Pollard",
@@ -592,7 +564,6 @@
     "estelle": {
       "name": "Estelle Weyl",
       "teams": [
-        "authors",
         "reviewers"
       ],
       "avatar_url": "https://avatars1.githubusercontent.com/u/69888?v=4&s=200",
@@ -609,16 +580,6 @@
       "website": "http://fantasai.inkedblade.net/",
       "github": "fantasai",
       "twitter": "fantasai"
-    },
-    "Gathea": {
-      "name": "Gaillard Thierry",
-      "teams": [
-        "reviewers"
-      ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/67320499?v=4&s=200",
-      "website": "https://www.gaillard-thierry.fr/",
-      "github": "Gathea",
-      "twitter": "gathea1369"
     },
     "giopunt": {
       "name": "Giovanni Puntil",
@@ -650,8 +611,7 @@
     "gregorywolf": {
       "name": "Greg Wolf",
       "teams": [
-        "analysts",
-        "reviewers"
+        "analysts"
       ],
       "avatar_url": "https://avatars1.githubusercontent.com/u/8494683?v=4&s=200",
       "github": "gregorywolf"
@@ -708,7 +668,6 @@
     "jaisanth": {
       "name": "Jai Santhosh",
       "teams": [
-        "analysts",
         "reviewers"
       ],
       "avatar_url": "https://avatars1.githubusercontent.com/u/679907?v=4&s=200",
@@ -775,26 +734,6 @@
       "github": "jessnicolet",
       "twitter": "jessica_nicolet"
     },
-    "clarkeclark": {
-      "name": "John Fox",
-      "teams": [
-        "reviewers"
-      ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/13718746?v=4&s=200",
-      "linkedin": "johnfox",
-      "github": "clarkeclark"
-    },
-    "logicalphase": {
-      "name": "John Teague",
-      "teams": [
-        "authors",
-        "reviewers"
-      ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/25212653?v=4&s=200",
-      "website": "https://gemservers.com",
-      "github": "logicalphase",
-      "twitter": "jtteag"
-    },
     "sirjonathan": {
       "name": "Jonathan Wold",
       "teams": [
@@ -853,8 +792,7 @@
     "LeaVerou": {
       "name": "Lea Verou",
       "teams": [
-        "authors",
-        "analysts"
+        "authors"
       ],
       "avatar_url": "https://avatars1.githubusercontent.com/u/175836?v=4&s=200",
       "website": "http://lea.verou.me/",
@@ -929,26 +867,6 @@
       "github": "matuzo",
       "twitter": "mmatuzo"
     },
-    "zeman": {
-      "name": "Mark Zeman",
-      "teams": [
-        "reviewers"
-      ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/204268?v=4&s=200",
-      "website": "https://speedcurve.com",
-      "github": "zeman",
-      "twitter": "MarkZeman"
-    },
-    "Nooshu": {
-      "name": "Matt Hobbs",
-      "teams": [
-        "reviewers"
-      ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/1223960?v=4&s=200",
-      "website": "https://nooshu.github.io/",
-      "github": "Nooshu",
-      "twitter": "TheRealNooshu"
-    },
     "max-ostapenko": {
       "name": "Max Ostapenko",
       "teams": [
@@ -963,7 +881,7 @@
     "mdiblasio": {
       "name": "Michael DiBlasio",
       "teams": [
-        "reviewers"
+        "authors"
       ],
       "avatar_url": "https://avatars1.githubusercontent.com/u/17748781?v=4&s=200",
       "github": "mdiblasio"
@@ -986,7 +904,7 @@
     "MikeBishop": {
       "name": "Mike Bishop",
       "teams": [
-        "reviewers"
+        "authors"
       ],
       "avatar_url": "https://avatars1.githubusercontent.com/u/4273797?v=4&s=200",
       "github": "MikeBishop"
@@ -1062,7 +980,6 @@
     "phacks": {
       "name": "Nicolas Goutay",
       "teams": [
-        "analysts",
         "reviewers"
       ],
       "avatar_url": "https://avatars1.githubusercontent.com/u/2587348?v=4&s=200",
@@ -1146,16 +1063,6 @@
       "github": "pearlbea",
       "twitter": "pblatteier"
     },
-    "dimension85": {
-      "name": "Phil",
-      "teams": [
-        "reviewers"
-      ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/2478174?v=4&s=200",
-      "website": "https://dimension85.com/",
-      "github": "dimension85",
-      "twitter": "dimension85"
-    },
     "dooman87": {
       "name": "Pokidov N. Dmitry",
       "teams": [
@@ -1185,16 +1092,6 @@
       "website": "https://rachelandrew.co.uk/",
       "github": "rachelandrew",
       "twitter": "rachelandrew"
-    },
-    "rachellcostello": {
-      "name": "Rachel Costello",
-      "teams": [
-        "editors",
-        "reviewers"
-      ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/49983543?v=4&s=200",
-      "github": "rachellcostello",
-      "twitter": "rachellcostello"
     },
     "raghuramakrishnan71": {
       "name": "Raghu Ramakrishnan",
@@ -1230,7 +1127,7 @@
     "rmarx": {
       "name": "Robin Marx",
       "teams": [
-        "reviewers"
+        "authors"
       ],
       "avatar_url": "https://avatars1.githubusercontent.com/u/2240689?s=460&v=4&s=200",
       "github": "rmarx",
@@ -1303,25 +1200,6 @@
       "github": "ibnesayeed",
       "twitter": "ibnesayeed"
     },
-    "sergeychernyshev": {
-      "name": "Sergey Chernyshev",
-      "teams": [
-        "reviewers"
-      ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/38076?v=4&s=200",
-      "website": "http://sergeychernyshev.com/",
-      "github": "sergeychernyshev",
-      "twitter": "sergeyche"
-    },
-    "exterkamp": {
-      "name": "Shane Exterkamp",
-      "teams": [
-        "reviewers"
-      ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/6392995?v=4&s=200",
-      "github": "exterkamp",
-      "twitter": "Shane_Exterkamp"
-    },
     "spanicker": {
       "name": "Shubhie Panicker",
       "teams": [
@@ -1373,8 +1251,7 @@
     "tpiros": {
       "name": "Tamas Piros",
       "teams": [
-        "authors",
-        "reviewers"
+        "authors"
       ],
       "avatar_url": "https://avatars1.githubusercontent.com/u/2042718?v=4&s=200",
       "website": "https://www.fullstacktraining.com",
@@ -1448,16 +1325,6 @@
       ],
       "avatar_url": "https://avatars1.githubusercontent.com/u/9135107?v=4&s=200",
       "github": "ydimova"
-    },
-    "YuLingCheng": {
-      "name": "Yu Ling Cheng",
-      "teams": [
-        "reviewers"
-      ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/7447041?v=4&s=200",
-      "website": "https://devux.tech",
-      "github": "YuLingCheng",
-      "twitter": "YuLingEC"
     }
   }
 }

--- a/src/config/2020.json
+++ b/src/config/2020.json
@@ -514,6 +514,16 @@
       "github": "obto",
       "twitter": "theobto"
     },
+    "dougsillars": {
+      "name": "Doug Sillars",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "https://avatars3.githubusercontent.com/u/1514288?v=4&s=200",
+      "website": "https://dougsillars.com",
+      "github": "dougsillars",
+      "twitter": "dougsillars"
+    },
     "drewzboto": {
       "name": "Drewz",
       "teams": [
@@ -532,15 +542,6 @@
       "github": "dsadhanala",
       "twitter": "dsadhanala"
     },
-    "edmondwwchan": {
-      "name": "Edmond W. W. Chan",
-      "teams": [
-        "reviewers"
-      ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/68361682?s=200&v=4",
-      "website": "https://edmondwwchan.github.io/",
-      "github": "edmondwwchan"
-    },
     "en3r0": {
       "name": "Dustin Montgomery",
       "teams": [
@@ -551,6 +552,15 @@
       "github": "en3r0",
       "twitter": "DustinMontSEO"
     },
+    "edmondwwchan": {
+      "name": "Edmond W. W. Chan",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "https://avatars3.githubusercontent.com/u/68361682?s=200&v=4",
+      "website": "https://edmondwwchan.github.io/",
+      "github": "edmondwwchan"
+    },
     "ericwbailey": {
       "name": "Eric Bailey",
       "teams": [
@@ -560,16 +570,6 @@
       "website": "https://ericwbailey.design/",
       "github": "ericwbailey",
       "twitter": "ericwbailey"
-    },
-    "estelle": {
-      "name": "Estelle Weyl",
-      "teams": [
-        "reviewers"
-      ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/69888?v=4&s=200",
-      "website": "http://standardista.com/",
-      "github": "estelle",
-      "twitter": "estellevw"
     },
     "fantasai": {
       "name": "Fantasai",

--- a/src/content/en/2019/javascript.md
+++ b/src/content/en/2019/javascript.md
@@ -4,7 +4,7 @@ chapter_number: 1
 title: JavaScript
 description: JavaScript chapter of the 2019 Web Almanac covering how much JavaScript we use on the web, compression, libraries and frameworks, loading, and source maps.
 authors: [housseindjirdeh]
-reviewers: [obto, paulcalvano, mathiasbynens]
+reviewers: [obto, paulcalvano, mathiasbynens, rviscomi]
 analysts: [rviscomi]
 translators: []
 discuss: 1756
@@ -313,12 +313,12 @@ In the past number of years, the JavaScript ecosystem has seen a rise in open-so
   )
 }}
 
-Only a subset of popular frameworks are being analyzed here, but it's important to note that all of them either follow one of these two approaches:   
+Only a subset of popular frameworks are being analyzed here, but it's important to note that all of them either follow one of these two approaches:
 
-- A [model-view-controller](https://developer.chrome.com/apps/app_frameworks) (or model-view-viewmodel) architecture   
-- A component-based architecture   
+- A [model-view-controller](https://developer.chrome.com/apps/app_frameworks) (or model-view-viewmodel) architecture
+- A component-based architecture
 
-Although there has been a shift towards a component-based model, many older frameworks that follow the MVC paradigm ([AngularJS](https://angularjs.org/), [Backbone.js](https://backbonejs.org/), [Ember](https://emberjs.com/)) are still being used in thousands of pages. However, [React](https://reactjs.org/), [Vue](https://vuejs.org/) and [Angular](https://angular.io/) are the most popular component-based frameworks ([Zone.js](https://github.com/angular/zone.js) is a package that is now part of Angular core).   
+Although there has been a shift towards a component-based model, many older frameworks that follow the MVC paradigm ([AngularJS](https://angularjs.org/), [Backbone.js](https://backbonejs.org/), [Ember](https://emberjs.com/)) are still being used in thousands of pages. However, [React](https://reactjs.org/), [Vue](https://vuejs.org/) and [Angular](https://angular.io/) are the most popular component-based frameworks ([Zone.js](https://github.com/angular/zone.js) is a package that is now part of Angular core).
 
 ## Differential loading
 
@@ -365,7 +365,7 @@ Similarly, very few sites (0.50%-0.80%) use the `nomodule` attribute for any scr
 [Preload](https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content) and [prefetch](https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ) are [resource hints](./resource-hints) which enable you to aid the browser in determining what resources need to be downloaded.
 
 - Preloading a resource with `<link rel="preload">` tells the browser to download this resource as soon as possible. This is especially helpful for critical resources which are discovered late in the page loading process (e.g., JavaScript located at the bottom of your HTML) and are otherwise downloaded last.
-- Using `<link rel="prefetch">` tells the browser to take advantage of any idle time it has to fetch these resources needed for future navigations 
+- Using `<link rel="prefetch">` tells the browser to take advantage of any idle time it has to fetch these resources needed for future navigations
 
 So, how many sites use preload and prefetch directives?
 

--- a/src/content/es/2019/javascript.md
+++ b/src/content/es/2019/javascript.md
@@ -4,7 +4,7 @@ chapter_number: 1
 title: JavaScript
 description: JavaScript chapter of the 2019 Web Almanac covering how much JavaScript we use on the web, compression, libraries and frameworks, loading, and source maps.
 authors: [housseindjirdeh]
-reviewers: [obto, paulcalvano, mathiasbynens]
+reviewers: [obto, paulcalvano, mathiasbynens, rviscomi]
 analysts: [rviscomi]
 translators: [c-torres]
 discuss: 1756

--- a/src/content/fr/2019/javascript.md
+++ b/src/content/fr/2019/javascript.md
@@ -4,7 +4,7 @@ chapter_number: 1
 title: JavaScript
 description: Chapitre JavaScript du Web Almanac 2019 couvrant la quantité de JavaScript que nous utilisons sur le web, la compression, les bibliothèques et les frameworks, le chargement et les cartographies de code source (source maps).
 authors: [housseindjirdeh]
-reviewers: [obto, paulcalvano, mathiasbynens]
+reviewers: [obto, paulcalvano, mathiasbynens, rviscomi]
 analysts: [rviscomi]
 translators: [borisschapira]
 discuss: 1756

--- a/src/content/ja/2019/javascript.md
+++ b/src/content/ja/2019/javascript.md
@@ -4,7 +4,7 @@ chapter_number: 1
 title: JavaScript
 description: 2019年のWeb AlmanacのJavaScriptの章では、Web上でどれだけJavaScriptを使用しているか、圧縮、ライブラリとフレームワーク、読み込み、ソースマップを網羅しています。
 authors: [housseindjirdeh]
-reviewers: [obto, paulcalvano, mathiasbynens]
+reviewers: [obto, paulcalvano, mathiasbynens, rviscomi]
 analysts: [rviscomi]
 translators: [ksakae]
 discuss: 1756
@@ -315,8 +315,8 @@ JavaScriptのリソースを圧縮しているサイトはどれくらいある�
 
 ここでは人気のあるフレームワークのサブセットのみを分析していますが、これらのフレームワークはすべて、これら2つのアプローチのいずれかに従っていることに注意することが重要です。
 
-- [モデルビューコントローラ](https://developer.chrome.com/apps/app_frameworks)（またはモデルビュービューモデル）アーキテクチャー   
-- コンポーネントベースアーキテクチャ   
+- [モデルビューコントローラ](https://developer.chrome.com/apps/app_frameworks)（またはモデルビュービューモデル）アーキテクチャー
+- コンポーネントベースアーキテクチャ
 
 コンポーネントベースモデルへの移行が進んでいるとはいえ、MVCパラダイムを踏襲した古いフレームワーク（[AngularJS](https://angularjs.org/)、[Backbone.js](https://backbonejs.org/)、[Ember](https://emberjs.com/)）は、いまだに何千ページにもわたって使われています。しかし、[React](https://reactjs.org/)、[Vue](https://vuejs.org/)、[Angular](https://angular.io/)はコンポーネントベースのフレームワークが主流です（[Zone.js](https://github.com/angular/zone.js)は現在Angular coreの一部となっているパッケージです）。
 

--- a/src/content/pt/2019/javascript.md
+++ b/src/content/pt/2019/javascript.md
@@ -4,7 +4,7 @@ chapter_number: 1
 title: JavaScript
 description: Capítulo de JavaScript de 2019 Web Almanac que cobre quanto JavaScript usamos na web, compressão, bibliotecas e estruturas, carregamento e mapas de origem.
 authors: [housseindjirdeh]
-reviewers: [obto, paulcalvano, mathiasbynens]
+reviewers: [obto, paulcalvano, mathiasbynens, rviscomi]
 analysts: [rviscomi]
 translators: [HakaCode]
 discuss: 1756
@@ -313,12 +313,12 @@ Nos últimos anos, o ecossistema JavaScript tem visto um aumento em bibliotecas 
   )
 }}
 
-Apenas um subconjunto de estruturas populares é discutido aqui, mas é importante observar que todos eles seguem uma das duas abordagens:   
+Apenas um subconjunto de estruturas populares é discutido aqui, mas é importante observar que todos eles seguem uma das duas abordagens:
 
-- Arquitetura [modelo-visualização-controlador](https://developer.chrome.com/apps/app_frameworks) (ou model-view-viewmodel)   
-- Arquitetura baseada em componentes   
+- Arquitetura [modelo-visualização-controlador](https://developer.chrome.com/apps/app_frameworks) (ou model-view-viewmodel)
+- Arquitetura baseada em componentes
 
-Embora tenha havido uma mudança em direção a um modelo baseado em componentes, muitos frameworks mais antigos que seguem o paradigma MVC ([AngularJS](https://angularjs.org/), [Backbone.js](https://backbonejs.org/), [Ember](https://emberjs.com/)) ainda estão sendo usados em milhares de páginas. Contudo, [React](https://reactjs.org/), [Vue](https://vuejs.org/) e [Angular](https://angular.io/) são frameworks baseadas em componentes mais populares ([Zone.js](https://github.com/angular/zone.js) é um pacote que agora faz parte do núcleo Angular).   
+Embora tenha havido uma mudança em direção a um modelo baseado em componentes, muitos frameworks mais antigos que seguem o paradigma MVC ([AngularJS](https://angularjs.org/), [Backbone.js](https://backbonejs.org/), [Ember](https://emberjs.com/)) ainda estão sendo usados em milhares de páginas. Contudo, [React](https://reactjs.org/), [Vue](https://vuejs.org/) e [Angular](https://angular.io/) são frameworks baseadas em componentes mais populares ([Zone.js](https://github.com/angular/zone.js) é um pacote que agora faz parte do núcleo Angular).
 
 ## Carregamento diferencial
 
@@ -365,7 +365,7 @@ Da mesma forma, poucos sites (0,50% - 0,80%) usam o atributo `nomodule` para qua
 [Preload](https://developer.mozilla.org/pt-BR/docs/Web/HTML/Preloading_content) e [prefetch](https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ) são [dicas de recursos](./resource-hints) que permitem que você ajude o navegador a determinar quais recursos precisam ser baixados.
 
 - Pré-carregar um recurso com `<link rel="preload">` diz ao navegador para baixar este recurso o mais rápido possível. Isso é especialmente útil para recursos críticos que são descobertos no final do processo de carregamento da página (por exemplo, JavaScript localizado na parte inferior de seu HTML) e, caso contrário, são baixados por último.
-- Usar `<link rel="prefetch">` diz ao navegador para tirar vantagem de qualquer tempo ocioso que ele tenha para buscar esses recursos necessários para navegações futuras. 
+- Usar `<link rel="prefetch">` diz ao navegador para tirar vantagem de qualquer tempo ocioso que ele tenha para buscar esses recursos necessários para navegações futuras.
 
 Então, quantos sites usam diretivas de preload e prefetch?
 


### PR DESCRIPTION
Contributors cleanup in `config/2020.json` file, updated some contributors teams and some contributors removed 

before: 
![image](https://user-images.githubusercontent.com/43988371/101495292-68200400-398e-11eb-9afb-5e56ff36a3ec.png)

after 
![image](https://user-images.githubusercontent.com/43988371/101496534-e5984400-398f-11eb-9d46-9b4e21d7b522.png)

info based on [https://github.com/HTTPArchive/almanac.httparchive.org/pull/1658](https://github.com/HTTPArchive/almanac.httparchive.org/pull/1658)
