### PR TITLE
Add Google Scholar meta data

### DIFF
--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -8,6 +8,7 @@
 
 {% block meta %}
     {{ super() }}
+    {% if lang == "en" %}
     <meta name="citation_title" content="{{ self.citation_title() }}">
     {% for author in metadata.get('authors') %}
     {%- set authordata = config.contributors[author] if author in config.contributors else None -%}
@@ -17,8 +18,10 @@
     <meta name="citation_publication_date" content="{{ date_published[0:4] }}/{{ date_published[5:7] }}/{{ date_published[8:10] }}">
     {% endif -%}
     <meta name="citation_journal_title" content="{{ self.citation_journal_title() }}">
-    <meta name="citation_volume" content="{{ year }}-{{ language }}">
+    <meta name="citation_volume" content="{{ year|int - 2018 }}">
+    <meta name="citation_issue" content="{{ chapter_config.chapter_number }}">
     <meta name="citation_technical_report_institution" content="HTTP Archive">
+    {% endif %}
 {% endblock %}
 
 {% block author_structured_data %}

--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -20,7 +20,10 @@
     <meta name="citation_journal_title" content="{{ self.citation_journal_title() }}">
     <meta name="citation_volume" content="{{ year|int - 2018 }}">
     <meta name="citation_issue" content="{{ chapter_config.chapter_number }}">
+    <meta name="citation_publisher" content="HTTP Archive">
     <meta name="citation_technical_report_institution" content="HTTP Archive">
+    <meta name="citation_language" content="{{ language }}">
+    <meta name="citation_fulltext_html_url" content="https://almanac.httparchive.org{{ url_for(request.endpoint, **get_view_args(lang=language.lang_code)) }}">
     {% endif %}
 {% endblock %}
 

--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -6,6 +6,21 @@
 {% block image_height %}433{% endblock %}
 {% block image_width %}866{% endblock %}
 
