### PR TITLE
Turn on Italian for 2019

### DIFF
--- a/src/config/2019.json
+++ b/src/config/2019.json
@@ -2,7 +2,7 @@
   "settings": [
     {
       "is_live": true,
-      "supported_languages": ["en","es","fr","hi","ja","nl","pt","ru","zh-CN","zh-TW"],
+      "supported_languages": ["en","es","fr","it","hi","ja","nl","pt","ru","zh-CN","zh-TW"],
       "ebook_languages": ["en","ja"]
     }
   ],
@@ -713,6 +713,16 @@
       ],
       "avatar_url": "https://avatars1.githubusercontent.com/u/3392338?v=4&s=200",
       "github": "ljme"
+    },
+    "chefleo": {
+      "name": "Leonardo Digiorgio",
+      "teams": [
+        "translators"
+      ],
+      "avatar_url": "https://avatars1.githubusercontent.com/u/26022943?s=460&u=64b286deddd79f94a2dc8dee0e7610e0dd2a7b34&v=4",
+      "website": "https://chefleo.dev/",
+      "github": "chefleo",
+      "twitter": "simdigiorgio"
     },
     "MSakamaki": {
       "name": "M.Sakamaki",

--- a/src/config/2020.json
+++ b/src/config/2020.json
@@ -584,7 +584,8 @@
     "giopunt": {
       "name": "Giovanni Puntil",
       "teams": [
-        "reviewers"
+        "reviewers",
+        "translators"
       ],
       "avatar_url": "https://avatars1.githubusercontent.com/u/1746646?v=4&s=200",
       "github": "giopunt",

--- a/src/content/en/2020/resource-hints.md
+++ b/src/content/en/2020/resource-hints.md
@@ -250,8 +250,6 @@ Now let's celebrate the first year of the [Native Lazy Loading](https://addyosma
   sql_file="native_lazy_loading_attrs.sql"
 ) }}
 
