### PR TITLE
User older version of super-linter for test website

### DIFF
--- a/.github/workflows/test_website.yml
+++ b/.github/workflows/test_website.yml
@@ -35,8 +35,10 @@ jobs:
     - name: Use more complete checks for generated HTML linting
       run: cp -f .github/linters/.htmlhintrc_morechecks .github/linters/.htmlhintrc
     - name: Lint Generated HTML
-      #uses: docker://github/super-linter:v3.15.3
-      uses: github/super-linter@v3.15.3
+      # Run older version of super-linter to allow linting of generated files
+      # (see https://github.com/github/super-linter/issues/1289)
+      uses: docker://github/super-linter:v3.14.0
+      #uses: github/super-linter@v3.15.3
       env:
         DEFAULT_BRANCH: main
         FILTER_REGEX_INCLUDE: src/static/html/.*


### PR DESCRIPTION
There is a bug in the latest version of the super-linter in that it [only lints git-tracked files](https://github.com/github/super-linter/issues/1289).

We test the generated HTML files as linting the EJS template files isn't always sufficient. However as these files are not tracked in git, they are not linted!

So let's temporarily revert the linter for this workflow only so we can still lint generated files, until the super-linter fix this, so can have confidence in translations.