### PR TITLE
Track ebook clicks from menu

### DIFF
--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -275,7 +275,7 @@
       <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}#ebook">{{ self.ebook_title() }}</a>
     </li>
     <li class="nav-dropdown-list-chapter ebook">
-      <a class="ebook-menu-download" href="/static/pdfs/web_almanac_{{ year }}_{{ lang }}.pdf" data-event="ebook-click" data-label="toc-menu">{{ self.ebook_download_short() }}</a>
+      <a href="/static/pdfs/web_almanac_{{ year }}_{{ lang }}.pdf" data-event="ebook-click" data-label="toc-menu">{{ self.ebook_download_short() }}</a>
     </li>
     {% endif %}
   </ul>
@@ -624,7 +624,7 @@
         });
 
         document.querySelectorAll('[data-event]').forEach(trackableElement => {
-          trackableElement.addEventListener("click", function (event) {
+          trackableElement.addEventListener('click', function (event) {
             gtag('event', event.target.dataset.event, {
               'event_category': 'clicks',
               'event_label': event.target.dataset.label,

--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -490,8 +490,8 @@
             //Reset the selector back in case user uses Back button
             var selectedValue = e.target.value;
 
-            if (selectedValue.startsWith('/static/pdfs')) {
-              gtag('event', 'ebook-click', { 'event_category': 'clicks', 'event_label': 'mobile menu ' + document.location.pathname, 'transport_type': 'beacon', 'value': 1 })
+            if (e.target.dataset.event) {
+              gtag('event', e.target.dataset.event, { 'event_category': 'clicks', 'event_label': 'mobile menu ' + document.location.pathname, 'transport_type': 'beacon', 'value': 1 })
             }
             if (selectedValue && selectedValue !== window.location.pathname) {
               e.target.value = window.location.pathname;

--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -118,7 +118,7 @@
   <label for="table-of-contents-switcher-{{switcher_name}}" class="visually-hidden">
     {{ self.table_of_contents_switcher() }}
   </label>
-  <select id="table-of-contents-switcher-{{switcher_name}}">
+  <select id="table-of-contents-switcher-{{switcher_name}}" data-label="toc-menu-mobile">
     {% if request.path.endswith("table-of-contents") %}
       <option selected disabled value="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</option>
       <option disabled value="{{ url_for('table_of_contents', year=year, lang=lang) }}#foreword">{{ self.foreword_title() }}</option>
@@ -179,7 +179,7 @@
     {% endif %}
 
     {% if ebook_size_in_mb and ebook_size_in_mb > 0 %}
-    <option value="/static/pdfs/web_almanac_{{ year }}_{{ lang }}.pdf">
+    <option value="/static/pdfs/web_almanac_{{ year }}_{{ lang }}.pdf" data-event="ebook-click">
       {{ self.ebook_download_short() }}
     </option>
     {% endif %}
@@ -275,7 +275,7 @@
       <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}#ebook">{{ self.ebook_title() }}</a>
     </li>
     <li class="nav-dropdown-list-chapter ebook">
-      <a class="ebook-menu-download" href="/static/pdfs/web_almanac_{{ year }}_{{ lang }}.pdf" data-event="ebook-click">{{ self.ebook_download_short() }}</a>
+      <a class="ebook-menu-download" href="/static/pdfs/web_almanac_{{ year }}_{{ lang }}.pdf" data-event="ebook-click" data-label="toc-menu">{{ self.ebook_download_short() }}</a>
     </li>
     {% endif %}
   </ul>
@@ -487,12 +487,16 @@
         for (var i = 0; i < languageYearSwitchers.length; i++) {
           languageYearSwitchers[i].addEventListener('change', function(e) {
 
+            if (e.target.dataset.label) {
+              gtag('event', this.options[this.selectedIndex].dataset.event, {
+                'event_category': 'clicks',
+                'event_label': e.target.dataset.label,
+                'transport_type': 'beacon',
+                'value': 1 })
+            }
+
             //Reset the selector back in case user uses Back button
             var selectedValue = e.target.value;
-
-            if (e.target.dataset.event) {
-              gtag('event', e.target.dataset.event, { 'event_category': 'clicks', 'event_label': 'mobile menu ' + document.location.pathname, 'transport_type': 'beacon', 'value': 1 })
-            }
             if (selectedValue && selectedValue !== window.location.pathname) {
               e.target.value = window.location.pathname;
               window.location = selectedValue;
@@ -617,15 +621,16 @@
           }
         });
 
-        var ebookLink = document.querySelector('#ebook-toc-download');
-        ebookLink && ebookLink.addEventListener("click", function (event) {
-          gtag('event', 'ebook-click', { 'event_category': 'clicks', 'event_label': 'toc-page', 'transport_type': 'beacon', 'value': 1 })
+        document.querySelectorAll('[data-event]').forEach(trackableElement => {
+          trackableElement.addEventListener("click", function (event) {
+            gtag('event', event.target.dataset.event, {
+              'event_category': 'clicks',
+              'event_label': event.target.dataset.label,
+              'transport_type': 'beacon',
+              'value': 1 })
+          });
         });
 
-        var ebookLink = document.querySelector('.ebook-menu-download');
-        ebookLink && ebookLink.addEventListener("click", function (event) {
-          gtag('event', 'ebook-click', { 'event_category': 'clicks', 'event_label': 'menu ' + document.location.pathname, 'transport_type': 'beacon', 'value': 1 })
-        });
       })();
     </script>
   {% endblock %}

--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -275,7 +275,7 @@
       <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}#ebook">{{ self.ebook_title() }}</a>
     </li>
     <li class="nav-dropdown-list-chapter ebook">
-      <a class="ebook-menu-download" href="/static/pdfs/web_almanac_{{ year }}_{{ lang }}.pdf">{{ self.ebook_download_short() }}</a>
+      <a class="ebook-menu-download" href="/static/pdfs/web_almanac_{{ year }}_{{ lang }}.pdf" data-event="ebook-click">{{ self.ebook_download_short() }}</a>
     </li>
     {% endif %}
   </ul>

--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -275,7 +275,7 @@
       <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}#ebook">{{ self.ebook_title() }}</a>
     </li>
     <li class="nav-dropdown-list-chapter ebook">
-      <a href="/static/pdfs/web_almanac_{{ year }}_{{ lang }}.pdf">{{ self.ebook_download_short() }}</a>
+      <a class="ebook-menu-download" href="/static/pdfs/web_almanac_{{ year }}_{{ lang }}.pdf">{{ self.ebook_download_short() }}</a>
     </li>
     {% endif %}
   </ul>
@@ -482,12 +482,17 @@
           element.hidden = false;
         });
 
-        // Language and Year switching
+        // Language, Year and ToC switching
         var languageYearSwitchers = document.querySelectorAll('.language-switcher select, .year-switcher select, .table-of-contents-switcher select');
         for (var i = 0; i < languageYearSwitchers.length; i++) {
           languageYearSwitchers[i].addEventListener('change', function(e) {
+
             //Reset the selector back in case user uses Back button
             var selectedValue = e.target.value;
+
+            if (selectedValue.startsWith('/static/pdfs')) {
+              gtag('event', 'ebook-click', { 'event_category': 'clicks', 'event_label': 'mobile menu ' + document.location.pathname, 'transport_type': 'beacon', 'value': 1 })
+            }
             if (selectedValue && selectedValue !== window.location.pathname) {
               e.target.value = window.location.pathname;
               window.location = selectedValue;
@@ -610,6 +615,16 @@
               menuBtn.focus();
             }
           }
+        });
+
+        var ebookLink = document.querySelector('#ebook-toc-download');
+        ebookLink && ebookLink.addEventListener("click", function (event) {
+          gtag('event', 'ebook-click', { 'event_category': 'clicks', 'event_label': 'toc-page', 'transport_type': 'beacon', 'value': 1 })
+        });
+
+        var ebookLink = document.querySelector('.ebook-menu-download');
+        ebookLink && ebookLink.addEventListener("click", function (event) {
+          gtag('event', 'ebook-click', { 'event_category': 'clicks', 'event_label': 'menu ' + document.location.pathname, 'transport_type': 'beacon', 'value': 1 })
         });
       })();
     </script>

--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -487,7 +487,7 @@
         for (var i = 0; i < languageYearSwitchers.length; i++) {
           languageYearSwitchers[i].addEventListener('change', function(e) {
 
-            let selectedOption = this.options[this.selectedIndex];
+            var selectedOption = this.options[this.selectedIndex];
 
             if (e.target.dataset.label && selectedOption.dataset.event) {
               gtag('event', selectedOption.dataset.event, {

--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -487,8 +487,10 @@
         for (var i = 0; i < languageYearSwitchers.length; i++) {
           languageYearSwitchers[i].addEventListener('change', function(e) {
 
-            if (e.target.dataset.label) {
-              gtag('event', this.options[this.selectedIndex].dataset.event, {
+            let selectedOption = this.options[this.selectedIndex];
+
+            if (e.target.dataset.label && selectedOption.dataset.event) {
+              gtag('event', selectedOption.dataset.event, {
                 'event_category': 'clicks',
                 'event_label': e.target.dataset.label,
                 'transport_type': 'beacon',

--- a/src/templates/base/table_of_contents.html
+++ b/src/templates/base/table_of_contents.html
@@ -146,7 +146,7 @@
     <section class="part">
       <h2 id="ebook" class="part-name"><a href="#ebook" class="anchor-link">{{ self.ebook_title() }}</a></h2>
       <div class="chapters">
-        <div id="ebook-download" class="chapter">
+        <div id="ebook-toc-download" class="chapter">
           <a href="/static/pdfs/web_almanac_{{ year }}_{{ lang }}.pdf">{{ self.ebook_download() }}</a><br>
           <small>{{ self.ebook_download_note() }}</small>
         </div>
@@ -162,16 +162,4 @@
     </div>
   </div>
 </main>
-{% endblock %}
-
-
-{% block scripts %}
-{{ super() }}
-<script nonce="{{ csp_nonce() }}">
-  var ebookLink = document.querySelector('#ebook-download');
-
-  ebookLink && ebookLink.addEventListener("click", function (event) {
-    gtag('event', 'ebook-click', { 'event_category': 'clicks', 'event_label': 'toc-page', 'value': 1 })
-  });
-</script>
 {% endblock %}

--- a/src/templates/base/table_of_contents.html
+++ b/src/templates/base/table_of_contents.html
@@ -146,7 +146,7 @@
     <section class="part">
       <h2 id="ebook" class="part-name"><a href="#ebook" class="anchor-link">{{ self.ebook_title() }}</a></h2>
       <div class="chapters">
-        <div id="ebook-toc-download" class="chapter">
+        <div class="chapter">
           <a href="/static/pdfs/web_almanac_{{ year }}_{{ lang }}.pdf" data-event="ebook-click" data-label="toc-page">{{ self.ebook_download() }}</a><br>
           <small>{{ self.ebook_download_note() }}</small>
         </div>

--- a/src/templates/base/table_of_contents.html
+++ b/src/templates/base/table_of_contents.html
@@ -147,7 +147,7 @@
       <h2 id="ebook" class="part-name"><a href="#ebook" class="anchor-link">{{ self.ebook_title() }}</a></h2>
       <div class="chapters">
         <div id="ebook-toc-download" class="chapter">
-          <a href="/static/pdfs/web_almanac_{{ year }}_{{ lang }}.pdf">{{ self.ebook_download() }}</a><br>
+          <a href="/static/pdfs/web_almanac_{{ year }}_{{ lang }}.pdf" data-event="ebook-click" data-label="toc-page">{{ self.ebook_download() }}</a><br>
           <small>{{ self.ebook_download_note() }}</small>
         </div>
       </div>


### PR DESCRIPTION
Fixes #1715 

Forgot I'd already done this for the ToC page link in #825 !

This adds clicks for the menu option.
It also switchers to `'transport_type': 'beacon'` which is better for tracking links that cause a page `unload` (like the PDF link will).