### PR TITLE
Fix bug with unsetting code background color in places

### DIFF
--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -1491,7 +1491,7 @@ th code {
   padding: 0;
   margin: 0;
   border-radius: 0;
-  background-color: none;
+  background-color: unset;
 }
 
 code {


### PR DESCRIPTION
@lex111 missed a slight bug in #1729 

`background-color: none;` is not valid CSS, so this wasn't doing anything. Changes to `unset` instead.