### PR TITLE
Adjust position of switcher arrow

### DIFF
--- a/src/config/2020.json
+++ b/src/config/2020.json
@@ -266,7 +266,8 @@
       "name": "Alexey Pyltsyn",
       "teams": [
         "translators",
-        "editors"
+        "editors",
+        "developers"
       ],
       "avatar_url": "https://avatars3.githubusercontent.com/u/4408379?v=4&s=200",
       "website": "https://lex111.ru/",

--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -689,7 +689,7 @@ header .cta {
 .year-switcher select {
   border: 1px solid currentColor;
   border-radius: 50px;
-  padding: 20px;
+  padding: 20px 38px 20px 20px;
   background: none;
   color: inherit;
   cursor: pointer;


### PR DESCRIPTION
I just noticed that on mobiles the arrow of switcher overlaps the text when the long option is selected.

Actually, since the arrow is absolutely positioned, we need to increase the padding for the option text to compensate width.

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/101830459-9562e280-3b45-11eb-8e35-5fb9408dd2ac.png) | ![image](https://user-images.githubusercontent.com/4408379/101830560-be837300-3b45-11eb-86ea-4a726ca4e272.png) |

The arrow is now outside the text area (as it should), :

| Before   | After    |
| -------- | -------- |
|![image](https://user-images.githubusercontent.com/4408379/101830722-fdb1c400-3b45-11eb-8633-a129ef8acfd4.png) | ![image](https://user-images.githubusercontent.com/4408379/101830775-11f5c100-3b46-11eb-9e74-973ab84a54ee.png) |