### PR TITLE
Upgrade flask-talisman to 0.8.1 and remove workaround

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,5 @@
 flask==2.0.1
-flask-talisman==0.7.0
+flask-talisman==0.8.1
 gunicorn==20.1.0
 pytest==6.2.4
 pytest-watch==4.2.0

--- a/src/server/routes.py
+++ b/src/server/routes.py
@@ -72,11 +72,6 @@ def accessibility_statement(lang):
     content_security_policy_nonce_in=['script-src']
 )
 def sitemap():
-    # Flask-Talisman doesn't allow override of content_security_policy_nonce_in
-    # per route yet
-    # https://github.com/GoogleCloudPlatform/flask-talisman/issues/62
-    # So remove Nonce value from request object for now which has same effect
-    delattr(request, 'csp_nonce')
     xml = render_template('sitemap.xml')
     resp = app.make_response(xml)
     resp.mimetype = "text/xml"
@@ -92,11 +87,6 @@ def sitemap():
     frame_options=None
 )
 def stories(lang, year, story):
-    # Flask-Talisman doesn't allow override of content_security_policy_nonce_in
-    # per route yet
-    # https://github.com/GoogleCloudPlatform/flask-talisman/issues/62
-    # So remove Nonce value from request object for now which has same effect
-    delattr(request, 'csp_nonce')
     return render_template('%s/%s/stories/%s.html' % (lang, year, story.replace('-', '_')))
 
 


### PR DESCRIPTION
Upgrade flask-talisman to 0.8.1 to fix some long-standing, minor, issues:
- Remove need for workaround for CSP for xml files
- Sets length of CSP nonce correctly thus fixing an error on nu validator
- Removes pointless `X-Content-Security-Policy` header

Note this also sets a default permission-policy to remove FLoC support. Doesn't really impact us as we don't use Google Ads but more an FYI.