### PR TITLE
Upgrade super linter and change it to work on pull requests

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -9,17 +9,10 @@
 name: Lint Code Base
 on:
   - workflow_dispatch
-  - push
   - pull_request
 jobs:
   lint:
     name: Lint Code Base
-    # Skip duplicate job for local branches
-    # except for linter upgrades (so it can be caught by below check to lint all)
-    if: |
-        github.event_name == 'push' ||
-        github.event.pull_request.head.repo.full_name != github.repository ||
-        startsWith(github.event.pull_request.title,'Bump github/super-linter')
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Code
@@ -35,7 +28,8 @@ jobs:
         run: |
           echo "VALIDATE_ALL_CODEBASE=false" >> $GITHUB_ENV
       - name: Lint Code Base
-        uses: docker://github/super-linter:v3.14.0
+        #uses: docker://github/super-linter:v3.15.3
+        uses: github/super-linter@v3.15.3
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_website.yml
+++ b/.github/workflows/test_website.yml
@@ -35,7 +35,8 @@ jobs:
     - name: Use more complete checks for generated HTML linting
       run: cp -f .github/linters/.htmlhintrc_morechecks .github/linters/.htmlhintrc
     - name: Lint Generated HTML
-      uses: docker://github/super-linter:v3.14.0
+      #uses: docker://github/super-linter:v3.15.3
+      uses: github/super-linter@v3.15.3
       env:
         DEFAULT_BRANCH: main
         FILTER_REGEX_INCLUDE: src/static/html/.*


### PR DESCRIPTION
Just noticed that when running in "pull mode" the GitHub super linter only lints the last commit rather than the full pull request. Therefore let's change it to run on pull, rather than push.

That does mean you don't get any linting checks until you open a pull request but think that's fine.

Also upgrading to latest version.