### PR TITLE
Address keyboard a11y issues

### DIFF
--- a/src/static/js/chapter.js
+++ b/src/static/js/chapter.js
@@ -5,7 +5,7 @@ function removeLazyLoading() {
   //If no Array.from then pretty sure there will be no native lazy-loading support to remove!
   if (Array.from) {
     console.log("Removing lazy loading...");
-    
+
     Array.from(document.querySelectorAll('img[loading], iframe[loading]')).forEach(function(element) {
       element.removeAttribute('loading');
     });
@@ -34,7 +34,7 @@ function isInPrintMode() {
   }
   gtag('event', 'print-mode', { 'event_category': 'user', 'event_label': '' + printMode, 'value': +printMode })
   return printMode;
-  
+
 }
 
 //Check if the screen meets minimum size requirements for Interactive figures
@@ -176,6 +176,7 @@ function upgradeInteractiveFigures() {
           //Set up some default attributes
           iframe.setAttribute('title', fig_img.getAttribute('alt'));
           iframe.setAttribute('class', 'fig-iframe');
+          iframe.setAttribute('tabindex', '-1'); // Google embeds are currently not keyboard interactive so disable tabindex
           if (fig_img.getAttribute('aria-labelledby')) {
             iframe.setAttribute('aria-labelledby', fig_img.getAttribute('aria-labelledby'));
           }
@@ -240,9 +241,9 @@ function setDiscussionCount() {
           }
           var el = document.getElementById('num_comments');
           el.innerText = comments;
-          
+
           document.getElementById(comments === 1 ? 'comment-singular' : 'comment-plural').removeAttribute('data-translation');
-          
+
           gtag('event', 'discussion-count', { 'event_category': 'user', 'event_label': 'enabled', 'value': 1 });
         })
         .catch(function (err) {
@@ -302,7 +303,7 @@ function indexHighlighter() {
   // Create a function to handle highlighting a new index item
   // that will be called by the IntersectionObserver
   function highlightIndexEntry(link) {
-    
+
     var indexLink = document.querySelector('.index-box a[href="#' + link + '"]');
     var oldIndexLink = document.querySelector('.index-box .active');
 
@@ -399,8 +400,49 @@ function addShowDescription() {
 
 }
 
+function addKeyboardScollableRegions() {
+  // If a table or code block is overflowing then should allow keyboard focus
+  // More details - https://adrianroselli.com/2020/11/under-engineered-responsive-tables.html
+
+  // Handle tables that have overflowed
+  var all_table_containers = document.querySelectorAll('.table-wrap-container');
+  for (var index = 0; index < all_table_containers.length; ++index) {
+    var table_container = all_table_containers[index];
+
+    if(table_container.scrollWidth > table_container.clientWidth) {
+      var figure = table_container.parentElement.parentElement;
+      if (figure && figure.nodeName == "FIGURE") {
+        var figid = figure.id;
+        var figcaption = figure.querySelector('figcaption');
+
+        if (figid && figcaption) {
+          figcaption.setAttribute('id',figid+'-caption');
+          table_container.setAttribute('tabindex','0');
+          table_container.setAttribute('role','region');
+          table_container.setAttribute('aria-labelledby', figid+  '-caption');
+        }
+      }
+    }
+  }
+
+  // Handle code blocks that have overflowed
+  var all_pre_elements = document.querySelectorAll('pre');
+  for (var index = 0; index < all_pre_elements.length; ++index) {
+    var pre_element = all_pre_elements[index];
+
+    if(pre_element.scrollWidth > pre_element.clientWidth) {
+      pre_element.setAttribute('tabindex','0');
+      pre_element.setAttribute('role','region');
+      pre_element.setAttribute('aria-label', `Code ${index}`);
+
+    }
+  }
+
+}
+
 indexHighlighter();
 addShowDescription();
 removeLazyLoadingOnPrint();
 upgradeInteractiveFigures();
+addKeyboardScollableRegions();
 setDiscussionCount();

--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -830,11 +830,11 @@
 {% endif %}
 
 <figure id="{{ anchor }}">
-  {%- if video != "" %}
-  <iframe class="fig-mobile fig-desktop video-embed" src="{{ video }}" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen width="{{ video_width }}" height="{{ video_height }}" aria-labelledby="{{ anchor }}-caption" aria-describedby="{{ anchor }}-description"></iframe>
-  {%- endif %}
   {%- if image != "" %}
   <div class="figure-wrapper">
+    {%- if video != "" %}
+    <iframe class="fig-mobile fig-desktop video-embed" src="{{ video }}" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen width="{{ video_width }}" height="{{ video_height }}" aria-labelledby="{{ anchor }}-caption" aria-describedby="{{ anchor }}-description"></iframe>
+    {%- endif %}
     {% if video %}{% set anchor_class="video-fallback-image"%}{% endif %}
     <a href="{{ link }}"  class="{{ anchor_class }}">
       {%- if chart_url != "" %}

--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -35,13 +35,13 @@
 <script nonce="{{ csp_nonce() }}">
 
 document.addEventListener("keyup", function onPress(event) {
-   if (event.key === 'p' || event.key === 'P' || event.key === ',' || event.key === '<' || event.key === 'ArrowLeft') {
+   if (event.key === 'p' || event.key === 'P' || event.key === ',' || event.key === '<') {
      var previous = document.getElementById('previous-chapter');
      if (previous) {
        previous.click();
      }
    }
-   if (event.key === 'n' || event.key === 'N' || event.key === '.' || event.key === '>' || event.key === 'ArrowRight') {
+   if (event.key === 'n' || event.key === 'N' || event.key === '.' || event.key === '>') {
      var next = document.getElementById('next-chapter');
      if (next) {
        next.click();

--- a/src/templates/en/2019/methodology.html
+++ b/src/templates/en/2019/methodology.html
@@ -84,7 +84,7 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you&#8217;ll get the HTML #}
-          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          {# Note extra attributes on pre tag to allow keyboard scroll so add them back in #}
           <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>

--- a/src/templates/en/2019/methodology.html
+++ b/src/templates/en/2019/methodology.html
@@ -84,7 +84,8 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you&#8217;ll get the HTML #}
-          <pre><code class="sql language-sql"><span class="comment">#standardSQL</span>
+          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>
   percentile,

--- a/src/templates/en/2020/methodology.html
+++ b/src/templates/en/2020/methodology.html
@@ -89,7 +89,8 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you&#8217;ll get the HTML #}
-          <pre><code class="sql language-sql"><span class="comment">#standardSQL</span>
+          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>
   percentile,

--- a/src/templates/en/2020/methodology.html
+++ b/src/templates/en/2020/methodology.html
@@ -89,7 +89,7 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you&#8217;ll get the HTML #}
-          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          {# Note extra attributes on pre tag to allow keyboard scroll so add them back in #}
           <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>

--- a/src/templates/fr/2019/methodology.html
+++ b/src/templates/fr/2019/methodology.html
@@ -84,7 +84,8 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          <pre><code class="sql language-sql"><span class="comment">#standardSQL</span>
+          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>
   percentile,

--- a/src/templates/fr/2019/methodology.html
+++ b/src/templates/fr/2019/methodology.html
@@ -84,7 +84,7 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          {# Note extra attributes on pre tag to allow keyboard scroll so add them back in #}
           <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>

--- a/src/templates/fr/2020/methodology.html
+++ b/src/templates/fr/2020/methodology.html
@@ -89,7 +89,8 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          <pre><code class="sql language-sql"><span class="comment">#standardSQL</span>
+          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>
   percentile,

--- a/src/templates/fr/2020/methodology.html
+++ b/src/templates/fr/2020/methodology.html
@@ -89,7 +89,7 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          {# Note extra attributes on pre tag to allow keyboard scroll so add them back in #}
           <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>

--- a/src/templates/hi/2019/methodology.html
+++ b/src/templates/hi/2019/methodology.html
@@ -84,7 +84,8 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          <pre><code class="sql language-sql"><span class="comment">#standardSQL</span>
+          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>
   percentile,

--- a/src/templates/hi/2019/methodology.html
+++ b/src/templates/hi/2019/methodology.html
@@ -84,7 +84,7 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          {# Note extra attributes on pre tag to allow keyboard scroll so add them back in #}
           <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>

--- a/src/templates/hi/2020/methodology.html
+++ b/src/templates/hi/2020/methodology.html
@@ -89,7 +89,8 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          <pre><code class="sql language-sql"><span class="comment">#standardSQL</span>
+          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>
   percentile,

--- a/src/templates/hi/2020/methodology.html
+++ b/src/templates/hi/2020/methodology.html
@@ -89,7 +89,7 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          {# Note extra attributes on pre tag to allow keyboard scroll so add them back in #}
           <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>

--- a/src/templates/ja/2019/methodology.html
+++ b/src/templates/ja/2019/methodology.html
@@ -84,7 +84,8 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          <pre><code class="sql language-sql"><span class="comment">#standardSQL</span>
+          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>
   percentile,

--- a/src/templates/ja/2019/methodology.html
+++ b/src/templates/ja/2019/methodology.html
@@ -84,7 +84,7 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          {# Note extra attributes on pre tag to allow keyboard scroll so add them back in #}
           <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>

--- a/src/templates/ja/2020/methodology.html
+++ b/src/templates/ja/2020/methodology.html
@@ -89,7 +89,8 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          <pre><code class="sql language-sql"><span class="comment">#standardSQL</span>
+          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>
   percentile,

--- a/src/templates/ja/2020/methodology.html
+++ b/src/templates/ja/2020/methodology.html
@@ -89,7 +89,7 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          {# Note extra attributes on pre tag to allow keyboard scroll so add them back in #}
           <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>

--- a/src/templates/nl/2019/methodology.html
+++ b/src/templates/nl/2019/methodology.html
@@ -84,7 +84,8 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          <pre><code class="sql language-sql"><span class="comment">#standardSQL</span>
+          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>
   percentile,

--- a/src/templates/nl/2019/methodology.html
+++ b/src/templates/nl/2019/methodology.html
@@ -84,7 +84,7 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          {# Note extra attributes on pre tag to allow keyboard scroll so add them back in #}
           <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>

--- a/src/templates/nl/2020/methodology.html
+++ b/src/templates/nl/2020/methodology.html
@@ -89,7 +89,8 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          <pre><code class="sql language-sql"><span class="comment">#standardSQL</span>
+          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>
   percentile,

--- a/src/templates/nl/2020/methodology.html
+++ b/src/templates/nl/2020/methodology.html
@@ -89,7 +89,7 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          {# Note extra attributes on pre tag to allow keyboard scroll so add them back in #}
           <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>

--- a/src/templates/ru/2019/methodology.html
+++ b/src/templates/ru/2019/methodology.html
@@ -84,7 +84,8 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          <pre><code class="sql language-sql"><span class="comment">#standardSQL</span>
+          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>
   percentile,

--- a/src/templates/ru/2019/methodology.html
+++ b/src/templates/ru/2019/methodology.html
@@ -84,7 +84,7 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          {# Note extra attributes on pre tag to allow keyboard scroll so add them back in #}
           <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>

--- a/src/templates/ru/2020/methodology.html
+++ b/src/templates/ru/2020/methodology.html
@@ -89,7 +89,8 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          <pre><code class="sql language-sql"><span class="comment">#standardSQL</span>
+          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>
   percentile,

--- a/src/templates/ru/2020/methodology.html
+++ b/src/templates/ru/2020/methodology.html
@@ -89,7 +89,7 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          {# Note extra attributes on pre tag to allow keyboard scroll so add them back in #}
           <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>

--- a/src/templates/zh-CN/2019/methodology.html
+++ b/src/templates/zh-CN/2019/methodology.html
@@ -84,7 +84,8 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          <pre><code class="sql language-sql"><span class="comment">#standardSQL</span>
+          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>
   percentile,

--- a/src/templates/zh-CN/2019/methodology.html
+++ b/src/templates/zh-CN/2019/methodology.html
@@ -84,7 +84,7 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          {# Note extra attributes on pre tag to allow keyboard scroll so add them back in #}
           <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>

--- a/src/templates/zh-CN/2020/methodology.html
+++ b/src/templates/zh-CN/2020/methodology.html
@@ -89,7 +89,8 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          <pre><code class="sql language-sql"><span class="comment">#standardSQL</span>
+          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>
   percentile,
@@ -311,7 +312,7 @@
       </p>
 
       <p>
-        Wappalyzer为很多章节提供动力，它分析开发人员工具的流行程度，例如 WordPress，Bootstrap，和jQuery。比如 <a href="{{ url_for('chapter', year=year, lang=lang, chapter='ecommerce') }}">电商</a> 和 <a href="{{ url_for('chapter', year=year, lang=lang, chapter='cms') }}">CMS</a> 章节非常依赖于Wappalyzer探测出的各自的 <a href="https://www.wappalyzer.com/categories/ecommerce">电商</a> 和 <a href="https://www.wappalyzer.com/categories/cms">CMS</a> 类别。 
+        Wappalyzer为很多章节提供动力，它分析开发人员工具的流行程度，例如 WordPress，Bootstrap，和jQuery。比如 <a href="{{ url_for('chapter', year=year, lang=lang, chapter='ecommerce') }}">电商</a> 和 <a href="{{ url_for('chapter', year=year, lang=lang, chapter='cms') }}">CMS</a> 章节非常依赖于Wappalyzer探测出的各自的 <a href="https://www.wappalyzer.com/categories/ecommerce">电商</a> 和 <a href="https://www.wappalyzer.com/categories/cms">CMS</a> 类别。
       </p>
 
       <p>
@@ -339,7 +340,7 @@
       <h3 id="third-party-web"><a href="#third-party-web" class="anchor-link">第三方资源网络</a></h3>
 
       <p>
-        <a href="https://www.thirdpartyweb.today/">第三方资源网络</a> 是一个研究工程，由 <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='patrickhulce') }}">Patrick Hulce</a>创立，他是<a href="{{ url_for('chapter', year=2019, lang=lang, chapter='third-parties') }}">2019 第三方资源</a> 章节的作者，它使用HTTP Archive和Lighthouse数据来识别和分析第三方资源对网络的影响。      
+        <a href="https://www.thirdpartyweb.today/">第三方资源网络</a> 是一个研究工程，由 <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='patrickhulce') }}">Patrick Hulce</a>创立，他是<a href="{{ url_for('chapter', year=2019, lang=lang, chapter='third-parties') }}">2019 第三方资源</a> 章节的作者，它使用HTTP Archive和Lighthouse数据来识别和分析第三方资源对网络的影响。
         </p>
 
       <p>

--- a/src/templates/zh-CN/2020/methodology.html
+++ b/src/templates/zh-CN/2020/methodology.html
@@ -89,7 +89,7 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          {# Note extra attributes on pre tag to allow keyboard scroll so add them back in #}
           <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>

--- a/src/templates/zh-TW/2020/methodology.html
+++ b/src/templates/zh-TW/2020/methodology.html
@@ -61,7 +61,7 @@
 
         <p>
           Web Almanac 網路年鑑的任務是將網路狀態成為公開的年度知識庫。我們的目標是透過主題專家的洞察語意讓網路社群無障礙的進入 HTTP Archive 資料庫。
-        </p> 
+        </p>
 
         <p>
           Web Almanac 網路年鑑2020年版共有四個部分：內文、體驗、發佈和傳遞。在這當中，每個章節都透過不同角度探索相關主題，例如第二部分探索使用者經驗在效能、隱私、無障礙網頁等各種角度。
@@ -89,7 +89,8 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          <pre><code class="sql language-sql"><span class="comment">#standardSQL</span>
+          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>
   percentile,

--- a/src/templates/zh-TW/2020/methodology.html
+++ b/src/templates/zh-TW/2020/methodology.html
@@ -89,7 +89,7 @@
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you'll get the HTML #}
-          {# Note extra attributes on <pre> tag to allow keyboard scroll so add them back in #}
+          {# Note extra attributes on pre tag to allow keyboard scroll so add them back in #}
           <pre role="region" aria-label="01_01b.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># 01_01b: Distribution of JS bytes by client</span>
 <span class="keyword">SELECT</span>


### PR DESCRIPTION
Fixes a number of keyboard issues on the site:
- Remove arrow left and arrow right going to previous and next pages to allow scrolling
- Add scroll on overflowing figures and code (see [Adrian's article](https://adrianroselli.com/2020/11/under-engineered-responsive-tables.html) and this [Twitter thread](https://twitter.com/tunetheweb/status/1356612778098905091?s=20) with @ericwbailey for background).
- Add similar scrolling to wide SQL in methodology pages.
- The interactive Google Sheets iframes are not actually keyboard interactive, so remove the tab stop as confusing when nothing is focusable.
- Videos have the additional menu in wrong place in middle of the figure caption (see image below). Correct that.

![Figure menu in middle of figure caption](https://user-images.githubusercontent.com/10931297/106653283-7d7c6d80-658e-11eb-94e4-244d02e03cfb.png)

Note chapter.js hasn't changed as much as suggests but first commit since adding editorconfig so a lot of whitespace changes. View [without white spaces diffs](https://github.com/HTTPArchive/almanac.httparchive.org/pull/1963/files?diff=split&w=1) to see real diffs.

Test version here: https://20210202t192322-dot-webalmanac.uk.r.appspot.com/en/2020/