### PR TITLE
Ebook layout issues

### DIFF
--- a/src/content/en/2020/css.md
+++ b/src/content/en/2020/css.md
@@ -679,7 +679,7 @@ And we are still missing out. Despite being [implemented in Safari in 2016](http
 Compatibility, right? You don’t want things to break? No. In the stylesheets we examined, we found solid use of fallback: with document order, the cascade, `@supports`, the `color-gamut` media query, all that good stuff. So in a style sheet we would see the color the designer wanted, expressed in display-p3, and also a fallback sRGB color. We computed the visible difference (a calculation called [ΔE2000](https://zschuessler.github.io/DeltaE/learn/)) between the desired and fallback color and this was typically quite modest. A small tweak. A careful exploration. In fact, 37.6% of the time, the color specified in display-p3 actually fell inside the range of colors (the gamut) that sRGB can manage.
 
 <figure>
-  <table>
+  <table class="large-table">
     <thead>
       <tr>
         <th scope="col" colspan="2">sRGB</th>

--- a/src/static/css/ebook.css
+++ b/src/static/css/ebook.css
@@ -73,6 +73,10 @@
   padding: 0;
 }
 
+.large-table td {
+  padding: 0.2rem;
+}
+
 th {
   padding: 0.75rem;
   text-align: center;
@@ -197,7 +201,7 @@ tbody tr:nth-child(even) {
   page-break-inside: avoid;
 }
 
-.code-block pre {
+pre {
   overflow: visible;
   white-space: pre-wrap;
 }


### PR DESCRIPTION
Fixes #1725 

Note I think I remember that PrinceXML has a known bug with tables that overflow so squashed that big table down. Not sure if there are any more big tables but can add that class to them if needed.

I've generated the new ebook and included that in this PR for review.