### PR TITLE
Improve inline code styling

### DIFF
--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -1494,7 +1494,9 @@ pre code {
 
 code {
   font-size: 1rem;
-  background-color: #ebedf0;
+  background: #f7f7f7;
+  border: 1px solid #dadce0;
+  padding: 1px 2px;
 }
 
 pre .comment {

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -1491,12 +1491,12 @@ th code  {
   padding: 0;
   margin: 0;
   border-radius: 0;
-  background: none;
+  background-color: none;
 }
 
 code {
   font-size: 1rem;
-  background: #f7f7f7;
+  background-color: #f7f7f7;
   border: 1px solid #dadce0;
   padding: 1px 2px;
 }

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -1486,7 +1486,7 @@ pre {
 
 pre code,
 td code,
-th code  {
+th code {
   border: 0;
   padding: 0;
   margin: 0;

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -1484,7 +1484,9 @@ pre {
   margin-bottom: 20px;
 }
 
-pre code {
+pre code,
+td code,
+th code  {
   border: 0;
   padding: 0;
   margin: 0;


### PR DESCRIPTION
See https://github.com/HTTPArchive/almanac.httparchive.org/pull/1718#issuecomment-742433677

Also in this PR the new styling of inline code inside table cell is removed.

Before:

![image](https://user-images.githubusercontent.com/4408379/101767484-50af5b00-3af5-11eb-9f9e-4006eb138cf2.png)

After:

![image](https://user-images.githubusercontent.com/4408379/101767392-34132300-3af5-11eb-9e8d-162a0234b2b4.png)
