### PR TITLE
Add a shortcut key to show/hide all the descriptions

### DIFF
--- a/src/static/js/almanac.js
+++ b/src/static/js/almanac.js
@@ -653,7 +653,7 @@ function addKeyboardScollableRegions() {
 
 }
 
-function addPrevNextEventListers() {
+function addShortKeyEventListers() {
   document.addEventListener("keyup", function onPress(event) {
     if (event.key === 'p' || event.key === 'P' || event.key === ',' || event.key === '<') {
       var previous = document.getElementById('previous-chapter');
@@ -666,6 +666,11 @@ function addPrevNextEventListers() {
       if (next) {
         next.click();
       }
+    }
+    if (event.key === 'd' || event.key === 'D') {
+      var next = document.querySelectorAll('.fig-description-button').forEach(descButton => {
+        descButton.click();
+      });
     }
   });
 }
@@ -707,4 +712,4 @@ removeLazyLoadingOnPrint();
 upgradeInteractiveFigures();
 addKeyboardScollableRegions();
 setDiscussionCount();
-addPrevNextEventListers();
+addShortKeyEventListers();


### PR DESCRIPTION
Makes progress of #1637 

Adds a shortcut key (`d` or `D`) to show all the descriptions for easy review or spell checking.