### PR TITLE
Better CSP

### DIFF
--- a/src/server/csp.py
+++ b/src/server/csp.py
@@ -5,8 +5,10 @@ csp = {
     ],
     'script-src': [
         '\'self\'',
+        '\'strict-dynamic\'',
         'www.google-analytics.com',
-        'www.googletagmanager.com'
+        'www.googletagmanager.com',
+        'unsafe-inline'
     ],
     'font-src': [
         '\'self\''
@@ -30,5 +32,11 @@ csp = {
         '\'self\'',
         'docs.google.com',
         'www.youtube.com'
+    ],
+    'object-src': [
+        '\'none\''
+    ],
+    'base-uri': [
+        '\'none\''
     ]
 }

--- a/src/server/csp.py
+++ b/src/server/csp.py
@@ -34,7 +34,7 @@ csp = {
         'www.youtube.com'
     ],
     'object-src': [
-        '\'none\''
+        '\'self\''
     ],
     'base-uri': [
         '\'none\''

--- a/src/server/csp.py
+++ b/src/server/csp.py
@@ -8,7 +8,7 @@ csp = {
         '\'strict-dynamic\'',
         'www.google-analytics.com',
         'www.googletagmanager.com',
-        'unsafe-inline'
+        '\'unsafe-inline\''
     ],
     'font-src': [
         '\'self\''

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -72,7 +72,7 @@
     {% block content %}{% endblock %}
 
     {% block bodyend %}
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-22381566-3"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-22381566-3" nonce="{{ csp_nonce() }}"></script>
     <link rel="preconnect" href="https://www.google-analytics.com">
     <script nonce="{{ csp_nonce() }}">
         window.dataLayer = window.dataLayer || [];
@@ -84,8 +84,8 @@
           'link_attribution': true
         });
     </script>
-    <script defer src="{{ get_versioned_filename('/static/js/web-vitals.js') }}"></script>
-    <script defer src="{{ get_versioned_filename('/static/js/send-web-vitals.js') }}"></script>
+    <script defer src="{{ get_versioned_filename('/static/js/web-vitals.js') }}" nonce="{{ csp_nonce() }}"></script>
+    <script defer src="{{ get_versioned_filename('/static/js/send-web-vitals.js') }}" nonce="{{ csp_nonce() }}"></script>
     {% endblock %}
   </body>
 </html>

--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -507,7 +507,7 @@
     </footer>
   {% endblock %}
   {% block scripts %}
-  <script async src="{{ get_versioned_filename('/static/js/almanac.js') }}"></script>
+  <script async src="{{ get_versioned_filename('/static/js/almanac.js') }}" nonce="{{ csp_nonce() }}"></script>
   {% endblock %}
 {% endblock %}
 


### PR DESCRIPTION
Adds a better CSP to address most of the suggestions in Lighthouse v8:

![Lighthouse v8 CSP audits for Web Almanac Website](https://user-images.githubusercontent.com/10931297/121927018-7d5b5e00-cd36-11eb-8837-4da4e67b4372.png)

Most are things we probably should have added before to be fair, though never been quite ready to go all-in with `strict-dynamic` until now but it's easy enough since we already support a `nonce`.

We do use `object-src` for [2020 CSS Chapter](https://almanac.httparchive.org/en/2020/css#fig-30) and annoyingly Lighthouse complains if set to anything but `'none'` so we'll need to live with that.

We also don't have yet is a `report-uri`. Will have a think about this, but always been somewhat cynical about use of them since they are so noisy.

Also note this doesn't fix another, unrelated CSP issues keeping our best practice score to 93 but [saw a fix for that got merged recently](https://github.com/GoogleChrome/lighthouse/issues/11862) so hopefully next Lighthouse release will include that.