### PR TITLE
Add highlight to inline code

### DIFF
--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -1489,6 +1489,7 @@ pre code {
   padding: 0;
   margin: 0;
   border-radius: 0;
+  background: none;
 }
 
 code {

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -1493,6 +1493,7 @@ pre code {
 
 code {
   font-size: 1rem;
+  background-color: #ebedf0;
 }
 
 pre .comment {


### PR DESCRIPTION
Usually, inline code elements are highlighted with light gray background. This increases the text readability, especially when there are lot of inline codes.

Just compare.

Before:

![image](https://user-images.githubusercontent.com/4408379/101677865-341c1000-3a6e-11eb-8727-ac5959df7248.png)

After:


![image](https://user-images.githubusercontent.com/4408379/101677830-25355d80-3a6e-11eb-8738-2b61e68c4785.png)
