### PR TITLE
Combine contributors bylines where it makes sense

### DIFF
--- a/src/content/en/2019/markup.md
+++ b/src/content/en/2019/markup.md
@@ -5,7 +5,8 @@ description: Markup chapter of the 2019 Web Almanac covering elements used, cust
 authors: [bkardell]
 reviewers: [zcorpan, tomhodgins, matthewp]
 analysts: [rviscomi]
-translators: [rviscomi]
+editors: [rviscomi]
+translators: []
 discuss: 1758
 results: https://docs.google.com/spreadsheets/d/1WnDKLar_0Btlt9UgT53Giy2229bpV4IM2D_v6OM_WzA/
 bkardell_bio: Brian Kardell is developer advocate at <a href="https://igalia.com">Igalia</a>, standards contributor, <a href="https://bkardell.com">blogger</a>, and is currently the W3C Advisory Committee Representative for the <a href="https://openjsf.org/">Open JS Foundation</a>. He was a founder of the Extensible Web Community Group and co-author of <a href="https://extensiblewebmanifesto.org">The Extensible Web Manifesto</a>.

--- a/src/content/en/2020/accessibility.md
+++ b/src/content/en/2020/accessibility.md
@@ -108,7 +108,7 @@ In 1995, [HTML 2.0](https://www.w3.org/MarkUp/html-spec/html-spec_5.html#SEC5.10
 
 {{ figure_markup(
   caption='Mobiles sites passing the "images with `alt` text" Lighthouse audit.',
-  content="54%.",
+  content="54%",
   classes="big-number",
   sheets_gid="580400436",
   sql_file="lighthouse_a11y_audits.sql"

--- a/src/content/fr/2019/seo.md
+++ b/src/content/fr/2019/seo.md
@@ -1,9 +1,10 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: SEO
-description: Chapitre SEO du web Almanac 2019. Découvrez des statistiques sur le contenu, les meta tags, l'indexation, les liens, la performance web...
+description: Chapitre SEO du web Almanac 2019. Découvrez des statistiques sur le contenu, les meta tags, l'indexation, les liens, la performance web.
 authors: [ymschaap, rachellcostello, AVGP]
 reviewers: [clarkeclark, andylimn, AymenLoukil, catalinred, mattludwig]
+analysts: [ymschaap]
 editors: [rachellcostello]
 translators: [AymenLoukil]
 discuss: 1765

--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -94,23 +94,25 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
   {% endfor %}{{ self.written_by_after() }}
   </div>
 
-  <div class="byline reviewers">{{ self.reviewed_by_before() }}
-  {% for reviewer in metadata.get('reviewers') %}
-    <a class="reviewer" href="{{ url_for('contributors', year=year, lang=lang, _anchor=reviewer) }}">{{ config.contributors[reviewer].name if reviewer in config.contributors else reviewer }}</a>{% if loop.length > 2 %}{{ self.comma() if loop.index < loop.length - 1 }}{{ self.oxford_comma() if loop.index == loop.length - 1 }}{% endif %}
-    {% if loop.index == loop.length - 1 %}{{ self.and() }}{% endif %}
-  {% endfor %}{{ self.reviewed_by_after() }}
-  </div>
+  {% if metadata.get('reviewers') and metadata.get('reviewers') | length >= 1 %}
+  <div class="byline reviewers">{% if metadata.get('reviewers') == metadata.get('analysts') %}{{ self.reviewed_and_analyzed_by_before() }}{% else %}{{ self.reviewed_by_before() }}{% endif %}
+    {% for reviewer in metadata.get('reviewers') %}
+      <a class="reviewer" href="{{ url_for('contributors', year=year, lang=lang, _anchor=reviewer) }}">{{ config.contributors[reviewer].name if reviewer in config.contributors else reviewer }}</a>{% if loop.length > 2 %}{{ self.comma() if loop.index < loop.length - 1 }}{{ self.oxford_comma() if loop.index == loop.length - 1 }}{% endif %}
+      {% if loop.index == loop.length - 1 %}{{ self.and() }}{% endif %}
+    {% endfor %}{% if metadata.get('reviewers') == metadata.get('analysts') %}{{ self.reviewed_and_analyzed_by_after() }}{% else %}{{ self.reviewed_by_after() }}{% endif %}
+    </div>
+    {% endif %}
 
-  {% if metadata.get('analysts') and metadata.get('analysts') | length >= 1 %}
-  <div class="byline analysts">{{ self.analysis_by_before() }}
+  {% if metadata.get('analysts') and metadata.get('analysts') | length >= 1 and metadata.get('analysts') != metadata.get('reviewers') %}
+  <div class="byline analysts">{% if metadata.get('editors') | length >= 1 and metadata.get('analysts') == metadata.get('editors') %}{{ self.analysis_and_editing_by_before() }}{% else %}{{ self.analysis_by_before() }}{% endif %}
   {% for analyst in metadata.get('analysts') %}
     <a class="analyst" href="{{ url_for('contributors', year=year, lang=lang, _anchor=analyst) }}">{{ config.contributors[analyst].name if analyst in config.contributors else analyst }}</a>{% if loop.length > 2 %}{{ self.comma() if loop.index < loop.length - 1 }}{{ self.oxford_comma() if loop.index == loop.length - 1 }}{% endif %}
     {% if loop.index == loop.length - 1 %}{{ self.and() }}{% endif %}
-  {% endfor %}{{ self.analysis_by_after() }}
+  {% endfor %}{% if metadata.get('editors') | length >= 1 and metadata.get('analysts') == metadata.get('editors') %}{{ self.analysis_and_editing_by_after() }}{% else %}{{ self.analysis_by_after() }}{% endif %}
   </div>
   {% endif %}
 
-  {% if metadata.get('editors') and metadata.get('editors') | length >= 1 %}
+  {% if metadata.get('editors') and metadata.get('editors') | length >= 1 and (metadata.get('reviewers') == metadata.get('analysts') or metadata.get('editors') != metadata.get('analysts')) %}
   <div class="byline editors">{{ self.edited_by_before() }}
   {% for editor in metadata.get('editors') %}
     <a class="editor" href="{{ url_for('contributors', year=year, lang=lang, _anchor=analyst) }}">{{ config.contributors[editor].name if editor in config.contributors else editor }}</a>{% if loop.length > 2 %}{{ self.comma() if loop.index < loop.length - 1 }}{{ self.oxford_comma() if loop.index == loop.length - 1 }}{% endif %}

--- a/src/templates/base/ebook.ejs.html
+++ b/src/templates/base/ebook.ejs.html
@@ -9,7 +9,7 @@
 
     {% set metadata = <%- JSON.stringify(chapter.metadata) %> %}
     {% set chapter_hero_dir = "/static/images/%s/%s/" % ("<%- chapter.hero_dir || '2019' %>", metadata.chapter) %}
-    <section class="chapter" id="chapter-{{ metadata.get('chapter_number') }}">
+    <section class="chapter" id="chapter-<%- chapter.chapter_number %>">
         <div class="body" id="{{ metadata.get('chapter') }}">
 
             <div class="subtitle">
@@ -40,23 +40,25 @@
                 {% endfor %}{{ self.written_by_after() }}
             </div>
 
-            <div class="byline reviewers">{{ self.reviewed_by_before() }}
+            {% if metadata.get('reviewers') and metadata.get('reviewers') | length >= 1 %}
+            <div class="byline reviewers">{% if metadata.get('reviewers') == metadata.get('analysts') %}{{ self.reviewed_and_analyzed_by_before() }}{% else %}{{ self.reviewed_by_before() }}{% endif %}
                 {% for reviewer in metadata.get('reviewers') %}
                 <a class="reviewer" href="#contributors-{{ reviewer }}">{{ config.contributors[reviewer].name if reviewer in config.contributors else reviewer }}</a>{% if loop.length > 2 %}{{ self.comma() if loop.index < loop.length - 1 }}{{ self.oxford_comma() if loop.index == loop.length - 1 }}{% endif %}
                 {% if loop.index == loop.length - 1 %}{{ self.and() }}{% endif %}
-                {% endfor %}{{ self.reviewed_by_after() }}
-            </div>
-
-            {% if metadata.get('analysts') and metadata.get('analysts') | length >= 1 %}
-            <div class="byline analysts">{{ self.analysis_by_before() }}
-                {% for analyst in metadata.get('analysts') %}
-                <a class="analyst" href="#contributors-{{ analyst }}">{{ config.contributors[analyst].name if analyst in config.contributors else analyst }}</a>{% if loop.length > 2 %}{{ self.comma() if loop.index < loop.length - 1 }}{{ self.oxford_comma() if loop.index == loop.length - 1 }}{% endif %}
-                {% if loop.index == loop.length - 1 %}{{ self.and() }}{% endif %}
-                {% endfor %}{{ self.analysis_by_after() }}
+                {% endfor %}{% if metadata.get('reviewers') == metadata.get('analysts') %}{{ self.reviewed_and_analyzed_by_after() }}{% else %}{{ self.reviewed_by_after() }}{% endif %}
             </div>
             {% endif %}
 
-            {% if metadata.get('editors') and metadata.get('editors') | length >= 1 %}
+            {% if metadata.get('analysts') and metadata.get('analysts') | length >= 1 and metadata.get('analysts') != metadata.get('reviewers') %}
+            <div class="byline analysts">{% if metadata.get('editors') | length >= 1 and metadata.get('analysts') == metadata.get('editors') %}{{ self.analysis_and_editing_by_before() }}{% else %}{{ self.analysis_by_before() }}{% endif %}
+                {% for analyst in metadata.get('analysts') %}
+                <a class="analyst" href="#contributors-{{ analyst }}">{{ config.contributors[analyst].name if analyst in config.contributors else analyst }}</a>{% if loop.length > 2 %}{{ self.comma() if loop.index < loop.length - 1 }}{{ self.oxford_comma() if loop.index == loop.length - 1 }}{% endif %}
+                {% if loop.index == loop.length - 1 %}{{ self.and() }}{% endif %}
+                {% endfor %}{% if metadata.get('editors') | length >= 1 and metadata.get('analysts') == metadata.get('editors') %}{{ self.analysis_and_editing_by_after() }}{% else %}{{ self.analysis_by_after() }}{% endif %}
+            </div>
+            {% endif %}
+
+            {% if metadata.get('editors') and metadata.get('editors') | length >= 1 and (metadata.get('reviewers') == metadata.get('analysts') or metadata.get('editors') != metadata.get('analysts')) %}
             <div class="byline editors">{{ self.edited_by_before() }}
                 {% for editor in metadata.get('editors') %}
                 <a class="editor" href="#contributors-{{ editor }}">{{ config.contributors[editor].name if editor in config.contributors else editor }}</a>{% if loop.length > 2 %}{{ self.comma() if loop.index < loop.length - 1 }}{{ self.oxford_comma() if loop.index == loop.length - 1 }}{% endif %}

--- a/src/templates/en/base.html
+++ b/src/templates/en/base.html
@@ -71,11 +71,15 @@ Our mission is to combine the raw stats and trends of the HTTP Archive with the 
 {% block translated_by_before %}Translated by{% endblock %}
 {% block analysis_by_before %}Analyzed by{% endblock %}
 {% block edited_by_before %}Edited by{% endblock %}
+{% block reviewed_and_analyzed_by_before %}Reviewed and analyzed by{% endblock %}
+{% block analysis_and_editing_by_before %}Analyzed and edited by{% endblock %}
 {% block written_by_after %}{% endblock %}
 {% block reviewed_by_after %}{% endblock %}
 {% block translated_by_after %}{% endblock %}
 {% block analysis_by_after %}{% endblock %}
 {% block edited_by_after %}{% endblock %}
+{% block reviewed_and_analyzed_by_after %}{% endblock %}
+{% block analysis_and_editing_by_after %}{% endblock %}
 
 {% block unedited %}[Unedited]{% endblock %}
 

--- a/src/templates/es/base.html
+++ b/src/templates/es/base.html
@@ -71,11 +71,15 @@
 {% block translated_by_before %}Traducido por{% endblock %}
 {% block analysis_by_before %}Análisis por{% endblock %}
 {% block edited_by_before %}Editado por{% endblock %}
+{% block reviewed_and_analyzed_by_before %}Revisado y análisis por{% endblock %}
+{% block analysis_and_editing_by_before %}Análisis y editado por{% endblock %}
 {% block written_by_after %}{% endblock %}
 {% block reviewed_by_after %}{% endblock %}
 {% block translated_by_after %}{% endblock %}
 {% block analysis_by_after %}{% endblock %}
 {% block edited_by_after %}{% endblock %}
+{% block reviewed_and_analyzed_by_after %}{% endblock %}
+{% block analysis_and_editing_by_after %}{% endblock %}
 
 {% block unedited %}[no corregido]{% endblock %}
 

--- a/src/templates/fr/base.html
+++ b/src/templates/fr/base.html
@@ -71,11 +71,15 @@ Notre mission est de combiner les statistiques brutes et les tendances de HTTP A
 {% block translated_by_before %}Traduit par{% endblock %}
 {% block analysis_by_before %}Analysé par{% endblock %}
 {% block edited_by_before %}Edité par{% endblock %}
+{% block reviewed_and_analyzed_by_before %}Relu et analysé par{% endblock %}
+{% block analysis_and_editing_by_before %}Analysé et edité par{% endblock %}
 {% block written_by_after %}{% endblock %}
 {% block reviewed_by_after %}{% endblock %}
 {% block translated_by_after %}{% endblock %}
 {% block analysis_by_after %}{% endblock %}
 {% block edited_by_after %}{% endblock %}
+{% block reviewed_and_analyzed_by_after %}{% endblock %}
+{% block analysis_and_editing_by_after %}{% endblock %}
 
 {% block unedited %}[non corrigé]{% endblock %}
 

--- a/src/templates/hi/base.html
+++ b/src/templates/hi/base.html
@@ -71,11 +71,15 @@
 {% block translated_by_before %}द्वारा अनुवादिद्त{% endblock %}
 {% block analysis_by_before %}द्वारा विश्लेषित{% endblock %}
 {% block edited_by_before %}द्वारा संपादित{% endblock %}
+{% block reviewed_and_analyzed_by_before %}द्वारा समीक्षित और विश्लेषित{% endblock %}
+{% block analysis_and_editing_by_before %}द्वारा विश्लेषित और संपादित{% endblock %}
 {% block written_by_after %}{% endblock %}
 {% block reviewed_by_after %}{% endblock %}
 {% block translated_by_after %}{% endblock %}
 {% block analysis_by_after %}{% endblock %}
 {% block edited_by_after %}{% endblock %}
+{% block reviewed_and_analyzed_by_after %}{% endblock %}
+{% block analysis_and_editing_by_after %}{% endblock %}
 
 {% block unedited %}[अप्रकाशित]{% endblock %}
 

--- a/src/templates/it/base.html
+++ b/src/templates/it/base.html
@@ -71,11 +71,15 @@ La nostra missione è combinare le statistiche grezze e le tendenze del HTTP Arc
 {% block translated_by_before %}Tradotta da{% endblock %}
 {% block analysis_by_before %}Analizzata da{% endblock %}
 {% block edited_by_before %}Modificato da{% endblock %}
+{% block reviewed_and_analyzed_by_before %}Revisionata e analizzata da{% endblock %}
+{% block analysis_and_editing_by_before %}Analizzata e modificato da{% endblock %}
 {% block written_by_after %}{% endblock %}
 {% block reviewed_by_after %}{% endblock %}
 {% block translated_by_after %}{% endblock %}
 {% block analysis_by_after %}{% endblock %}
 {% block edited_by_after %}{% endblock %}
+{% block reviewed_and_analyzed_by_after %}{% endblock %}
+{% block analysis_and_editing_by_after %}{% endblock %}
 
 {% block unedited %}[Inedito]{% endblock %}
 

--- a/src/templates/ja/base.html
+++ b/src/templates/ja/base.html
@@ -71,11 +71,15 @@
 {% block translated_by_before %}{% endblock %}
 {% block analysis_by_before %}{% endblock %}
 {% block edited_by_before %}{% endblock %}
+{% block reviewed_and_analyzed_by_before %}{% endblock %}
+{% block analysis_and_editing_by_before %}{% endblock %}
 {% block written_by_after %}によって書かれた。{% endblock %}
 {% block reviewed_by_after %}によってレビュ。{% endblock %}
 {% block translated_by_after %}によって翻訳された。{% endblock %}
 {% block analysis_by_after %}による分析。{% endblock %}
 {% block edited_by_after %}編集。{% endblock %}
+{% block reviewed_and_analyzed_by_after %}によってレビュ と による分析。{% endblock %}
+{% block analysis_and_editing_by_after %}による分析 と 編集。{% endblock %}
 
 {% block unedited %}[未編集]{% endblock %}
 

--- a/src/templates/nl/base.html
+++ b/src/templates/nl/base.html
@@ -71,11 +71,15 @@
 {% block translated_by_before %}Vertaald door{% endblock %}
 {% block analysis_by_before %}Geanalyseerd door{% endblock %}
 {% block edited_by_before %}Bewerkt door{% endblock %}
+{% block reviewed_and_analyzed_by_before %}Beoordeeld en geanalyseerd door{% endblock %}
+{% block analysis_and_editing_by_before %}Geanalyseerd en bewerkt door{% endblock %}
 {% block written_by_after %}{% endblock %}
 {% block reviewed_by_after %}{% endblock %}
 {% block translated_by_after %}{% endblock %}
 {% block analysis_by_after %}{% endblock %}
 {% block edited_by_after %}{% endblock %}
+{% block reviewed_and_analyzed_by_after %}{% endblock %}
+{% block analysis_and_editing_by_after %}{% endblock %}
 
 {% block unedited %}[Onuitgegeven]{% endblock %}
 

--- a/src/templates/pt/base.html
+++ b/src/templates/pt/base.html
@@ -71,11 +71,15 @@ Nossa missão é combinar as estatísticas brutas e as tendências do HTTP Archi
 {% block translated_by_before %}Traduzido por{% endblock %}
 {% block analysis_by_before %}Análise por{% endblock %}
 {% block edited_by_before %}Editado por{% endblock %}
+{% block reviewed_and_analyzed_by_before %}Revisado e análise por{% endblock %}
+{% block analysis_and_editing_by_before %}Análise e Editado por{% endblock %}
 {% block written_by_after %}{% endblock %}
 {% block reviewed_by_after %}{% endblock %}
 {% block translated_by_after %}{% endblock %}
 {% block analysis_by_after %}{% endblock %}
 {% block edited_by_after %}{% endblock %}
+{% block reviewed_and_analyzed_by_after %}{% endblock %}
+{% block analysis_and_editing_by_after %}{% endblock %}
 
 {% block unedited %}[Não editado]{% endblock %}
 

--- a/src/templates/ru/base.html
+++ b/src/templates/ru/base.html
@@ -71,11 +71,15 @@
 {% block translated_by_before %}Переводчики:{% endblock %}
 {% block analysis_by_before %}Аналитики:{% endblock %}
 {% block edited_by_before %}Под редакцией:{% endblock %}
+{% block reviewed_and_analyzed_by_before %}Редакторы и Аналитики:{% endblock %}
+{% block analysis_and_editing_by_before %}Аналитики и Под редакцией:{% endblock %}
 {% block written_by_after %}{% endblock %}
 {% block reviewed_by_after %}{% endblock %}
 {% block translated_by_after %}{% endblock %}
 {% block analysis_by_after %}{% endblock %}
 {% block edited_by_after %}{% endblock %}
+{% block reviewed_and_analyzed_by_after %}{% endblock %}
+{% block analysis_and_editing_by_after %}{% endblock %}
 
 {% block unedited %}[Неотредактированная версия]{% endblock %}
 

--- a/src/templates/uk/base.html
+++ b/src/templates/uk/base.html
@@ -71,11 +71,15 @@
 {% block translated_by_before %}Перекладачі: {% endblock %}
 {% block analysis_by_before %}Аналітики: {% endblock %}
 {% block edited_by_before %}Редактори: {% endblock %}
+{% block reviewed_and_analyzed_by_before %}Рецензенти і Аналітики: {% endblock %}
+{% block analysis_and_editing_by_before %}Аналітики і Редактори: {% endblock %}
 {% block written_by_after %}{% endblock %}
 {% block reviewed_by_after %}{% endblock %}
 {% block translated_by_after %}{% endblock %}
 {% block analysis_by_after %}{% endblock %}
 {% block edited_by_after %}{% endblock %}
+{% block reviewed_and_analyzed_by_after %}{% endblock %}
+{% block analysis_and_editing_by_after %}{% endblock %}
 
 {% block unedited %}[Очікує корегування]{% endblock %}
 

--- a/src/templates/zh-CN/base.html
+++ b/src/templates/zh-CN/base.html
@@ -71,11 +71,15 @@
 {% block translated_by_before %}翻译者： {% endblock %}
 {% block analysis_by_before %}分析者： {% endblock %}
 {% block edited_by_before %}编辑： {% endblock %}
+{% block reviewed_and_analyzed_by_before %}审稿者和分析者：{% endblock %}
+{% block analysis_and_editing_by_before %}分析者和编辑：{% endblock %}
 {% block written_by_after %}{% endblock %}
 {% block reviewed_by_after %}{% endblock %}
 {% block translated_by_after %}{% endblock %}
 {% block analysis_by_after %}{% endblock %}
 {% block edited_by_after %}{% endblock %}
+{% block reviewed_and_analyzed_by_after %}{% endblock %}
+{% block analysis_and_editing_by_after %}{% endblock %}
 
 {% block unedited %}[未编辑]{% endblock %}
 

--- a/src/templates/zh-TW/base.html
+++ b/src/templates/zh-TW/base.html
@@ -71,11 +71,15 @@
 {% block translated_by_before %}翻譯者：{% endblock %}
 {% block analysis_by_before %}分析者：{% endblock %}
 {% block edited_by_before %}編輯：{% endblock %}
+{% block reviewed_and_analyzed_by_before %}審稿者和分析者：{% endblock %}
+{% block analysis_and_editing_by_before %}分析者和編輯：{% endblock %}
 {% block written_by_after %}{% endblock %}
 {% block reviewed_by_after %}{% endblock %}
 {% block translated_by_after %}{% endblock %}
 {% block analysis_by_after %}{% endblock %}
 {% block edited_by_after %}{% endblock %}
+{% block reviewed_and_analyzed_by_after %}{% endblock %}
+{% block analysis_and_editing_by_after %}{% endblock %}
 
 {% block unedited %}[Unedited]{% endblock %}
 


### PR DESCRIPTION
Fixes #1616 

Only does it for:
- Reviewers and Analysts
- Analysts and Editors

As those are those only ones we  currently have, and I believe the only ones we'll have (unless some editors become translators).
