### PR TITLE
Correct capitalisation of ruby in Markup chapter

### DIFF
--- a/src/content/en/2020/markup.md
+++ b/src/content/en/2020/markup.md
@@ -452,7 +452,7 @@ Standard elements are those that are or were part of the HTML specification. Whi
   <figcaption>{{ figure_link(caption="Low probabilities of finding a given element in pages of the sample.", sheets_gid="184700688", sql_file="pages_element_count_by_device_and_element_type_present.sql") }}</figcaption>
 </figure>
 
-We're including these elements to give an idea what elements may have gone out of favor. But while `dir` and `basefont` were last specified in XHTML 1.0 (2000) and are no longer part of HTML, the rare use of `rp` (which was mentioned [as early as 1998](https://www.w3.org/TR/1998/WD-ruby-19981221/#a2-4) and is [still part of HTML](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rp-element)), may just suggest that [ruby markup](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ruby) is not very popular.
+We're including these elements to give an idea what elements may have gone out of favor. But while `dir` and `basefont` were last specified in XHTML 1.0 (2000) and are no longer part of HTML, the rare use of `rp` (which was mentioned [as early as 1998](https://www.w3.org/TR/1998/WD-ruby-19981221/#a2-4) and is [still part of HTML](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rp-element)), may just suggest that [ruby markup](https://www.w3.org/TR/ruby/) is not very popular.
 
 
 ### Custom elements

--- a/src/content/en/2020/markup.md
+++ b/src/content/en/2020/markup.md
@@ -452,7 +452,7 @@ Standard elements are those that are or were part of the HTML specification. Whi
   <figcaption>{{ figure_link(caption="Low probabilities of finding a given element in pages of the sample.", sheets_gid="184700688", sql_file="pages_element_count_by_device_and_element_type_present.sql") }}</figcaption>
 </figure>
 
-We're including these elements to give an idea what elements may have gone out of favor. But while `dir` and `basefont` were last specified in XHTML 1.0 (2000) and are no longer part of HTML, the rare use of `rp` (which was mentioned [as early as 1998](https://www.w3.org/TR/1998/WD-ruby-19981221/#a2-4) and is [still part of HTML](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rp-element)), may just suggest that ruby markup is not very popular.
+We're including these elements to give an idea what elements may have gone out of favor. But while `dir` and `basefont` were last specified in XHTML 1.0 (2000) and are no longer part of HTML, the rare use of `rp` (which was mentioned [as early as 1998](https://www.w3.org/TR/1998/WD-ruby-19981221/#a2-4) and is [still part of HTML](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rp-element)), may just suggest that [ruby markup](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ruby) is not very popular.
 
 
 ### Custom elements

--- a/src/content/en/2020/markup.md
+++ b/src/content/en/2020/markup.md
@@ -452,7 +452,7 @@ Standard elements are those that are or were part of the HTML specification. Whi
   <figcaption>{{ figure_link(caption="Low probabilities of finding a given element in pages of the sample.", sheets_gid="184700688", sql_file="pages_element_count_by_device_and_element_type_present.sql") }}</figcaption>
 </figure>
 
-We're including these elements to give an idea what elements may have gone out of favor. But while `dir` and `basefont` were last specified in XHTML 1.0 (2000) and are no longer part of HTML, the rare use of `rp` (which was mentioned [as early as 1998](https://www.w3.org/TR/1998/WD-ruby-19981221/#a2-4) and is [still part of HTML](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rp-element)), may just suggest that Ruby markup is not very popular.
+We're including these elements to give an idea what elements may have gone out of favor. But while `dir` and `basefont` were last specified in XHTML 1.0 (2000) and are no longer part of HTML, the rare use of `rp` (which was mentioned [as early as 1998](https://www.w3.org/TR/1998/WD-ruby-19981221/#a2-4) and is [still part of HTML](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rp-element)), may just suggest that ruby markup is not very popular.
 
 
 ### Custom elements

--- a/src/content/nl/2020/markup.md
+++ b/src/content/nl/2020/markup.md
@@ -452,7 +452,7 @@ Standaardelementen zijn elementen die deel uitmaken van de HTML-specificatie. We
   <figcaption>{{ figure_link(caption="Lage kansen om een bepaald element op pagina's van de steekproef te vinden.", sheets_gid="184700688", sql_file="pages_element_count_by_device_and_element_type_present.sql") }}</figcaption>
 </figure>
 
-We nemen deze elementen op om een idee te geven welke elementen mogelijk uit de gratie zijn geraakt. Maar hoewel `dir` en` basefont` voor het laatst werden gespecificeerd in XHTML 1.0 (2000) en niet langer deel uitmaken van HTML, het zeldzame gebruik van `rp`, [dat al in 1998 werd genoemd](https://www.w3.org/TR/1998/WD-rubya2-4) en dat [nog steeds deel uitmaakt van HTML](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rp-element), suggereert misschien dat Ruby-opmaak niet erg populair is.
+We nemen deze elementen op om een idee te geven welke elementen mogelijk uit de gratie zijn geraakt. Maar hoewel `dir` en` basefont` voor het laatst werden gespecificeerd in XHTML 1.0 (2000) en niet langer deel uitmaken van HTML, het zeldzame gebruik van `rp`, [dat al in 1998 werd genoemd](https://www.w3.org/TR/1998/WD-rubya2-4) en dat [nog steeds deel uitmaakt van HTML](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rp-element), suggereert misschien dat [ruby-opmaak](https://www.w3.org/TR/ruby/) niet erg populair is.
 
 
 ### Aangepaste elementen


### PR DESCRIPTION
@j9t this one is my fault I think.

I thought this was for Ruby the programming language (I did wonder why such a thing was in HTML!) but apparently this is some typesetting thing. So shouldn’t be capital R.