### PR TITLE
Fix overflowing big-numbers

### DIFF
--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -600,6 +600,7 @@ figure .medium-number {
   font: bold 3rem/1em Poppins, sans-serif;
   color: #62718b;
   overflow-wrap: break-word;
+  word-break: break-all;
 }
 
 figure .really-big-number {
@@ -608,6 +609,7 @@ figure .really-big-number {
   font: bold 1.5rem/1em Poppins, sans-serif;
   color: #62718b;
   overflow-wrap: break-word;
+  word-break: break-all;
 }
 
 figure .fig-mobile {

--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -828,7 +828,7 @@
   <div id="{{ anchor }}-description" class="visually-hidden">{{ description|safe }}</div>
   {%- elif content != "" %}
   <div class="figure-wrapper">
-    <span class="{{ classes }}">{{ content|safe }}</span>
+    <div class="{{ classes }}">{{ content|safe }}</div>
     {% if not ebook %}{{ figure_dropdown(metadata, id, sheets_gid, sql_file, image, ebook) }}{% endif %}
   </div>
   {%- endif %}


### PR DESCRIPTION
Looks like #1726 incorrectly caused big numbers to overflow:

![big-number overflowing](https://user-images.githubusercontent.com/10931297/103146789-11fce000-4746-11eb-8ebd-9498063e7125.png)

Got alerted to this by a Google Search Console alert:

![GSC error](https://user-images.githubusercontent.com/10931297/103146803-3953ad00-4746-11eb-9104-1abc29f468bf.png)
