### PR TITLE
Consolidate home page methodology text

### DIFF
--- a/src/templates/en/2019/base.html
+++ b/src/templates/en/2019/base.html
@@ -2,9 +2,8 @@
 
 {% block methodology_stat_1 %}5.8M{% endblock %}
 {% block methodology_stat_2 %}20.9 TB{% endblock %}
-{% block methodology_description %}
-Unless otherwise noted, the metrics in all of the 20 chapters of the Web Almanac are sourced from the HTTP Archive dataset. HTTP Archive is a community-run project that has been tracking how the web is built since 2010. Using WebPageTest and Lighthouse under the hood, metadata about nearly 6 million websites are tested monthly and included in a public BigQuery database for analysis. The July 2019 dataset was used as the basis for the Web Almanac&#8217;s metrics. For more information, see the Methodology page.
-{% endblock %}
+{% block total_websites %}nearly 6 million{% endblock %}
+{% block dataset %}July 2019{% endblock %}
 
 {% block foreword %}
   <p>

--- a/src/templates/en/2020/base.html
+++ b/src/templates/en/2020/base.html
@@ -2,10 +2,8 @@
 
 {% block methodology_stat_1 %}7.5M{% endblock %}
 {% block methodology_stat_2 %}31.3 TB{% endblock %}
-{% block methodology_description %}
-Unless otherwise noted, the metrics in all of the 22 chapters of the Web Almanac are sourced from the HTTP Archive dataset. HTTP Archive is a community-run project that has been tracking how the web is built since 2010. Using WebPageTest and Lighthouse under the hood, metadata about over 7.5 million websites are tested monthly and included in a public BigQuery database for analysis. The August 2020 dataset was used as the basis for the Web Almanac&#8217;s metrics. For more information, see the Methodology page.
-{% endblock %}
-
+{% block total_websites %}over 7.5 million{% endblock %}
+{% block dataset %}August 2020{% endblock %}
 
 {% block foreword %}
   <p>

