### PR TITLE
Better overflow wrap

### DIFF
--- a/src/content/en/2020/capabilities.md
+++ b/src/content/en/2020/capabilities.md
@@ -222,7 +222,7 @@ The use of the interface is currently very low. Over 2020, only one or two pages
 
 PWAs are a versatile application model. However, in some cases, it may still make sense to offer a separate native application: for example, if the app needs to use features that are not available on the web, or based on the programming experience of the app developer team. When the user already has a native app installed, apps might not want to send notifications twice or promote the installation of a corresponding PWA.
 
-To detect if the user already has a related native application or PWA on the system, developers can use the <a hreflang="en" href="https://web.dev/get-installed-related-apps/">getInstalledRelatedApps() method</a> (<a hreflang="en" href="https://wicg.github.io/get-installed-related-apps/spec/">WICG Draft Community Group Report</a>) on the `navigator` object. This method is currently provided by Chromium-based browsers and works for both Android and Universal Windows Platform (UWP) apps. Developers need to adjust the native app bundles to refer to the website and add information about the native app(s) to the Web App Manifest of the PWA. Calling the `getInstalledRelatedApps()` method will then return the list of apps installed on the user's device:
+To detect if the user already has a related native application or PWA on the system, developers can use the <a hreflang="en" href="https://web.dev/get-installed-related-apps/">`getInstalledRelatedApps()` method</a> (<a hreflang="en" href="https://wicg.github.io/get-installed-related-apps/spec/">WICG Draft Community Group Report</a>) on the `navigator` object. This method is currently provided by Chromium-based browsers and works for both Android and Universal Windows Platform (UWP) apps. Developers need to adjust the native app bundles to refer to the website and add information about the native app(s) to the Web App Manifest of the PWA. Calling the `getInstalledRelatedApps()` method will then return the list of apps installed on the user's device:
 
 ```js
 const relatedApps = await navigator.getInstalledRelatedApps();
@@ -233,8 +233,8 @@ relatedApps.forEach((app) => {
 
 {{ figure_markup(
   image="get_installed_related_apps.png",
-  caption="Number of pages using getInstalledRelatedApps().",
-  description="Chart of getInstalledRelatedApps() usage, based on the number of pages monitored by HTTP Archive. It compares the usage on mobile and desktop devices. It shows a steady growth for mobile devices, peaking at 363 pages in October 2020 compared to 44 desktop pages.",
+  caption="Number of pages using `getInstalledRelatedApps()`.",
+  description="Chart of `getInstalledRelatedApps()` usage, based on the number of pages monitored by HTTP Archive. It compares the usage on mobile and desktop devices. It shows a steady growth for mobile devices, peaking at 363 pages in October 2020 compared to 44 desktop pages.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vTxqot9ALgxcgOVJntkzIKnkpo3idIPy-tL0t_nzC5BwFuq0ThgK5OXOYVVOpama4vB2EyggX813d33/pubchart?oid=1774881171&format=interactive",
   sheets_gid="860146688",
   sql_file="get_installed_related_apps_usage.sql"

--- a/src/static/css/almanac.css
+++ b/src/static/css/almanac.css
@@ -1377,13 +1377,11 @@ p.copyright a {
 /* Allow more wrapping for extremely small screens (e.g. very zoomed in) */
 @media (max-width: 20em) {
   body {
-    word-break: break-word;
     overflow-wrap: break-word;
   }
 
   .no-wrap {
     white-space: initial;
-    word-break: break-word;
     overflow-wrap: break-word;
   }
 }
@@ -1419,7 +1417,6 @@ th code {
   border-radius: 0;
   background-color: transparent;
   background-color: unset;
-  word-break: unset;
   overflow-wrap: unset;
 }
 
@@ -1429,7 +1426,6 @@ code {
   background-color: #f7f7f7;
   border: 1px solid #dadce0;
   padding: 1px 2px;
-  word-break: break-all;
   overflow-wrap: break-word;
 }
 

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -481,6 +481,7 @@ figcaption {
   margin: 8px auto 0;
   margin: 0.5rem auto 0;
   text-align: center;
+  max-width: 100%;
 }
 
 .figure-wrapper {


### PR DESCRIPTION
Fixes #2240 

There was definitely a problem with `getInstalledRelatedApps()` on Capabilities chapter for [figure 9 caption](https://almanac.httparchive.org/en/2020/capabilities#fig-9) particularly on 200% font zoom on mobile (unlikely I know but WCAG says we should support it).

However looks like the better way is to stop `figcaption` overflowing with `max-width: 100%` so that does wrap. Not sure why that is needed to be honest but it does the job.

So removed all instances of `word-break: break-word`.

This fixes the issues:

Old:

![Incorrect wrapping](https://user-images.githubusercontent.com/10931297/121779691-d3909b80-cb94-11eb-8fdd-fbf195d96dc9.png)

New:

![Correct wrapping](https://user-images.githubusercontent.com/10931297/121779679-c07dcb80-cb94-11eb-95d9-56b92ba09bbb.png)

Also fixed up some instances of `getInstalledRelatedApps()` which were not code formatted when they should be.

Available here if you wanna test: https://20210612t153415-dot-webalmanac.uk.r.appspot.com