### PR TITLE
Stop figures overflowing on mobile

### DIFF
--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -714,7 +714,6 @@ figure .fig-desktop {
 }
 
 @media (max-width: 600px) {
-
   figure {
     margin: 0 15px;
   }

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -714,6 +714,15 @@ figure .fig-desktop {
 }
 
 @media (max-width: 600px) {
+
+  figure {
+    margin: 0 15px;
+  }
+
+  .figure-dropdown {
+    right: -40px;
+  }
+
   figure .big-number {
     font-size: 80px;
     font-size: 5rem;

--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -641,7 +641,7 @@
 {% macro figure_dropdown(metadata, id, sheets_gid="", sql_file="", image="", caption="") %}
   {% if sheets_gid != "" or  sql_file != "" or image != "" %}
   <div class="figure-dropdown nav-dropdown">
-    <button class="nav-dropdown-btn js-enable hidden" disabled aria-expanded="false" title="Figure options&hellip;">
+    <button class="nav-dropdown-btn js-enable hidden" disabled aria-expanded="false" title="{{ self.explore_the_results() }}">
       <span class="visually-hidden">{{ self.explore_the_results() }}</span>
       <svg aria-hidden="true" width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
         <path fill-rule="evenodd" d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"/>


### PR DESCRIPTION
With the addition of the drop down menu the figures overflow the width on mobile creating a bouncing effect as you scroll which is very annoying. This reigns it in a big to prevent this.

The alternative is just not to display the figure menus on mobile?