### PR TITLE
Correct ordering of pre-release script

### DIFF
--- a/.github/workflows/predeploy.yml
+++ b/.github/workflows/predeploy.yml
@@ -50,14 +50,14 @@ jobs:
       run: sudo apt install pdftk
     - name: Run the website
       run: ./src/tools/scripts/run_and_test_website.sh
-    - name: Update timestamps
-      run: |
-        cd src
-        npm run timestamps
     - name: Generating Ebooks
       run: |
         cd src
         npm run ebooks
+    - name: Update timestamps
+      run: |
+        cd src
+        npm run timestamps
     - name: Create Pull Request
       id: cpr
       uses: peter-evans/create-pull-request@v3.5.2


### PR DESCRIPTION
Currently we generate hashes of our content (including ebooks), then generate the new ebooks. That's the wrong way around!

Luckily as we generate the ebooks each time it hasn't matter so much, but still - it's wrong so let's fix it.