### PR TITLE
Fix large table in CSS chapter in ebook

### DIFF
--- a/src/content/en/2020/css.md
+++ b/src/content/en/2020/css.md
@@ -679,7 +679,7 @@ And we are still missing out. Despite being [implemented in Safari in 2016](http
 Compatibility, right? You don’t want things to break? No. In the stylesheets we examined, we found solid use of fallback: with document order, the cascade, `@supports`, the `color-gamut` media query, all that good stuff. So in a style sheet we would see the color the designer wanted, expressed in display-p3, and also a fallback sRGB color. We computed the visible difference (a calculation called [ΔE2000](https://zschuessler.github.io/DeltaE/learn/)) between the desired and fallback color and this was typically quite modest. A small tweak. A careful exploration. In fact, 37.6% of the time, the color specified in display-p3 actually fell inside the range of colors (the gamut) that sRGB can manage.
 
 <figure>
-  <table>
+  <table class="large-table">
     <thead>
       <tr>
         <th scope="col" colspan="2">sRGB</th>


### PR DESCRIPTION
Looks like this bit (part of fix in #1727) accidentally got reverted in #1735 

Means this is what ebook looks like:

![Bad big table in ebook](https://user-images.githubusercontent.com/10931297/102020864-e9530e80-3d73-11eb-9467-013ee1527ced.png)