+{% block meta %}
+    {{ super() }}
+    <meta name="citation_title" content="{{ self.citation_title() }}">
+    {% for author in metadata.get('authors') %}
+    {%- set authordata = config.contributors[author] if author in config.contributors else None -%}
+    <meta name="citation_author" content="{{ authordata.name if authordata.name else author }}">
+    {% endfor -%}
+    {% if date_published and date_published|length > 10 -%}
+    <meta name="citation_publication_date" content="{{ date_published[0:4] }}/{{ date_published[5:7] }}/{{ date_published[8:10] }}">
+    {% endif -%}
+    <meta name="citation_journal_title" content="{{ self.citation_journal_title() }}">
+    <meta name="citation_volume" content="{{ year }}-{{ language }}">
+    <meta name="citation_technical_report_institution" content="HTTP Archive">
+{% endblock %}
+
 {% block author_structured_data %}
       {% for author in metadata.get('authors') %}{% if loop.length > 1 and loop.index == 1 %}[{% endif -%}
       {% set authordata = config.contributors[author] if author in config.contributors else None -%}

--- a/src/templates/en/base_chapter.html
+++ b/src/templates/en/base_chapter.html
@@ -1,6 +1,8 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | The Web Almanac by HTTP Archive{% endblock %}
+{% block citation_title %}The {{ year }} Web Almanac: {{ metadata.get('title') }} chapter{% endblock %}
+{% block citation_journal_title %}The {{ year }} Web Almanac{% endblock %}
 
 {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac probing into the use of ' + metadata.get('description',metadata.get('title')) + ' on the web.') }}{% endblock %}
 

--- a/src/templates/en/base_chapter.html
+++ b/src/templates/en/base_chapter.html
@@ -1,7 +1,7 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | The Web Almanac by HTTP Archive{% endblock %}
-{% block citation_title %}The {{ year }} Web Almanac: {{ metadata.get('title') }} chapter{% endblock %}
+{% block citation_title %}The {{ year }} Web Almanac: {{ metadata.get('title') }}{% endblock %}
 {% block citation_journal_title %}The {{ year }} Web Almanac{% endblock %}
 
 {% block description %}{{ metadata.get('description',metadata.get('title') + ' chapter of the ' + year + ' Web Almanac probing into the use of ' + metadata.get('description',metadata.get('title')) + ' on the web.') }}{% endblock %}

--- a/src/templates/es/base_chapter.html
+++ b/src/templates/es/base_chapter.html
@@ -1,7 +1,7 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | Web Almanac por HTTP Archive{% endblock %}
-{% block citation_title %}Web Almanac {{ year }}: Capítulo {{ metadata.get('title') }}{% endblock %}
+{% block citation_title %}Web Almanac {{ year }}: {{ metadata.get('title') }}{% endblock %}
 {% block citation_journal_title %}Web Almanac {{ year }}{% endblock %}
 
 {% block description %}{{ metadata.get('description','Capítulo' + metadata.get('title') + ' del Web Almanac '+ year + " explorando el uso de " + metadata.get('description',metadata.get('title')) + ' en la web.') }}{% endblock %}

--- a/src/templates/es/base_chapter.html
+++ b/src/templates/es/base_chapter.html
@@ -1,6 +1,8 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | Web Almanac por HTTP Archive{% endblock %}
+{% block citation_title %}Web Almanac {{ year }}: Capítulo {{ metadata.get('title') }}{% endblock %}
+{% block citation_journal_title %}Web Almanac {{ year }}{% endblock %}
 
 {% block description %}{{ metadata.get('description','Capítulo' + metadata.get('title') + ' del Web Almanac '+ year + " explorando el uso de " + metadata.get('description',metadata.get('title')) + ' en la web.') }}{% endblock %}
 

--- a/src/templates/fr/base_chapter.html
+++ b/src/templates/fr/base_chapter.html
@@ -1,7 +1,7 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | Le Web Almanac par HTTP Archive{% endblock %}
-{% block citation_title %}Le Web Almanac {{ year }} : Chapitre {{ metadata.get('title') }}{% endblock %}
+{% block citation_title %}Le Web Almanac {{ year }} : {{ metadata.get('title') }}{% endblock %}
 {% block citation_journal_title %}Le Web Almanac {{ year }}{% endblock %}
 
 {% block description %}{{ metadata.get('description','Chapitre' + metadata.get('title') + ' du Web Almanac'+ year + " explorant l’utilisation des " + metadata.get('description',metadata.get('title')) + ' sur le web.') }}{% endblock %}

--- a/src/templates/fr/base_chapter.html
+++ b/src/templates/fr/base_chapter.html
@@ -1,6 +1,8 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | Le Web Almanac par HTTP Archive{% endblock %}
+{% block citation_title %}Le Web Almanac {{ year }} : Chapitre {{ metadata.get('title') }}{% endblock %}
+{% block citation_journal_title %}Le Web Almanac {{ year }}{% endblock %}
 
 {% block description %}{{ metadata.get('description','Chapitre' + metadata.get('title') + ' du Web Almanac'+ year + " explorant l’utilisation des " + metadata.get('description',metadata.get('title')) + ' sur le web.') }}{% endblock %}
 

--- a/src/templates/hi/base_chapter.html
+++ b/src/templates/hi/base_chapter.html
@@ -1,7 +1,7 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | HTTP Archive द्वारा Web Almanac{% endblock %}
-{% block citation_title %}{{ year }} Web Almanac: {{ metadata.get('title') }} अध्याय{% endblock %}
+{% block citation_title %}{{ year }} Web Almanac: {{ metadata.get('title') }}{% endblock %}
 {% block citation_journal_title %}{{ year }} Web Almanac{% endblock %}
 
 {% block description %}{{ 'Web Almanac ' + year + ' के ' metadata.get('description',metadata.get('title') + ' अध्याय में ' + metadata.get('description',metadata.get('title')) + ' को कवर किया गया है!') }}{% endblock %}

--- a/src/templates/hi/base_chapter.html
+++ b/src/templates/hi/base_chapter.html
@@ -1,6 +1,8 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | HTTP Archive द्वारा Web Almanac{% endblock %}
+{% block citation_title %}{{ year }} Web Almanac: {{ metadata.get('title') }} अध्याय{% endblock %}
+{% block citation_journal_title %}{{ year }} Web Almanac{% endblock %}
 
 {% block description %}{{ 'Web Almanac ' + year + ' के ' metadata.get('description',metadata.get('title') + ' अध्याय में ' + metadata.get('description',metadata.get('title')) + ' को कवर किया गया है!') }}{% endblock %}
 

--- a/src/templates/it/base_chapter.html
+++ b/src/templates/it/base_chapter.html
@@ -1,6 +1,8 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | Il Web Almanac di HTTP Archive{% endblock %}
+{% block citation_title %}Il Web Almanac {{ year }}: {{ metadata.get('title') }} Capitolo{% endblock %}
+{% block citation_journal_title %}Il Web Almanac {{ year }}{% endblock %}
 
 {% block description %}{{ metadata.get('description','Capitolo' + metadata.get('title') + ' del Web Almanac ' + year + ' esamina l\'uso di ' + metadata.get('description',metadata.get('title')) + ' sul web.') }}{% endblock %}
 

--- a/src/templates/it/base_chapter.html
+++ b/src/templates/it/base_chapter.html
@@ -1,7 +1,7 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | Il Web Almanac di HTTP Archive{% endblock %}
-{% block citation_title %}Il Web Almanac {{ year }}: {{ metadata.get('title') }} Capitolo{% endblock %}
+{% block citation_title %}Il Web Almanac {{ year }}: {{ metadata.get('title') }}{% endblock %}
 {% block citation_journal_title %}Il Web Almanac {{ year }}{% endblock %}
 
 {% block description %}{{ metadata.get('description','Capitolo' + metadata.get('title') + ' del Web Almanac ' + year + ' esamina l\'uso di ' + metadata.get('description',metadata.get('title')) + ' sul web.') }}{% endblock %}

--- a/src/templates/ja/base_chapter.html
+++ b/src/templates/ja/base_chapter.html
@@ -1,6 +1,8 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | HTTP ArchiveによるWeb Almanac{% endblock %}
+{% block citation_title %}{{ metadata.get('title') }} の章 {{ year }} Web Almanac{% endblock %}
+{% block citation_journal_title %}{{ year }} Web Almanac{% endblock %}
 
 {% block description %}{{ metadata.get('description',metadata.get('title') + ' の章 ' + year + ' Web Almanacの使用状況を調べる ' + metadata.get('description',metadata.get('title')) + ' をウェブ上で公開しています。') }}{% endblock %}
 

--- a/src/templates/ja/base_chapter.html
+++ b/src/templates/ja/base_chapter.html
@@ -1,7 +1,7 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | HTTP ArchiveによるWeb Almanac{% endblock %}
-{% block citation_title %}{{ metadata.get('title') }} の章 {{ year }} Web Almanac{% endblock %}
+{% block citation_title %}{{ year }} Web Almanac: {{ metadata.get('title') }}{% endblock %}
 {% block citation_journal_title %}{{ year }} Web Almanac{% endblock %}
 
 {% block description %}{{ metadata.get('description',metadata.get('title') + ' の章 ' + year + ' Web Almanacの使用状況を調べる ' + metadata.get('description',metadata.get('title')) + ' をウェブ上で公開しています。') }}{% endblock %}

--- a/src/templates/nl/base_chapter.html
+++ b/src/templates/nl/base_chapter.html
@@ -1,7 +1,7 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | De Web Almanac door HTTP Archive{% endblock %}
-{% block citation_title %}De {{ year }} Web Almanac: {{ metadata.get('title') }} hoofdstuk{% endblock %}
+{% block citation_title %}De {{ year }} Web Almanac: {{ metadata.get('title') }}{% endblock %}
 {% block citation_journal_title %}De {{ year }} Web Almanac{% endblock %}
 
 {% block description %}{{ metadata.get('description',metadata.get('title') + ' hoofdstuk van de ' + year + ' Web Almanac waarin het gebruik van ' + metadata.get('description',metadata.get('title')) + ' op internet wordt onderzocht.') }}{% endblock %}

--- a/src/templates/nl/base_chapter.html
+++ b/src/templates/nl/base_chapter.html
@@ -1,6 +1,8 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | De Web Almanac door HTTP Archive{% endblock %}
+{% block citation_title %}De {{ year }} Web Almanac: {{ metadata.get('title') }} hoofdstuk{% endblock %}
+{% block citation_journal_title %}De {{ year }} Web Almanac{% endblock %}
 
 {% block description %}{{ metadata.get('description',metadata.get('title') + ' hoofdstuk van de ' + year + ' Web Almanac waarin het gebruik van ' + metadata.get('description',metadata.get('title')) + ' op internet wordt onderzocht.') }}{% endblock %}
 

--- a/src/templates/pt/base_chapter.html
+++ b/src/templates/pt/base_chapter.html
@@ -1,6 +1,8 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | Web Almanac por HTTP Archive{% endblock %}
+{% block citation_title %}Web Almanac {{ year }}: Capítulo {{ metadata.get('title') }}{% endblock %}
+{% block citation_journal_title %}Web Almanac {{ year }}{% endblock %}
 
 {% block description %}{{ metadata.get('description',metadata.get('title') + ' capítulo do ' + year + ' Web Almanac sondando o uso de ' + metadata.get('description',metadata.get('title')) + ' na web.') }}{% endblock %}
 

--- a/src/templates/pt/base_chapter.html
+++ b/src/templates/pt/base_chapter.html
@@ -1,7 +1,7 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | Web Almanac por HTTP Archive{% endblock %}
-{% block citation_title %}Web Almanac {{ year }}: Capítulo {{ metadata.get('title') }}{% endblock %}
+{% block citation_title %}Web Almanac {{ year }}: {{ metadata.get('title') }}{% endblock %}
 {% block citation_journal_title %}Web Almanac {{ year }}{% endblock %}
 
 {% block description %}{{ metadata.get('description',metadata.get('title') + ' capítulo do ' + year + ' Web Almanac sondando o uso de ' + metadata.get('description',metadata.get('title')) + ' na web.') }}{% endblock %}

--- a/src/templates/ru/base_chapter.html
+++ b/src/templates/ru/base_chapter.html
@@ -1,7 +1,7 @@
 {% extends "base//base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | Web Almanac от HTTP Archive{% endblock %}
-{% block citation_title %}Глава "{{ metadata.get('title') }}" издания Web Almanac за {{ year }}{% endblock %}
+{% block citation_title %}Web Almanac за {{ year }} год: {{ metadata.get('title') }}{% endblock %}
 {% block citation_journal_title %}Web Almanac за {{ year }} год{% endblock %}
 
 {% block description %}{{ 'Глава ' + metadata.get('description',metadata.get('title') + ' в Web Almanac за ' + year + ' год разбирает использование ' + metadata.get('description',metadata.get('title')) + ' в вебе.') }}{% endblock %}

--- a/src/templates/ru/base_chapter.html
+++ b/src/templates/ru/base_chapter.html
@@ -1,6 +1,8 @@
 {% extends "base//base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | Web Almanac от HTTP Archive{% endblock %}
+{% block citation_title %}Глава "{{ metadata.get('title') }}" издания Web Almanac за {{ year }}{% endblock %}
+{% block citation_journal_title %}Web Almanac за {{ year }} год{% endblock %}
 
 {% block description %}{{ 'Глава ' + metadata.get('description',metadata.get('title') + ' в Web Almanac за ' + year + ' год разбирает использование ' + metadata.get('description',metadata.get('title')) + ' в вебе.') }}{% endblock %}
 

--- a/src/templates/tr/base_chapter.html
+++ b/src/templates/tr/base_chapter.html
@@ -1,7 +1,7 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | Web Almanac HTTP Archive&#8217;dan {% endblock %}
-{% block citation_title %}{{ year }} Web Almanac: {{ metadata.get('title') }} Bölümü{% endblock %}
+{% block citation_title %}{{ year }} Web Almanac: {{ metadata.get('title') }}{% endblock %}
 {% block citation_journal_title %}{{ year }} Web Almanac{% endblock %}
 
 {% block description %}{{ metadata.get('description', + year + ' Web Almanac&#8217;ın' + metadata.get('title') + ' bölümü '  + ' web üzerinde ' + metadata.get('description',metadata.get('title'))&#8217;ın + kullanımını araştırır.') }}{% endblock %}

--- a/src/templates/tr/base_chapter.html
+++ b/src/templates/tr/base_chapter.html
@@ -1,6 +1,8 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | Web Almanac HTTP Archive&#8217;dan {% endblock %}
+{% block citation_title %}{{ year }} Web Almanac: {{ metadata.get('title') }} Bölümü{% endblock %}
+{% block citation_journal_title %}{{ year }} Web Almanac{% endblock %}
 
 {% block description %}{{ metadata.get('description', + year + ' Web Almanac&#8217;ın' + metadata.get('title') + ' bölümü '  + ' web üzerinde ' + metadata.get('description',metadata.get('title'))&#8217;ın + kullanımını araştırır.') }}{% endblock %}
 

--- a/src/templates/uk/base_chapter.html
+++ b/src/templates/uk/base_chapter.html
@@ -1,6 +1,8 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | Web Almanac від HTTP Archive{% endblock %}
+{% block citation_title %}Web Almanac {{ year }}: Розділ {{ metadata.get('title') }}{% endblock %}
+{% block citation_journal_title %}Web Almanac {{ year }}{% endblock %}
 
 {% block description %}'Розділ ' + metadata.get('description',metadata.get('title')) + ' у Web Almanac ' + year + ' досліджує, як використовується ' + metadata.get('description',metadata.get('title')) + ' у вебі.'{% endblock %}
 

--- a/src/templates/uk/base_chapter.html
+++ b/src/templates/uk/base_chapter.html
@@ -1,7 +1,7 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | Web Almanac від HTTP Archive{% endblock %}
-{% block citation_title %}Web Almanac {{ year }}: Розділ {{ metadata.get('title') }}{% endblock %}
+{% block citation_title %}Web Almanac {{ year }}: {{ metadata.get('title') }}{% endblock %}
 {% block citation_journal_title %}Web Almanac {{ year }}{% endblock %}
 
 {% block description %}'Розділ ' + metadata.get('description',metadata.get('title')) + ' у Web Almanac ' + year + ' досліджує, як використовується ' + metadata.get('description',metadata.get('title')) + ' у вебі.'{% endblock %}

--- a/src/templates/zh-CN/base_chapter.html
+++ b/src/templates/zh-CN/base_chapter.html
@@ -1,6 +1,8 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | Web Almanac 源于 HTTP Archive{% endblock %}
+{% block citation_title %}{{ year }} Web Almanac网络年鉴: {{ metadata.get('title') }} 章节{% endblock %}
+{% block citation_journal_title %}{{ year }} Web Almanac网络年鉴{% endblock %}
 
 {% block description %}{{ metadata.get('description',metadata.get('title') + ' 章节 ' + year + ' 调查Web Almanac的使用状况 ' + metadata.get('description',metadata.get('title')) + ' 在 web中。') }}{% endblock %}
 

--- a/src/templates/zh-CN/base_chapter.html
+++ b/src/templates/zh-CN/base_chapter.html
@@ -1,7 +1,7 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | Web Almanac 源于 HTTP Archive{% endblock %}
-{% block citation_title %}{{ year }} Web Almanac网络年鉴: {{ metadata.get('title') }} 章节{% endblock %}
+{% block citation_title %}{{ year }} Web Almanac网络年鉴: {{ metadata.get('title') }}{% endblock %}
 {% block citation_journal_title %}{{ year }} Web Almanac网络年鉴{% endblock %}
 
 {% block description %}{{ metadata.get('description',metadata.get('title') + ' 章节 ' + year + ' 调查Web Almanac的使用状况 ' + metadata.get('description',metadata.get('title')) + ' 在 web中。') }}{% endblock %}

--- a/src/templates/zh-TW/base_chapter.html
+++ b/src/templates/zh-TW/base_chapter.html
@@ -1,6 +1,8 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | Web Almanac 精粹自 HTTP Archive{% endblock %}
+{% block citation_title %}{{ year }} Web Almanac: {{ metadata.get('title') }} 章節{% endblock %}
+{% block citation_journal_title %}{{ year }} Web Almanac{% endblock %}
 
 {% block description %}{{ metadata.get('description',metadata.get('title') + ' 章節 ' + year + ' Web Almanac 探索使用狀況 ' + metadata.get('description',metadata.get('title')) + ' 在網路中。') }}{% endblock %}
 

--- a/src/templates/zh-TW/base_chapter.html
+++ b/src/templates/zh-TW/base_chapter.html
@@ -1,7 +1,7 @@
 {% extends "base/base_chapter.html" %}
 
 {% block title %}{{ metadata.get('title') }} | {{ year }} | Web Almanac 精粹自 HTTP Archive{% endblock %}
-{% block citation_title %}{{ year }} Web Almanac: {{ metadata.get('title') }} 章節{% endblock %}
+{% block citation_title %}{{ year }} Web Almanac: {{ metadata.get('title') }}{% endblock %}
 {% block citation_journal_title %}{{ year }} Web Almanac{% endblock %}
 
 {% block description %}{{ metadata.get('description',metadata.get('title') + ' 章節 ' + year + ' Web Almanac 探索使用狀況 ' + metadata.get('description',metadata.get('title')) + ' 在網路中。') }}{% endblock %}


### PR DESCRIPTION
Makes progress on #1325 

I've added the meta data to the individual chapters, rather than the eBook as most citations are for a chapter with URL reference. This also avoids the issue of making the ebook HTML indexable (it's currently set to `noindex` as we prefer the PDF to be indexed, and it's VERY big to be downloaded regularly).

Example of meta data:

```
    <meta name="citation_title" content="The 2020 Web Almanac: HTTP/2 chapter">
    <meta name="citation_author" content="Andrew Galloni">
    <meta name="citation_author" content="Robin Marx">
    <meta name="citation_author" content="Mike Bishop">
    <meta name="citation_publication_date" content="2020/12/09">
    <meta name="citation_journal_title" content="The 2020 Web Almanac">
    <meta name="citation_volume" content="2020-English">
    <meta name="citation_technical_report_institution" content="HTTP Archive">
```

** Edit: Updated as discussed below, see https://github.com/HTTPArchive/almanac.httparchive.org/pull/2191#issuecomment-832862193 for the latest version **

Any thought on `citation_volume`? Should we include the Language? Or should we only have this Metadata for English language versions as they are the primary one and Google Scholar doesn't seem to have many options for translations, or `citation_language` or similar.
