### PR TITLE
Stop home page bouncing on mobile

### DIFF
--- a/src/static/css/index.css
+++ b/src/static/css/index.css
@@ -587,8 +587,8 @@ p {
   }
 
   .people-number {
-    font-size: 240px;
-    line-height: 240px;
+    font-size: 220px;
+    line-height: 220px;
     overflow: visible;
     top: 40px;
     position: relative;


### PR DESCRIPTION
Reduce contributor big number font-size to stop home screen overflowing and doing that annoying bouncing thing as you scroll up and down.