### PR TITLE
Misc fixes to table of contents menu

### DIFF
--- a/src/static/css/almanac.css
+++ b/src/static/css/almanac.css
@@ -698,6 +698,7 @@ header .cta {
   appearance: none;
   min-width: 100px;
   min-width: 6.35rem;
+  text-align-last: center;
 }
 
 .table-of-contents-switcher select,

--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -667,9 +667,15 @@
     <ul class="figure-dropdown-list nav-dropdown-list floating-card hidden">
       {% if sheets_gid != "" %}
       <li>
+        {% if sheets_gid.startswith("https") %}
+        <a href="{{ sheets_gid }}">
+          {{ self.figure_data() }}
+        </a>
+        {% else %}
         <a href="{{ metadata.get('results') }}#gid={{ sheets_gid }}">
           {{ self.figure_data() }}
         </a>
+        {% endif %}
       </li>
       {% endif %}
       {% if sql_file != "" %}

--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -119,13 +119,17 @@
     {{ self.table_of_contents_switcher() }}
   </label>
   <select id="table-of-contents-switcher-{{switcher_name}}" data-label="toc-menu-mobile">
+    {% if request.path.endswith("/") %}
+      <option selected disabled value="{{ url_for('home', year=year, lang=lang) }}">{{ self.home() }}</option>
+    {% else %}
+      <option value="{{ url_for('home', year=year, lang=lang) }}">{{ self.home() }}</option>
+    {% endif %}
     {% if request.path.endswith("table-of-contents") %}
       <option selected disabled value="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</option>
-      <option disabled value="{{ url_for('table_of_contents', year=year, lang=lang) }}#foreword">{{ self.foreword_title() }}</option>
     {% else %}
       <option value="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</option>
-      <option value="{{ url_for('table_of_contents', year=year, lang=lang) }}#foreword">{{ self.foreword_title() }}</option>
     {% endif %}
+    <option value="{{ url_for('table_of_contents', year=year, lang=lang) }}#foreword">{{ self.foreword_title() }}</option>
     {% for part_config in config.outline %}
     {% for chapter_config in part_config.chapters %}
       {% set title = localizedChapterTitles[chapter_config.slug] if localizedChapterTitles[chapter_config.slug]|length else chapter_config.title %}
@@ -196,15 +200,28 @@
   </button>
   <ul class="nav-dropdown-list hidden {{switcher_name}}-list">
 
-    {% if request.path.endswith('table-of-contents') %}
-    <li class="nav-dropdown-list-part foreword nav-dropdown-list-current">
-      <span>{{ self.foreword_title() }}</span>
+    {% if request.path.endswith('/') %}
+    <li class="nav-dropdown-list-part nav-dropdown-list-current">
+      <span>{{ self.home() }}</span>
     </li>
     {% else %}
-    <li class="nav-dropdown-list-part foreword">
-      <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.foreword_title() }}</a>
+    <li class="nav-dropdown-list-part">
+      <a href="{{ url_for('home', year=year, lang=lang) }}">{{ self.home() }}</a>
     </li>
     {% endif %}
+
+    {% if request.path.endswith('table-of-contents') %}
+    <li class="nav-dropdown-list-part nav-dropdown-list-current">
+      <span>{{ self.table_of_contents_title() }}</span>
+    </li>
+    {% else %}
+    <li class="nav-dropdown-list-part">
+      <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</a>
+    </li>
+    {% endif %}
+    <li class="nav-dropdown-list-chapter foreword">
+      <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}#foreword">{{ self.foreword_title() }}</a>
+    </li>
 
     {% for part_config in config.outline %}
     <li class="nav-dropdown-list-part">
@@ -650,15 +667,9 @@
     <ul class="figure-dropdown-list nav-dropdown-list floating-card hidden">
       {% if sheets_gid != "" %}
       <li>
-        {% if sheets_gid.startswith("https") %}
-        <a href="{{ sheets_gid }}">
-          {{ self.figure_data() }}
-        </a>
-        {% else %}
         <a href="{{ metadata.get('results') }}#gid={{ sheets_gid }}">
           {{ self.figure_data() }}
         </a>
-        {% endif %}
       </li>
       {% endif %}
       {% if sql_file != "" %}

--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -129,7 +129,7 @@
     {% else %}
       <option value="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</option>
     {% endif %}
