### PR TITLE
Remove TODO's from 2020 SEO and Resource Hints chapters

### DIFF
--- a/src/content/en/2020/resource-hints.md
+++ b/src/content/en/2020/resource-hints.md
@@ -236,8 +236,6 @@ In the case of "[Preconnect to required origins](https://web.dev/uses-rel-precon
 
 Lastly, running Lighthouse's "[Preload key requests](https://web.dev/uses-rel-preload/)" audit resulted in 84.6% of pages passing the test. If you are looking to use `preload` for the first time, remember, fonts and critical scripts are a good place to start.
 
-{# TODO(authors/reviewers) - revisit this sentence - Ref https://github.com/HTTPArchive/almanac.httparchive.org/pull/1587#discussion_r532291496 #}
-
 ### Native Lazy Loading
 
 Now let's celebrate the first year of the [Native Lazy Loading](https://addyosmani.com/blog/lazy-loading/) API, which at the time of publishing already has over [72%](https://caniuse.com/loading-lazy-attr) browser support. This new API can be used to defer the load of below-the-fold iframes and images on the page until the user scrolls near them. This can reduce data usage, memory usage, and helps speed up above-the-fold content. Opting-in to lazy load is as simple as adding `loading=lazy`  on `<iframe>` or `<img>` elements.

--- a/src/content/en/2020/seo.md
+++ b/src/content/en/2020/seo.md
@@ -501,7 +501,6 @@ With meta descriptions continuing to power other snippets such as social and new
 
 The usage of images, particularly using `img` tags, within a page often suggests a focus on visual presentation of content. Although search engine capabilities regarding computer vision have continued to improve, we have no indication that this technology is being used in the ranking of pages. `alt` attributes remain the primary way to explain an image in lieu of a search engine's ability to "see" it. `alt` attributes also support accessibility and clarify the elements on the page for users that are visually impaired.
 
-{# TODO(authors): Why are the growth of bandwidth and ubiquity of smartphones contributors to image heaviness? #}
 The median desktop page includes 21 `img` tags and the median mobile page has 19 `img` tags. The web continues to trend toward image-heaviness with the growth of bandwidth and the ubiquity of smartphones. However, this comes at a cost of performance.
 
 {{ figure_markup(
@@ -514,7 +513,6 @@ The median desktop page includes 21 `img` tags and the median mobile page has 19
   sql_file="pages_markup_by_device_and_percentile.sql"
 ) }}
 
-{# TODO(authors): Add your interpretation of these results. What do you hope readers get from it? #}
 The median web page is missing 2.99% of `alt` attributes on desktop and 2.44% of `alt` attributes on mobile. For more information on the importance of `alt` attributes, see the [Accessibility](./accessibility) chapter.
 
 {{ figure_markup(
@@ -528,7 +526,6 @@ The median web page is missing 2.99% of `alt` attributes on desktop and 2.44% of
   )
 }}
 
-{# TODO(authors, analysts): I don't think the interpretation of these stats was correct, so I edited out anything that I didn't think was accurate. Please double check my edit and feel free to expand on it. Note that this is incompatible with last year's stat because that was a Lighthouse audit checking that all images have alt attributes, while this data was calculated directly from the markup. There's something off if 40+% of pages have perfect alt coverage, but this chart has less than perfect coverage at the 75th percentile. Either coverage got much _worse_ this year or they're measuring different things. For example Lighthouse may be more lenient about which images should have alt attributes. Do you have those audit results based on 2020 data here for better comparison? #}
 We found that the median page contains `alt` attributes on only 51.22% of their images.
 
 {{ figure_markup(
@@ -776,7 +773,6 @@ Desktop websites that have separate mobile versions are recommended to link to t
 
 Having a fast-loading website is fundamental to provide a great user search experience. Because of its importance, it has been taken into consideration as a ranking factor by search engines for years. Google initially announced using site speed as a [ranking factor in 2010](https://webmasters.googleblog.com/2010/04/using-site-speed-in-web-search-ranking.html), and then [in 2018 did the same for mobile searches](https://webmasters.googleblog.com/2018/01/using-page-speed-in-mobile-search.html).
 
-{# NOTE(authors): I've made some ruthless edits to this section to remove everything related to synthetic measurement of CWV, including the entire Lighthouse discussion, which is orthogonal to the real-user aspect of CWV. Please push back if you disagree with any of these edits. #}
 As announced in November 2020, three performance metrics known as [Core Web Vitals](https://webmasters.googleblog.com/2020/05/evaluating-page-experience.html) are on track to be a ranking factor as part of the "page experience" signals in May 2021. Core Web Vitals consist of:
 
 **[Largest Contentful Paint](https://web.dev/lcp/) (LCP)**

--- a/src/content/it/2020/resource-hints.md
+++ b/src/content/it/2020/resource-hints.md
@@ -240,8 +240,6 @@ Infine, l'esecuzione dell'audit "<a hreflang="en" href="https://web.dev/uses-rel
 
 Ora festeggiamo il primo anno dell'API <a hreflang="en" href="https://addyosmani.com/blog/lazy-loading/">Native Lazy Loading</a>, che al momento della pubblicazione ha già superato il <a hreflang="en" href="https://caniuse.com/loading-lazy-attr">72%</a> supporto browser. Questa nuova API può essere utilizzata per posticipare il caricamento di iframe e immagini sulla pagina finché l'utente non scorre accanto a essi. Ciò può ridurre l'utilizzo dei dati, l'utilizzo della memoria e velocizzare i contenuti. Attivare il lazy load è semplice come aggiungere `loading = lazy` sugli elementi `<iframe>` o `<img>`.
 
-La percentuale di pagine che utilizzano il Native Lazy Loading.
-
 {{ figure_markup(
   caption="La percentuale di pagine che utilizzano il native lazy loading.",
   content="4.02%",


### PR DESCRIPTION
Removing some `TODO`'s from chapters noticed in #1750 