--- a/src/templates/en/base.html
+++ b/src/templates/en/base.html
@@ -116,6 +116,9 @@ The Web Almanac has been made possible by the hard work of the web community. {{
 {% block methodology_stat_1_title %}Websites Tested{% endblock %}
 {% block methodology_stat_2_title %}Data Processed{% endblock %}
 {% block methodology_link %}Learn about our Methodology{% endblock %}
+{% block methodology_description %}
+Unless otherwise noted, the metrics in all of the {{ supported_chapters | length }} chapters of the Web Almanac are sourced from the HTTP Archive dataset. HTTP Archive is a community-run project that has been tracking how the web is built since 2010. Using WebPageTest and Lighthouse under the hood, metadata about {{ self.total_websites() }} websites are tested monthly and included in a public BigQuery database for analysis. The {{ self.dataset() }} dataset was used as the basis for the Web Almanac&#8217;s metrics. For more information, see the Methodology page.
+{% endblock %}
 
 {% block introduction %}Introduction{% endblock %}
 

--- a/src/templates/es/2019/base.html
+++ b/src/templates/es/2019/base.html
@@ -2,9 +2,8 @@
 
 {% block methodology_stat_1 %}5,8M{% endblock %}
 {% block methodology_stat_2 %}20,9 TB{% endblock %}
-{% block methodology_description %}
-A menos que se indique lo contrario, las métricas en los 20 capítulos del Web Almanac provienen del conjunto de datos del HTTP Archive. HTTP Archive es un proyecto administrado por la comunidad que ha estado rastreando cómo se construye la web desde 2010. Utilizando WebPageTest y Lighthouse bajo el capó, se prueban metadatos de aproximadamente 6 millones de sitios web mensualmente y se incluyen en una base de datos pública de BigQuery para su análisis. El conjunto de datos de Julio de 2019 se utilizó como base para las métricas de Web Almanac. Para obtener más información, consulte la página de Metodología.
-{% endblock %}
+{% block total_websites %}aproximadamente 6 millones{% endblock %}
+{% block dataset %}Julio de 2019{% endblock %}
 
 {% block foreword %}
   <p>

--- a/src/templates/es/2020/base.html
+++ b/src/templates/es/2020/base.html
@@ -2,9 +2,8 @@
 
 {% block methodology_stat_1 %}7,5M{% endblock %}
 {% block methodology_stat_2 %}31,3 TB{% endblock %}
-{% block methodology_description %}
-A menos que se indique lo contrario, las métricas en los 22 capítulos del Web Almanac provienen del conjunto de datos del HTTP Archive. HTTP Archive es un proyecto administrado por la comunidad que ha estado rastreando cómo se construye la web desde 2010. Utilizando WebPageTest y Lighthouse bajo el capó, se prueban metadatos de más de 7.5 millones de sitios web mensualmente y se incluyen en una base de datos pública de BigQuery para su análisis. El conjunto de datos de Agosto de 2020 se utilizó como base para las métricas de Web Almanac. Para obtener más información, consulte la página de Metodología.
-{% endblock %}
+{% block total_websites %}más de 7.5 millones{% endblock %}
+{% block dataset %}Agosto de 2020{% endblock %}
 
 {% block foreword %}
 {# TODO - Write this! #}

--- a/src/templates/es/base.html
+++ b/src/templates/es/base.html
@@ -116,6 +116,9 @@ Web Almanac ha sido posible gracias al arduo trabajo de la comunidad web. {{ sel
 {% block methodology_stat_1_title %}Sitios web analizados{% endblock %}
 {% block methodology_stat_2_title %}Información procesada{% endblock %}
 {% block methodology_link %}Conozca nuestra Metodología{% endblock %}
+{% block methodology_description %}
+A menos que se indique lo contrario, las métricas en los {{ supported_chapters | length }} capítulos del Web Almanac provienen del conjunto de datos del HTTP Archive. HTTP Archive es un proyecto administrado por la comunidad que ha estado rastreando cómo se construye la web desde 2010. Utilizando WebPageTest y Lighthouse bajo el capó, se prueban metadatos de {{ self.total_websites() }} de sitios web mensualmente y se incluyen en una base de datos pública de BigQuery para su análisis. El conjunto de datos de {{ self.dataset() }} se utilizó como base para las métricas de Web Almanac. Para obtener más información, consulte la página de Metodología.
+{% endblock %}
 
 {% block introduction %}Introducción{% endblock %}
 

--- a/src/templates/fr/2019/base.html
+++ b/src/templates/fr/2019/base.html
@@ -2,9 +2,8 @@
 
 {% block methodology_stat_1 %}5,8&nbsp;M{% endblock %}
 {% block methodology_stat_2 %}20,9&nbsp;To{% endblock %}
-{% block methodology_description %}
-Sauf indication contraire, les statistiques des 20 chapitres du Web Almanac proviennent du jeu de données HTTP Archive, un projet communautaire qui suit l’évolution de la construction du web depuis 2010. Grâce à WebPageTest et Lighthouse, HTTP Archive collecte chaque mois les métadonnées de près de 6 millions de sites Web et les insère dans une base de données publique BigQuery pour les analyser. Le jeu de données de juillet 2019 a servi de base aux mesures du Web Almanac. Pour plus d’informations, consultez la page Méthodologie.
-{% endblock %}
+{% block total_websites %}près de 6 millions{% endblock %}
+{% block dataset %}juillet 2019{% endblock %}
 
 {% block foreword %}
   <p>

--- a/src/templates/fr/2020/base.html
+++ b/src/templates/fr/2020/base.html
@@ -2,26 +2,25 @@
 
 {% block methodology_stat_1 %}7,5&nbsp;M{% endblock %}
 {% block methodology_stat_2 %}31,3&nbsp;To{% endblock %}
-{% block methodology_description %}
-Sauf indication contraire, les statistiques des 22 chapitres du Web Almanac proviennent du jeu de données HTTP Archive, un projet communautaire qui suit l’évolution de la construction du web depuis 2010. Grâce à WebPageTest et Lighthouse, HTTP Archive collecte chaque mois les métadonnées de plus de 7,5 millions de sites Web et les insère dans une base de données publique BigQuery pour les analyser. Le jeu de données de août 2020 a servi de base aux mesures du Web Almanac. Pour plus d’informations, consultez la page Méthodologie.
-{% endblock %}
+{% block total_websites %}plus de 7,5 millions{% endblock %}
+{% block dataset %}août 2020{% endblock %}
 
 {% block foreword %}
-<p>
-  2020 a été une année que beaucoup d’entre nous aimeraient oublier. Il est rare qu’une communauté aussi mondialisée que la nôtre soit touchée par des événements aussi importants que la pandémie COVID-19 et les protestations contre l’injustice raciale. Ces événements nous ont presque découragés de relancer le projet cette année – avec autant de personnes physiquement et émotionnellement épuisées, comment pourrions-nous attendre d’une personne qu’elle <em>veuille</em> contribuer, et encore moins qu’elle ait le temps et l’énergie de le faire ? Nous avons avancé en douceur, en espérant qu’il y avait encore de l’intérêt pour la communauté.
-</p>
+  <p>
+    2020 a été une année que beaucoup d’entre nous aimeraient oublier. Il est rare qu’une communauté aussi mondialisée que la nôtre soit touchée par des événements aussi importants que la pandémie COVID-19 et les protestations contre l’injustice raciale. Ces événements nous ont presque découragés de relancer le projet cette année – avec autant de personnes physiquement et émotionnellement épuisées, comment pourrions-nous attendre d’une personne qu’elle <em>veuille</em> contribuer, et encore moins qu’elle ait le temps et l’énergie de le faire ? Nous avons avancé en douceur, en espérant qu’il y avait encore de l’intérêt pour la communauté.
+  </p>
 
-<p>
-  L’objectif de cette édition du Web Almanac n’est pas d’oublier l’année 2020, mais de la commémorer. Pour le meilleur ou pour le pire, c’est un chapitre de notre histoire. Malgré toutes les pressions extérieures de cette année, <em>plus d’une centaine de <a href="./contributors">contributeurs et contributrices</a></em> de la communauté web se sont inscrits et ont donné d’innombrables heures de leur temps pour un projet consacré à la mémoire de 2020 et à l’état du web. Étonnamment, nous avons en fait réussi à <em> élargir</em> la portée de l’édition de cette année en ajoutant trois nouveaux chapitres et en n’en perdant qu’un.
-</p>
+  <p>
+    L’objectif de cette édition du Web Almanac n’est pas d’oublier l’année 2020, mais de la commémorer. Pour le meilleur ou pour le pire, c’est un chapitre de notre histoire. Malgré toutes les pressions extérieures de cette année, <em>plus d’une centaine de <a href="./contributors">contributeurs et contributrices</a></em> de la communauté web se sont inscrits et ont donné d’innombrables heures de leur temps pour un projet consacré à la mémoire de 2020 et à l’état du web. Étonnamment, nous avons en fait réussi à <em> élargir</em> la portée de l’édition de cette année en ajoutant trois nouveaux chapitres et en n’en perdant qu’un.
+  </p>
 
-<p>
-  Chaque fois que je demande aux personnes ayant contribué ce qu’elles apprécient le plus dans le projet, la réponse concerne presque toujours les gens. Nous travaillons en équipe, nous nous soutenons mutuellement et, en cinq mois seulement, nous sommes capables de construire l’équivalent d’un livre de de 600 pages ! C’est un énorme défi, et bien que nous n’ayons pas résolu les problèmes du monde, nous avons montré ce qui est possible lorsque les gens choisissent de travailler ensemble.
-</p>
+  <p>
+    Chaque fois que je demande aux personnes ayant contribué ce qu’elles apprécient le plus dans le projet, la réponse concerne presque toujours les gens. Nous travaillons en équipe, nous nous soutenons mutuellement et, en cinq mois seulement, nous sommes capables de construire l’équivalent d’un livre de de 600 pages ! C’est un énorme défi, et bien que nous n’ayons pas résolu les problèmes du monde, nous avons montré ce qui est possible lorsque les gens choisissent de travailler ensemble.
+  </p>
 
-<p>
-  Je vous prie d’apprécier le Web Almanac 2020, le point culminant de notre travail d’amour pour le web. N’hésitez pas à <a href="https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/CONTRIBUTING.md">nous contacter</a> si vous souhaitez rejoindre l’équipe.
-</p>
+  <p>
+    Je vous prie d’apprécier le Web Almanac 2020, le point culminant de notre travail d’amour pour le web. N’hésitez pas à <a href="https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/CONTRIBUTING.md">nous contacter</a> si vous souhaitez rejoindre l’équipe.
+  </p>
 
-<p>— <em><a href="{{ url_for('contributors', year=year, lang=lang, _anchor='rviscomi') }}">Rick Viscomi</a>, Rédacteur en chef du Web Almanac</em></p>
+  <p>— <em><a href="{{ url_for('contributors', year=year, lang=lang, _anchor='rviscomi') }}">Rick Viscomi</a>, Rédacteur en chef du Web Almanac</em></p>
 {% endblock %}

--- a/src/templates/fr/base.html
+++ b/src/templates/fr/base.html
@@ -116,6 +116,9 @@ Le Web Almanac a été rendu possible grâce au travail acharné de la communaut
 {% block methodology_stat_1_title %}Sites Web testés{% endblock %}
 {% block methodology_stat_2_title %}Données traitées{% endblock %}
 {% block methodology_link %}En savoir plus sur la Méthodologie{% endblock %}
+{% block methodology_description %}
+Sauf indication contraire, les statistiques des {{ supported_chapters | length }} chapitres du Web Almanac proviennent du jeu de données HTTP Archive, un projet communautaire qui suit l’évolution de la construction du web depuis 2010. Grâce à WebPageTest et Lighthouse, HTTP Archive collecte chaque mois les métadonnées de {{ self.total_websites() }} de sites Web et les insère dans une base de données publique BigQuery pour les analyser. Le jeu de données de {{ self.dataset() }} a servi de base aux mesures du Web Almanac. Pour plus d’informations, consultez la page Méthodologie.
+{% endblock %}
 
 {% block introduction %}Introduction{% endblock %}
 

--- a/src/templates/hi/2019/base.html
+++ b/src/templates/hi/2019/base.html
@@ -2,9 +2,8 @@
 
 {% block methodology_stat_1 %}5.8M{% endblock %}
 {% block methodology_stat_2 %}20.9 TB{% endblock %}
-{% block methodology_description %}
-जब तक अन्यथा नोट न किया जाए, Web Almanac के सभी 20 अध्यायों में मौजूद मेट्रिक्स HTTP Archive के स्रोतों से लिये जाते हैं। HTTP Archive एक समुदाय द्वारा संचालित परियोजना है, जो 2010 के बाद से वेब कैसे बनाया जा रहा है इस पर निगाह रखें हुए हैं। WebPageTest और Lighthouse का अति उत्कृष्ट उपयोग करते हुए, लगभग 6 मिलियन वेबसाइटों के बारे में मेटाडेटा को मासिक रूप से परीक्षण किया जाता है और विश्लेषण के लिए एक सार्वजनिक BigQuery डेटाबेस में शामिल किया जाता है। जुलाई 2019 डेटासेट का उपयोग Web Almanac के मैट्रिक्स के आधार के रूप में किया गया था। अधिक जानकारी के लिए, कार्यप्रणाली पृष्ठ देखें।
-{% endblock %}
+{% block total_websites %}लगभग 6 मिलियन{% endblock %}
+{% block dataset %}जुलाई 2019{% endblock %}
 
 {% block foreword %}
   <p>

--- a/src/templates/hi/2020/base.html
+++ b/src/templates/hi/2020/base.html
@@ -2,9 +2,8 @@
 
 {% block methodology_stat_1 %}7.5M{% endblock %}
 {% block methodology_stat_2 %}31.3 TB{% endblock %}
-{% block methodology_description %}
-जब तक अन्यथा नोट न किया जाए, Web Almanac के सभी 22 अध्यायों में मौजूद मेट्रिक्स HTTP Archive के स्रोतों से लिये जाते हैं। HTTP Archive एक समुदाय द्वारा संचालित परियोजना है, जो 2010 के बाद से वेब कैसे बनाया जा रहा है इस पर निगाह रखें हुए हैं। WebPageTest और Lighthouse का अति उत्कृष्ट उपयोग करते हुए, 7.5 मिलियन से अधिक वेबसाइटों के बारे में मेटाडेटा को मासिक रूप से परीक्षण किया जाता है और विश्लेषण के लिए एक सार्वजनिक BigQuery डेटाबेस में शामिल किया जाता है। अगस्त 2020 डेटासेट का उपयोग Web Almanac के मैट्रिक्स के आधार के रूप में किया गया था। अधिक जानकारी के लिए, कार्यप्रणाली पृष्ठ देखें।
-{% endblock %}
+{% block total_websites %}7.5 मिलियन से अधिक{% endblock %}
+{% block dataset %}अगस्त 2020{% endblock %}
 
 {% block foreword %}
 {# TODO - Write this! #}

--- a/src/templates/hi/base.html
+++ b/src/templates/hi/base.html
@@ -116,7 +116,9 @@ Web Almanac वेब समुदाय की मेहनत से संभ
 {% block methodology_stat_1_title %}वेबसाइटों का परीक्षण किया गया{% endblock %}
 {% block methodology_stat_2_title %}डेटा संसाधित किया गया{% endblock %}
 {% block methodology_link %}हमारी कार्यप्रणाली के बारे में जानें{% endblock %}
-
+{% block methodology_description %}
+जब तक अन्यथा नोट न किया जाए, Web Almanac के सभी {{ supported_chapters | length }} अध्यायों में मौजूद मेट्रिक्स HTTP Archive के स्रोतों से लिये जाते हैं। HTTP Archive एक समुदाय द्वारा संचालित परियोजना है, जो 2010 के बाद से वेब कैसे बनाया जा रहा है इस पर निगाह रखें हुए हैं। WebPageTest और Lighthouse का अति उत्कृष्ट उपयोग करते हुए, {{ self.total_websites() }} वेबसाइटों के बारे में मेटाडेटा को मासिक रूप से परीक्षण किया जाता है और विश्लेषण के लिए एक सार्वजनिक BigQuery डेटाबेस में शामिल किया जाता है। {{ self.dataset() }} डेटासेट का उपयोग Web Almanac के मैट्रिक्स के आधार के रूप में किया गया था। अधिक जानकारी के लिए, कार्यप्रणाली पृष्ठ देखें।
+{% endblock %}
 {% block introduction %}परिचय{% endblock %}
 
 {% block foreword_title %}प्रस्तावना{% endblock %}

--- a/src/templates/it/2019/base.html
+++ b/src/templates/it/2019/base.html
@@ -2,10 +2,8 @@
 
 {% block methodology_stat_1 %}5.8M{% endblock %}
 {% block methodology_stat_2 %}20.9 TB{% endblock %}
-{% block methodology_description %}
-Se non diversamente specificato, le metriche in tutti i 20 capitoli del Web Almanac provengono dal dataset dell'archivio HTTP. HTTP Archive è un progetto gestito dalla comunità che tiene traccia del modo in cui è costruito il Web dal 2010. Utilizzando WebPageTest e Lighthouse "under the hood", i metadati di quasi 6 milioni di siti Web vengono testati mensilmente e inclusi in un database BigQuery pubblico per l'analisi. Il set di dati di luglio 2020 è stato utilizzato come base per le metriche del Web Almanac. Per ulteriori informazioni, vedere la pagina Methodology.
-{% endblock %}
-
+{% block total_websites %}quasi 6 milioni{% endblock %}
+{% block dataset %}luglio 2020{% endblock %}
 
 {% block foreword %}
   <p>

--- a/src/templates/it/2020/base.html
+++ b/src/templates/it/2020/base.html
@@ -2,10 +2,8 @@
 
 {% block methodology_stat_1 %}7.5M{% endblock %}
 {% block methodology_stat_2 %}31.3 TB{% endblock %}
-{% block methodology_description %}
-Se non diversamente specificato, le metriche in tutti i 22 capitoli del Web Almanac provengono dal dataset dell'archivio HTTP. HTTP Archive è un progetto gestito dalla comunità che tiene traccia del modo in cui è costruito il Web dal 2010. Utilizzando WebPageTest e Lighthouse "under the hood", i metadati di oltre 7,5 milioni di siti Web vengono testati mensilmente e inclusi in un database BigQuery pubblico per l'analisi. Il set di dati di agosto 2020 è stato utilizzato come base per le metriche del Web Almanac. Per ulteriori informazioni, vedere la pagina Methodology.
-{% endblock %}
-
+{% block total_websites %}oltre 7,5 milioni{% endblock %}
+{% block dataset %}agosto 2020{% endblock %}
 
 {% block foreword %}
   <p>

--- a/src/templates/it/base.html
+++ b/src/templates/it/base.html
@@ -116,6 +116,9 @@ Il Web Almanac è stato reso possibile grazie al duro lavoro della web community
 {% block methodology_stat_1_title %}Siti web testati{% endblock %}
 {% block methodology_stat_2_title %}Dati trattati{% endblock %}
 {% block methodology_link %}Scopri la nostra metodologia{% endblock %}
+{% block methodology_description %}
+Se non diversamente specificato, le metriche in tutti i {{ supported_chapters | length }} capitoli del Web Almanac provengono dal dataset dell'archivio HTTP. HTTP Archive è un progetto gestito dalla comunità che tiene traccia del modo in cui è costruito il Web dal 2010. Utilizzando WebPageTest e Lighthouse "under the hood", i metadati di {{ self.total_websites() }} di siti Web vengono testati mensilmente e inclusi in un database BigQuery pubblico per l'analisi. Il set di dati di {{ self.dataset() }} è stato utilizzato come base per le metriche del Web Almanac. Per ulteriori informazioni, vedere la pagina Methodology.
+{% endblock %}
 
 {% block introduction %}Introduzione{% endblock %}
 

--- a/src/templates/ja/2019/base.html
+++ b/src/templates/ja/2019/base.html
@@ -2,9 +2,8 @@
 
 {% block methodology_stat_1 %}5.8M{% endblock %}
 {% block methodology_stat_2 %}20.9 TB{% endblock %}
-{% block methodology_description %}
-特に断りのない限り、Web Almanacの20章すべてのメトリクスは、HTTP Archiveのデータセットから取得しています。HTTP Archiveは、2010年以来、ウェブの構築方法を追跡してきたコミュニティが運営するプロジェクトです。WebPageTestとLighthouseをアンダーグラウンドに使用して、約600万のWebサイトに関するメタデータが毎月テストされ、分析のために公開されているBigQueryデータベースに含まれています。2019年7月のデータセットは、Web Almanacのメトリクスの基礎として使用されました。詳細については、方法論のページを参照してください。
-{% endblock %}
+{% block total_websites %}約600万の{% endblock %}
+{% block dataset %}2019年7{% endblock %}
 
 {% block foreword %}
   <p>

--- a/src/templates/ja/2020/base.html
+++ b/src/templates/ja/2020/base.html
@@ -2,9 +2,8 @@
 
 {% block methodology_stat_1 %}7.5M{% endblock %}
 {% block methodology_stat_2 %}31.3 TB{% endblock %}
-{% block methodology_description %}
-特に断りのない限り、Web Almanacの22章すべてのメトリクスは、HTTP Archiveのデータセットから取得しています。HTTP Archiveは、2010年以来、ウェブの構築方法を追跡してきたコミュニティが運営するプロジェクトです。WebPageTestとLighthouseをアンダーグラウンドに使用して、約750万のWebサイトに関するメタデータが毎月テストされ、分析のために公開されているBigQueryデータベースに含まれています。2020年8月のデータセットは、Web Almanacのメトリクスの基礎として使用されました。詳細については、方法論のページを参照してください。
-{% endblock %}
+{% block total_websites %}約750万の{% endblock %}
+{% block dataset %}2020年8{% endblock %}
 
 {% block foreword %}
 {# TODO - Write this! #}

--- a/src/templates/ja/base.html
+++ b/src/templates/ja/base.html
@@ -115,6 +115,9 @@ Web Almanacは、ウェブ・コミュニティの努力によって実現して
 {% block methodology_stat_1_title %}テストしたウェブサイト{% endblock %}
 {% block methodology_stat_2_title %}処理されたデータ{% endblock %}
 {% block methodology_link %}方法論についてはこちらをご覧ください。{% endblock %}
+{% block methodology_description %}
+特に断りのない限り、Web Almanacの{{ supported_chapters | length }}章すべてのメトリクスは、HTTP Archiveのデータセットから取得しています。HTTP Archiveは、2010年以来、ウェブの構築方法を追跡してきたコミュニティが運営するプロジェクトです。WebPageTestとLighthouseをアンダーグラウンドに使用して、{{ self.total_websites() }}Webサイトに関するメタデータが毎月テストされ、分析のために公開されているBigQueryデータベースに含まれています。{{ self.dataset() }}月のデータセットは、Web Almanacのメトリクスの基礎として使用されました。詳細については、方法論のページを参照してください。
+{% endblock %}
 
 {% block introduction %}導入{% endblock %}
 

--- a/src/templates/nl/2019/base.html
+++ b/src/templates/nl/2019/base.html
@@ -2,9 +2,8 @@
 
 {% block methodology_stat_1 %}5.8M{% endblock %}
 {% block methodology_stat_2 %}20.9 TB{% endblock %}
-{% block methodology_description %}
-Tenzij anders vermeld, zijn de statistieken in alle 20 hoofdstukken van de Web Almanac afkomstig uit de HTTP Archive-dataset. HTTP Archive is een door de gemeenschap gerund project dat sinds 2010 bijhoudt hoe het web is opgebouwd. Met behulp van WebPageTest en Lighthouse onder de motorkap worden maandelijks metagegevens over bijna 6 miljoen websites getest en voor analyse opgenomen in een openbare BigQuery-database. De dataset van juli 2019 werd gebruikt als basis voor de statistieken van de Web Almanac. Zie de Methodologie-pagina voor meer informatie.
-{% endblock %}
+{% block total_websites %}bijna 6 miljoen{% endblock %}
+{% block dataset %}juli 2019{% endblock %}
 
 {% block foreword %}
   <p>

--- a/src/templates/nl/2020/base.html
+++ b/src/templates/nl/2020/base.html
@@ -2,10 +2,8 @@
 
 {% block methodology_stat_1 %}7.5M{% endblock %}
 {% block methodology_stat_2 %}31.3 TB{% endblock %}
-{% block methodology_description %}
-Tenzij anders vermeld, zijn de statistieken in alle 22 hoofdstukken van de Web Almanac afkomstig uit de HTTP Archive-dataset. HTTP Archive is een door de gemeenschap gerund project dat sinds 2010 bijhoudt hoe het web is opgebouwd. Met WebPageTest en Lighthouse onder de motorkap worden maandelijks metagegevens over meer dan 7,5 miljoen websites getest en voor analyse opgenomen in een openbare BigQuery-database. De gegevensset van augustus 2020 werd gebruikt als basis voor de statistieken van de Web Almanac. Zie de Methodologie-pagina voor meer informatie.
-{% endblock %}
-
+{% block total_websites %}meer dan 7,5 miljoen{% endblock %}
+{% block dataset %}augustus 2020{% endblock %}
 
 {% block foreword %}
   <p>

--- a/src/templates/nl/base.html
+++ b/src/templates/nl/base.html
@@ -116,6 +116,9 @@ De Web Almanac is mogelijk gemaakt door het harde werk van de webgemeenschap. {{
 {% block methodology_stat_1_title %}Websites Getest{% endblock %}
 {% block methodology_stat_2_title %}Verwerkte Gegevens{% endblock %}
 {% block methodology_link %}Lees meer over onze Methodologie{% endblock %}
+{% block methodology_description %}
+Tenzij anders vermeld, zijn de statistieken in alle {{ supported_chapters | length }} hoofdstukken van de Web Almanac afkomstig uit de HTTP Archive-dataset. HTTP Archive is een door de gemeenschap gerund project dat sinds 2010 bijhoudt hoe het web is opgebouwd. Met WebPageTest en Lighthouse onder de motorkap worden maandelijks metagegevens over {{ self.total_websites() }} websites getest en voor analyse opgenomen in een openbare BigQuery-database. De gegevensset van {{ self.dataset() }} werd gebruikt als basis voor de statistieken van de Web Almanac. Zie de Methodologie-pagina voor meer informatie.
+{% endblock %}
 
 {% block introduction %}Introductie{% endblock %}
 

--- a/src/templates/pt/2019/base.html
+++ b/src/templates/pt/2019/base.html
@@ -2,9 +2,8 @@
 
 {% block methodology_stat_1 %}5.8M{% endblock %}
 {% block methodology_stat_2 %}20.9 TB{% endblock %}
-{% block methodology_description %}
-Salvo indicação em contrário, as métricas em todos os 20 capítulos do Web Almanac são originárias do conjunto de dados do HTTP Archive. O HTTP Archive é um projeto administrado pela comunidade que acompanha como a Web é criada desde 2010. Usando o WebPageTest e o Lighthouse, os metadados de cerca de 6 milhões de sites são testados mensalmente e incluídos em um banco de dados público do BigQuery para análise. O conjunto de dados de julho de 2019 foi usado como base para as métricas do Web Almanac. Para mais informações, consulte a página Metodologia.
-{% endblock %}
+{% block total_websites %}cerca de 6 milhões{% endblock %}
+{% block dataset %}julho de 2019{% endblock %}
 
 {% block foreword %}
   <p>

--- a/src/templates/pt/2020/base.html
+++ b/src/templates/pt/2020/base.html
@@ -2,9 +2,8 @@
 
 {% block methodology_stat_1 %}7.5M{% endblock %}
 {% block methodology_stat_2 %}31.3 TB{% endblock %}
-{% block methodology_description %}
-Salvo indicação em contrário, as métricas em todos os 22 capítulos do Web Almanac são originárias do conjunto de dados do HTTP Archive. O HTTP Archive é um projeto administrado pela comunidade que acompanha como a Web é criada desde 2010. Usando o WebPageTest e o Lighthouse, os metadados de mais de 7.5 milhões de sites são testados mensalmente e incluídos em um banco de dados público do BigQuery para análise. O conjunto de dados de agosto de 2020 foi usado como base para as métricas do Web Almanac. Para mais informações, consulte a página Metodologia.
-{% endblock %}
+{% block total_websites %}mais de 7.5 milhões{% endblock %}
+{% block dataset %}agosto de 2020{% endblock %}
 
 {% block foreword %}
 {# TODO - Write this! #}

--- a/src/templates/pt/base.html
+++ b/src/templates/pt/base.html
@@ -116,6 +116,9 @@ O Web Almanac Isso foi possível graças ao trabalho árduo da comunidade da web
 {% block methodology_stat_1_title %}Sites testados{% endblock %}
 {% block methodology_stat_2_title %}Dados processados{% endblock %}
 {% block methodology_link %}Conheça nossa Metodologia{% endblock %}
+{% block methodology_description %}
+Salvo indicação em contrário, as métricas em todos os {{ supported_chapters | length }} capítulos do Web Almanac são originárias do conjunto de dados do HTTP Archive. O HTTP Archive é um projeto administrado pela comunidade que acompanha como a Web é criada desde 2010. Usando o WebPageTest e o Lighthouse, os metadados de {{ self.total_websites() }} de sites são testados mensalmente e incluídos em um banco de dados público do BigQuery para análise. O conjunto de dados de {{ self.dataset() }} foi usado como base para as métricas do Web Almanac. Para mais informações, consulte a página Metodologia.
+{% endblock %}
 
 {% block introduction %}Introdução{% endblock %}
 

--- a/src/templates/ru/2019/base.html
+++ b/src/templates/ru/2019/base.html
@@ -2,9 +2,8 @@
 
 {% block methodology_stat_1 %}5.8 млн{% endblock %}
 {% block methodology_stat_2 %}20.9 Тб{% endblock %}
-{% block methodology_description %}
-Если не указано иное, метрики во всех 20 главах Web Almanac получены из набора данных HTTP Archive. HTTP Archive — это управляемый сообществом проект по исследованию веба с 2010 года. При помощи WebPageTest и Lighthouse ежемесячно проверяются метаданные около 6 миллионов сайтов, которые затем вносятся в общедоступную базу данных BigQuery для последующего анализа. В качестве основы для метрик Web Almanac был использован набор данных за июль 2019 года. Дополнительную информацию смотрите на странице по методологии.
-{% endblock %}
+{% block total_websites %}около 6 миллионов{% endblock %}
+{% block dataset %}июль 2019{% endblock %}
 
 {% block foreword %}
   <p>

--- a/src/templates/ru/2020/base.html
+++ b/src/templates/ru/2020/base.html
@@ -2,9 +2,8 @@
 
 {% block methodology_stat_1 %}7.5 млн{% endblock %}
 {% block methodology_stat_2 %}31.3 Тб{% endblock %}
-{% block methodology_description %}
-Если не указано иное, метрики во всех 22 главах Web Almanac получены из набора данных HTTP Archive. HTTP Archive — это проект сообщества по исследованию развития веба, созданный в 2010 году. При помощи WebPageTest и Lighthouse ежемесячно проверяются метаданные около 7,5 миллионов сайтов, которые затем вносятся в общедоступную базу данных BigQuery для последующего анализа. В качестве основы для метрик отчёта Web Almanac был использован набор данных за август 2020 года. Дополнительную информацию смотрите на странице методологии.
-{% endblock %}
+{% block total_websites %}около 7,5 миллионов{% endblock %}
+{% block dataset %}август 2020{% endblock %}
 
 {% block foreword %}
 {# TODO - Write this! #}

--- a/src/templates/ru/base.html
+++ b/src/templates/ru/base.html
@@ -116,6 +116,9 @@
 {% block methodology_stat_1_title %}Количество проверенных сайтов{% endblock %}
 {% block methodology_stat_2_title %}Размер обработанных данных{% endblock %}
 {% block methodology_link %}Узнать подробнее про методологию{% endblock %}
+{% block methodology_description %}
+Если не указано иное, метрики во всех {{ supported_chapters | length }} главах Web Almanac получены из набора данных HTTP Archive. HTTP Archive — это управляемый сообществом проект по исследованию веба с 2010 года. При помощи WebPageTest и Lighthouse ежемесячно проверяются метаданные {{ self.total_websites() }} сайтов, которые затем вносятся в общедоступную базу данных BigQuery для последующего анализа. В качестве основы для метрик Web Almanac был использован набор данных за {{ self.dataset() }} года. Дополнительную информацию смотрите на странице по методологии.
+{% endblock %}
 
 {% block introduction %}Введение{% endblock %}
 

--- a/src/templates/uk/2019/base.html
+++ b/src/templates/uk/2019/base.html
@@ -2,9 +2,8 @@
 
 {% block methodology_stat_1 %}5,8&nbsp;млн{% endblock %}
 {% block methodology_stat_2 %}20,9&nbsp;ТБ{% endblock %}
-{% block methodology_description %}
-Якщо не вказано інше, метрики в усіх 20 розділах Web Almanac взяті з датасету HTTP Archive. HTTP Archive – це громадський проект, що відслідковує, як будується веб з 2010 року. Метадата про більш ніж 6 мільйонів веб-сайтів тестується щомісяця, використовуючи WebPageTest та Lighthouse, і додається до публічної бази даних BigQuery для аналізу. Для метрик Web Almanac був використаний як базис набір даних від липня 2019 року. Більше інформації на сторінці Методологія.
-{% endblock %}
+{% block total_websites %}майже 6 мільйонів{% endblock %}
+{% block dataset %}липня 2019{% endblock %}
 
 {% block foreword %}
   <p>

--- a/src/templates/uk/2020/base.html
+++ b/src/templates/uk/2020/base.html
@@ -2,10 +2,8 @@
 
 {% block methodology_stat_1 %}7,5&nbsp;млн{% endblock %}
 {% block methodology_stat_2 %}31,3&nbsp;ТБ{% endblock %}
-{% block methodology_description %}
-Якщо не вказано інше, метрики в усіх 22 розділах Web Almanac взяті з датасету HTTP Archive. HTTP Archive – це громадський проект, що відслідковує, як будується веб з 2010 року. Метадата про більш ніж 7,5 мільйонів вебсайтів тестується щомісяця, використовуючи WebPageTest та Lighthouse, і додається до публічної бази даних BigQuery для аналізу. Для метрик Web Almanac був використаний як базис набір даних від серпня 2020 року. Більше інформації на сторінці Методологія.
-{% endblock %}
-
+{% block total_websites %}більш ніж 7,5 мільйонів{% endblock %}
+{% block dataset %}серпня 2020{% endblock %}
 
 {% block foreword %}
   <p>

--- a/src/templates/uk/base.html
+++ b/src/templates/uk/base.html
@@ -116,6 +116,9 @@
 {% block methodology_stat_1_title %}Протестовано сайтів{% endblock %}
 {% block methodology_stat_2_title %}Оброблено даних{% endblock %}
 {% block methodology_link %}Дізнатися про нашу Методологію{% endblock %}
+{% block methodology_description %}
+Якщо не вказано інше, метрики в усіх {{ supported_chapters | length }} розділах Web Almanac взяті з датасету HTTP Archive. HTTP Archive – це громадський проект, що відслідковує, як будується веб з 2010 року. Метадата про {{ self.total_websites() }} вебсайтів тестується щомісяця, використовуючи WebPageTest та Lighthouse, і додається до публічної бази даних BigQuery для аналізу. Для метрик Web Almanac був використаний як базис набір даних від {{ self.dataset() }} року. Більше інформації на сторінці Методологія.
+{% endblock %}
 
 {% block introduction %}Вступ{% endblock %}
 

--- a/src/templates/zh-CN/2019/base.html
+++ b/src/templates/zh-CN/2019/base.html
@@ -2,9 +2,8 @@
 
 {% block methodology_stat_1 %}5.8M{% endblock %}
 {% block methodology_stat_2 %}20.9 TB{% endblock %}
-{% block methodology_description %}
-除非另有说明，在所有20章的Web Almanac网络年鉴的指标都来自HTTP Archive数据集。HTTP Archive是一个社区运行的项目，自2010年以来一直在跟踪web是如何构建的。使用WebPageTest和Lighthouse，每月测试大约600万个网站的元数据，并将其包含在一个公开的BigQuery数据库中进行分析。Web Almanac 网络年鉴使用了2019年7月的数据集作为度量的基础。有关更多信息，请参见方法论页面。
-{% endblock %}
+{% block total_websites %}大约600万个{% endblock %}
+{% block dataset %}2019年7{% endblock %}
 
 {% block foreword %}
   <p>

--- a/src/templates/zh-CN/2020/base.html
+++ b/src/templates/zh-CN/2020/base.html
@@ -2,9 +2,8 @@
 
 {% block methodology_stat_1 %}7.5M{% endblock %}
 {% block methodology_stat_2 %}31.3 TB{% endblock %}
-{% block methodology_description %}
-除非另有说明，在所有22章的Web Almanac网络年鉴的指标都来自HTTP Archive数据集。HTTP Archive是一个社区运行的项目，自2010年以来一直在跟踪web是如何构建的。使用WebPageTest和Lighthouse，每月测试超过750万个网站的元数据，并将其包含在一个公开的BigQuery数据库中进行分析。Web Almanac 网络年鉴使用了2020年8月的数据集作为度量的基础。有关更多信息，请参见方法论页面。
-{% endblock %}
+{% block total_websites %}超过750万个{% endblock %}
+{% block dataset %}2020年8{% endblock %}
 
 {% block foreword %}
 {# TODO - Write this! #}

--- a/src/templates/zh-CN/base.html
+++ b/src/templates/zh-CN/base.html
@@ -116,6 +116,9 @@
 {% block methodology_stat_1_title %}测试的站点{% endblock %}
 {% block methodology_stat_2_title %}处理的数据{% endblock %}
 {% block methodology_link %}了解方法论{% endblock %}
+{% block methodology_description %}
+除非另有说明，在所有{{ supported_chapters | length }}章的Web Almanac网络年鉴的指标都来自HTTP Archive数据集。HTTP Archive是一个社区运行的项目，自2010年以来一直在跟踪web是如何构建的。使用WebPageTest和Lighthouse，每月测试{{ self.total_websites() }}网站的元数据，并将其包含在一个公开的BigQuery数据库中进行分析。Web Almanac 网络年鉴使用了{{ self.dataset() }}月的数据集作为度量的基础。有关更多信息，请参见方法论页面。
+{% endblock %}
 
 {% block introduction %}介绍{% endblock %}
 

--- a/src/templates/zh-TW/2019/base.html
+++ b/src/templates/zh-TW/2019/base.html
@@ -2,9 +2,8 @@
 
 {% block methodology_stat_1 %}5.8 M{% endblock %}
 {% block methodology_stat_2 %}20.9 TB{% endblock %}
-{% block methodology_description %}
-除另有備註外，Web Almanac 網路年鑑20個章節的統計指標皆萃取自HTTP Archive數據集。HTTP Archive是社群推動的專案，自2010年開始持續追蹤網路如何建置，每月透過WebPageTest和Lighthouse測試將近6百萬個網站並將資料集公開置於BigQuery供眾分析。Web Almanac網路年鑑的統計指標採用2019年7月的數據集為基準，更多的資訊請參閱統計方法頁面。
-{% endblock %}
+{% block total_websites %}近6百萬{% endblock %}
+{% block dataset %}2019年7{% endblock %}
 
 {% block foreword %}
   <p>

--- a/src/templates/zh-TW/2020/base.html
+++ b/src/templates/zh-TW/2020/base.html
@@ -2,9 +2,8 @@
 
 {% block methodology_stat_1 %}7.5 M{% endblock %}
 {% block methodology_stat_2 %}31.3 TB{% endblock %}
-{% block methodology_description %}
-除另有備註外，Web Almanac 網路年鑑22個章節的統計指標皆萃取自HTTP Archive數據集。HTTP Archive是社群推動的專案，自2010年開始持續追蹤網路如何建置，每月透過WebPageTest和Lighthouse測試將近7.5百萬個網站並將資料集公開置於BigQuery供眾分析。Web Almanac網路年鑑的統計指標採用2020年8月的數據集為基準，更多的資訊請參閱統計方法頁面。
-{% endblock %}
+{% block total_websites %}超過7.5百萬{% endblock %}
+{% block dataset %}2020年8{% endblock %}
 
 {% block foreword %}
 {# TODO - Write this! #}

--- a/src/templates/zh-TW/base.html
+++ b/src/templates/zh-TW/base.html
@@ -116,6 +116,9 @@ Web Almanac 網路年鑑是被熱情的網路社群擁抱而茁壯。 {{ self.co
 {% block methodology_stat_1_title %}網站測試數{% endblock %}
 {% block methodology_stat_2_title %}數據處理數{% endblock %}
 {% block methodology_link %}瞭解統計方法{% endblock %}
+{% block methodology_description %}
+除另有備註外，Web Almanac 網路年鑑{{ supported_chapters | length }}個章節的統計指標皆萃取自HTTP Archive數據集。HTTP Archive是社群推動的專案，自2010年開始持續追蹤網路如何建置，每月透過WebPageTest和Lighthouse測試將{{ self.total_websites() }}個網站並將資料集公開置於BigQuery供眾分析。Web Almanac網路年鑑的統計指標採用{{ self.dataset() }}月的數據集為基準，更多的資訊請參閱統計方法頁面。
+{% endblock %}
 
 {% block introduction %}介紹{% endblock %}
 


### PR DESCRIPTION
The methodology text on the home page is the same across years except for 3 pieces of text. Let's consolidate to make future years and translations easier and more consistent.

This is also how the other sections (the mission statement, and contributors sections) are handled.