### PR TITLE
Fix figure number bug

### DIFF
--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -655,7 +655,7 @@
   {% endblock %}
 {% endblock %}
 
-{% macro figure_dropdown(metadata, id, sheets_gid="", sql_file="", image="", caption="") %}
+{% macro figure_dropdown(metadata, chapter_config, id, sheets_gid="", sql_file="", image="", caption="") %}
   {% if sheets_gid != "" or  sql_file != "" or image != "" %}
   <div class="figure-dropdown nav-dropdown">
     <button class="nav-dropdown-btn js-enable hidden" disabled aria-expanded="false" title="{{ self.explore_the_results() }}">
@@ -770,10 +770,11 @@
   {% endmacro %}
 {% endif %}
 
-{% macro figure_id(metadata, id) %}{{ metadata.chapter_number }}.{{ id }}{% endmacro %}
+{% macro figure_id(metadata, chapter_config, id) %}{{ chapter_config.chapter_number }}.{{ id }}{% endmacro %}
 
 {% macro figure_link(
   metadata,
+  chapter_config,
   id,
   caption,
   sheets_gid="",
@@ -783,9 +784,9 @@
   )
 %}
 {% if ebook %}
-<a href="#fig-{{ metadata.chapter_number }}-{{ id }}" class="anchor-link">{{ figure_text(metadata, id) }}</a> {{ caption|safe }}
+<a href="#fig-{{ chapter_config.chapter_number }}-{{ id }}" class="anchor-link">{{ figure_text(metadata, chapter_config, id) }}</a> {{ caption|safe }}
 {% else %}
-<a href="#fig-{{ id }}" class="anchor-link">{{ figure_text(metadata, id) }}</a> {{ caption|safe }}
+<a href="#fig-{{ id }}" class="anchor-link">{{ figure_text(metadata, chapter_config, id) }}</a> {{ caption|safe }}
 {% endif %}
 {% endmacro %}
 
@@ -810,7 +811,8 @@
   content="",
   classes="",
   metadata="",
-  ebook=false
+  ebook=false,
+  chapter_config=""
   )
 %}
 
@@ -845,17 +847,17 @@
       <img src="{{ image }}" class="{{ classes }}" alt="{{ caption|striptags }}" aria-labelledby="{{ anchor }}-caption" aria-describedby="{{ anchor }}-description" width="{{ width }}" height="{{ height }}" loading="lazy" />
       {%- endif %}
     </a>
-    {% if not ebook %}{{ figure_dropdown(metadata, id, sheets_gid, sql_file, image) }}{% endif %}
+    {% if not ebook %}{{ figure_dropdown(metadata, chapter_config, id, sheets_gid, sql_file, image) }}{% endif %}
   </div>
-  <button hidden="" class="fig-description-button" aria-expanded="false" aria-controls="{{ anchor }}-description" data-show-text="{{ show_description(metadata,id) }}" data-hide-text="{{ hide_description(metadata,id) }}">{{ show_description(metadata,id) }}</button>
+  <button hidden="" class="fig-description-button" aria-expanded="false" aria-controls="{{ anchor }}-description" data-show-text="{{ show_description(metadata,chapter_config,id) }}" data-hide-text="{{ hide_description(metadata,id) }}">{{ show_description(metadata,chapter_config,id) }}</button>
   <div id="{{ anchor }}-description" class="visually-hidden">{{ description|safe }}</div>
   {%- elif content != "" %}
   <div class="figure-wrapper">
     <div class="{{ classes }}">{{ content|safe }}</div>
-    {% if not ebook %}{{ figure_dropdown(metadata, id, sheets_gid, sql_file, image, ebook) }}{% endif %}
+    {% if not ebook %}{{ figure_dropdown(metadata, chapter_config, id, sheets_gid, sql_file, image, ebook) }}{% endif %}
   </div>
   {%- endif %}
-  <figcaption id="{{ anchor }}-caption">{{ figure_link(metadata, id, caption, ebook=ebook, sheets_gid=sheets_gid, sql_file=sql_file, image=image) }}</figcaption>
+  <figcaption id="{{ anchor }}-caption">{{ figure_link(metadata, chapter_config, id, caption, ebook=ebook, sheets_gid=sheets_gid, sql_file=sql_file, image=image) }}</figcaption>
 </figure>
 {%- endmacro %}
 

