### PR TITLE
Alternative improvement to figure menus

### DIFF
--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -491,21 +491,15 @@ figcaption {
 
 .figure-dropdown {
   position: absolute;
-  top: 10px;
-  right: -5px;
+  top: -10px;
+  right: -50px;
   display: flex;
   flex-direction: column;
   align-items: flex-end;
 }
 
-.media-figure-wrapper .figure-dropdown {
-  top: -5px;
-  top: -10px;
-}
-
-.content-figure-wrapper .figure-dropdown {
-  top: -10px;
-  right: -10px;
+.table-wrap .figure-dropdown {
+  top: 0;
 }
 
 .figure-dropdown button {
@@ -579,10 +573,6 @@ th,
 td {
   padding: 10px;
   padding: 0.625rem;
-}
-
-thead tr th:last-child {
-  padding: 0 40px;
 }
 
 th.numeric,

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -591,7 +591,6 @@ figure .big-number {
   color: #62718b;
   overflow-wrap: break-word;
   word-break: break-all;
-  padding: 20px;
 }
 
 figure .medium-number {
@@ -600,7 +599,6 @@ figure .medium-number {
   font: bold 3rem/1em Poppins, sans-serif;
   color: #62718b;
   overflow-wrap: break-word;
-  padding: 20px;
 }
 
 figure .really-big-number {
@@ -609,7 +607,6 @@ figure .really-big-number {
   font: bold 1.5rem/1em Poppins, sans-serif;
   color: #62718b;
   overflow-wrap: break-word;
-  padding: 20px;
 }
 
 figure .fig-mobile {

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -22,6 +22,7 @@
   padding: 1rem;
   max-width: 100%;
   justify-content: center;
+  position: relative;
 }
 
 .table-wrap-container {
@@ -483,13 +484,28 @@ figcaption {
   text-align: center;
 }
 
+.figure-wrapper {
+  position: relative;
+  margin: 0 auto;
+}
+
 .figure-dropdown {
   position: absolute;
-  top: 0px;
-  right: 0px;
+  top: 10px;
+  right: -5px;
   display: flex;
   flex-direction: column;
   align-items: flex-end;
+}
+
+.media-figure-wrapper .figure-dropdown {
+  top: -5px;
+  top: -10px;
+}
+
+.content-figure-wrapper .figure-dropdown {
+  top: -10px;
+  right: -10px;
 }
 
 .figure-dropdown button {
@@ -565,6 +581,10 @@ td {
   padding: 0.625rem;
 }
 
+thead tr th:last-child {
+  padding: 0 40px;
+}
+
 th.numeric,
 td.numeric {
   text-align: right;
@@ -581,6 +601,7 @@ figure .big-number {
   color: #62718b;
   overflow-wrap: break-word;
   word-break: break-all;
+  padding: 20px;
 }
 
 figure .medium-number {
@@ -589,6 +610,7 @@ figure .medium-number {
   font: bold 3rem/1em Poppins, sans-serif;
   color: #62718b;
   overflow-wrap: break-word;
+  padding: 20px;
 }
 
 figure .really-big-number {
@@ -597,6 +619,7 @@ figure .really-big-number {
   font: bold 1.5rem/1em Poppins, sans-serif;
   color: #62718b;
   overflow-wrap: break-word;
+  padding: 20px;
 }
 
 figure .fig-mobile {

--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -809,7 +809,7 @@
   <iframe class="fig-mobile fig-desktop video-embed" src="{{ video }}" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen width="{{ video_width }}" height="{{ video_height }}" aria-labelledby="{{ anchor }}-caption" aria-describedby="{{ anchor }}-description"></iframe>
   {%- endif %}
   {%- if image != "" %}
-  <div class="figure-wrapper media-figure-wrapper">
+  <div class="figure-wrapper">
     {% if video %}{% set anchor_class="video-fallback-image"%}{% endif %}
     <a href="{{ link }}"  class="{{ anchor_class }}">
       {%- if chart_url != "" %}
@@ -822,12 +822,12 @@
       <img src="{{ image }}" alt="{{ caption|striptags }}" aria-labelledby="{{ anchor }}-caption" aria-describedby="{{ anchor }}-description" width="{{ width }}" height="{{ height }}" loading="lazy" />
       {%- endif %}
     </a>
-    {{ figure_dropdown(metadata, id, sheets_gid, sql_file, image, ebook) }}}
+    {{ figure_dropdown(metadata, id, sheets_gid, sql_file, image, ebook) }}
   </div>
   <button hidden="" class="fig-description-button" aria-expanded="false" aria-controls="{{ anchor }}-description" data-show-text="{{ show_description(metadata,id) }}" data-hide-text="{{ hide_description(metadata,id) }}">{{ show_description(metadata,id) }}</button>
   <div id="{{ anchor }}-description" class="visually-hidden">{{ description|safe }}</div>
   {%- elif content != "" %}
-  <div class="figure-wrapper content-figure-wrapper">
+  <div class="figure-wrapper">
     <span class="{{ classes }}">{{ content|safe }}</span>
     {{ figure_dropdown(metadata, id, sheets_gid, sql_file, image, ebook) }}
   </div>

--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -638,8 +638,8 @@
   {% endblock %}
 {% endblock %}
 
-{% macro figure_dropdown(metadata, id, sheets_gid="", sql_file="", image="") %}
-  {% if sheets_gid != "" or  sql_file != "" or image != "" %}
+{% macro figure_dropdown(metadata, id, sheets_gid="", sql_file="", image="", ebook=false) %}
+  {% if not ebook and (sheets_gid != "" or  sql_file != "" or image != "") %}
   <div class="figure-dropdown nav-dropdown">
     <button class="nav-dropdown-btn js-enable hidden" disabled aria-expanded="false" title="Figure options&hellip;">
       <span class="visually-hidden">{{ self.explore_the_results() }}</span>
@@ -822,14 +822,14 @@
       <img src="{{ image }}" alt="{{ caption|striptags }}" aria-labelledby="{{ anchor }}-caption" aria-describedby="{{ anchor }}-description" width="{{ width }}" height="{{ height }}" loading="lazy" />
       {%- endif %}
     </a>
-    {{ figure_dropdown(metadata, id, sheets_gid, sql_file, image) }}
+    {{ figure_dropdown(metadata, id, sheets_gid, sql_file, image, ebook) }}}
   </div>
   <button hidden="" class="fig-description-button" aria-expanded="false" aria-controls="{{ anchor }}-description" data-show-text="{{ show_description(metadata,id) }}" data-hide-text="{{ hide_description(metadata,id) }}">{{ show_description(metadata,id) }}</button>
   <div id="{{ anchor }}-description" class="visually-hidden">{{ description|safe }}</div>
   {%- elif content != "" %}
   <div class="figure-wrapper content-figure-wrapper">
     <span class="{{ classes }}">{{ content|safe }}</span>
-    {{ figure_dropdown(metadata, id, sheets_gid, sql_file, image) }}
+    {{ figure_dropdown(metadata, id, sheets_gid, sql_file, image, ebook) }}
   </div>
   {%- endif %}
   <figcaption id="{{ anchor }}-caption">{{ figure_link(metadata, id, caption, ebook=ebook, sheets_gid=sheets_gid, sql_file=sql_file, image=image) }}</figcaption>

--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -763,7 +763,6 @@
 <a href="#fig-{{ metadata.chapter_number }}-{{ id }}" class="anchor-link">{{ figure_text(metadata, id) }}</a> {{ caption|safe }}
 {% else %}
 <a href="#fig-{{ id }}" class="anchor-link">{{ figure_text(metadata, id) }}</a> {{ caption|safe }}
-{{ figure_dropdown(metadata, id, sheets_gid, sql_file, image) }}
 {% endif %}
 {% endmacro %}
 
@@ -810,22 +809,28 @@
   <iframe class="fig-mobile fig-desktop video-embed" src="{{ video }}" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen width="{{ video_width }}" height="{{ video_height }}" aria-labelledby="{{ anchor }}-caption" aria-describedby="{{ anchor }}-description"></iframe>
   {%- endif %}
   {%- if image != "" %}
-  {% if video %}{% set anchor_class="video-fallback-image"%}{% endif %}
-  <a href="{{ link }}"  class="{{ anchor_class }}">
-    {%- if chart_url != "" %}
-    <img src="{{ image }}" alt="{{ caption|striptags }}" aria-labelledby="{{ anchor }}-caption" aria-describedby="{{ anchor }}-description" width="{{ width }}" height="{{ height }}" data-width="{{ data_width }}" data-height="{{ data_height }}" data-seamless="" data-frameborder="0" data-scrolling="no" data-iframe="{{ chart_url|safe }}" loading="lazy" />
-    {%- elif not ebook and object != "" %}
-    <object type="image/svg+xml" width="{{ width }}" height="{{ height }}" data="{{ image }}">
-      {{ caption }}
-    </object>
-    {% else %}
-    <img src="{{ image }}" alt="{{ caption|striptags }}" aria-labelledby="{{ anchor }}-caption" aria-describedby="{{ anchor }}-description" width="{{ width }}" height="{{ height }}" loading="lazy" />
-    {%- endif %}
-  </a>
+  <div class="figure-wrapper media-figure-wrapper">
+    {% if video %}{% set anchor_class="video-fallback-image"%}{% endif %}
+    <a href="{{ link }}"  class="{{ anchor_class }}">
+      {%- if chart_url != "" %}
+      <img src="{{ image }}" alt="{{ caption|striptags }}" aria-labelledby="{{ anchor }}-caption" aria-describedby="{{ anchor }}-description" width="{{ width }}" height="{{ height }}" data-width="{{ data_width }}" data-height="{{ data_height }}" data-seamless="" data-frameborder="0" data-scrolling="no" data-iframe="{{ chart_url|safe }}" loading="lazy" />
+      {%- elif not ebook and object != "" %}
+      <object type="image/svg+xml" width="{{ width }}" height="{{ height }}" data="{{ image }}">
+        {{ caption }}
+      </object>
+      {% else %}
+      <img src="{{ image }}" alt="{{ caption|striptags }}" aria-labelledby="{{ anchor }}-caption" aria-describedby="{{ anchor }}-description" width="{{ width }}" height="{{ height }}" loading="lazy" />
+      {%- endif %}
+    </a>
+    {{ figure_dropdown(metadata, id, sheets_gid, sql_file, image) }}
+  </div>
   <button hidden="" class="fig-description-button" aria-expanded="false" aria-controls="{{ anchor }}-description" data-show-text="{{ show_description(metadata,id) }}" data-hide-text="{{ hide_description(metadata,id) }}">{{ show_description(metadata,id) }}</button>
   <div id="{{ anchor }}-description" class="visually-hidden">{{ description|safe }}</div>
   {%- elif content != "" %}
-  <div class="{{ classes }}">{{ content|safe }}</div>
+  <div class="figure-wrapper content-figure-wrapper">
+    <span class="{{ classes }}">{{ content|safe }}</span>
+    {{ figure_dropdown(metadata, id, sheets_gid, sql_file, image) }}
+  </div>
   {%- endif %}
   <figcaption id="{{ anchor }}-caption">{{ figure_link(metadata, id, caption, ebook=ebook, sheets_gid=sheets_gid, sql_file=sql_file, image=image) }}</figcaption>
 </figure>

--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -638,8 +638,8 @@
   {% endblock %}
 {% endblock %}
 
-{% macro figure_dropdown(metadata, id, sheets_gid="", sql_file="", image="", ebook=false) %}
-  {% if not ebook and (sheets_gid != "" or  sql_file != "" or image != "") %}
+{% macro figure_dropdown(metadata, id, sheets_gid="", sql_file="", image="", caption="") %}
+  {% if sheets_gid != "" or  sql_file != "" or image != "" %}
   <div class="figure-dropdown nav-dropdown">
     <button class="nav-dropdown-btn js-enable hidden" disabled aria-expanded="false" title="Figure options&hellip;">
       <span class="visually-hidden">{{ self.explore_the_results() }}</span>
@@ -822,14 +822,14 @@
       <img src="{{ image }}" alt="{{ caption|striptags }}" aria-labelledby="{{ anchor }}-caption" aria-describedby="{{ anchor }}-description" width="{{ width }}" height="{{ height }}" loading="lazy" />
       {%- endif %}
     </a>
-    {{ figure_dropdown(metadata, id, sheets_gid, sql_file, image, ebook) }}
+    {% if not ebook %}{{ figure_dropdown(metadata, id, sheets_gid, sql_file, image) }}{% endif %}
   </div>
   <button hidden="" class="fig-description-button" aria-expanded="false" aria-controls="{{ anchor }}-description" data-show-text="{{ show_description(metadata,id) }}" data-hide-text="{{ hide_description(metadata,id) }}">{{ show_description(metadata,id) }}</button>
   <div id="{{ anchor }}-description" class="visually-hidden">{{ description|safe }}</div>
   {%- elif content != "" %}
   <div class="figure-wrapper">
     <span class="{{ classes }}">{{ content|safe }}</span>
-    {{ figure_dropdown(metadata, id, sheets_gid, sql_file, image, ebook) }}
+    {% if not ebook %}{{ figure_dropdown(metadata, id, sheets_gid, sql_file, image, ebook) }}{% endif %}
   </div>
   {%- endif %}
   <figcaption id="{{ anchor }}-caption">{{ figure_link(metadata, id, caption, ebook=ebook, sheets_gid=sheets_gid, sql_file=sql_file, image=image) }}</figcaption>

--- a/src/tools/generate/generate_chapters.js
+++ b/src/tools/generate/generate_chapters.js
@@ -11,6 +11,7 @@ const { generate_featured_chapters, generate_chapter_featured_quote } = require(
 const { generate_sitemap } = require('./generate_sitemap');
 const { lazy_load_content } = require('./lazy_load_content');
 const { wrap_tables } = require('./wrap_tables');
+const { table_dropdowns } = require('./generate_table_figure_dropdowns');
 const { remove_unnecessary_markup } = require('./remove_unnecessary_markup');
 const { generate_ebooks } = require('./generate_ebooks');
 const { generate_js } = require('./generate_js');
@@ -143,6 +144,7 @@ const parse_file = async (markdown,chapter) => {
   body = generate_header_links(body);
   body = generate_figure_ids(body);
   body = wrap_tables(body);
+  body = table_dropdowns(body);
   body = lazy_load_content(body);
   body = remove_unnecessary_markup(body);
   const toc = generate_table_of_contents(body);

--- a/src/tools/generate/generate_chapters.js
+++ b/src/tools/generate/generate_chapters.js
@@ -11,7 +11,7 @@ const { generate_featured_chapters, generate_chapter_featured_quote } = require(
 const { generate_sitemap } = require('./generate_sitemap');
 const { lazy_load_content } = require('./lazy_load_content');
 const { wrap_tables } = require('./wrap_tables');
-const { table_dropdowns } = require('./generate_table_figure_dropdowns');
+const { generate_table_figure_dropdowns } = require('./generate_table_figure_dropdowns');
 const { remove_unnecessary_markup } = require('./remove_unnecessary_markup');
 const { generate_ebooks } = require('./generate_ebooks');
 const { generate_js } = require('./generate_js');
@@ -144,7 +144,7 @@ const parse_file = async (markdown,chapter) => {
   body = generate_header_links(body);
   body = generate_figure_ids(body);
   body = wrap_tables(body);
-  body = table_dropdowns(body);
+  body = generate_table_figure_dropdowns(body);
   body = lazy_load_content(body);
   body = remove_unnecessary_markup(body);
   const toc = generate_table_of_contents(body);

--- a/src/tools/generate/generate_ebooks.js
+++ b/src/tools/generate/generate_ebooks.js
@@ -12,6 +12,8 @@ const update_links = (chapter) => {
   body = body.replace(/figure_markup\(/g,'figure_markup(\nebook=true,');
   // Add ebook=true to figure_link templates
   body = body.replace(/figure_link\(/g,'figure_link(\nebook=true,');
+  // Remove figure_dropdowns as not needed
+  body = body.replace(/{{\s*figure_dropdown.*?}}/gsm,'');
   // Replace current chapter header ids to full id (e.g. <h2 id="introduction"> -> <h2 id="javascript-introduction">)
   body = body.replace(/<h([0-6]) id="/g,'<h$1 id="' + chapter.metadata.chapter + '-');
   // Replace other chapter references with hash to anchor link (e.g. ./javascript#fig-1 -> #javascript-fig-1)

--- a/src/tools/generate/generate_table_figure_dropdowns.js
+++ b/src/tools/generate/generate_table_figure_dropdowns.js
@@ -1,0 +1,27 @@
+const jsdom = require("jsdom");
+const { JSDOM } = jsdom;
+
+/* Grab all the <figcaptions> from tables and add a figure_link in the table-wrap div */
+const table_dropdowns = (html) => {
+  const dom = new JSDOM(`<!DOCTYPE html><body>${html}</body>`);
+
+  const figures = dom.window.document.querySelectorAll('figure');
+  [...figures].forEach(figure => {
+      const figcaption = figure.querySelector('figcaption');
+      if (figcaption) {
+        let figure_dropdown = figcaption.innerHTML.replace(/figure_link/, 'figure_dropdown');
+        figure_dropdown = figure_dropdown.replace(/caption=".*?"(,\s)+/, ' ');
+        figure_dropdown_node = dom.window.document.createTextNode(figure_dropdown);
+        const table_wrap = figure.querySelector('.table-wrap');
+        if (table_wrap) {
+          table_wrap.appendChild(figure_dropdown_node);
+        }
+      }
+  });
+
+  return dom.window.document.querySelector('body').innerHTML;
+};
+
+module.exports = {
+  table_dropdowns
+};

--- a/src/tools/generate/generate_table_figure_dropdowns.js
+++ b/src/tools/generate/generate_table_figure_dropdowns.js
@@ -10,10 +10,11 @@ const table_dropdowns = (html) => {
       const figcaption = figure.querySelector('figcaption');
       if (figcaption) {
         let figure_dropdown = figcaption.innerHTML.replace(/figure_link/, 'figure_dropdown');
-        figure_dropdown = figure_dropdown.replace(/caption=".*?"(,\s)+/, ' ');
+        figure_dropdown = figure_dropdown.replace(/caption=".*?"[,\s]*/, '');
+        figure_dropdown = figure_dropdown.replace(/caption='.*?'[,\s]*/, '');
         figure_dropdown_node = dom.window.document.createTextNode(figure_dropdown);
         const table_wrap = figure.querySelector('.table-wrap');
-        if (table_wrap) {
+        if (figure_dropdown && table_wrap) {
           table_wrap.appendChild(figure_dropdown_node);
         }
       }

--- a/src/tools/generate/generate_table_figure_dropdowns.js
+++ b/src/tools/generate/generate_table_figure_dropdowns.js
@@ -2,19 +2,17 @@ const jsdom = require("jsdom");
 const { JSDOM } = jsdom;
 
 /* Grab all the <figcaptions> from tables and add a figure_link in the table-wrap div */
-const table_dropdowns = (html) => {
+const generate_table_figure_dropdowns = (html) => {
   const dom = new JSDOM(`<!DOCTYPE html><body>${html}</body>`);
 
   const figures = dom.window.document.querySelectorAll('figure');
   [...figures].forEach(figure => {
       const figcaption = figure.querySelector('figcaption');
-      if (figcaption) {
+      const table_wrap = figure.querySelector('.table-wrap');
+      if (figcaption && table_wrap) {
         let figure_dropdown = figcaption.innerHTML.replace(/figure_link/, 'figure_dropdown');
-        figure_dropdown = figure_dropdown.replace(/caption=".*?"[,\s]*/, '');
-        figure_dropdown = figure_dropdown.replace(/caption='.*?'[,\s]*/, '');
         figure_dropdown_node = dom.window.document.createTextNode(figure_dropdown);
-        const table_wrap = figure.querySelector('.table-wrap');
-        if (figure_dropdown && table_wrap) {
+        if (figure_dropdown) {
           table_wrap.appendChild(figure_dropdown_node);
         }
       }
@@ -24,5 +22,5 @@ const table_dropdowns = (html) => {
 };
 
 module.exports = {
-  table_dropdowns
+  generate_table_figure_dropdowns
 };


### PR DESCRIPTION
Fixes #1716 

This is an alternative to #1728 keeping the menu in the top right but handling it better.

For tables this is a bit more painful and have to inject it into the DOM at build time as need it in the `<div class="table-wrap">` element so it's not all the way on the right.

Staged link: https://20201216t175100-dot-webalmanac.uk.r.appspot.com

[Example graph](https://20201216t175100-dot-webalmanac.uk.r.appspot.com/en/2020/http2#fig-6): 

![Example graph](https://user-images.githubusercontent.com/10931297/102381773-8a82d480-3fc1-11eb-9f1a-aa28990b34c6.png)

[Example table](https://20201216t175100-dot-webalmanac.uk.r.appspot.com/en/2020/http2#fig-3):

![Example table](https://user-images.githubusercontent.com/10931297/102381805-953d6980-3fc1-11eb-93de-da01fc1e9a14.png)

[Example Big Figure](https://20201216t175100-dot-webalmanac.uk.r.appspot.com/en/2020/http2#fig-2):

![Example Big Figure](https://user-images.githubusercontent.com/10931297/102386766-6fb35e80-3fc7-11eb-896f-9d8c6ca3dcdc.png)

