### PR TITLE
Upgrade smartypants 0.1.15

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -19,7 +19,7 @@
         "recursive-readdir": "2.2.2",
         "run-script-os": "1.1.6",
         "showdown": "1.9.1",
-        "smartypants": "0.1.1",
+        "smartypants": "0.1.4",
         "web-vitals": "1.1.1",
         "xml-js": "1.6.11"
       }
@@ -1181,9 +1181,9 @@
       }
     },
     "node_modules/smartypants": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/smartypants/-/smartypants-0.1.1.tgz",
-      "integrity": "sha512-cmRfqgUdTIYHW2ljYxrsfb636T/okoGbRLfidSr3VQqXzXwWz+UeI3I5fCxk5eXW+H6QRMsn1sA/I7igXLB7lA==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/smartypants/-/smartypants-0.1.4.tgz",
+      "integrity": "sha512-BiUEDyDJf+5q71UqwaJd6cVIIcv7ZE7CwervYmyP2wW2DNtaOVI/wzRZKeOI/INgHtZMX07Q1KnJ1T/8gc3k0w==",
       "dev": true,
       "bin": {
         "smartypants": "bin/smartypants.js",
@@ -2485,9 +2485,9 @@
       }
     },
     "smartypants": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/smartypants/-/smartypants-0.1.1.tgz",
-      "integrity": "sha512-cmRfqgUdTIYHW2ljYxrsfb636T/okoGbRLfidSr3VQqXzXwWz+UeI3I5fCxk5eXW+H6QRMsn1sA/I7igXLB7lA==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/smartypants/-/smartypants-0.1.4.tgz",
+      "integrity": "sha512-BiUEDyDJf+5q71UqwaJd6cVIIcv7ZE7CwervYmyP2wW2DNtaOVI/wzRZKeOI/INgHtZMX07Q1KnJ1T/8gc3k0w==",
       "dev": true
     },
     "source-map": {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -19,7 +19,7 @@
         "recursive-readdir": "2.2.2",
         "run-script-os": "1.1.6",
         "showdown": "1.9.1",
-        "smartypants": "0.1.4",
+        "smartypants": "0.1.5",
         "web-vitals": "1.1.1",
         "xml-js": "1.6.11"
       }
@@ -1181,9 +1181,9 @@
       }
     },
     "node_modules/smartypants": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/smartypants/-/smartypants-0.1.4.tgz",
-      "integrity": "sha512-BiUEDyDJf+5q71UqwaJd6cVIIcv7ZE7CwervYmyP2wW2DNtaOVI/wzRZKeOI/INgHtZMX07Q1KnJ1T/8gc3k0w==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/smartypants/-/smartypants-0.1.5.tgz",
+      "integrity": "sha512-EK7VrYu61ZGtiD6I0JyYerBqrdXt82Wjb1y+Me21MLaAus8g6SUeBa/slsF/Y9bw5Y1aiB4Ufh8lilUq/B5uWw==",
       "dev": true,
       "bin": {
         "smartypants": "bin/smartypants.js",
@@ -2485,9 +2485,9 @@
       }
     },
     "smartypants": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/smartypants/-/smartypants-0.1.4.tgz",
-      "integrity": "sha512-BiUEDyDJf+5q71UqwaJd6cVIIcv7ZE7CwervYmyP2wW2DNtaOVI/wzRZKeOI/INgHtZMX07Q1KnJ1T/8gc3k0w==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/smartypants/-/smartypants-0.1.5.tgz",
+      "integrity": "sha512-EK7VrYu61ZGtiD6I0JyYerBqrdXt82Wjb1y+Me21MLaAus8g6SUeBa/slsF/Y9bw5Y1aiB4Ufh8lilUq/B5uWw==",
       "dev": true
     },
     "source-map": {

--- a/src/package.json
+++ b/src/package.json
@@ -43,7 +43,7 @@
     "recursive-readdir": "2.2.2",
     "run-script-os": "1.1.6",
     "showdown": "1.9.1",
-    "smartypants": "0.1.1",
+    "smartypants": "0.1.4",
     "web-vitals": "1.1.1",
     "xml-js": "1.6.11"
   }

--- a/src/package.json
+++ b/src/package.json
@@ -43,7 +43,7 @@
     "recursive-readdir": "2.2.2",
     "run-script-os": "1.1.6",
     "showdown": "1.9.1",
-    "smartypants": "0.1.4",
+    "smartypants": "0.1.5",
     "web-vitals": "1.1.1",
     "xml-js": "1.6.11"
   }

--- a/src/tools/generate/generate_typographic_punctuation.js
+++ b/src/tools/generate/generate_typographic_punctuation.js
@@ -15,11 +15,6 @@ const generate_typographic_punctuation_body = (body) => {
   // Now do the actual conversion
   body = smartypants.smartypants(body);
 
-  // There's a few bugs in SmartyPants where it sometimes leaves an extra "$1" lying around
-  // https://github.com/othree/smartypants.js/issues/9
-  // so let's clean them up:
-  body = body.replace(/\$1&#82/g,'&#82');
-
   // Uncomment Jinja functions
   body = body.replace(/<!--<jinja-macro/g,'');
   body = body.replace(/><\/jinja-macro>-->/g,'');
@@ -37,11 +32,6 @@ const generate_typographic_punctuation_metadata = (metadata) => {
     metadata[item] = metadata[item].replace(/&quot;/g, '"');
     metadata[item] = smartypants.smartypants(metadata[item]);
     metadata[item] = metadata[item].replace(/"/g, '&quot;');
-
-    // There's a few bugs in SmartyPants where it sometimes leaves an extra "$1" lying around
-    // https://github.com/othree/smartypants.js/issues/9
-    // so let's clean them up:
-    metadata[item] = metadata[item].replace(/\$1&#82/g,'&#82');
   }
 
   return metadata;


### PR DESCRIPTION
Upgrades Smartypants to v0.1.15 to fix a smart quote issue which required a workaround in the code (this PR also removes the workaround).

Edit: Also fixes some other smart quotes errors I didn't even realise where in there!

2019 Accessibility Chapter:
![Bad smart quotes in 2019 Accessibility Chapter](https://user-images.githubusercontent.com/10931297/114084136-bcd57c00-98a7-11eb-8cda-2511437d3f06.png)

2020 Caching chapter
![Bad smart quotes in 2020 Caching chapter](https://user-images.githubusercontent.com/10931297/114084056-a7605200-98a7-11eb-9394-2de0e32593fb.png)

See - this is why Smart Quotes were more bother than they were worth :-)