--- a/src/templates/base/ebook.ejs.html
+++ b/src/templates/base/ebook.ejs.html
@@ -9,11 +9,12 @@
 
     {% set metadata = <%- JSON.stringify(chapter.metadata) %> %}
     {% set chapter_hero_dir = "/static/images/%s/%s/" % ("<%- chapter.hero_dir || '2019' %>", metadata.chapter) %}
+    {% set chapter_config = <%- JSON.stringify(chapter) %> %}
     <section class="chapter" id="chapter-<%- chapter.chapter_number %>">
         <div class="body" id="{{ metadata.get('chapter') }}">
 
             <div class="subtitle">
-                {{ self.part() }} <%- chapter.part %> {{ self.chapter() }} <%- chapter.chapter_number %>
+                {{ self.part() }} {{ chapter_config.part }} {{ self.chapter() }} {{ chapter_config.chapter_number }}
             </div>
             <h1 class="title title-lg">
                 {{ metadata.get('title') }}

--- a/src/templates/en/base.html
+++ b/src/templates/en/base.html
@@ -62,9 +62,9 @@ Our mission is to combine the raw stats and trends of the HTTP Archive with the 
 {% block open %}Open{% endblock %}
 {% block close %}Close{% endblock %}
 
-{% macro figure_text(metadata, id) %}Figure {{ figure_id(metadata, id) }}.{% endmacro %}
-{% macro show_description(metadata, id) %}Show description of Figure {{ figure_id(metadata, id) }}{% endmacro %}
-{% macro hide_description(metadata, id) %}Hide description of Figure {{ figure_id(metadata, id) }}{% endmacro %}
+{% macro figure_text(metadata, chapter_config, id) %}Figure {{ figure_id(metadata, chapter_config, id) }}.{% endmacro %}
+{% macro show_description(metadata, chapter_config, id) %}Show description of Figure {{ figure_id(metadata, chapter_config, id) }}{% endmacro %}
+{% macro hide_description(metadata, chapter_config, id) %}Hide description of Figure {{ figure_id(metadata, chapter_config, id) }}{% endmacro %}
 
 {% block written_by_before %}Written by{% endblock %}
 {% block reviewed_by_before %}Reviewed by{% endblock %}

--- a/src/templates/es/base.html
+++ b/src/templates/es/base.html
@@ -62,9 +62,9 @@
 {% block open %}Abrir{% endblock %}
 {% block close %}Cerrar{% endblock %}
 
-{% macro figure_text(metadata, id) %}Figura {{ figure_id(metadata, id) }}.{% endmacro %}
-{% macro show_description(metadata, id) %}Mostrar descripción de la Figura {{ figure_id(metadata, id) }}{% endmacro %}
-{% macro hide_description(metadata, id) %}Ocultar descripción de la Figura {{ figure_id(metadata, id) }}{% endmacro %}
+{% macro figure_text(metadata, chapter_config, id) %}Figura {{ figure_id(metadata, chapter_config, id) }}.{% endmacro %}
+{% macro show_description(metadata, chapter_config, id) %}Mostrar descripción de la Figura {{ figure_id(metadata, chapter_config, id) }}{% endmacro %}
+{% macro hide_description(metadata, chapter_config, id) %}Ocultar descripción de la Figura {{ figure_id(metadata, chapter_config, id) }}{% endmacro %}
 
 {% block written_by_before %}Escrito por{% endblock %}
 {% block reviewed_by_before %}Revisado por{% endblock %}

--- a/src/templates/fr/base.html
+++ b/src/templates/fr/base.html
@@ -62,9 +62,9 @@ Notre mission est de combiner les statistiques brutes et les tendances de HTTP A
 {% block open %}Ouvrez{% endblock %}
 {% block close %}Fermez{% endblock %}
 
-{% macro figure_text(metadata, id) %}Figure {{ figure_id(metadata, id) }}.{% endmacro %}
-{% macro show_description(metadata, id) %}Afficher la description de la figure {{ figure_id(metadata, id) }}{% endmacro %}
-{% macro hide_description(metadata, id) %}Masquer la description de la figure  {{ figure_id(metadata, id) }}{% endmacro %}
+{% macro figure_text(metadata, chapter_config, id) %}Figure {{ figure_id(metadata, chapter_config, id) }}.{% endmacro %}
+{% macro show_description(metadata, chapter_config, id) %}Afficher la description de la figure {{ figure_id(metadata, chapter_config, id) }}{% endmacro %}
+{% macro hide_description(metadata, chapter_config, id) %}Masquer la description de la figure  {{ figure_id(metadata, chapter_config, id) }}{% endmacro %}
 
 {% block written_by_before %}Écrit par{% endblock %}
 {% block reviewed_by_before %}Relu par{% endblock %}

