### PR TITLE
log of add contributors and their team fixes

### DIFF
--- a/src/config/2019.json
+++ b/src/config/2019.json
@@ -252,7 +252,8 @@
     "ghedo": {
       "name": "Alessandro Ghedini",
       "teams": [
-        "brainstormers"
+        "brainstormers",
+        "reviewers"
       ],
       "avatar_url": "https://avatars3.githubusercontent.com/u/117643?v=4&s=200",
       "website": "https://ghedini.me/",
@@ -316,7 +317,8 @@
     "andydavies": {
       "name": "Andy Davies",
       "teams": [
-        "authors"
+        "authors",
+        "reviewers"
       ],
       "avatar_url": "https://avatars1.githubusercontent.com/u/427052?v=4&s=200",
       "website": "http://andydavies.me/",
@@ -374,7 +376,8 @@
       "name": "Brian Kardell",
       "teams": [
         "brainstormers",
-        "authors"
+        "authors",
+        "reviewers"
       ],
       "avatar_url": "https://avatars1.githubusercontent.com/u/870501?v=4&s=200",
       "website": "https://bkardell.com",
@@ -528,7 +531,8 @@
     "enygren": {
       "name": "Erik Nygren",
       "teams": [
-        "brainstormers"
+        "brainstormers",
+        "reviewers"
       ],
       "avatar_url": "https://avatars2.githubusercontent.com/u/6840678?v=4&s=200",
       "website": "https://erik.nygren.org/",
@@ -854,6 +858,7 @@
         "brainstormers",
         "authors",
         "analysts",
+        "reviewers",
         "developers"
       ],
       "avatar_url": "https://avatars3.githubusercontent.com/u/7459458?v=4&s=200",

--- a/src/config/2020.json
+++ b/src/config/2020.json
@@ -230,16 +230,6 @@
       "github": "ahmadawais",
       "twitter": "MrAhmadAwais"
     },
-    "AAgar": {
-      "name": "Akshar Agarwal",
-      "teams": [
-        "analysts"
-      ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/12477271?v=4&s=200",
-      "website": "https://aagar.github.io/",
-      "github": "AAgar",
-      "twitter": "AAgar"
-    },
     "adityapandey1998": {
       "name": "Aditya Pandey",
       "teams": [
@@ -328,6 +318,7 @@
     "denar90": {
       "name": "Artem Denysov",
       "teams": [
+        "reviewers",
         "analysts"
       ],
       "avatar_url": "https://avatars1.githubusercontent.com/u/6231516?v=4&s=200",
@@ -420,14 +411,6 @@
       "website": "https://catalin.red/",
       "github": "catalinred",
       "twitter": "catalinred"
-    },
-    "cheneytsai": {
-      "name": "Cheney Tsai",
-      "teams": [
-        "reviewers"
-      ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/672494?v=4&s=200",
-      "github": "cheneytsai"
     },
     "svgeesus": {
       "name": "Chris Lilley",
@@ -684,7 +667,8 @@
     "jrharalson": {
       "name": "Jason Haralson",
       "teams": [
-        "reviewers"
+        "reviewers",
+        "analysts"
       ],
       "avatar_url": "https://avatars1.githubusercontent.com/u/7421844?v=4&s=200",
       "github": "jrharalson"
@@ -709,16 +693,6 @@
       "website": "https://meiert.com/en/",
       "github": "j9t",
       "twitter": "j9t"
-    },
-    "malchata": {
-      "name": "Jeremy Wagner",
-      "teams": [
-        "reviewers"
-      ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/1635238?v=4&s=200",
-      "website": "https://jeremy.codes/",
-      "github": "malchata",
-      "twitter": "malchata"
     },
     "jessnicolet": {
       "name": "Jessica Nicolet",

--- a/src/tools/generate/get_contributors_diff.js
+++ b/src/tools/generate/get_contributors_diff.js
@@ -52,17 +52,17 @@ const get_contributors_difference = async (configs, chapter_contributors) => {
     const year_chapter_reviewers = year_chapter_contributors.reviewers;
     const year_chapter_analysts = year_chapter_contributors.analysts;
     year_chapter_authors.forEach(author => {
-      if (!config_contributors[author]) {
+      if (!config_contributors[author] || !config_contributors[author].teams.includes("authors")) {
         contributed_but_not_in_file[year].authors.add(author);
       }
     });
     year_chapter_reviewers.forEach(reviewer => {
-      if (!config_contributors[reviewer]) {
+      if (!config_contributors[reviewer] || !config_contributors[reviewer].teams.includes("reviewers")) {
         contributed_but_not_in_file[year].reviewers.add(reviewer);
       }
     });
     year_chapter_analysts.forEach(analyst => {
-      if (!config_contributors[analyst]) {
+      if (!config_contributors[analyst] || !config_contributors[analyst].teams.includes("analysts")) {
         contributed_but_not_in_file[year].analysts.add(analyst);
       }
     });


### PR DESCRIPTION
Forget to add whether a contributor includes that team in which they actually contributed, which fixes in this pull request, Now getting more accurate results.

in continuation of pull request [https://github.com/HTTPArchive/almanac.httparchive.org/pull/1658](https://github.com/HTTPArchive/almanac.httparchive.org/pull/1658)