### PR TITLE
Fix spacing in ToC footer menu

### DIFF
--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -1418,11 +1418,11 @@ p.copyright a {
   padding: 0;
 }
 
-.header-list li:last-child:not(.ebook) {
+.header-list li:last-child {
   padding-bottom: 16px;
 }
 
-.footer-list li:last-child:not(.ebook) {
+.footer-list li:last-child {
   padding-top: 16px;
 }
 
@@ -1439,7 +1439,6 @@ p.copyright a {
 .nav-dropdown-list-chapter.ebook {
   display: flex;
   flex-direction: column;
-  padding: 0 0 24px 24px;
 }
 
 .nav-dropdown-list-todo,
@@ -1455,6 +1454,10 @@ p.copyright a {
 .footer .nav-dropdown-list .help-translate {
   border-bottom: 1px dashed #bdbdbd;
   border-top: none;
+}
+
+.footer .nav-dropdown-list-part {
+  padding: 8px 8px 16px 16px;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Discovered while testing #1753 that the footer menu is off:

![Bad menu](https://user-images.githubusercontent.com/10931297/102008042-97839780-3d25-11eb-8e08-fe55f09787a9.png)

Ebook link is way off
Section headers closer to preceding section that their section.

Corrected version:

![Corrected menu](https://user-images.githubusercontent.com/10931297/102179654-6dee7b80-3e9f-11eb-9529-aff81f4ec122.png)
