### PR TITLE
Fix relative links in ebook

### DIFF
--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -777,6 +777,7 @@
 {# Ebook needs a unique fig id. 2019 is already out there so reluctant to change that, so "if" statemnt it is! #}
 {% if ebook %}
 {% set anchor="fig-%s-%s" % (metadata.chapter_number, id) %}
+{% if link.startswith("/") %}{% set link="https://almanac.httparchive.org%s" % link %}{% endif %}
 {% else %}
 {% set anchor="fig-%s" % (id) %}
 {% endif %}


### PR DESCRIPTION
The ebook retains links on our figures. At the minute those links all point to http://127.0.0.1:8080 :-(

This was working, as we change from relative to absolute paths in [generate_ebooks.js](https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/src/tools/generate/generate_ebooks.js):

https://github.com/HTTPArchive/almanac.httparchive.org/blob/fd2e15d608fac09a50dcf98064dbfdccbd961f7b/src/tools/generate/generate_ebooks.js#L27-L28

I think it broke when we moved to `figure_markup` macro in #1236 as no longer have path in markdown now, so above JS won't help with those (though it will help with other relative links so still good to keep).

So, for the figures, we now need to override when that macro is executed - which this PR now does.