-{# TODO(authors/reviewers) - revisit this figure - Ref https://github.com/HTTPArchive/almanac.httparchive.org/pull/1587#discussion_r532292106 #}
-
 Adoption is still in its early days, especially with the official thresholds earlier this year being too conservative, and only [recently](https://addyosmani.com/blog/better-image-lazy-loading-in-chrome/) aligning with developer expectations. With almost 72% of browsers supporting native image/source lazy loading, this is another area of opportunity especially for pages looking to improve data usage and performance on low-end devices.
 
 Running Lighthouse's "[Defer offscreen images](https://web.dev/offscreen-images/)" audit resulted in 68.65% of pages passing the test. For those pages there is an opportunity to lazy-load images after all critical resources have finished loading.

--- a/src/templates/it/2019/base.html
+++ b/src/templates/it/2019/base.html
@@ -1,0 +1,28 @@
+{% extends "%s/base.html" % lang %}
+
+{% block methodology_stat_1 %}5.8M{% endblock %}
+{% block methodology_stat_2 %}20.9 TB{% endblock %}
+{% block methodology_description %}
+Se non diversamente specificato, le metriche in tutti i 20 capitoli del Web Almanac provengono dal dataset dell'archivio HTTP. HTTP Archive è un progetto gestito dalla comunità che tiene traccia del modo in cui è costruito il Web dal 2010. Utilizzando WebPageTest e Lighthouse "under the hood", i metadati di quasi 6 milioni di siti Web vengono testati mensilmente e inclusi in un database BigQuery pubblico per l'analisi. Il set di dati di luglio 2020 è stato utilizzato come base per le metriche del Web Almanac. Per ulteriori informazioni, vedere la pagina Methodology.
+{% endblock %}
+
+
+{% block foreword %}
+  <p>
+    Il web aperto è una rete di tecnologie incredibilmente complessa e in continua evoluzione. Intere industrie e carriere sono costruite sul Web e per avere successo dipendono dal suo vivace ecosistema. Per quanto il Web sia fondamentale, capire come sta andando è stato sorprendentemente sfuggente. Dal 2010, la missione del progetto HTTP Archive è stata quella di monitorare come è costruito il Web e sta facendo un lavoro straordinario. Tuttavia, c'è stata una lacuna che è stata particolarmente difficile da colmare: dare un significato ai dati che il progetto HTTP Archive ha raccolto e consentire alla comunità di comprendere facilmente le prestazioni del web. È qui che entra in gioco il Web Almanac.
+  </p>
+
+  <p>
+    La missione del Web Almanac è ​​quella di raccogliere il tesoro di intuizioni che altrimenti sarebbero accessibili solo a intrepidi data miner e impacchettarlo in un modo facile da capire. Ciò è reso possibile con l'aiuto di esperti del settore che possono dare un senso ai dati e dirci cosa significano. Ciascuno dei 20 capitoli del Web Almanac si concentra su un aspetto specifico del Web e ciascuno è stato creato e sottoposto a revisione tra pari da esperti nel proprio campo. La forza del Web Almanac deriva direttamente dall'esperienza delle persone che lo scrivono.
+  </p>
+
+  <p>
+    Molti dei risultati nel Web Almanac sono degni di essere celebrati, ma è anche un importante promemoria del lavoro ancora necessario per fornire esperienze utente di alta qualità. Le analisi basate sui dati in ogni capitolo sono una forma di responsabilità che tutti condividiamo per lo sviluppo di un Web migliore. Non si tratta di svergognare coloro che stanno sbagliando, ma di far brillare una luce guida sul percorso delle migliori pratiche in modo che ci sia un modo chiaro e giusto di fare le cose. Con il continuo aiuto della comunità web, speriamo di renderlo una tradizione annuale, così ogni anno possiamo monitorare i nostri progressi e apportare correzioni al corso secondo necessità.
+  </p>
+
+  <p>
+    C'è così tanto da imparare in questo rapporto, quindi inizia a esplorare e condividere i tuoi suggerimenti con la comunità in modo che possiamo far progredire collettivamente la nostra comprensione dello stato del Web.
+  </p>
+
+  <p>— <em><a href="{{ url_for('contributors', year=year, lang=lang, _anchor='rviscomi') }}">Rick Viscomi</a>, Web Almanac Editor-in-Chief</em></p>
+{% endblock %}

--- a/src/templates/it/2019/base.html
+++ b/src/templates/it/2019/base.html
@@ -21,7 +21,7 @@ Se non diversamente specificato, le metriche in tutti i 20 capitoli del Web Alma
   </p>
 
   <p>
-    C'è così tanto da imparare in questo rapporto, quindi inizia a esplorare e condividere i tuoi suggerimenti con la comunità in modo che possiamo far progredire collettivamente la nostra comprensione dello stato del Web.
+    C'è così tanto da imparare in questo report, quindi inizia a esplorare e condividere i tuoi suggerimenti con la comunità in modo che possiamo far progredire collettivamente la nostra comprensione dello stato del Web.
   </p>
 
   <p>— <em><a href="{{ url_for('contributors', year=year, lang=lang, _anchor='rviscomi') }}">Rick Viscomi</a>, Web Almanac Editor-in-Chief</em></p>

--- a/src/templates/it/2019/contributors.html
+++ b/src/templates/it/2019/contributors.html
@@ -1,8 +1,8 @@
 {% extends "base/contributors.html" %}
 
-{% block title %}2019 Collaboratori | Le Web Almanac di HTTP Archive{% endblock %}
+{% block title %}2019 Collaboratori | Il Web Almanac di HTTP Archive{% endblock %}
 
-{% block description %}Le {{ config.contributors.items() | length }} persone che hanno contribuito al 2019 Web Almanac as Analisti, Autori, Brainstormers, Designer, Sviluppatori, Editori, Revisori e Traduttori.{% endblock %}
+{% block description %}Le {{ config.contributors.items() | length }} persone che hanno contribuito al 2019 Web Almanac come Analisti, Autori, Brainstormers, Designer, Sviluppatori, Editori, Revisori e Traduttori.{% endblock %}
 
 {% block filter_by_team %}Filtra per squadra: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> di <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> collaboratori.{% endblock %}
 {% block filter_by %}Filtra per{% endblock %}

--- a/src/templates/it/2019/contributors.html
+++ b/src/templates/it/2019/contributors.html
@@ -1,0 +1,11 @@
+{% extends "base/contributors.html" %}
+
+{% block title %}2019 Collaboratori | Le Web Almanac di HTTP Archive{% endblock %}
+
+{% block description %}Le {{ config.contributors.items() | length }} persone che hanno contribuito al 2019 Web Almanac as Analisti, Autori, Brainstormers, Designer, Sviluppatori, Editori, Revisori e Traduttori.{% endblock %}
+
+{% block filter_by_team %}Filtra per squadra: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> di <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> collaboratori.{% endblock %}
+{% block filter_by %}Filtra per{% endblock %}
+
+{% block join_the_team_title%}Unisciti al team di Web Almanac{% endblock %}
+{% block join_the_team_text%}Unisciti alla squadra!{% endblock %}

--- a/src/templates/it/2019/index.html
+++ b/src/templates/it/2019/index.html
@@ -1,0 +1,6 @@
+{% extends "base/index.html" %}
+
+{% block title %}Web Almanac {{ year }}{% endblock %}
+{% block description %}Il Web Almanac è un report annuale sullo stato del Web che combina l'esperienza della comunità Web con i dati e le tendenze del HTTP Archive.{% endblock %}
+
+{% block twitter_image_alt %}Web Almanac {{ year }}{% endblock %}

--- a/src/templates/it/2019/table_of_contents.html
+++ b/src/templates/it/2019/table_of_contents.html
@@ -1,0 +1,7 @@
+{% extends "base/table_of_contents.html" %}
+
+{% block title %}Sommario | Web Almanac 2019{% endblock %}
+
+{% block description %}Sommario per il Web Almanac 2019, elencando ciascuna sezione: Page Contents, User Experience, Content Publishing, Content Distribution.{% endblock %}
+
+{% block twitter_image_alt %}{{ year }} Web Almanac methodology{% endblock %}

--- a/src/templates/it/2020/contributors.html
+++ b/src/templates/it/2020/contributors.html
@@ -1,8 +1,8 @@
 {% extends "base/contributors.html" %}
 
-{% block title %}{{ year }} Collaboratori | Le Web Almanac di HTTP Archive{% endblock %}
+{% block title %}{{ year }} Collaboratori | Il Web Almanac di HTTP Archive{% endblock %}
 
-{% block description %}Le {{ config.contributors.items() | length }} persone che hanno contribuito al {{ year }} Web Almanac as Analisti, Autori, Designer, Sviluppatori, Editori, Revisori e Traduttori.{% endblock %}
+{% block description %}Le {{ config.contributors.items() | length }} persone che hanno contribuito al {{ year }} Web Almanac come Analisti, Autori, Designer, Sviluppatori, Editori, Revisori e Traduttori.{% endblock %}
 
 {% block filter_by_team %}Filtra per squadra: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> di <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> collaboratori.{% endblock %}
 {% block filter_by %}Filtra per{% endblock %}

--- a/src/templates/it/2020/contributors.html
+++ b/src/templates/it/2020/contributors.html
@@ -1,0 +1,11 @@
+{% extends "base/contributors.html" %}
+
+{% block title %}{{ year }} Collaboratori | Le Web Almanac di HTTP Archive{% endblock %}
+
+{% block description %}Le {{ config.contributors.items() | length }} persone che hanno contribuito al {{ year }} Web Almanac as Analisti, Autori, Designer, Sviluppatori, Editori, Revisori e Traduttori.{% endblock %}
+
+{% block filter_by_team %}Filtra per squadra: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> di <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> collaboratori.{% endblock %}
+{% block filter_by %}Filtra per{% endblock %}
+
+{% block join_the_team_title%}Unisciti al team di Web Almanac{% endblock %}
+{% block join_the_team_text%}Unisciti alla squadra!{% endblock %}

--- a/src/templates/it/base.html
+++ b/src/templates/it/base.html
@@ -1,8 +1,11 @@
 {% extends "base/base.html" %}
+
 {% block description %}Web Almanac è un report annuale sullo stato del Web che combina l'esperienza della comunità Web con i dati e le tendenze dell'archivio HTTP.{% endblock %}
 
 {% block twitter_image_alt %}{{ year }} Web Almanac{% endblock %}
+
 {% block skip_navigation %}Salta la navigazione{% endblock %}
+
 {% block organization %}Web Almanac di HTTP Archive{% endblock %}
 {% block web_almanac_logo %}
   <span class="wa">Web Almanac</span>
@@ -20,6 +23,7 @@
 La nostra missione è combinare le statistiche grezze e le tendenze del HTTP Archive con l'esperienza della comunità web. Il Web Almanac è un rapporto completo sullo stato del web, supportato da dati reali e da esperti web di fiducia. È composto da {{supported_chapters | length}} capitoli che abbracciano aspetti del page content, user experience, publishing e distribution.
 </p>
 {% endblock %}
+
 {% block read_last_years_almanac %}Leggi il Web Almanac del {{ year | int - 1 }}{% endblock %}
 
 {% block http_archive_link %}Pagina iniziale HTTP Archive{% endblock %}


### PR DESCRIPTION
Makes progress on #585

With all the awesome work in #1842 it's only a small amount to turn on 2019 for Italian too so we might as well do that.

@chefleo @Zizzamia @giopunt could you review `it/2019/base.html` as that's the only one that really changes. I did a quick Google Translate on the [current English text](https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/src/templates/en/2019/base.html) but am sure the Italian could be improved!

The other templates are pretty much identical to the 2020 ones so a straight copy/paste and year update for them.