### PR TITLE
Add typographic punctuation

### DIFF
--- a/src/content/en/2019/caching.md
+++ b/src/content/en/2019/caching.md
@@ -707,7 +707,7 @@ Lighthouse computes a score for each audit, ranging from 0% to 100%, and those s
 
 {{ figure_markup(
   image="fig21.png",
-  caption="Distribution of Lighthouse scores for the \"Uses Long Cache TTL\" audit for mobile web pages.",
+  caption='Distribution of Lighthouse scores for the "Uses Long Cache TTL" audit for mobile web pages.',
   description="A stacked bar chart 38.2% of websites get a score of < 10%, 29.0% of websites get a score between 10% and 39%, 18.7% of websites get a score of 40%-79%, 10.7% of websites get a score of 80% - 99%, and 3.4% of websites get a score of 100%.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vT3GWCs19Wq0mu0zgIlKRc8zcXgmVEk2xFHuzZACiWVtqOv8FO5gfHwBxa0mhU6O9TBY8ODdN4Zjd_O/pubchart?oid=827424070&format=interactive"
   )

--- a/src/content/en/2019/compression.md
+++ b/src/content/en/2019/compression.md
@@ -336,7 +336,7 @@ Because the [HTTP Archive runs Lighthouse audits](./methodology#lighthouse) for 
 
 {{ figure_markup(
   image="fig11.png",
-  caption="Lighthouse \"enable text compression\" audit scores.",
+  caption='Lighthouse "enable text compression" audit scores.',
   description="Stacked bar chart showing 7.6% are costing less than 10%, 13.2% of sites are scoring between 10-39%, 13.7% of sites scoring between 40-79%, 2.9% of sites scoring between 80-99%, and 62.5% of sites have a pass with over 100% of text assets being compressed.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vQNIyMEGYE_1W0OdFYLIKsxg6M3o_ZsTTuaX73Zzv6Alw4x4D6oH0jdg9BSgw-jy4E-MmX_Qaf-B98W/pubchart?oid=2048155673&format=interactive",
   width=760,
@@ -350,7 +350,7 @@ Lighthouse also indicates how many bytes could be saved by enabling text-based c
 
 {{ figure_markup(
   image="fig12.png",
-  caption="Lighthouse \"enable text compression\" audit potential byte savings.",
+  caption='Lighthouse "enable text compression" audit potential byte savings.',
   description="Stacked bar chart showing 82.11% of sites could save less than 1 MB, 15.88% of sites could save 1 - 2 MB and 2% of sites could save > 3 MB.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vQNIyMEGYE_1W0OdFYLIKsxg6M3o_ZsTTuaX73Zzv6Alw4x4D6oH0jdg9BSgw-jy4E-MmX_Qaf-B98W/pubchart?oid=738657382&format=interactive",
   width=760,

--- a/src/content/en/2019/fonts.md
+++ b/src/content/en/2019/fonts.md
@@ -548,7 +548,7 @@ Let's have a look at what `font-display` values are popular:
   image="fig11.png",
   alt="Usage of font-display values.",
   caption="Usage of <code>font-display</code> values.",
-  description="Bar chart showing the usage of the font-display style. 2.6% of mobile pages set this style to \"swap\", 1.5% to \"auto\", 0.7% to \"block\", 0.4% to \"fallback\", 0.2% to optional, and 0.1% to \"swap\" enclosed in quotes, which is invalid. The desktop distribution is similar except \"swap\" usage is lower by 0.4 percentage points and \"auto\" usage is higher by 0.1 percentage points.",
+  description="Bar chart showing the usage of the font-display style. 2.6% of mobile pages set this style to `swap`, 1.5% to `auto`, 0.7% to `block`, 0.4% to `fallback`, 0.2% to optional, and 0.1% to `swap` enclosed in quotes, which is invalid. The desktop distribution is similar except `swap` usage is lower by 0.4 percentage points and `auto` usage is higher by 0.1 percentage points.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vQDogXDb3BwZZHrBT39qccP_LJoCScD3QEi_FmjT_8VDPD_1Srpz-g7ZuuTUEb8pYXBpDmQzZ1hQh7q/pubchart?oid=1988783738&format=interactive"
   )
 }}
@@ -652,7 +652,7 @@ Even at 1.8% this was higher than expected, although I am excited to see this ta
   image="fig19.png",
   alt="Usage of font-variation-settings axes.",
   caption="Usage of <code>font-variation-settings</code> axes.",
-  description="Bar chart showing the usage of the font-variation-settings property. 42% of properties on desktop pages are set to the \"opsz\" value, 32% to \"wght\", 16% to \"wdth\", 2% or fewer to \"roun\", \"crsb\", \"slnt\", \"inln\", and more. The most notable differences between desktop and mobile pages are 26% usage of \"opsz\", 38% of \"wght\", and 23% of \"wdth\".",
+  description="Bar chart showing the usage of the font-variation-settings property. 42% of properties on desktop pages are set to the `opsz` value, 32% to `wght`, 16% to `wdth`, 2% or fewer to `roun`, `crsb`, `slnt`, `inln`, and more. The most notable differences between desktop and mobile pages are 26% usage of `opsz`, 38% of `wght`, and 23% of `wdth`.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vQDogXDb3BwZZHrBT39qccP_LJoCScD3QEi_FmjT_8VDPD_1Srpz-g7ZuuTUEb8pYXBpDmQzZ1hQh7q/pubchart?oid=699343351&format=interactive"
   )
 }}

--- a/src/content/en/2019/markup.md
+++ b/src/content/en/2019/markup.md
@@ -196,7 +196,7 @@ It's interesting, then, to see what the distribution of these elements looks lik
   link="https://rainy-periwinkle.glitch.me/scatter/html",
   image="element_categories.png",
   caption="Element popularity categorized by standardization.",
-  description="Scatter graph showing HTML, SVG, and Math ML use relatively few tags while non-standard elements (split into \"in global ns\", \"dasherized\" and \"colon\") are much more spread out.",
+  description='Scatter graph showing HTML, SVG, and Math ML use relatively few tags while non-standard elements (split into "in global ns", "dasherized" and "colon") are much more spread out.',
   width=600,
   height=1065
   )

--- a/src/content/en/2019/media.md
+++ b/src/content/en/2019/media.md
@@ -296,7 +296,7 @@ The utility of `srcset` is usually dependent on the precision of the `sizes` med
   image="fig16_top_patterns_of_img_sizes.png",
   alt="Top patterns of img sizes.",
   caption="Top patterns of <code><img sizes></code>.",
-  description="Bar chart showing 11.3 million images use 'img sizes=\"(max-width: 300px) 100vw, 300px\"', 1.60 million use 'auto', 1.00 million use 'img sizes=\"(max-width: 767px) 89vw...etc.\"', 0.23 million use '100vw' and 0.13 million use '300px'",
+  description="Bar chart showing 11.3 million images use 'img sizes=`(max-width: 300px) 100vw, 300px`', 1.60 million use 'auto', 1.00 million use 'img sizes=`(max-width: 767px) 89vw...etc.`', 0.23 million use '100vw' and 0.13 million use '300px'",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vSViHIntdF6-bHAI0cl1HelY_X8rR4lf0P3W2Y8I5SyVMxG-ptggTHfWA0qrrU47RvuAydLE6Zex6L3/pubchart?oid=663985412&format=interactive"
   )
 }}

