### PR TITLE
Fix a couple of small styling issues in ebook

### DIFF
--- a/src/static/css/2019.css
+++ b/src/static/css/2019.css
@@ -1493,6 +1493,7 @@ th code {
   padding: 0;
   margin: 0;
   border-radius: 0;
+  background-color: transparent;
   background-color: unset;
 }
 

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -471,6 +471,7 @@ figure img {
 
 .height-16vw-122px {
   max-height: 122px;
+  height: 122px;
   height: 16vw;
 }
 


### PR DESCRIPTION
Color-stop diagram is too small as prince doesn't support `vw`:

![image](https://user-images.githubusercontent.com/10931297/104859834-d6f26480-591f-11eb-9d76-00013221c688.png)


Code blocks have background as prince doesn't support `unset`.

![image](https://user-images.githubusercontent.com/10931297/104859826-cc37cf80-591f-11eb-8439-39f197daaad9.png)

Added fallbacks to CSS