--- a/src/templates/hi/base.html
+++ b/src/templates/hi/base.html
@@ -62,9 +62,9 @@
 {% block open %}खोलें{% endblock %}
 {% block close %}बंद करें{% endblock %}
 
-{% macro figure_text(metadata, id) %}खंड {{ figure_id(metadata, id) }}.{% endmacro %}
-{% macro show_description(metadata, id) %}खंड का विवरण देखें {{ figure_id(metadata, id) }}{% endmacro %}
-{% macro hide_description(metadata, id) %}खंड का विवरण छिपाएँ {{ figure_id(metadata, id) }}{% endmacro %}
+{% macro figure_text(metadata, chapter_config, id) %}खंड {{ figure_id(metadata, chapter_config, id) }}.{% endmacro %}
+{% macro show_description(metadata, chapter_config, id) %}खंड का विवरण देखें {{ figure_id(metadata, chapter_config, id) }}{% endmacro %}
+{% macro hide_description(metadata, chapter_config, id) %}खंड का विवरण छिपाएँ {{ figure_id(metadata, chapter_config, id) }}{% endmacro %}
 
 {% block written_by_before %}द्वारा लिखित{% endblock %}
 {% block reviewed_by_before %}द्वारा समीक्षित{% endblock %}

--- a/src/templates/it/base.html
+++ b/src/templates/it/base.html
@@ -62,9 +62,9 @@ La nostra missione è combinare le statistiche grezze e le tendenze del HTTP Arc
 {% block open %}Apri{% endblock %}
 {% block close %}Chiudi{% endblock %}
 
-{% macro figure_text(metadata, id) %}Figura {{ figure_id(metadata, id) }}.{% endmacro %}
-{% macro show_description(metadata, id) %}Mostra la descrizione della Figura {{ figure_id(metadata, id) }}{% endmacro %}
-{% macro hide_description(metadata, id) %}Nascondi la descrizione della Figura {{ figure_id(metadata, id) }}{% endmacro %}
+{% macro figure_text(metadata, chapter_config, id) %}Figura {{ figure_id(metadata, chapter_config, id) }}.{% endmacro %}
+{% macro show_description(metadata, chapter_config, id) %}Mostra la descrizione della Figura {{ figure_id(metadata, chapter_config, id) }}{% endmacro %}
+{% macro hide_description(metadata, chapter_config, id) %}Nascondi la descrizione della Figura {{ figure_id(metadata, chapter_config, id) }}{% endmacro %}
 
 {% block written_by_before %}Scritta da{% endblock %}
 {% block reviewed_by_before %}Revisionata da{% endblock %}

--- a/src/templates/ja/base.html
+++ b/src/templates/ja/base.html
@@ -62,9 +62,9 @@
 {% block open %}開く{% endblock %}
 {% block close %}閉じる{% endblock %}
 
-{% macro figure_text(metadata, id) %}図{{ figure_id(metadata, id) }}.{% endmacro %}
-{% macro show_description(metadata, id) %}図{{ figure_id(metadata, id) }}の説明を表示{% endmacro %}
-{% macro hide_description(metadata, id) %}図{{ figure_id(metadata, id) }}の説明を非表示{% endmacro %}
+{% macro figure_text(metadata, chapter_config, id) %}図{{ figure_id(metadata, chapter_config, id) }}.{% endmacro %}
+{% macro show_description(metadata, chapter_config, id) %}図{{ figure_id(metadata, chapter_config, id) }}の説明を表示{% endmacro %}
+{% macro hide_description(metadata, chapter_config, id) %}図{{ figure_id(metadata, chapter_config, id) }}の説明を非表示{% endmacro %}
 
 {% block written_by_before %}{% endblock %}
 {% block reviewed_by_before %}{% endblock %}

--- a/src/templates/nl/base.html
+++ b/src/templates/nl/base.html
@@ -62,9 +62,9 @@
 {% block open %}Open{% endblock %}
 {% block close %}Sluit{% endblock %}
 