--- a/src/content/en/2019/performance.md
+++ b/src/content/en/2019/performance.md
@@ -259,8 +259,8 @@ When we apply the PSI labeling to desktop and phone experiences, the distinction
 
 {{ figure_markup(
   image="fig17.png",
-  alt='Distribution of websites labeled as having fast, moderate, or slow FID, broken down by ECT.",
-  caption="Distribution of websites labeled as having fast, moderate, or slow FID, broken down by <abbr title="effective connection type">ECT</abbr>.',
+  alt="Distribution of websites labeled as having fast, moderate, or slow FID, broken down by ECT.",
+  caption='Distribution of websites labeled as having fast, moderate, or slow FID, broken down by <abbr title="effective connection type">ECT</abbr>.',
   description="Bar chart of FID distributions per effective connection type. 4G fast, moderate, slow: 41%, 45%, and 15% respectively. 3G: 22%, 52%, and 26%. 2G: 19%, 58%, 23%. Slow 2G: 15%, 58%, 27%.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vSQlf3_ySLPB5322aTumUZhbVGdaUdkmi1Hs4bYuO3Z1kqM4xspx7REbwXukwPd_tsOSg6oImzpYLM9/pubchart?oid=1173039776&format=interactive"
   )

--- a/src/content/en/2020/compression.md
+++ b/src/content/en/2020/compression.md
@@ -258,7 +258,7 @@ Because the [HTTP Archive runs Lighthouse audits](./methodology#lighthouse) for 
 {{ figure_markup(
   image="text-compression-lighthouse-scores.png",
   caption="Text compression Lighthouse scores.",
-  description="Stacked bar chart breaking down the scores pages receive for the \"enable text compression\" Lighthouse audit. It shows that 7% of sites score less than 10%, 6% of sites are scoring between 10-39%, 10% of sites scoring between 40-79%, 3% of sites scoring between 80-99%, and 74% of sites have a pass with over 100% of text assets being compressed.",
+  description='Stacked bar chart breaking down the scores pages receive for the "enable text compression" Lighthouse audit. It shows that 7% of sites score less than 10%, 6% of sites are scoring between 10-39%, 10% of sites scoring between 40-79%, 3% of sites scoring between 80-99%, and 74% of sites have a pass with over 100% of text assets being compressed.',
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTxUj8-0vKTqPAblIXqekSbiRh1D1lEuA3gVD9w23qwGPtJRE8FbgrURfPAgfFZX2l0t84Wy5ZAGqzR/pubchart?oid=1438276663&format=interactive",
   sheets_gid="1284073179",
   sql_file="19_04.distribution_of_text_compression_lighthouse.sql"

--- a/src/content/en/2020/markup.md
+++ b/src/content/en/2020/markup.md
@@ -1271,7 +1271,7 @@ We can see how `https` and `http` are most dominant, followed by "benign" links 
 ### Links in new windows
 
 {{ figure_markup(
-  caption="Percent of pages having neither `noopener` nor `noreferrer` attributes on `target=\"_blank\"` links.",
+  caption='Percent of pages having neither `noopener` nor `noreferrer` attributes on `target="_blank"` links.',
   content="71.35%",
   classes="big-number",
   sheets_gid="1876528165",

--- a/src/content/en/2020/resource-hints.md
+++ b/src/content/en/2020/resource-hints.md
@@ -168,7 +168,7 @@ With `preload` many different content-types can be preloaded and the [full list]
 {{ figure_markup(
   image="mobile-as-attribute-values-by-year.png",
   caption="Mobile `as` attribute values by year.",
-  description="A bar chart comparing the rate of `as` attribute values on mobile pages from 2019 and 2020, broken down by `as` attribute value. The majority of `as` values are \"script\" with 81% usage in 2019 and 64% usage in 2020. \"script\" usage fell 17% year over year, while all other values increased in usage. \"not set\" increased 8%, \"font\" increased 5%, \"style\" increased 2%, the rest of the notable values are 1% or less for both years.",
+  description="A bar chart comparing the rate of `as` attribute values on mobile pages from 2019 and 2020, broken down by `as` attribute value. The majority of `as` values are `script` with 81% usage in 2019 and 64% usage in 2020. `script` usage fell 17% year over year, while all other values increased in usage. `not set` increased 8%, `font` increased 5%, `style` increased 2%, the rest of the notable values are 1% or less for both years.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTYAbLxN40s6mNR1jo0XDe_V4siN8TAsx2mryMp5IQmlJ-9O9eJxYROz7Rw6ozyFP6hlIZHxxh95GqX/pubchart?oid=903180926&format=interactive",
   sheets_gid="1829901599",
   sql_file="as_attribute_by_year.sql"
@@ -330,7 +330,7 @@ So far only 0.77% websites adopted this new hint as Chrome is still [actively](h
 The largest use is with script elements, which is unsurprising as the number of JS primary and third-party files continues to grow.
 
 {{ figure_markup(
-  caption="The percent of mobile resources with a hint that use the \"low\" priority.",
+  caption="The percent of mobile resources with a hint that use the `low` priority.",
   content="16%",
   classes="big-number",
   sheets_gid="1098063134",

--- a/src/content/es/2019/css.md
+++ b/src/content/es/2019/css.md
@@ -462,7 +462,7 @@ Los sitios web se sienten como papel digital, ¿verdad? Como usuarios, generalme
 {{ figure_markup(
   image="fig32.png",
   caption="Adopción de las media queries para todos, impresión, pantalla y voz.",
-  description="Gráfico de barras que muestra el 35% de las páginas de escritorio con el tipo de media query \"todos\", el 46% con impresión, el 72% con pantalla y el 0% con voz. La adopción es inferior en aproximadamente 5 puntos porcentuales para el escritorio en comparación con el móvil.",
+  description='Gráfico de barras que muestra el 35% de las páginas de escritorio con el tipo de media query "todos", el 46% con impresión, el 72% con pantalla y el 0% con voz. La adopción es inferior en aproximadamente 5 puntos porcentuales para el escritorio en comparación con el móvil.',
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vQO5CabwLwQ5Lj1_9bbEFnFM1qEqCorymaBHrcaNiMSJ7sYDKHUI5iish5VAS-SxN447UTW-1-5-OjE/pubchart?oid=939890574&format=interactive"
   )
 }}
@@ -720,7 +720,7 @@ CSS `@supports` es una forma para que el navegador verifique si una combinación
 {{ figure_markup(
   image="fig38.png",
   caption="Popularidad de las reglas CSS 'arroba'.",
-  description="Gráfico de barras que muestra la popularidad de las reglas @import y @supports \"arroba\". En el escritorio, @import se usa en el 28% de las páginas y @supports se usa en el 31%. Para dispositivos móviles, @import se usa en el 26% de las páginas y @supports se usa en el 29%.",
+  description='Gráfico de barras que muestra la popularidad de las reglas @import y @supports "arroba". En el escritorio, @import se usa en el 28% de las páginas y @supports se usa en el 31%. Para dispositivos móviles, @import se usa en el 26% de las páginas y @supports se usa en el 29%.',
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vQO5CabwLwQ5Lj1_9bbEFnFM1qEqCorymaBHrcaNiMSJ7sYDKHUI5iish5VAS-SxN447UTW-1-5-OjE/pubchart?oid=1739611283&format=interactive"
   )
 }}

--- a/src/content/es/2019/fonts.md
+++ b/src/content/es/2019/fonts.md
@@ -546,7 +546,7 @@ Echemos un vistazo a los valores de `font-display` que son populares:
   image="fig11.png",
   alt="Uso de valores font-display.",
   caption="Uso de valores <code>font-display</code>.",
-  description="Gráfico de barras que muestra el uso del estilo font-display. El 2,6% de las páginas móviles configuran este estilo en \"swap\", 1,5% en \"auto\", 0,7% en \"block\", 0,4% en \"fallback\", 0,2% en \"optional\" y 0,1% en \"swap\" entre comillas. que no es válido. La distribución de escritorio es similar, excepto que el uso de \"swap\" es menor en 0.4 puntos porcentuales y el uso \"auto\" es mayor en 0.1 puntos porcentuales.",
+  description="Gráfico de barras que muestra el uso del estilo font-display. El 2,6% de las páginas móviles configuran este estilo en `swap`, 1,5% en `auto`, 0,7% en `block`, 0,4% en `fallback`, 0,2% en `optional` y 0,1% en `swap` entre comillas. que no es válido. La distribución de escritorio es similar, excepto que el uso de `swap` es menor en 0.4 puntos porcentuales y el uso `auto` es mayor en 0.1 puntos porcentuales.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vQDogXDb3BwZZHrBT39qccP_LJoCScD3QEi_FmjT_8VDPD_1Srpz-g7ZuuTUEb8pYXBpDmQzZ1hQh7q/pubchart?oid=1988783738&format=interactive"
   )
 }}
@@ -650,7 +650,7 @@ Incluso con un 1.8%, esto fue más alto de lo esperado, aunque estoy emocionado 
   image="fig19.png",
   alt="Uso de los ejes font-variation-settings.",
   caption="Uso de los ejes <code>font-variation-settings</code>.",
-  description="Gráfico de barras que muestra el uso de la propiedad font-variation-settings. El 42% de las propiedades en las páginas de escritorio se establecen en el valor \"opsz\", el 32% en \"wght\", el 16% en \"wdth\", el 2% o menos en \"roun\", \"crsb\", \"slnt\", \"inln\" , y más. Las diferencias más notables entre las páginas de escritorio y móviles son el 26% de uso de \"opsz\", el 38% de \"wght\" y el 23% de \"wdth\".",
+  description="Gráfico de barras que muestra el uso de la propiedad font-variation-settings. El 42% de las propiedades en las páginas de escritorio se establecen en el valor `opsz`, el 32% en `wght`, el 16% en `wdth`, el 2% o menos en `roun`, `crsb`, `slnt`, `inln` , y más. Las diferencias más notables entre las páginas de escritorio y móviles son el 26% de uso de `opsz`, el 38% de `wght` y el 23% de `wdth`.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vQDogXDb3BwZZHrBT39qccP_LJoCScD3QEi_FmjT_8VDPD_1Srpz-g7ZuuTUEb8pYXBpDmQzZ1hQh7q/pubchart?oid=699343351&format=interactive"
   )
 }}

--- a/src/content/es/2019/javascript.md
+++ b/src/content/es/2019/javascript.md
@@ -76,7 +76,7 @@ Aunque estos datos muestran cuánto tiempo puede llevar un dispositivo móvil pr
 {{ figure_markup(
   image="js-processing-reddit.png",
   alt="Tiempos de procesamiento de JavaScript para Reddit.com.",
-  caption='Tiempos de procesamiento de JavaScript para Reddit.com. Tomado de <a href="https://v8.dev/blog/cost-of-javascript-2019\">El costo de JavaScript en 2019</a>.',
+  caption='Tiempos de procesamiento de JavaScript para Reddit.com. Tomado de <a href="https://v8.dev/blog/cost-of-javascript-2019">El costo de JavaScript en 2019</a>.',
   description="Gráfico de barras que muestra 3 dispositivos diferentes: en la parte superior, un Pixel 3, que tiene un tiempo de procesamiento pequeño tanto en el hilo principal como en el hilo worker de menos de 400 ms. Para un Moto G4 es de aproximadamente 900 ms en el subproceso principal y otros 300 ms en el subproceso del worker. Y la barra final es un Alcatel 1X 5059D con más de 2.000 ms en el subproceso principal y más de 500 ms en el subproceso del worker.",
   width=600,
   height=363

--- a/src/content/es/2019/markup.md
+++ b/src/content/es/2019/markup.md
@@ -196,7 +196,7 @@ Es interesante, entonces, ver cómo se ve la distribución de estos elementos y 
   link="https://rainy-periwinkle.glitch.me/scatter/html",
   image="element_categories.png",
   caption="Elemento de popularidad categorizado por estandarización.",
-  description="Los gráficos de dispersión que muestran HTML, SVG y Math ML usan relativamente pocas etiquetas, mientras que los elementos no estándar (divididos en \"en ns globales\", \"dasherized\" y \"dos puntos\") están mucho más dispersos.",
+  description='Los gráficos de dispersión que muestran HTML, SVG y Math ML usan relativamente pocas etiquetas, mientras que los elementos no estándar (divididos en "en ns globales", "dasherized" y "dos puntos") están mucho más dispersos.',
   width=600,
   height=1065
   )

--- a/src/content/es/2019/media.md
+++ b/src/content/es/2019/media.md
@@ -296,7 +296,7 @@ La utilidad de `srcset` normalmente depende de la precisión de la media query `
   image="fig16_top_patterns_of_img_sizes.png",
   alt="Top de patrones de img sizes.",
   caption="Top de patrones de <code><img sizes></code>.",
-  description="Gráfico de barras que muestra que 11,3 millones de imágenes usan 'img sizes=\"(max-width: 300px) 100vw, 300px\"', 1,60 millones usan 'auto', 1 millón usan 'img sizes=\"(max-width: 767px) 89vw...etc.\"', 0,23 millones usan '100vw' y 0,13 millones usan '300px'",
+  description="Gráfico de barras que muestra que 11,3 millones de imágenes usan 'img sizes=`(max-width: 300px) 100vw, 300px`', 1,60 millones usan 'auto', 1 millón usan 'img sizes=`(max-width: 767px) 89vw...etc.`', 0,23 millones usan '100vw' y 0,13 millones usan '300px'",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vSViHIntdF6-bHAI0cl1HelY_X8rR4lf0P3W2Y8I5SyVMxG-ptggTHfWA0qrrU47RvuAydLE6Zex6L3/pubchart?oid=663985412&format=interactive"
   )
 }}

--- a/src/content/fr/2019/caching.md
+++ b/src/content/fr/2019/caching.md
@@ -697,7 +697,7 @@ L'outil [Lighthouse](https://developers.google.com/web/tools/lighthouse) de Goog
 {{ figure_markup(
   image="ch16_fig15_lighthouse_example.jpg",
   caption="Rapport Lighthouse soulignant les améliorations possibles de la politique des caches.",
-  description="Une capture d'écran d'une partie d'un rapport de l'outil Google Lighthouse, avec la section \"Servir des ressources statiques avec une politique de cache efficace\" ouverte où il énumère un certain nombre de ressources, dont les noms ont été masqués, et le TTL du cache par rapport à la taille.",
+  description="Une capture d'écran d'une partie d'un rapport de l'outil Google Lighthouse, avec la section “Servir des ressources statiques avec une politique de cache efficace” ouverte où il énumère un certain nombre de ressources, dont les noms ont été masqués, et le TTL du cache par rapport à la taille.",
   width=600,
   height=459
   )
@@ -707,7 +707,7 @@ Lighthouse calcule un score pour chaque audit, allant de 0 à 100&nbsp;%, et ces
 
 {{ figure_markup(
   image="fig21.png",
-  caption="Distribution des scores Lighthouse pour l'audit \"Définit un long cache TTL\" pour les pages web mobiles.",
+  caption="Distribution des scores Lighthouse pour l'audit “Définit un long cache TTL” pour les pages web mobiles.",
   description="Un diagramme à barres superposées&nbsp;: 38,2&nbsp;% des sites web obtiennent un score de < 10&nbsp;%, 29,0&nbsp;% des sites web obtiennent un score entre 10 et 39&nbsp;%, 18,7&nbsp;% des sites web obtiennent un score de 40 à 79&nbsp;%, 10,7&nbsp;% des sites web obtiennent un score de 80 à 99&nbsp;%, et 3,4&nbsp;% des sites web obtiennent un score de 100&nbsp;%.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vT3GWCs19Wq0mu0zgIlKRc8zcXgmVEk2xFHuzZACiWVtqOv8FO5gfHwBxa0mhU6O9TBY8ODdN4Zjd_O/pubchart?oid=827424070&format=interactive"
   )

--- a/src/content/fr/2019/javascript.md
+++ b/src/content/fr/2019/javascript.md
@@ -352,7 +352,7 @@ Lorsqu’ils sont utilisés ensemble, les navigateurs qui prennent en charge les
 {{ figure_markup(
   image="fig14.png",
   caption="Pourcentage de sites utilisant nomodule.",
-  description="Diagramme à barres montrant que 0,8&nbsp;% des sites sur ordinateurs de bureau utilisent \"nomodule\", et 0,5&nbsp;% des sites sur mobile.",
+  description="Diagramme à barres montrant que 0,8&nbsp;% des sites sur ordinateurs de bureau utilisent `nomodule`, et 0,5&nbsp;% des sites sur mobile.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTpzDb9HGbdVvin6YPTOmw11qBVGGysltxmH545fUfnqIThAq878F_b-KxUo65IuXaeFVSnlmJ5K1Dm/pubchart?oid=781034243&format=interactive"
   )
 }}

--- a/src/content/fr/2019/media.md
+++ b/src/content/fr/2019/media.md
@@ -295,7 +295,7 @@ L’utilité de `srcset` dépend généralement de la précision de la requête 
   image="fig16_top_patterns_of_img_sizes.png",
   alt="Top patterns of img sizes.",
   caption="Principaux modèles de conception de <code><img sizes></code>.",
-  description="Diagramme à barres montrant que 11,3 millions d’images utilisent 'img sizes=\"(max-width: 300px) 100vw, 300px\"', 1,60 million utilisent 'auto', 1,00 million utilisent 'img sizes=\"(max-width : 767px) 89vw...etc.\"', 0,23 million utilisent '100vw' et 0,13 million utilisent '300px'.",
+  description="Diagramme à barres montrant que 11,3 millions d’images utilisent 'img sizes=`(max-width: 300px) 100vw, 300px`', 1,60 million utilisent 'auto', 1,00 million utilisent 'img sizes=`(max-width : 767px) 89vw...etc.`', 0,23 million utilisent '100vw' et 0,13 million utilisent '300px'.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vSViHIntdF6-bHAI0cl1HelY_X8rR4lf0P3W2Y8I5SyVMxG-ptggTHfWA0qrrU47RvuAydLE6Zex6L3/pubchart?oid=663985412&format=interactive"
   )
 }}

--- a/src/content/fr/2019/third-parties.md
+++ b/src/content/fr/2019/third-parties.md
@@ -165,7 +165,7 @@ Bien qu’ils servent 57 % des scripts, les tiers représentent 64 % des octet
 {{ figure_markup(
   image="fig7.png",
   caption="Répartition des octets de ressource par catégorie de tiers.",
-  description="Graphique montrant la répartition des octets pour chaque type de contenu par catégorie de tiers. Les images et les scripts sont répartis de manière relativement égale entre les catégories. 80 % des polices proviennent de CDN. La vidéo provient de tiers spécialisés en \"Contenus\".",
+  description="Graphique montrant la répartition des octets pour chaque type de contenu par catégorie de tiers. Les images et les scripts sont répartis de manière relativement égale entre les catégories. 80 % des polices proviennent de CDN. La vidéo provient de tiers spécialisés en “Contenus”.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRO5jS8JpjYdTr9poYmpyw-BL1LPQtfzHx_1hLRk9lgwkHQERuyELgF_rQ-4CpTbdbAyI9u1ggtPlLQ/pubchart?oid=1167032693&format=interactive",
   width=600,
   height=387,

--- a/src/content/it/2020/resource-hints.md
+++ b/src/content/it/2020/resource-hints.md
@@ -168,7 +168,7 @@ Con `preload` possono essere precaricati molti diversi tipi di contenuto e la <a
 {{ figure_markup(
   image="mobile-as-attribute-values-by-year.png",
   caption="Valori dell'attributo `as` mobile per anno.",
-  description="Un grafico a barre che confronta il tasso di valori dell'attributo `as` sulle pagine mobile del 2019 e del 2020, suddiviso per valore dell'attributo `as`. La maggior parte dei valori `as` sono \"script\" con l'81% di utilizzo nel 2019 e il 64% nel 2020. L'utilizzo di \"script\" è diminuito del 17% anno su anno, mentre tutti gli altri valori sono aumentati. \"non impostato\" aumentato dell'8%, \"font\" aumentato del 5%, \"style\" aumentato del 2%, il resto dei valori notevoli sono dell'1% o meno per entrambi gli anni.",
+  description="Un grafico a barre che confronta il tasso di valori dell'attributo `as` sulle pagine mobile del 2019 e del 2020, suddiviso per valore dell'attributo `as`. La maggior parte dei valori `as` sono `script` con l'81% di utilizzo nel 2019 e il 64% nel 2020. L'utilizzo di `script` è diminuito del 17% anno su anno, mentre tutti gli altri valori sono aumentati. `non impostato` aumentato dell'8%, `font` aumentato del 5%, `style` aumentato del 2%, il resto dei valori notevoli sono dell'1% o meno per entrambi gli anni.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTYAbLxN40s6mNR1jo0XDe_V4siN8TAsx2mryMp5IQmlJ-9O9eJxYROz7Rw6ozyFP6hlIZHxxh95GqX/pubchart?oid=903180926&format=interactive",
   sheets_gid="1829901599",
   sql_file="as_attribute_by_year.sql"
@@ -330,7 +330,7 @@ Finora solo lo 0,77% dei siti web ha adottato questo nuovo hint poiché Chrome s
 L'utilizzo maggiore è con elementi di script, il che non sorprende poiché il numero di file JS primari e di terze parti continua a crescere.
 
 {{ figure_markup(
-  caption="La percentuale di risorse nei dispositivi mobile con un hint che utilizza la \"low\" priority.",
+  caption="La percentuale di risorse nei dispositivi mobile con un hint che utilizza la `low` priority.",
   content="16%",
   classes="big-number",
   sheets_gid="1098063134",

--- a/src/content/ja/2019/fonts.md
+++ b/src/content/ja/2019/fonts.md
@@ -653,7 +653,7 @@ Google FontsはそのCSSのほとんど（すべてではないにしても）�
   image="fig19.png",
   alt="font-variation-settings軸の使用法。",
   caption="<code>font-variation-settings</code> 軸の使用法。",
-  description="font-variation-settingsプロパティの使用状況を示す棒グラフ。デスクトップページのプロパティの42%が\"opsz\"の値に設定されており、32%が\"wght\"、16%が\"wdth\"、2%以下が\"roun\"、\"crsb\"、\"slnt\"、\"inln\"などに設定されています。デスクトップページとモバイルページで顕著な違いは、\"opsz\"の使用率が26％、\"wght\"の使用率が38％、\"wdth\"の使用率が23％となっており、\"wght\"の使用率は、\"wght\"の使用率と\"wght\"の使用率の差が大きい。",
+  description="font-variation-settingsプロパティの使用状況を示す棒グラフ。デスクトップページのプロパティの42%が`opsz`の値に設定されており、32%が`wght`、16%が`wdth`、2%以下が`roun`、`crsb`、`slnt`、`inln`などに設定されています。デスクトップページとモバイルページで顕著な違いは、`opsz`の使用率が26％、`wght`の使用率が38％、`wdth`の使用率が23％となっており、`wght`の使用率は、`wght`の使用率と`wght`の使用率の差が大きい。",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vQDogXDb3BwZZHrBT39qccP_LJoCScD3QEi_FmjT_8VDPD_1Srpz-g7ZuuTUEb8pYXBpDmQzZ1hQh7q/pubchart?oid=699343351&format=interactive"
   )
 }}

--- a/src/content/ja/2019/media.md
+++ b/src/content/ja/2019/media.md
@@ -296,7 +296,7 @@ CSSピクセルと自然ピクセル量を見ると、中央値のウェブサ�
  {{ figure_markup(
   image="fig16_top_patterns_of_img_sizes.png",
   caption="<code><img sizes></code> のトップパターン。",
-  description="1,130万枚の画像が「img sizes=\"(max-width: 300px) 100vw, 300px\"」を使用しており、「auto」が160万枚、「img sizes=\"(max-width: 767px) 89vwなどなど\"」が100万枚、「100vw」が23万枚、「300px」が13万枚であることを棒グラフで示しています。",
+  description="1,130万枚の画像が「img sizes=`(max-width: 300px) 100vw, 300px`」を使用しており、「auto」が160万枚、「img sizes=`(max-width: 767px) 89vwなどなど`」が100万枚、「100vw」が23万枚、「300px」が13万枚であることを棒グラフで示しています。",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vSViHIntdF6-bHAI0cl1HelY_X8rR4lf0P3W2Y8I5SyVMxG-ptggTHfWA0qrrU47RvuAydLE6Zex6L3/pubchart?oid=663985412&format=interactive"
   )
 }}

--- a/src/content/nl/2020/capabilities.md
+++ b/src/content/nl/2020/capabilities.md
@@ -50,7 +50,7 @@ De Async Clipboard API biedt twee methoden voor het lezen van inhoud van het kle
 {{ figure_markup(
   image="async_clipboard_api.png",
   alt="Percentage pagina's dat wordt geladen in Chrome met behulp van de Async Clipboard API",
-  caption='Percentage pagina\'s dat wordt geladen in Chrome met behulp van de Async Clipboard API.<br>(Bronnen: <a hreflang="en" href="https://chromestatus.com/metrics/feature/timeline/popularity/2369">Async Clipboard Read</a>, <a hreflang="en" href="https://chromestatus.com/metrics/feature/timeline/popularity/2370">Async Clipboard Write</a>)',
+  caption='Percentage pagina’s dat wordt geladen in Chrome met behulp van de Async Clipboard API.<br>(Bronnen: <a hreflang="en" href="https://chromestatus.com/metrics/feature/timeline/popularity/2369">Async Clipboard Read</a>, <a hreflang="en" href="https://chromestatus.com/metrics/feature/timeline/popularity/2370">Async Clipboard Write</a>)',
   description="Grafiek van het gebruik van de Async Clipboard API, gebaseerd op het percentage pagina's dat met deze functie in Chrome wordt geladen. Het vergelijkt het gebruik van de `read`- en `write`-methoden en laat een exponentiële groei zien voor `write` in de loop van 2020, terwijl `read` lineair groeit. In oktober 2020 werd `read` aangeroepen tijdens 0,0003% van alle paginaladingen in Chrome, `write` voor 0,0006%.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTxqot9ALgxcgOVJntkzIKnkpo3idIPy-tL0t_nzC5BwFuq0ThgK5OXOYVVOpama4vB2EyggX813d33/pubchart?oid=1740212588&format=interactive",
   sheets_gid="2077755325"
@@ -116,7 +116,7 @@ Op verschillende platforms is het gebruikelijk dat applicaties een badge present
 {{ figure_markup(
   image="badging_api.png",
   alt="Percentage pagina's dat wordt geladen in Chrome met behulp van de Badging-API",
-  caption='Percentage pagina\'s dat wordt geladen in Chrome met behulp van de Badging-API.<br>(Bronnen: <a hreflang="en" href="https://chromestatus.com/metrics/feature/timeline/popularity/2726">Badge Set</a>, <a hreflang="en" href="https://chromestatus.com/metrics/feature/timeline/popularity/2727">Badge Clear</a>)',
+  caption='Percentage pagina’s dat wordt geladen in Chrome met behulp van de Badging-API.<br>(Bronnen: <a hreflang="en" href="https://chromestatus.com/metrics/feature/timeline/popularity/2726">Badge Set</a>, <a hreflang="en" href="https://chromestatus.com/metrics/feature/timeline/popularity/2727">Badge Clear</a>)',
   description="Grafiek van Badging API-gebruik, gebaseerd op het percentage pagina's dat met deze functie in Chrome wordt geladen. Het vergelijkt de `set` en `clear` methoden. Het gebruik van beide methoden groeit in de loop van de tijd, waarbij de `set` methode over het algemeen vaker wordt aangeroepen. In oktober 2020 is er een plotselinge groei voor beide methoden, met een piek van 0,025% van het laden van pagina's voor de `set` methode en 0,016% voor `clear`.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTxqot9ALgxcgOVJntkzIKnkpo3idIPy-tL0t_nzC5BwFuq0ThgK5OXOYVVOpama4vB2EyggX813d33/pubchart?oid=1145004925&format=interactive",
   sheets_gid="1154751352"
@@ -139,7 +139,7 @@ registration.showNotification('Title', {
 {{ figure_markup(
   image="notification_triggers_api.png",
   alt="Percentage pagina's dat wordt geladen in Chrome met behulp van de Notification Triggers API",
-  caption='Percentage pagina\'s dat wordt geladen in Chrome met behulp van de Notification Triggers API.<br>(Bron: <a hreflang="en" href="https://chromestatus.com/metrics/feature/timeline/popularity/3017">Notification Triggers</a>)',
+  caption='Percentage pagina’s dat wordt geladen in Chrome met behulp van de Notification Triggers API.<br>(Bron: <a hreflang="en" href="https://chromestatus.com/metrics/feature/timeline/popularity/3017">Notification Triggers</a>)',
   description="Diagram met Notification Triggers API-gebruik, gebaseerd op het percentage pagina's dat in Chrome wordt geladen met deze functie. Het vertoont een piek in maart 2020 met ongeveer 0,00003% van de paginaladingen, en daalt tot nul in oktober 2020.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTxqot9ALgxcgOVJntkzIKnkpo3idIPy-tL0t_nzC5BwFuq0ThgK5OXOYVVOpama4vB2EyggX813d33/pubchart?oid=1388597384&format=interactive",
   sheets_gid="1740370570"
@@ -176,7 +176,7 @@ Om dit te doen, biedt de API een nieuwe `IdleDetector` interface op het globale 
 {{ figure_markup(
   image="idle_detection_api.png",
   alt="Percentage pagina's dat wordt geladen in Chrome met behulp van Idle Detection API",
-  caption='Percentage pagina\'s dat wordt geladen in Chrome met behulp van Idle Detection API.<br>(Bron: <a hreflang="en" href="https://chromestatus.com/metrics/feature/timeline/popularity/3017">Idle Detection</a>)',
+  caption='Percentage pagina’s dat wordt geladen in Chrome met behulp van Idle Detection API.<br>(Bron: <a hreflang="en" href="https://chromestatus.com/metrics/feature/timeline/popularity/3017">Idle Detection</a>)',
   description="Grafiek van API-gebruik voor inactieve detectie, gebaseerd op het percentage pagina's dat met deze functie in Chrome wordt geladen. Er zijn alleen gegevens beschikbaar voor juli en oktober 2020, wat een zeer lage acceptatie van de API aantoont.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTxqot9ALgxcgOVJntkzIKnkpo3idIPy-tL0t_nzC5BwFuq0ThgK5OXOYVVOpama4vB2EyggX813d33/pubchart?oid=963792757&format=interactive",
   sheets_gid="1324588405"
@@ -260,7 +260,7 @@ De Content Indexing API breidt de Service Worker API uit met een nieuwe `Content
 {{ figure_markup(
   image="content_indexing_api.png",
   alt="Percentage pagina's dat wordt geladen in Chrome met behulp van Content Indexing API",
-  caption='Percentage pagina\'s dat wordt geladen in Chrome met behulp van Content Indexing API.<br>(Bron: <a hreflang="en" href="https://chromestatus.com/metrics/feature/timeline/popularity/3017">Content Indexing</a>)',
+  caption='Percentage pagina’s dat wordt geladen in Chrome met behulp van Content Indexing API.<br>(Bron: <a hreflang="en" href="https://chromestatus.com/metrics/feature/timeline/popularity/3017">Content Indexing</a>)',
   description="Grafiek van het gebruik van Content Indexing API, gebaseerd op het percentage pagina's dat met deze functie in Chrome wordt geladen. Het vertoont in eerste instantie een relatief laag gebruik, totdat het in oktober 2020 plotseling vertienvoudigt, en wordt gebruikt tijdens 0,0021% van de paginaladingen in Chrome.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTxqot9ALgxcgOVJntkzIKnkpo3idIPy-tL0t_nzC5BwFuq0ThgK5OXOYVVOpama4vB2EyggX813d33/pubchart?oid=258329620&format=interactive",
   sheets_gid="626752011"
@@ -289,7 +289,7 @@ De WebSocketStream API lost op transparante wijze tegendruk op, aangezien de str
 {{ figure_markup(
   image="websocketstreams.png",
   alt="Percentage pagina's dat in Chrome wordt geladen met WebSocketStreams",
-  caption='Percentage pagina\'s dat in Chrome wordt geladen met WebSocketStreams.<br>(Bron: <a hreflang="en" href="https://chromestatus.com/metrics/feature/timeline/popularity/3018">WebSocketStream</a>)',
+  caption='Percentage pagina’s dat in Chrome wordt geladen met WebSocketStreams.<br>(Bron: <a hreflang="en" href="https://chromestatus.com/metrics/feature/timeline/popularity/3018">WebSocketStream</a>)',
   description="Grafiek van het gebruik van WebSocketStreams, gebaseerd op het percentage pagina's dat met deze functie in Chrome wordt geladen. Het vertoont een piek in juni en juli 2020, waar de API werd gebruikt tijdens ongeveer 0,0008% van de paginaladingen.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTxqot9ALgxcgOVJntkzIKnkpo3idIPy-tL0t_nzC5BwFuq0ThgK5OXOYVVOpama4vB2EyggX813d33/pubchart?oid=1714443590&format=interactive",
   sheets_gid="691106754"
@@ -315,7 +315,7 @@ QuicTransport is een geldig alternatief voor WebSockets, omdat het de gebruikssc
 {{ figure_markup(
   image="quic_transport.png",
   alt="Percentage pagina's dat in Chrome wordt geladen met Quic Transport",
-  caption='Percentage pagina\'s dat in Chrome wordt geladen met Quic Transport.<br>(Bron: <a hreflang="en" href="https://chromestatus.com/metrics/feature/timeline/popularity/3184">QuicTransport</a>)',
+  caption='Percentage pagina’s dat in Chrome wordt geladen met Quic Transport.<br>(Bron: <a hreflang="en" href="https://chromestatus.com/metrics/feature/timeline/popularity/3184">QuicTransport</a>)',
   description="Grafiek van het gebruik van QuicTransport, gebaseerd op het percentage pagina's dat met deze functie in Chrome wordt geladen. Het vertoont een piek in oktober 2020, waar de API werd gebruikt tijdens ongeveer 0.00089% van de paginaladingen.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTxqot9ALgxcgOVJntkzIKnkpo3idIPy-tL0t_nzC5BwFuq0ThgK5OXOYVVOpama4vB2EyggX813d33/pubchart?oid=1571330893&format=interactive",
   sheets_gid="708893754"

--- a/src/content/nl/2020/cms.md
+++ b/src/content/nl/2020/cms.md
@@ -350,7 +350,7 @@ Een "goed" LCP wordt beschouwd als minder dan 2,5 seconden. De gemiddelde websit
 {{ figure_markup(
   image="cms-real-user-largest-contentful-paint-experiences.png",
   caption="Largest Contentful Paint-ervaringen door echte gebruikers.",
-  description="Staafdiagram met de top 5 CMS'en en of ze een \"goede\" Largest Contentful Paint-ervaring hebben. WordPress is middelmatig met 33% op desktop en 25% op mobiel, Drupal is de beste met 61% op desktop en 47% op mobiel, Joomla is de tweede beste met 48% op desktop en 28% op mobiel, Squarespace heeft 37% op desktop maar slechts 12% op mobiel en Wix is het laagste met 9% op desktop en 9% op mobiel.",
+  description="Staafdiagram met de top 5 CMS'en en of ze een “goede” Largest Contentful Paint-ervaring hebben. WordPress is middelmatig met 33% op desktop en 25% op mobiel, Drupal is de beste met 61% op desktop en 47% op mobiel, Joomla is de tweede beste met 48% op desktop en 28% op mobiel, Squarespace heeft 37% op desktop maar slechts 12% op mobiel en Wix is het laagste met 9% op desktop en 9% op mobiel.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTkUxfuK-FCn3_IYDJiEsKDmdmyKb0TSEhG8dFc0XBIXej1NO2uUOmd-9NCbWuh-MZ3xzMhK_kNT-4u/pubchart?oid=188727692&format=interactive",
   sheets_gid="465267881",
   sql_file="core_web_vitals_distribution.sql"
@@ -368,7 +368,7 @@ FID is erg snel voor de gemiddelde CMS-website op desktop - alleen Wix scoort la
 {{ figure_markup(
   image="cms-real-user-first-input-delay-experiences.png",
   caption="First Input Delay-ervaringen door echte gebruikers.",
-  description="Staafdiagram met de top 5 CMS'en en of ze een \"goede\" ervaring met de eerste invoervertraging hebben. Ze hebben allemaal een ervaringsscore van 100% op desktop, behalve Wix met 87%. Voor mobiel heeft WordPress 88%, Drupal 76%, Joomla 71%, Squarespace 91% en Wix 46%.",
+  description="Staafdiagram met de top 5 CMS'en en of ze een “goede” ervaring met de eerste invoervertraging hebben. Ze hebben allemaal een ervaringsscore van 100% op desktop, behalve Wix met 87%. Voor mobiel heeft WordPress 88%, Drupal 76%, Joomla 71%, Squarespace 91% en Wix 46%.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTkUxfuK-FCn3_IYDJiEsKDmdmyKb0TSEhG8dFc0XBIXej1NO2uUOmd-9NCbWuh-MZ3xzMhK_kNT-4u/pubchart?oid=893606466&format=interactive",
   sheets_gid="465267881",
   sql_file="core_web_vitals_distribution.sql"
@@ -388,7 +388,7 @@ Een score van 0,1 of lager wordt gemeten als "goed", meer dan 0,25 is "slecht" e
 {{ figure_markup(
   image="cms-real-user-cumulative-layout-shift-experiences.png",
   caption="Cumulatieve Layout Shift-ervaringen door echte gebruikers.",
-  description="Staafdiagram met de top 5 CMS'en en of ze een \"goede\" ervaring hebben met Cumulative Layout Shift. WordPress heeft 47% van de desktopsites met een \"goede ervaring\" en 57% van de mobiele sites. Drupal heeft 58% voor desktop en 70% voor mobiel, Joomla heeft 51% voor desktop en 63% voor mobiel, Squarespace heeft 35% voor desktop en 44% voor mobiel, en Wix heeft 58% voor desktop en 59% voor mobiel.",
+  description="Staafdiagram met de top 5 CMS'en en of ze een “goede” ervaring hebben met Cumulative Layout Shift. WordPress heeft 47% van de desktopsites met een “goede ervaring” en 57% van de mobiele sites. Drupal heeft 58% voor desktop en 70% voor mobiel, Joomla heeft 51% voor desktop en 63% voor mobiel, Squarespace heeft 35% voor desktop en 44% voor mobiel, en Wix heeft 58% voor desktop en 59% voor mobiel.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTkUxfuK-FCn3_IYDJiEsKDmdmyKb0TSEhG8dFc0XBIXej1NO2uUOmd-9NCbWuh-MZ3xzMhK_kNT-4u/pubchart?oid=1265001868&format=interactive",
   sheets_gid="465267881",
   sql_file="core_web_vitals_distribution.sql"

--- a/src/content/nl/2020/javascript.md
+++ b/src/content/nl/2020/javascript.md
@@ -355,7 +355,7 @@ De populaire bibliotheken die in gebruik zijn, zijn grotendeels ongewijzigd ten 
 {{ figure_markup(
   image="frameworks-libraries.png",
   caption="Overname van de beste JavaScript-frameworks en -bibliotheken als percentage van de pagina's.",
-  description="Staafdiagram dat de acceptatie van de belangrijkste frameworks en bibliotheken weergeeft als percentage van de pagina's (niet paginaweergaven of npm-downloads). jQuery is de overweldigende leider, te vinden op 83% van de mobiele pagina\'s. Het wordt gevolgd door jQuery migrate op 30%, jQuery UI op 21%, Modernizr op 15%, FancyBox op 7%, Slick en Lightbox op 6%, en de resterende frameworks en bibliotheken op 4% of 3%: Moment.js, Underscore.js, Lodash, React, GSAP, Select2, RequireJS en prettyPhoto.",
+  description="Staafdiagram dat de acceptatie van de belangrijkste frameworks en bibliotheken weergeeft als percentage van de pagina's (niet paginaweergaven of npm-downloads). jQuery is de overweldigende leider, te vinden op 83% van de mobiele pagina's. Het wordt gevolgd door jQuery migrate op 30%, jQuery UI op 21%, Modernizr op 15%, FancyBox op 7%, Slick en Lightbox op 6%, en de resterende frameworks en bibliotheken op 4% of 3%: Moment.js, Underscore.js, Lodash, React, GSAP, Select2, RequireJS en prettyPhoto.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=419887153&format=interactive",
   sheets_gid="1654577118",
   sql_file="frameworks_libraries.sql"

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -938,6 +938,12 @@
         "yargs": "^14.2"
       }
     },
+    "smartypants": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/smartypants/-/smartypants-0.1.1.tgz",
+      "integrity": "sha512-cmRfqgUdTIYHW2ljYxrsfb636T/okoGbRLfidSr3VQqXzXwWz+UeI3I5fCxk5eXW+H6QRMsn1sA/I7igXLB7lA==",
+      "dev": true
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",

--- a/src/package.json
+++ b/src/package.json
@@ -44,6 +44,7 @@
     "xml-js": "1.6.11",
     "run-script-os": "1.1.5",
     "node-watch": "0.7.1",
-    "rainbow-code": "2.1.7"
+    "rainbow-code": "2.1.7",
+    "smartypants": "0.1.1"
   }
 }

--- a/src/tools/generate/generate_chapters.js
+++ b/src/tools/generate/generate_chapters.js
@@ -7,6 +7,7 @@ const { find_markdown_files, get_yearly_configs, size_of, parse_array } = requir
 const { generate_table_of_contents } = require('./generate_table_of_contents');
 const { generate_header_links } = require('./generate_header_links');
 const { generate_figure_ids } = require('./generate_figure_ids');
+const { generate_typographic_punctuation } = require('./generate_typographic_punctuation');
 const { generate_featured_chapters, generate_chapter_featured_quote } = require('./generate_featured_chapters');
 const { generate_sitemap } = require('./generate_sitemap');
 const { lazy_load_content } = require('./lazy_load_content');
@@ -150,6 +151,7 @@ const parse_file = async (markdown,chapter) => {
   body = generate_table_figure_dropdowns(body);
   body = lazy_load_content(body);
   body = remove_unnecessary_markup(body);
+  body = generate_typographic_punctuation(body);
   const toc = generate_table_of_contents(body);
 
   const chapter_number = Number(m.chapter_number);

--- a/src/tools/generate/generate_typographic_punctuation.js
+++ b/src/tools/generate/generate_typographic_punctuation.js
@@ -1,0 +1,27 @@
+const smartypants = require('smartypants');
+
+const generate_typographic_punctuation = (html) => {
+
+  // Temporarily comment out any Jinja macros to avoid them being converted
+  // as smartypants doesn't recognise those parameters as
+  html = html.replace(/\{\{/g,'<!--<jinja-macro{{');
+  html = html.replace(/\}\}/g,'}}></jinja-macro>-->');
+  // However do want descriptions and captions, so uncomment those arguments
+  html = html.replace(/(\{\{[^}]*description=")(.*?[^\\])(")/g,'$1<jinja-arg>-->$2<!--</jinja-arg>$3');
+  html = html.replace(/(\{\{[^}]*caption=")(.*?[^\\])(")/g,'$1<jinja-arg>-->$2<!--</jinja-arg>$3');
+  html = html.replace(/(\{\{[^}]*description=')(.*?[^\\])(')/g,'$1<jinja-arg>-->$2<!--</jinja-arg>$3');
+  html = html.replace(/(\{\{[^}]*caption=')(.*?[^\\])(')/g,'$1<jinja-arg>-->$2<!--</jinja-arg>$3');
+  html = smartypants.smartypants(html);
+
+  // Uncomment Jinja functions
+  html = html.replace(/<!--<jinja-macro/g,'');
+  html = html.replace(/><\/jinja-macro>-->/g,'');
+  html = html.replace(/<jinja-arg>-->/g,'');
+  html = html.replace(/<!--<\/jinja-arg>/g,'');
+
+  return html;
+};
+
+module.exports = {
+  generate_typographic_punctuation
+};


### PR DESCRIPTION
Fixes #1485 

This converts simple quotes (" and ') to typographic quotes (“,”, and ‘’), sometimes know as curly quotes or smart quotes.

It does this using the [smartypants](https://www.npmjs.com/package/smartypants) library. I tried a few of these, and this one was the only one I could get working consistently as it ignores code formatting and comments.

Still needs a little fudging for our Jinja2 macros (figure markup) but actually quite clean.

I also fixed a lot of captions and descriptions to allow them to be typographic quotes too.

Currently it only handles English punctuation so translations for languages with different punctuation marks still need to convert.