### PR TITLE
Remove unnecessary focus-visible style

### DIFF
--- a/src/static/css/almanac.css
+++ b/src/static/css/almanac.css
@@ -1228,10 +1228,6 @@ p.copyright a {
   outline: none;
 }
 
-.nav-dropdown-btn:focus-visible {
-  outline: revert;
-}
-
 .nav-dropdown-btn::after,
 .nav-dropdown-list-current::after {
   content: "";


### PR DESCRIPTION
Can't remember why I thought I needed this line, but definitely don's as line above it is sufficient.