-{% macro figure_text(metadata, id) %}Figuur {{ figure_id(metadata, id) }}.{% endmacro %}
-{% macro show_description(metadata, id) %}Toon beschrijving van Figuur {{ figure_id(metadata, id) }}{% endmacro %}
-{% macro hide_description(metadata, id) %}Verberg beschrijving van Figuur {{ figure_id(metadata, id) }}{% endmacro %}
+{% macro figure_text(metadata, chapter_config, id) %}Figuur {{ figure_id(metadata, chapter_config, id) }}.{% endmacro %}
+{% macro show_description(metadata, chapter_config, id) %}Toon beschrijving van Figuur {{ figure_id(metadata, chapter_config, id) }}{% endmacro %}
+{% macro hide_description(metadata, chapter_config, id) %}Verberg beschrijving van Figuur {{ figure_id(metadata, chapter_config, id) }}{% endmacro %}
 
 {% block written_by_before %}Geschreven door{% endblock %}
 {% block reviewed_by_before %}Beoordeeld door{% endblock %}

--- a/src/templates/pt/base.html
+++ b/src/templates/pt/base.html
@@ -62,9 +62,9 @@ Nossa missão é combinar as estatísticas brutas e as tendências do HTTP Archi
 {% block open %}Abrir{% endblock %}
 {% block close %}Fechar{% endblock %}
 
-{% macro figure_text(metadata, id) %}Figura {{ figure_id(metadata, id) }}.{% endmacro %}
-{% macro show_description(metadata, id) %}Mostrar descrição da figura {{ figure_id(metadata, id) }}{% endmacro %}
-{% macro hide_description(metadata, id) %}Ocultar descrição da figura {{ figure_id(metadata, id) }}{% endmacro %}
+{% macro figure_text(metadata, chapter_config, id) %}Figura {{ figure_id(metadata, chapter_config, id) }}.{% endmacro %}
+{% macro show_description(metadata, chapter_config, id) %}Mostrar descrição da figura {{ figure_id(metadata, chapter_config, id) }}{% endmacro %}
+{% macro hide_description(metadata, chapter_config, id) %}Ocultar descrição da figura {{ figure_id(metadata, chapter_config, id) }}{% endmacro %}
 
 {% block written_by_before %}Escrito por{% endblock %}
 {% block reviewed_by_before %}Revisado por{% endblock %}

--- a/src/templates/ru/base.html
+++ b/src/templates/ru/base.html
@@ -62,9 +62,9 @@
 {% block open %}Открыть{% endblock %}
 {% block close %}Закрыть{% endblock %}
 
-{% macro figure_text(metadata, id) %}График {{ figure_id(metadata, id) }}.{% endmacro %}
-{% macro show_description(metadata, id) %}Показать описание графика {{ figure_id(metadata, id) }}{% endmacro %}
-{% macro hide_description(metadata, id) %}Скрыть описание графика {{ figure_id(metadata, id) }}{% endmacro %}
+{% macro figure_text(metadata, chapter_config, id) %}График {{ figure_id(metadata, chapter_config, id) }}.{% endmacro %}
+{% macro show_description(metadata, chapter_config, id) %}Показать описание графика {{ figure_id(metadata, chapter_config, id) }}{% endmacro %}
+{% macro hide_description(metadata, chapter_config, id) %}Скрыть описание графика {{ figure_id(metadata, chapter_config, id) }}{% endmacro %}
 
 {% block written_by_before %}Авторы:{% endblock %}
 {% block reviewed_by_before %}Редакторы:{% endblock %}

--- a/src/templates/uk/base.html
+++ b/src/templates/uk/base.html
@@ -62,9 +62,9 @@
 {% block open %}Відкрити{% endblock %}
 {% block close %}Закрити{% endblock %}
 
-{% macro figure_text(metadata, id) %}Рис. {{ figure_id(metadata, id) }}.{% endmacro %}
-{% macro show_description(metadata, id) %}Показати пояснення до рис. {{ figure_id(metadata, id) }}{% endmacro %}
-{% macro hide_description(metadata, id) %}Сховати пояснення до рис. {{ figure_id(metadata, id) }}{% endmacro %}
+{% macro figure_text(metadata, chapter_config, id) %}Рис. {{ figure_id(metadata, chapter_config, id) }}.{% endmacro %}
+{% macro show_description(metadata, chapter_config, id) %}Показати пояснення до рис. {{ figure_id(metadata, chapter_config, id) }}{% endmacro %}
+{% macro hide_description(metadata, chapter_config, id) %}Сховати пояснення до рис. {{ figure_id(metadata, chapter_config, id) }}{% endmacro %}
 
 {% block written_by_before %}Автори: {% endblock %}
 {% block reviewed_by_before %}Рецензенти: {% endblock %}

