### PR TITLE
Handle larger spine for 2020 ebook

### DIFF
--- a/.github/workflows/predeploy.yml
+++ b/.github/workflows/predeploy.yml
@@ -13,7 +13,7 @@ name: Predeploy script
 
 env:
   # Update periodically from https://www.princexml.com/latest/
-  PRINCE_PACKAGE: 'prince_20200728-1_ubuntu20.04_amd64.deb'
+  PRINCE_PACKAGE: 'prince_20210108-1_ubuntu20.04_amd64.deb'
 
 on:
   workflow_dispatch:

--- a/src/README.md
+++ b/src/README.md
@@ -185,7 +185,8 @@ prince "http://127.0.0.1:8080/en/2019/ebook?cover" -o static/pdfs/web_almanac_20
 
 Extra params accepted for the cover are are (note spine and pageWidth are unit-less to allow for easy addition in the code):
 
-- spine - the width of the spine (defaults to 25)
+- spine - the width of the spine (defaults to 25 for 2019 and 34.5 for 2020)
+- spinePadding - padding of the spine (defaults to "(spine - 25) / 2") to allow spine to look similar across years even though 2020 was a lot thicker than 2019.
 - pageWidth - the front cover width (note is just the page width and not the full width of front cover and back cover and spine) - defaults to 148 (for A5).
 - pageHeight - defaults to 210 (for A5)
 - unit - which unit the above measurements are in (defaults to mm)

--- a/src/templates/base/base_ebook.html
+++ b/src/templates/base/base_ebook.html
@@ -113,10 +113,15 @@
 
 {% set unit = 'mm' %}
 {% set spine = 25 %}
+{% if year == '2020' %}
+{% set spine = 34.5 %}
+{% endif %}
 {% set pageWidth = 148 %}
 {% set pageHeight = 210 %}
 {% if request.args.get('unit') != None %}{% set unit = request.args.get('unit') %}{% endif %}
 {% if request.args.get('spine') != None %}{% set spine = request.args.get('spine')|float %}{% endif %}
+{% set spinePadding = (spine - 25) / 2 %}
+{% if request.args.get('spinePadding') != None %}{% set spinePadding = request.args.get('spinePadding')|float %}{% endif %}
 {% if request.args.get('pageWidth') != None %}{% set pageWidth = request.args.get('pageWidth')|float %}{% endif %}
 {% if request.args.get('pageHeight') != None %}{% set pageHeight = request.args.get('pageHeight')|float %}{% endif %}
 {% set totalWidth = pageWidth + spine + pageWidth %}
@@ -129,18 +134,19 @@
 }
 
 #front-cover .ha-logo-wrapper {
-  max-width: {{ spine }}{{ unit }};
-  height: {{ halfSpine }}{{ unit }};
+  max-width: {{ spine - spinePadding - spinePadding }}{{ unit }};
+  height: {{ halfSpine - spinePadding }}{{ unit }};
 }
 
 #spine {
   left: {{ pageWidth }}{{ unit }};
   width: {{ spine }}{{ unit }};
+  padding: 0 {{ spinePadding }}{{ unit }};
 }
 
 #spine .ha-logo-wrapper {
-  max-width: {{ spine }}{{ unit }};
-  height: {{ halfSpine }}{{ unit }};
+  max-width: {{ spine - spinePadding - spinePadding }}{{ unit }};
+  height: {{ halfSpine - spinePadding }}{{ unit }};
 }
 
 #back-cover {
@@ -148,8 +154,8 @@
 }
 
 #back-cover .ha-logo-wrapper {
-  max-width: {{ spine }}{{ unit }};
-  height: {{ halfSpine }}{{ unit }};
+  max-width: {{ spine - spinePadding - spinePadding }}{{ unit }};
+  height: {{ halfSpine - spinePadding }}{{ unit }};
 }
 
 @prince-pdf {
@@ -432,7 +438,7 @@
     <div id="spine">
 
       <h3 class="spine-author">
-        <svg viewBox="0 0 90 16">
+        <svg viewBox="0 0 65 16">
           <text x="8" y="15">Viscomi</text>
         </svg>
       </h3>


### PR DESCRIPTION
Handle larger spine for 600 page ebook versus 440 page previously by introducing padding (otherwise parts of spine grow and look very big).

Also upgrade princexml version.