### PR TITLE
Avoid scrollbars on desktop

### DIFF
--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -447,8 +447,8 @@ figure {
   position: relative;
   display: flex;
   flex-direction: column;
-  margin: 15px -8px;
-  margin: 0.9375rem -0.5rem;
+  margin: 22.4px;
+  margin: 1.4rem;
   padding: 8px;
   padding: 0.5rem;
   font-style: italic;
@@ -723,6 +723,7 @@ figure .fig-desktop {
 @media (max-width: 600px) {
   figure {
     margin: 0 15px;
+    margin: 0 0.9375rem;
   }
 
   .figure-dropdown {


### PR DESCRIPTION
Noticed horizontal scroll bars appear on tablet and desktop size. Looks similar to #1830 but missed it when fixing that as not as noticeable or annoying on Desktop. Still simple enough CSS fix so let's fix it.