### PR TITLE
Allow stories to be framed

### DIFF
--- a/src/server/routes.py
+++ b/src/server/routes.py
@@ -83,14 +83,19 @@ def sitemap():
     return resp
 
 
-# Stories requires it's own CSP
+# Stories requires it's own CSP and to allow framing
 @app.route('/<lang>/<year>/stories/<story>')
 @validate
 @talisman(
     content_security_policy=stories_csp.csp,
-    content_security_policy_nonce_in=['script-src']
+    content_security_policy_nonce_in=['script-src'],
+    frame_options=None
 )
 def stories(lang, year, story):
+    # Flask-Talisman doesn't allow override of content_security_policy_nonce_in
+    # per route yet
+    # https://github.com/GoogleCloudPlatform/flask-talisman/issues/62
+    # So remove Nonce value from request object for now which has same effect
     delattr(request, 'csp_nonce')
     return render_template('%s/%s/stories/%s.html' % (lang, year, story.replace('-', '_')))
 

--- a/src/server/routes.py
+++ b/src/server/routes.py
@@ -83,7 +83,7 @@ def sitemap():
     return resp
 
 
-# Stories requires it's own CSP and to allow framing
+# Stories require their own CSP and to allow framing
 @app.route('/<lang>/<year>/stories/<story>')
 @validate
 @talisman(

--- a/src/server/stories_csp.py
+++ b/src/server/stories_csp.py
@@ -35,5 +35,8 @@ csp = {
         '\'self\'',
         'docs.google.com',
         'www.youtube.com'
+    ],
+    'frame-ancestors': [
+        '*'
     ]
 }


### PR DESCRIPTION
As discussed in https://github.com/HTTPArchive/almanac.httparchive.org/pull/1800#issuecomment-750418345

Test site: https://20201224t113956-dot-webalmanac.uk.r.appspot.com/en/2020/stories/page-content

Test Framing: https://www.tunetheweb.com/experiments/amp-stories/ (works)
Compared to production: https://www.tunetheweb.com/experiments/amp-stories/production.html (doesn't work)