### PR TITLE
Oxford commas for Contributor teams

### DIFF
--- a/src/static/css/ebook.css
+++ b/src/static/css/ebook.css
@@ -167,15 +167,17 @@ tbody tr:nth-child(even) {
 .contributor-teams {
   line-height: 1;
   color: #757575;
+  font-size: 8px;
+  font-size: 0.8rem;
 }
 
 .contributor-team,
 .contributor-social,
 .contributor-social a,
 .contributor-social a:visited {
+  color: #757575;
   font-size: 8px;
   font-size: 0.8rem;
-  color: #757575;
 }
 
 .authors .social,

--- a/src/templates/base/base_ebook.html
+++ b/src/templates/base/base_ebook.html
@@ -390,7 +390,7 @@
           {% endif %}
           <div class="contributor-teams">
             {% for id in contributor.teams | sort() %}
-              <span class="contributor-team team-{{ id }}">{{ localizedTeamNames[id] if localizedTeamNames[id]|length else team.name }}</span>{{ self.comma() if not loop.last  and loop.length > 2 }}
+              <span class="contributor-team">{% if loop.last and loop.length > 1 %} {{ self.and() }} {% endif %}</span><span class="contributor-team team-{{ id }}">{{ localizedTeamNames[id] if localizedTeamNames[id]|length else team.name }}</span>{{ self.comma() if not loop.last and loop.length > 2 }}
             {% endfor %}
           </div>
         </div>

--- a/src/templates/base/base_ebook.html
+++ b/src/templates/base/base_ebook.html
@@ -390,7 +390,7 @@
           {% endif %}
           <div class="contributor-teams">
             {% for id in contributor.teams | sort() %}
-              <span class="contributor-team">{% if loop.last and loop.length > 1 %} {{ self.and() }} {% endif %}</span><span class="contributor-team team-{{ id }}">{{ localizedTeamNames[id] if localizedTeamNames[id]|length else team.name }}</span>{{ self.comma() if not loop.last and loop.length > 2 }}
+              {% if loop.last and loop.length > 1 %} {{ self.and() }} {% endif %}<span class="contributor-team team-{{ id }}">{{ localizedTeamNames[id] if localizedTeamNames[id]|length else team.name }}</span>{{ self.comma() if not loop.last and loop.length > 2 }}
             {% endfor %}
           </div>
         </div>

--- a/src/templates/base/contributors.html
+++ b/src/templates/base/contributors.html
@@ -139,6 +139,8 @@
   margin-top: 5px;
   text-align: center;
   color: #757575;
+  font-size: 14px;
+  font-size: 0.875rem;
 }
 
 .contributor-team {
@@ -343,7 +345,7 @@
 
         <div class="contributor-teams">
           {% for id in contributor.teams | sort() %}
-          <span class="contributor-team">{% if loop.last and loop.length > 1 %} {{ self.and() }} {% endif %}</span><span class="contributor-team team-{{ id }}">{{ localizedTeamNames[id] if localizedTeamNames[id]|length else team.name }}</span>{{ self.comma() if not loop.last and loop.length > 2 }}
+          {% if loop.last and loop.length > 1 %} {{ self.and() }} {% endif %}<span class="contributor-team team-{{ id }}">{{ localizedTeamNames[id] if localizedTeamNames[id]|length else team.name }}</span>{{ self.comma() if not loop.last and loop.length > 2 }}
           {% endfor %}
         </div>
       </li>

--- a/src/templates/base/contributors.html
+++ b/src/templates/base/contributors.html
@@ -343,7 +343,7 @@
 
         <div class="contributor-teams">
           {% for id in contributor.teams | sort() %}
-            <span class="contributor-team team-{{ id }}">{{ localizedTeamNames[id] if localizedTeamNames[id]|length else team.name }}</span>{{ self.comma() if not loop.last }}
+          <span class="contributor-team">{% if loop.last and loop.length > 1 %} {{ self.and() }} {% endif %}</span><span class="contributor-team team-{{ id }}">{{ localizedTeamNames[id] if localizedTeamNames[id]|length else team.name }}</span>{{ self.comma() if not loop.last and loop.length > 2 }}
           {% endfor %}
         </div>
       </li>
@@ -356,10 +356,10 @@
 {% block scripts %}
   {{ super() }}
   <script nonce="{{ csp_nonce() }}">
-  
+
   // Randomise the contributors on reload as server-side random will be cached at CDN.
   // Only run this if the page is reloaded for performance reasons.
-  
+
   // Support both newer PerformanceNavigationTiming API for newer browsers
   // and older Navigation Timing API for older browsers
   if ((performance.getEntriesByType("navigation")[0] && performance.getEntriesByType("navigation")[0].type === "reload")
@@ -465,7 +465,7 @@
               button.setAttribute('aria-pressed',false);
             }
         }
-        
+
         var filteredCount = getFilteredContributorCount();
         counter.innerText = filteredCount;
         if ( counter.innerText ===  totalContributors.innerText ) {
@@ -479,7 +479,7 @@
   }
 
   try {
-    loaded() 
+    loaded()
   } catch(e) {
     gtag('event', 'exception', {
       'description': e,
@@ -489,7 +489,7 @@
 
   var contributorsGrid = document.querySelector('.contributor-grid');
   contributorsGrid.setAttribute('data-rendered', true);
-    
+
   </script>
   <!-- add chapter.js to handle print mode and avoid duplicating code -->
   <script src="{{ get_versioned_filename('/static/js/chapter.js') }}" defer></script>


### PR DESCRIPTION
Looks like we broke contributors with two teams for ebook in #1266 

![Two teams screenshot](https://user-images.githubusercontent.com/10931297/102618380-95a94200-4132-11eb-83a7-5d2d72288e97.png)

Still works for more that two teams:

![Multiple teams screenshot](https://user-images.githubusercontent.com/10931297/102618406-a5288b00-4132-11eb-9ff4-df7adae9bc33.png)

Let's move to Oxford commas for both Contributors and Ebook!

Staged here: https://20201218t132416-dot-webalmanac.uk.r.appspot.com/en/2020/contributors#ibnesayeed
And ebook here: https://20201218t132416-dot-webalmanac.uk.r.appspot.com/static/pdfs/web_almanac_2020_en.pdf

Screenshots:

![Two teams screenshot fixed](https://user-images.githubusercontent.com/10931297/102618282-67c3fd80-4132-11eb-9d29-7b79dba7889d.png)

![Multiple teams screenshot fixed](https://user-images.githubusercontent.com/10931297/102618323-76aab000-4132-11eb-93c1-58b943e73827.png)



