### PR TITLE
Accessibility statement not in sitemap

### DIFF
--- a/src/config/last_updated.json
+++ b/src/config/last_updated.json
@@ -95,7 +95,7 @@
     "hash": "820e1c55682b83e93a5003dbe3cfccc3",
     "size": 25
   },
-  "en/2019/accessibility_statement.html": {
+  "en/accessibility_statement.html": {
     "date_published": "2020-02-03T00:00:00.000Z",
     "date_modified": "2020-11-21T00:00:00.000Z",
     "hash": "7076971c35dd64e55dcb78964e1b3a59"
@@ -450,7 +450,7 @@
     "date_modified": "2020-11-26T00:00:00.000Z",
     "hash": "b46e32b0430ec8739f501d87adbaa287"
   },
-  "fr/2019/accessibility_statement.html": {
+  "fr/accessibility_statement.html": {
     "date_published": "2020-02-03T00:00:00.000Z",
     "date_modified": "2020-11-21T00:00:00.000Z",
     "hash": "fb9f8946090b4e1e1511f22c603773ad"
@@ -560,7 +560,7 @@
     "date_modified": "2020-11-26T00:00:00.000Z",
     "hash": "46b5effe870d63057c7ca457c0bbdedd"
   },
-  "hi/2019/accessibility_statement.html": {
+  "hi/accessibility_statement.html": {
     "date_published": "2020-11-18T00:00:00.000Z",
     "date_modified": "2020-11-21T00:00:00.000Z",
     "hash": "b388a95747301d06791a38b832ad5411"
@@ -640,7 +640,7 @@
     "date_modified": "2021-01-13T00:00:00.000Z",
     "hash": "e8f944dea01c584acc945222de0bbdf0"
   },
-  "ja/2019/accessibility_statement.html": {
+  "ja/accessibility_statement.html": {
     "date_published": "2020-02-03T00:00:00.000Z",
     "date_modified": "2020-11-21T00:00:00.000Z",
     "hash": "159aea896b67e21d8b8941f66ace4bf6"
@@ -985,7 +985,7 @@
     "date_modified": "2021-01-17T00:00:00.000Z",
     "hash": "6fc527f1f8edb74f3eefa68eec049804"
   },
-  "zh-CN/2019/accessibility_statement.html": {
+  "zh-CN/accessibility_statement.html": {
     "date_published": "2020-02-03T00:00:00.000Z",
     "date_modified": "2020-11-21T00:00:00.000Z",
     "hash": "d8680ced915210433a58a838f6b588ab"

--- a/src/tools/generate/generate_featured_chapters.js
+++ b/src/tools/generate/generate_featured_chapters.js
@@ -39,7 +39,7 @@ const generate_chapter_featured_quote = (metadata) => {
 
 const generate_featured_chapters = async (featured_quotes) => {
 
-  console.log('Generating featured chapters')
+  console.log('\n Generating featured chapters')
 
   for (let language of Object.keys(featured_quotes)) {
 

--- a/src/tools/generate/generate_sitemap.js
+++ b/src/tools/generate/generate_sitemap.js
@@ -4,7 +4,7 @@ const ejs = require('ejs');
 const min_publish_date = '2019-11-11';
 const sitemap_template = `templates/sitemap.ejs.xml`;
 const sitemap_path = `templates/sitemap.xml`;
-const static_pages = [
+const static_pages_lang_year = [
   'index.html',
   'table_of_contents.html',
   'methodology.html',
@@ -14,7 +14,7 @@ const static_pages = [
   'stories/content_publishing.html',
   'stories/content_distribution.html'
 ];
-const static_pages_no_year = [
+const static_pages_lang = [
   'accessibility_statement.html'
 ];
 const ebook_path = "static/pdfs/web_almanac_";
@@ -55,6 +55,7 @@ const get_static_pages = async (sitemap_languages) => {
   for (const year in sitemap_languages) {
     for (const language in sitemap_languages[year]) {
       languages_and_years.push(`${sitemap_languages[year][language]}/${year}`);
+      // Get a list of just languages as well
       const lang_code = `${sitemap_languages[year][language]}`;
       if (!languages.includes(`${lang_code}`)) languages.push(`${lang_code}`);
     }
@@ -62,9 +63,9 @@ const get_static_pages = async (sitemap_languages) => {
 
   let urls = [];
 
-  // Get all of the static pages for each combination
+  // Get all of the static pages for each combination of language and year
   const files = languages_and_years
-    .map((x) => static_pages.map((p) => `${x}/${p}`))
+    .map((x) => static_pages_lang_year.map((p) => `${x}/${p}`))
     .reduce((x, y) => [...x, ...y], []);
 
   // Get the sitemap entries for those pages
@@ -77,9 +78,9 @@ const get_static_pages = async (sitemap_languages) => {
     }
   }
 
-  // Get all of the static pages with no year for each combination
+  // Get all of the static pages with no year for each language
   const files_no_year = languages
-    .map((x) => static_pages_no_year.map((p) => `${x}/${p}`))
+    .map((x) => static_pages_lang.map((p) => `${x}/${p}`))
     .reduce((x, y) => [...x, ...y], []);
 
   for (const loc of await files_no_year) {

--- a/src/tools/generate/generate_sitemap.js
+++ b/src/tools/generate/generate_sitemap.js
@@ -9,11 +9,13 @@ const static_pages = [
   'table_of_contents.html',
   'methodology.html',
   'contributors.html',
-  'accessibility_statement.html',
   'stories/page_content.html',
   'stories/user_experience.html',
   'stories/content_publishing.html',
   'stories/content_distribution.html'
+];
+const static_pages_no_year = [
+  'accessibility_statement.html'
 ];
 const ebook_path = "static/pdfs/web_almanac_";
 
@@ -48,12 +50,17 @@ const generate_sitemap = async (sitemap_chapters,sitemap_languages) => {
 const get_static_pages = async (sitemap_languages) => {
 
   var languages_and_years = [];
+  var languages = [];
 
   for (const year in sitemap_languages) {
-    for (const languages in sitemap_languages[year]) {
-      languages_and_years.push(`${sitemap_languages[year][languages]}/${year}`);
+    for (const language in sitemap_languages[year]) {
+      languages_and_years.push(`${sitemap_languages[year][language]}/${year}`);
+      const lang_code = `${sitemap_languages[year][language]}`;
+      if (!languages.includes(`${lang_code}`)) languages.push(`${lang_code}`);
     }
   }
+
+  let urls = [];
 
   // Get all of the static pages for each combination
   const files = languages_and_years
@@ -61,9 +68,21 @@ const get_static_pages = async (sitemap_languages) => {
     .reduce((x, y) => [...x, ...y], []);
 
   // Get the sitemap entries for those pages
-  let urls = [];
-
   for (const loc of await files) {
+    if (fs.existsSync(`templates/${loc}`)) {
+      const lastmod = get_lastmod_date(loc);
+      const url = convert_file_name(loc);
+
+      urls.push({ url, lastmod });
+    }
+  }
+
+  // Get all of the static pages with no year for each combination
+  const files_no_year = languages
+    .map((x) => static_pages_no_year.map((p) => `${x}/${p}`))
+    .reduce((x, y) => [...x, ...y], []);
+
+  for (const loc of await files_no_year) {
     if (fs.existsSync(`templates/${loc}`)) {
       const lastmod = get_lastmod_date(loc);
       const url = convert_file_name(loc);

--- a/src/tools/generate/generate_timestamps.js
+++ b/src/tools/generate/generate_timestamps.js
@@ -82,7 +82,7 @@ const get_asset_file_dates = async () => {
 
 const get_template_pages_dates = async (supported_languages) => {
 
-  // Get all of the static pages for each combination
+  // Get all of the static pages for each combination of language and year
   const files = get_static_lang_year_files(supported_languages);
 
   // Get the sitemap entries for those pages

--- a/src/tools/generate/generate_timestamps.js
+++ b/src/tools/generate/generate_timestamps.js
@@ -2,22 +2,9 @@ const fs = require('fs-extra');
 const { find_markdown_files } = require('./shared');
 const { find_asset_files } = require('./shared');
 const { get_yearly_configs } = require('./shared');
+const { get_static_lang_year_files } = require('./shared');
+const { get_static_lang_files } = require('./shared');
 const crypto = require('crypto');
-
-const static_pages_lang_year = [
-  'index.html',
-  'table_of_contents.html',
-  'methodology.html',
-  'contributors.html',
-  'ebook.html',
-  'stories/page_content.html',
-  'stories/user_experience.html',
-  'stories/content_publishing.html',
-  'stories/content_distribution.html'
-];
-const static_pages_lang = [
-  'accessibility_statement.html'
-];
 
 const path = "config/last_updated.json";
 
@@ -95,22 +82,8 @@ const get_asset_file_dates = async () => {
 
 const get_template_pages_dates = async (supported_languages) => {
 
-  var languages_and_years = [];
-  var languages = [];
-
-  for (const year in supported_languages) {
-    for (const language in supported_languages[year]) {
-      languages_and_years.push(`${supported_languages[year][language]}/${year}`);
-      // Get a list of just languages as well
-      const lang_code = `${supported_languages[year][language]}`;
-      if (!languages.includes(`${lang_code}`)) languages.push(`${lang_code}`);
-    }
-  }
-
   // Get all of the static pages for each combination
-  const files = languages_and_years
-    .map((x) => static_pages_lang_year.map((p) => `${x}/${p}`))
-    .reduce((x, y) => [...x, ...y], []);
+  const files = get_static_lang_year_files(supported_languages);
 
   // Get the sitemap entries for those pages
   let static_pages_dates = [];
@@ -124,9 +97,7 @@ const get_template_pages_dates = async (supported_languages) => {
   }
 
   // Get all of the static pages with no year for each language
-  const files_no_year = languages
-    .map((x) => static_pages_lang.map((p) => `${x}/${p}`))
-    .reduce((x, y) => [...x, ...y], []);
+  const files_no_year = get_static_lang_files(supported_languages);
 
   for (const file of await files_no_year) {
     if (fs.existsSync(`templates/${file}`)) {

--- a/src/tools/generate/shared.js
+++ b/src/tools/generate/shared.js
@@ -1,5 +1,18 @@
 const fs = require('fs-extra');
 const recursive = require('recursive-readdir');
+const static_pages_lang_year = [
+  'index.html',
+  'table_of_contents.html',
+  'methodology.html',
+  'contributors.html',
+  'stories/page_content.html',
+  'stories/user_experience.html',
+  'stories/content_publishing.html',
+  'stories/content_distribution.html'
+];
+const static_pages_lang = [
+  'accessibility_statement.html'
+];
 
 const find_template_files = async () => {
   const filter = (file, stats) => {
@@ -51,11 +64,11 @@ const get_yearly_configs = async () => {
   let configs = {};
 
   for (const config_file of await find_config_files()) {
-    const re = (process.platform != 'win32') 
-                  ? /config\/([0-9]*).json/ 
+    const re = (process.platform != 'win32')
+                  ? /config\/([0-9]*).json/
                   : /config\\([0-9]*).json/;
     const [path,year] = config_file.match(re);
-    
+
     configs[year] = JSON.parse(await fs.readFile(`config/${year}.json`, 'utf8'));
   }
   return configs;
@@ -82,6 +95,56 @@ const parse_array = (array_as_string) => {
     .map((value) => value.trim()));
 };
 
+const get_languages_and_years_as_array = (language_array) => {
+
+  var languages_and_years = [];
+  var languages = [];
+
+  for (const year in language_array) {
+    for (const language in language_array[year]) {
+      languages_and_years.push(`${language_array[year][language]}/${year}`);
+      // Get a list of just languages as well
+      const lang_code = `${language_array[year][language]}`;
+      if (!languages.includes(`${lang_code}`)) languages.push(`${lang_code}`);
+    }
+  }
+
+  return [languages_and_years,languages];
+
+};
+
+const get_static_lang_year_files = (language_array) => {
+
+  var languages_and_years = [];
+  var languages = [];
+
+  [languages_and_years, languages] = get_languages_and_years_as_array(language_array);
+
+  // Get all of the static pages for each combination of language and year
+  const files = languages_and_years
+    .map((x) => static_pages_lang_year.map((p) => `${x}/${p}`))
+    .reduce((x, y) => [...x, ...y], []);
+
+  return files;
+
+};
+
+const get_static_lang_files = (language_array) => {
+
+  var languages_and_years = [];
+  var languages = [];
+
+  [languages_and_years, languages] = get_languages_and_years_as_array(language_array);
+
+  // Get all of the static pages for each language
+  const files = languages
+    .map((x) => static_pages_lang.map((p) => `${x}/${p}`))
+    .reduce((x, y) => [...x, ...y], []);
+
+  return files;
+
+};
+
 module.exports = {
   find_markdown_files,
   find_template_files,
@@ -89,5 +152,7 @@ module.exports = {
   find_config_files,
   get_yearly_configs,
   size_of,
-  parse_array
+  parse_array,
+  get_static_lang_year_files,
+  get_static_lang_files
 };


### PR DESCRIPTION
When we moved the sitemap from the 2019 to language directory we stopped including it in the sitemap as we were looking in the wrong place. Also tracking the timestamp incorrectly for same reason.

This fixes it, and also refactors some code to avoid duplication.