-    <option value="{{ url_for('table_of_contents', year=year, lang=lang) }}#foreword">{{ self.foreword_title() }}</option>
+    <option value="{{ url_for('table_of_contents', year=year, lang=lang, _anchor='foreword') }}">{{ self.foreword_title() }}</option>
     {% for part_config in config.outline %}
     {% for chapter_config in part_config.chapters %}
       {% set title = localizedChapterTitles[chapter_config.slug] if localizedChapterTitles[chapter_config.slug]|length else chapter_config.title %}
@@ -220,12 +220,12 @@
     </li>
     {% endif %}
     <li class="nav-dropdown-list-chapter foreword">
-      <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}#foreword">{{ self.foreword_title() }}</a>
+      <a href="{{ url_for('table_of_contents', year=year, lang=lang, _anchor='foreword') }}">{{ self.foreword_title() }}</a>
     </li>
 
     {% for part_config in config.outline %}
     <li class="nav-dropdown-list-part">
-      <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}#part-{{ part_config.part_number }}">{{ self.part() }} {{ localizedPartTitles[part_config.part] if localizedPartTitles[part_config.part]|length else chapter_config.title }}</a>
+      <a href="{{ url_for('table_of_contents', year=year, lang=lang, _anchor='part-' + part_config.part_number) }}">{{ self.part() }} {{ localizedPartTitles[part_config.part] if localizedPartTitles[part_config.part]|length else chapter_config.title }}</a>
     </li>
     {% for chapter_config in part_config.chapters %}
     {% set title = localizedChapterTitles[chapter_config.slug] if localizedChapterTitles[chapter_config.slug]|length else chapter_config.title %}
@@ -266,7 +266,7 @@
     {% endfor %}
 
     <li class="nav-dropdown-list-part">
-      <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}#appendices">{{ self.appendices() }}</a>
+      <a href="{{ url_for('table_of_contents', year=year, lang=lang, _anchor='appendices') }}">{{ self.appendices() }}</a>
     </li>
     {% if request.path.endswith("methodology") %}
     <li class="nav-dropdown-list-chapter nav-dropdown-list-current">
@@ -289,7 +289,7 @@
 
     {% if ebook_size_in_mb and ebook_size_in_mb > 0 %}
     <li class="nav-dropdown-list-part">
-      <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}#ebook">{{ self.ebook_title() }}</a>
+      <a href="{{ url_for('table_of_contents', year=year, lang=lang, _anchor='ebook') }}">{{ self.ebook_title() }}</a>
     </li>
     <li class="nav-dropdown-list-chapter ebook">
       <a href="/static/pdfs/web_almanac_{{ year }}_{{ lang }}.pdf" data-event="ebook-click" data-label="toc-menu">{{ self.ebook_download_short() }}</a>

--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -119,7 +119,7 @@
     {{ self.table_of_contents_switcher() }}
   </label>
   <select id="table-of-contents-switcher-{{switcher_name}}" data-label="toc-menu-mobile">
-    {% if request.path.endswith("/") %}
+    {% if request.path.endswith("/" + year + "/") %}
       <option selected disabled value="{{ url_for('home', year=year, lang=lang) }}">{{ self.home() }}</option>
     {% else %}
       <option value="{{ url_for('home', year=year, lang=lang) }}">{{ self.home() }}</option>
@@ -200,7 +200,7 @@
   </button>
   <ul class="nav-dropdown-list hidden {{switcher_name}}-list">
 
-    {% if request.path.endswith('/') %}
+    {% if request.path.endswith("/" + year + "/") %}
     <li class="nav-dropdown-list-part nav-dropdown-list-current">
       <span>{{ self.home() }}</span>
     </li>


### PR DESCRIPTION
Center options (Chromium and Firefox only):

Old versus New
![Old - not centered](https://user-images.githubusercontent.com/10931297/106036544-65f43f00-60cd-11eb-9642-3b522c2454ac.png) ![New - centered](https://user-images.githubusercontent.com/10931297/106036692-8fad6600-60cd-11eb-879a-9af915d89a6f.png)

Also adds Home links:

Desktop:

![Desktop screenshot](https://user-images.githubusercontent.com/10931297/106036791-ab187100-60cd-11eb-8902-3f224ec54f70.png)

Mobile:

![Mobile screenshot](https://user-images.githubusercontent.com/10931297/106036850-bff50480-60cd-11eb-87b1-d4b4ebfce9ba.png)