--- a/src/templates/zh-CN/base.html
+++ b/src/templates/zh-CN/base.html
@@ -62,9 +62,9 @@
 {% block open %}打开{% endblock %}
 {% block close %}关闭{% endblock %}
 
-{% macro figure_text(metadata, id) %}图 {{ figure_id(metadata, id) }}.{% endmacro %}
-{% macro show_description(metadata, id) %}显示图像描述 {{ figure_id(metadata, id) }}{% endmacro %}
-{% macro hide_description(metadata, id) %}隐藏图像描述 {{ figure_id(metadata, id) }}{% endmacro %}
+{% macro figure_text(metadata, chapter_config, id) %}图 {{ figure_id(metadata, chapter_config, id) }}.{% endmacro %}
+{% macro show_description(metadata, chapter_config, id) %}显示图像描述 {{ figure_id(metadata, chapter_config, id) }}{% endmacro %}
+{% macro hide_description(metadata, chapter_config, id) %}隐藏图像描述 {{ figure_id(metadata, chapter_config, id) }}{% endmacro %}
 
 {% block written_by_before %}作者： {% endblock %}
 {% block reviewed_by_before %}审稿者： {% endblock %}

--- a/src/templates/zh-TW/base.html
+++ b/src/templates/zh-TW/base.html
@@ -62,9 +62,9 @@
 {% block open %}開啟{% endblock %}
 {% block close %}關閉{% endblock %}
 
-{% macro figure_text(metadata, id) %}圖表 {{ figure_id(metadata, id) }}.{% endmacro %}
-{% macro show_description(metadata, id) %}顯示圖表說明 {{ figure_id(metadata, id) }}{% endmacro %}
-{% macro hide_description(metadata, id) %}隱藏圖表說明 {{ figure_id(metadata, id) }}{% endmacro %}
+{% macro figure_text(metadata, chapter_config, id) %}圖表 {{ figure_id(metadata, chapter_config, id) }}.{% endmacro %}
+{% macro show_description(metadata, chapter_config, id) %}顯示圖表說明 {{ figure_id(metadata, chapter_config, id) }}{% endmacro %}
+{% macro hide_description(metadata, chapter_config, id) %}隱藏圖表說明 {{ figure_id(metadata, chapter_config, id) }}{% endmacro %}
 
 {% block written_by_before %}作者：{% endblock %}
 {% block reviewed_by_before %}審稿者：{% endblock %}

--- a/src/tools/generate/generate_figure_ids.js
+++ b/src/tools/generate/generate_figure_ids.js
@@ -4,7 +4,7 @@ const generate_figure_ids = (html) => {
 
   // Add metadata and _figid_ placeholders to figure_markups
   let re = /figure_markup\s*\(/g;
-  html = html.replace(re, () => 'figure_markup(metadata=metadata, id=_figid_, ');
+  html = html.replace(re, () => 'figure_markup(metadata=metadata, chapter_config=chapter_config, id=_figid_, ');
 
   // Add handle tables which don't use figure_markups
   // Need to add id in <figure> element at top of table
@@ -13,7 +13,7 @@ const generate_figure_ids = (html) => {
   re = /<figure>|<figure markdown>|<figure data-markdown="1">/gi;
   html = html.replace(re, () => '<figure id="fig-_figid_">');
   re = /figure_link\s*\(/g;
-  html = html.replace(re, () => 'figure_link(metadata=metadata, id=_figidn_, ');
+  html = html.replace(re, () => 'figure_link(metadata=metadata, chapter_config=chapter_config, id=_figidn_, ');
 
   // replace _figid_ with i and increment
   // replace _figidn_ with i and do not increment


### PR DESCRIPTION
Last release introduced a bug in two places in the figure labels:

![Missing chapter number on figure labels](https://user-images.githubusercontent.com/10931297/106366543-79edaa00-6334-11eb-9f3d-eb7b5a10e8c1.png)

