### PR TITLE
Stop doing author check for single chapter generation

### DIFF
--- a/src/tools/generate/generate_chapters.js
+++ b/src/tools/generate/generate_chapters.js
@@ -128,9 +128,9 @@ const generate_chapters = async (chapter_match) => {
 
     const sitemap_path = await generate_sitemap(sitemap,sitemap_languages);
     await size_of(sitemap_path);
-  }
 
-  await get_contributors_difference(configs, contributors);
+    await get_contributors_difference(configs, contributors);
+  }
 
 };
 


### PR DESCRIPTION
FYI @bharatagsrwal we also generate single chapters sometimes but this is listing basically all contributors not in that as being missing.

Moving into if statement to prevent this.