### PR TITLE
[ES][2020] 2020 JavaScript Spanish Translation

### DIFF
--- a/src/config/2020.json
+++ b/src/config/2020.json
@@ -233,7 +233,16 @@
       "website": "https://AhmadAwais.com",
       "github": "ahmadawais",
       "twitter": "MrAhmadAwais"
-    } ,
+    },
+    "alangdm": {
+      "name": "Alan Dávalos",
+      "teams": [
+        "translators"
+      ],
+      "avatar_url": "https://avatars.githubusercontent.com/u/6799159?v=4&s=200",
+      "github": "alangdm",
+      "twitter": "AlanGDavalos"
+    },
     "alankent": {
       "name": "Alan Kent",
       "teams": [

--- a/src/content/es/2020/javascript.md
+++ b/src/content/es/2020/javascript.md
@@ -620,7 +620,6 @@ Herramientas como React, GSAP y RequireJS tienden a ocupar mucho del tiempo de e
 
 También vale la pena indagar en el intervalo que existe entre la experiencia que un _framework_ provee en escritorio y móvil. El tráfico de dispositivos móviles cada vez se vuelve más dominante y es crítico que nuestras herramientas se desempeñen tan bien como sea posible en móviles. Una gran diferencia en el desempeño en móviles de un _framework_ es una gran alerta roja.
 
-
 {{ figure_markup(
   image="frameworks-main-thread-no-ember-diff.png",
   caption="Diferencia entre la mediana del tiempo de ejecución del hilo principal por página por framework de JavaScript, sin contar Ember.js.",
@@ -759,6 +758,7 @@ De las casi 5 millones de páginas móviles que fueron probadas, 81% de ellas co
 En otras palabras, si podemos hacer que se haga una migración de esas versiones viejas y vulnerables de jQuery, veríamos el número de sitios con vulnerabilidades conocidas desplomarse (al menos hasta que encontremos vulnerabilidades en los _frameworks_ más nuevos).
 
 La mayor parte de las vulnerabilidades encontradas cae en la categoría de severidad "media".
+
 {{ figure_markup(
   image="vulnerabilities-by-severity.png",
   caption="Distribución del porcentaje de páginas móviles que tienen vulnerabilidades en JavaScript por severidad.",

--- a/src/content/es/2020/javascript.md
+++ b/src/content/es/2020/javascript.md
@@ -678,30 +678,30 @@ La correlación entre los bytes de JavaScript y las calificaciones de desempeño
 
 La conexión entre el Tiempo Total de Bloqueo y los bytes de JavaScript es aún más significativa (0.55 para bytes totales y 0.48 para bytes de terceros). Esto no es sorpresivo debido a que conocemos todo el trabajo extra que los navegadores deben hacer para hacer que el código JavaScript corra en una página—más bytes significa más tiempo.
 
-### Security vulnerabilities
+### Vulnerabilidades de seguridad
 
-One other helpful audit that Lighthouse runs is to check for known security vulnerabilities in third-party libraries. It does this by detecting which libraries and frameworks are used on a given page, and what version is used of each. Then it checks <a hreflang="en" href="https://snyk.io/vuln?type=npm">Snyk's open-source vulnerability database</a> to see what vulnerabilities have been discovered in the identified tools.
+Otra auditoría útil que Lighthouse corre es revisar si existen vulnerabilidades de seguridad conocidas en librerías de terceros. Hace esto detectando que librerías y _frameworks_ y que versiones son usadas en una página. Después revisa la <a hreflang="en" href="https://snyk.io/vuln?type=npm">base de datos _open source_ de Snyk</a> para ver si alguna vulnerabilidad ha sido descubierta en las herramientas detectadas.
 
 {{ figure_markup(
-  caption="Percent of mobile pages contain at least one vulnerable JavaScript library.",
+  caption="Porcentaje de páginas móviles con al menos una librería de JavaScript vulnerable.",
   content="83.50%",
   classes="big-number",
   sheets_gid="1326928130",
   sql_file="lighthouse_vulnerabilities.sql"
 ) }}
 
-According to the audit, 83.5% of mobile pages use a JavaScript library or framework with at least one known security vulnerability.
+De acuerdo a la auditoría, 83.5% de las páginas móviles usan una librería o _framework_ con al menos una vulnerabilidad de seguridad conocida.
 
-This is what we call the jQuery effect. Remember how we saw that jQuery is used on a whopping 83% of pages? Several older versions of jQuery contain known vulnerabilities, which comprises the vast majority of the vulnerabilities this audit checks.
+Esto es a lo que llamamos el efecto jQuery. Anteriormente vismo como jQuery es usado en un 83% de las páginas. Múltiples versiones viejas de jQuery contienen vulnerabilidades conocidas, lo cual constituye la vasta mayoría de las vulnerabilidades que esta auditoría revisó.
 
-Of the roughly 5 million or so mobile pages that are tested against, 81% of them contain a vulnerable version of jQuery—a sizeable lead over the second most commonly found vulnerable library—jQuery UI at 15.6%.
+De las casi 5 millones de páginas móviles que fueron probadas, 81% de ellas contiene una versión vulnerable de jQuery—una delantera considerable contra la segunda librería vulnerable más común—jQuery UI con un 15.6%.
 
 <figure>
   <table>
     <thead>
       <tr>
-        <th>Library</th>
-        <th>Vulnerable pages</th>
+        <th>Librería</th>
+        <th>Páginas vulnerables</th>
       </tr>
     </thead>
     <tbody>
@@ -749,21 +749,20 @@ Of the roughly 5 million or so mobile pages that are tested against, 81% of them
   </table>
   <figcaption>
     {{ figure_link(
-      caption="Top 10 libraries contributing to the highest numbers of vulnerable mobile pages according to Lighthouse.",
+      caption="Top 10 de librerías que contribuyen la mayor cantidad de páginas móviles vulnerables de acuerdo a Lighthouse.",
       sheets_gid="1803013938",
       sql_file="lighthouse_vulnerable_libraries.sql"
     ) }}
   </figcaption>
 </figure>
 
-In other words, if we can get folks to migrate away from those outdated, vulnerable versions of jQuery, we would see the number of sites with known vulnerabilities plummet (at least, until we start finding some in the newer frameworks).
+En otras palabras, si podemos hacer que se haga una migración de esas versiones viejas y vulnerables de jQuery, veríamos el número de sitios con vulnerabilidades conocidas desplomarse (al menos hasta que encontremos vulnerabilidades en los _frameworks_ más nuevos).
 
-The bulk of the vulnerabilities found fall into the "medium" severity category.
-
+La mayor parte de las vulnerabilidades encontradas cae en la categoría de severidad "media".
 {{ figure_markup(
   image="vulnerabilities-by-severity.png",
-  caption="Distribution of the percent of mobile pages having JavaScript vulnerabilities by severity.",
-  description="Pie chart showing 13.7% of mobile pages having no JavaScript vulnerabilities, 0.7% having low severity vulnerabilities, 69.1% having medium severity, and 16.4% having high severity.",
+  caption="Distribución del porcentaje de páginas móviles que tienen vulnerabilidades en JavaScript por severidad.",
+  description="Gráfica de pie mostrando que 13.7% de las páginas móviles no tienen vulnerabilidades de JavaScript, 0.7 tienen vulnerabilidades de baja severidad, 69.1% tienen vulnerabilidades de media severidad y 16.4% tienen alta severidad.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=1932740277&format=interactive",
   sheets_gid="1409147642",
   sql_file="lighthouse_vulnerabilities_by_severity.sql"

--- a/src/content/es/2020/javascript.md
+++ b/src/content/es/2020/javascript.md
@@ -112,12 +112,12 @@ Los números sin procesar pueden o no saltar a tu vista dependiendo de que tan a
 
 Esos 153 KB equivalen a ~37% del tamaño total del código que le enviamos a los dispositivos móviles. Esto definitivamente puede mejorar.
 
-### `module` and `nomodule`
-One mechanism we have to potentially reduce the amount of code we send down is to take advantage of the <a hreflang="en" href="https://web.dev/serve-modern-code-to-modern-browsers/">`module`/`nomodule` pattern</a>. With this pattern, we create two sets of bundles: one bundle intended for modern browsers and one intended for legacy browsers. The bundle intended for modern browsers gets a `type=module` and the bundle intended for legacy browsers gets a `type=nomodule`.
+### `module` y `nomodule`
+Un mecanismo que tenemos que tiene el potencial de reducir la cantidad de código que enviamos es utilizar <a hreflang="en" href="https://web.dev/serve-modern-code-to-modern-browsers/">el patrón `module`/`nomodule`</a>. Con este patrón, creamos dos <i lang="en">bundles</i>: uno para navegadores modernos y otro para navegadores <i lang="en">legacy</i>. Al <i lang="en">bundle</i> para navegadores modernos se le asigna `type=module` y al <i lang="en">bundle</i> para navegadores <i lang="en">legacy</i> se le asigna `type=nomodule`.
 
-This approach lets us create smaller bundles with modern syntax optimized for the browsers that support it, while providing conditionally loaded polyfills and different syntax to the browsers that don't.
+Esta estrategia nos permite crear <i lang="en">bundles</i> más pequeños utilizando sintaxis moderna optimizada para los browsers que son compatibles, mientras tanto, también proveemos <i lang="en">polyfills</i> cargados condicionalmente y una sintaxis diferente para los que no son compatibles.
 
-Support for `module` and `nomodule` is broadening, but still relatively new. As a result, adoption is still a bit low. Only 3.6% of mobile pages use at least one script with `type=module` and only 0.7% of mobile pages use at least one script with `type=nomodule` to support legacy browsers.
+La compatibilidad con `module` y `nomodule` va en aumento pero aún es una estrategia relativamente nueva. Como resultado, la adopción aún es baja. Solo 3.6% de las páginas móviles usa al menos un script con `type=module` y solo 0.7% de las páginas móviles usa al menos un script con `type=nomodule` para ser compatible con navegadores <i lang="en">legacy</i>.
 
 ### Request count
 

--- a/src/content/es/2020/javascript.md
+++ b/src/content/es/2020/javascript.md
@@ -371,24 +371,24 @@ De hecho, la dominación de jQuery tiene un mayor respaldo si consideramos que, 
 
 ### Frameworks
 
-When we look at the frameworks, we also don't see much of a dramatic change in terms of adoption in the main frameworks that were highlighted last year. Vue.js has seen a significant increase, and AMP grew a bit, but most of them are more or less where they were a year ago.
+Cuando tomamos un vistazo a los frameworks, no vemos un cambio dramático en términos de uso en los frameworks principales que fueron destacados el año pasado. Vue.js ha incrementado su uso significativamente y AMP creció un poco, pero la mayoría siguen más o menos donde estaban el año pasado.
 
-It's worth noting that the <a hreflang="en" href="https://github.com/AliasIO/wappalyzer/issues/2450">detection issue that was noted last year still applies</a>, and still impacts the results here. It's possible that there _has_ been a significant change in popularity for a few more of these tools, but we just don't see it with the way the data is currently collected.
+Vale la pena mencionar que <a hreflang="en" href="https://github.com/AliasIO/wappalyzer/issues/2450">el problema de detección que fue notado el año pasado aún aplica</a> e impacta los resultados aquí. Es posible que _haya_ habido un cambio significativo en la popularidad de más de estas herramientas pero no podemos notarla con la manera en la que estos datos son recolectados en este momento.
 
-### What it all means
+### Qué significa todo esto
 
-More interesting to us than the popularity of the tools themselves is the impact they have on the things we build.
+Nos interesa más el impacto que tienen estas herramientas en las cosas que construimos que su popularidad.
 
-First, it's worth noting that while we may think of the usage of one tool versus another, in reality, we rarely only use a single library or framework in production. Only 21% of pages analyzed report only one library or framework. Two or three frameworks are pretty common, and the long-tail gets very long, very quickly.
+Para empezar, es importante notar que mientras podemos pensar en el uso de una herramienta contra el de otra, en realidad, pocas veces usamos sólo una librería o framework en producción. Sólo el 21% de las páginas analizadas usaban sólo una librería o _framework_. Dos o tres _frameworks_ era algo común y la cola se vuelve larga muy rápidamente.
 
-When we look at the common combinations that we see in production, most of them are to be expected. Knowing jQuery's dominance, it's unsurprising that most of the popular combinations include jQuery and any number of jQuery-related plugins.
+Cuando observamos las combinaciones más comunes en producción, la mayoría son esperadas. Sabiendo el dominio de jQuery, no sorprende ver que la mayoría de las combinaciones populares incluyen jQuery y algún número de _plugins_ relacionados a jQuery.
 
 <figure>
   <table>
     <thead>
       <tr>
-        <th>Combinations</th>
-        <th>Pages</th>
+        <th>Combinaciones</th>
+        <th>Páginas</th>
         <th>(%)</th>
       </tr>
     </thead>
@@ -498,22 +498,22 @@ When we look at the common combinations that we see in production, most of them 
 
   <figcaption>
     {{ figure_link(
-      caption="The most popular combinations of libraries and frameworks on mobile pages.",
+      caption="Las combinaciones más populares de librerías y frameworks en páginas móviles.",
       sheets_gid="795160444",
       sql_file="frameworks_libraries_combos.sql"
     ) }}
   </figcaption>
 </figure>
 
-We do also see a fair amount of more "modern" frameworks like React, Vue, and Angular paired with jQuery, for example as a result of migration or inclusion by third-parties.
+Tambien podemos ver una cantidad relativamente alta de _frameworks_ "modernos" como React, Vue y Angular usados en conjunto con jQuery, por ejemplo como resultado de una migración o inclusión por terceros.
 
 <figure>
   <table>
     <thead>
       <tr>
-        <th scope="col">Combination</th>
-        <th scope="col">Without jQuery</th>
-        <th scope="col">With jQuery</th>
+        <th scope="col">Combinación</th>
+        <th scope="col">Sin jQuery</th>
+        <th scope="col">Con jQuery</th>
       </tr>
     </thead>
     <tbody>
@@ -560,7 +560,7 @@ We do also see a fair amount of more "modern" frameworks like React, Vue, and An
     </tbody>
     <tfoot>
       <tr>
-        <th scope="col">Grand Total</th>
+        <th scope="col">Total</th>
         <th scope="col" class="numeric">1.7%</th>
         <th scope="col" class="numeric">1.4%</th>
       </tr>
@@ -568,23 +568,23 @@ We do also see a fair amount of more "modern" frameworks like React, Vue, and An
   </table>
   <figcaption>
     {{ figure_link(
-      caption="The most popular combinations of React, Angular, and Vue with and without jQuery.",
+      caption="Las combinaciones más populares de React, Angular y vue con y sin jQuery.",
       sheets_gid="795160444",
       sql_file="frameworks_libraries_combos.sql"
     ) }}
   </figcaption>
 </figure>
 
-More importantly, all these tools typically mean more code and more processing time.
+Es más importante notar que todas estas herramientas usualmente derivan en más código y más tiempo de procesamiento.
 
-Looking specifically at the frameworks in use, we see that the median JavaScript bytes for pages using them varies dramatically depending on _what_ is being used.
+Revisando específicamente los _frameworks_ en uso, vemos que la mediana de bytes de JavaScript por páginas usándolos varía dramáticamente dependiendo de _qué_ está siendo usado.
 
-The graph below shows the median bytes for pages where any of the top 35 most commonly detected frameworks were found, broken down by client.
+La gráfica sigueiente muestra la mediana de bytes por páginas donde cualquiera de los 35 frameworks más comunes fueron encontrados dividido por tipo de cliente.
 
 {{ figure_markup(
   image="frameworks-bytes.png",
-  caption="The median number of JavaScript kilobytes per page by JavaScript framework.",
-  description="Bar chart showing the median number of JavaScript kilobytes per page broken down and sorted by JavaScript framework popularity. The most popular framework, React, has a median amount of JS at 1,328 on mobile pages. Other frameworks like RequireJS and Angular have high numbers of median JS bytes per page. Pages with MooTools, Prototype, AMP, RightJS, Alpine.js, and Svelte have medians under 500 KB per mobile page. Ember.js has an outlier of about 1,800 KB of median JS per mobile page.",
+  caption="La mediana de kilobytes de JavaScript por página por framework de JavaScript.",
+  description="Gráfica de barras mostrando la mediana de kilobytes de JavaScript por página dividida y ordenada por popularidad de los frameworks de JavaScript. El framework más popular, React, tiene una mediana de 1,328 en páginas móviles. Otros frameworks como RequireJS y Angular tienen números altos de bytes de JS por página. Páginas con MooTools, Prototype, AMP, RightJS, Alpine.js y Svelte tienen medianas de menos de 500KB por página móvil. Ember.js es un caso aparte con alrededor de 1,800 KB de JS por página móvil.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=955720480&format=interactive",
   sheets_gid="1206934500",
   width="600",

--- a/src/content/es/2020/javascript.md
+++ b/src/content/es/2020/javascript.md
@@ -768,10 +768,10 @@ La mayor parte de las vulnerabilidades encontradas cae en la categoría de sever
   sql_file="lighthouse_vulnerabilities_by_severity.sql"
 ) }}
 
-## Conclusion
+## Conclusión
 
-JavaScript is steadily rising in popularity, and there's a lot that's positive about that. It's incredible to consider what we're able to accomplish on today's web thanks to JavaScript that, even a few years ago, would have been unimaginable.
+La popularidad de JavaScript está aumentando contínuamente y eso tiene muchos lados positivos. Es increíble considerar todo lo que podemos lograr con la web de hoy gracias a JavaScript que, hasta hace unos años, sería inimaginable.
 
-But it's clear we've also got to tread carefully. The amount of JavaScript consistently rises each year (if the stock market were that predictable, we'd all be incredibly wealthy), and that comes with trade-offs. More JavaScript is connected to an increase in processing time which negatively impacts key metrics like Total Blocking Time. And, if we let those libraries languish without keeping them updated, they carry the risk of exposing users through known security vulnerabilities.
+Pero es claro que también debemos andar con cuidado. La cantidad de JavaScript aumenta de manera consistente cada año (si el mercado accionario fuera así de predecible todos seríamos increíblemente ricos) y eso tiene sus contras. Mayores cantidades de JavaScript están conectadas a un incremento en el tiempo de procesamiento lo cual afecta negativamente métricas clave como el Tiempo Total de Bloqueo. Y, si descuidamos todas esas librerías sin actualizarlas, corremos el riesgo de exponer a los usuarios a vulnerabilidades de seguridad conocidas.
 
-Carefully weighing the cost of the scripts we add to our pages and being willing to place a critical eye on our tools and ask more of them are our best bets for ensuring that we build a web that is accessible, performant, and safe.
+Nuestras mejores apuestas para asegurar que construyamos una web accesible, con buen desempeño y segura son medir cuidadosamente el costo de los scripts que agregamos a nuestras páginas y estas dispuestos a ver con un ojo crítico a las herramientas que usamos y pedirles que sean mejores.

--- a/src/content/es/2020/javascript.md
+++ b/src/content/es/2020/javascript.md
@@ -299,45 +299,45 @@ Algo interesante es que, si bien hemos sido quisquillosos con las peticiones a t
   sql_file="lighthouse_unminified_js_by_3p.sql"
 ) }}
 
-### Compression
+### Compresión
 
-Minification is a great way to help reduce file size, but compression is even more effective and, therefore, more important—it provides the bulk of network savings more often than not.
+Minimizar los scripts es una buena manera de reducir el tamaño de los archivos, pero la compresión es aún más efectiva y por ende más importante. La compresión provee la mayor parte del ahorro en transmisión con mayor frecuencia.
 
 {{ figure_markup(
   image="compression-method-request.png",
-  caption="Distribution of the percent of JavaScript requests by compression method.",
-  description="Bar chart showing the distribution of the percent of JavaScript requests by compression method. Desktop and mobile values are very similar. 65% of JavaScript requests use Gzip compression, 20% use br (Brotli), 15% don't use any compression, and deflate, UTF-8, identity, and none appear as having 0%",
+  caption="Distribución del porcentaje de peticiones de JavaScript por método de compresión.",
+  description="Gráfica de barras mostrando la distribución del porcentaje de peticiones de JavaScript por método de compresión. Los valores en escritorio y móviles son muy similares. 65% de las peticiones de JavaScript usan compresión Gzip, 20% usan br (Brotli), 15% no usan compresión y deflate, UTF-8 y ninguno aparecen con un 0%.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=263239275&format=interactive",
   sheets_gid="1270710983",
   sql_file="compression_method.sql"
 ) }}
 
-85% of all JavaScript requests have some level of network compression applied. Gzip makes up the majority of that, with 65% of scripts having Gzip compression applied compared to 20% for Brotli (br). While the percentage of Brotli (which is more effective than Gzip) is low compared to its browser support, it's trending in the right direction, increasing by 5 percentage points in the last year.
+85% de todas las peticiones de JavaScript usan algún tipo de compresion. Gzip ocupa la mayoría de ese porcentaje, con 65% de los scripts siendo comprimidos usando Gzip en comparación a un 20% para Brotli (br). Mientras que el porcentaje de Brotli (qué es más efectivo que Gzip) es bajo tomando en cuenta el soporte que tiene en los navegadores, la tendencia va en la dirección correcta, pues subió 5 puntos porcentuales comparado con el año pasado.
 
-Once again, this appears to be an area where third-party scripts are actually doing better than first-party scripts. If we break the compression methods out by first- and third-party, we see that 24% of third-party scripts have Brotli applied, compared to only 15% of first-party scripts.
+Una vez más, esta parece ser un área donde los scripts de terceros están haciendo un mejor trabajo que los propios. Si hacemos la comparativa entre los métodos de compresión entre scripts propios y de terceros, podemos ver que el 24% de los scripts de terceros son comprimidos usando Brotli en comparación con un 15% en scripts propios.
 
 {{ figure_markup(
   image="compression-method-3p.png",
-  caption="Distribution of the percent of mobile JavaScript requests by compression method and host.",
-  description="Bar chart showing the distribution of the percent of mobile JavaScript requests by compression method and host. 66% and 64% of first and third party JavaScript requests use Gzip. 15% of first party and 24% of third party scripts requests use Brotli. And 19% of first party and 12% of third party scripts do not have a compression method set.",
+  caption="Distribución del porcentaje de peticiones de JavaScript en móviles por método de compresión y host.",
+  description="Gráfica de barras mostrando la distribución del porcentaje de peticiones de JavaScript en móviles por método de compresión y host. 66% de las peticiones de Javascript propias y 64% de las de terceros usan Gzip. 15% de las peticiones de scripts propios y 24% de las de terceros usan Brotli. Y el 19% de los scripts propios y el 12% de los de terceros no usan ningún método de compresión.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=1402692197&format=interactive",
   sheets_gid="564760060",
   sql_file="compression_method_by_3p.sql"
 ) }}
 
-Third-party scripts are also least likely to be served without any compression at all: 12% of third-party scripts have neither Gzip nor Brotli applied, compared to 19% of first-party scripts.
+Los scripts de terceros también son menos propensos a ser servidos sin ningún tipo de compresión: 12% de los scripts de terceros no usan ni Gzip ni Brotli comparado al 19% de scripts propios.
 
-It's worth taking a closer look at those scripts that _don't_ have compression applied. Compression becomes more efficient in terms of savings the more content it has to work with. In other words, if the file is tiny, sometimes the cost of compressing the file doesn't outweight the miniscule reduction in file size.
+Vale la pena ver más de cerca a los scripts que _no_ usan compresión. La compresión se vuelve más eficiente en términos de ahorros mientras más contenido tiene que comprimir. En otras palabras, si el archivo es pequeño, a veces el costo de compresión no sobrepasa la minúscula reducción al tamaño del archivo.
 
 {{ figure_markup(
-  caption="Percent of uncompressed third-party JavaScript requests under 5 KB.",
+  caption="Porcentaje de peticiones de JavaScript de terceros sin comprimir cuyo tamaño es menor a 5 KB.",
   content="90.25%",
   classes="big-number",
   sheets_gid="347926930",
   sql_file="compression_none_by_bytes.sql"
 ) }}
 
-Thankfully, that's exactly what we see, particularly in third-party scripts where 90% of uncompressed scripts are less than 5 KB in size. On the other hand, 49% of uncompressed first-party scripts are less than 5 KB and 37% of uncompressed first-party scripts are over 10 KB. So while we do see a lot of small uncompressed first-party scripts, there are still quite a few that would benefit from some compression.
+Por fortuna, eso es exactamente lo que podemos observar, en paricular para los scripts de terceros donde el 90% de los scripts sin comprimir tiene un tamaño menor a 5 KB. Por otro lado, 49% de los scripts propios son de menos de 5 KB y 37% de los scripts propios sin comprimir son de más de 10 KB. Así que mientras que si vemos una gran cantidad de scripts propios pequeños sin comprimir, aún existen muchos que podrían beneficiarse de la compresión.
 
 ## What do we use?
 

--- a/src/content/es/2020/javascript.md
+++ b/src/content/es/2020/javascript.md
@@ -7,7 +7,7 @@ reviewers: [ibnesayeed, denar90]
 analysts: [rviscomi, paulcalvano]
 editors: [rviscomi]
 translators: [alangdm]
-tkadlec_bio: Tim es un consultor y entrenador sobre desempeño web enfocado en crear una web que todos podamos usar. El es autor de <i lang="en">High Performance Images</i> (O'Reilly, 2016) y <i lang="en">Implementing Responsive Design</i> (New Riders, 2012). El escribe sobre la web en general en <a hreflang="en" href="https://timkadlec.com/">timkadlec.com</a>. Puedes encontrarlo compartiendo sus opiniones en un formato más breve en Twitter con el usuario <a href="https://twitter.com/tkadlec">@tkadlec</a>.
+tkadlec_bio: Tim es un consultor y entrenador sobre desempeño web enfocado en crear una web que todos podamos usar. El es autor de <i lang="en">High Performance Images</i> (O'Reilly, 2016) y <i lang="en">Implementing Responsive Design</i> (New Riders, 2012). Él escribe sobre la web en general en <a hreflang="en" href="https://timkadlec.com/">timkadlec.com</a>. Puedes encontrarlo compartiendo sus opiniones en un formato más breve en Twitter con el usuario <a href="https://twitter.com/tkadlec">@tkadlec</a>.
 discuss: 2038
 results: https://docs.google.com/spreadsheets/d/1cgXJrFH02SHPKDGD0AelaXAdB3UI7PIb5dlS0dxVtfY/
 featured_quote: JavaScript ha avanzado mucho desde su origen humilde hasta ser considerado el tercer pilar de la web junto con CSS y HTML. Hoy en día, JavaScript ha comenzado a invadir un amplio espectro del <i lang="en">stack</i> técnico. JavaScript ya no se encuentra limitado al lado del cliente y se ha convertido en una elección cada vez más popular para crear herramientas de construcción y <i lang="en">scripting</i> del lado del servidor. JavaScript también se ha adentrado en la capa de CDN gracias a soluciones de <i lang="en">edge computing</i>.
@@ -23,7 +23,7 @@ featured_stat_label_3: Porcentaje de <i lang="en">scripts</i> cargados asíncron
 
 JavaScript ha avanzado mucho desde su origen humilde hasta ser considerado el tercer pilar de la web junto con CSS y HTML. Hoy en día, JavaScript ha comenzado a invadir un amplio espectro del <i lang="en">stack</i> técnico. JavaScript ya no se encuentra limitado al lado del cliente y se ha convertido en una elección cada vez más popular para crear herramientas de construcción y <i lang="en">scripting</i> del lado del servidor. JavaScript también se ha adentrado en la capa de CDN gracias a soluciones de <i lang="en">edge computing</i>.
 
-Los desarroladores amamos usar JavaScript. De acuerdo con el capítulo de marcado, el elemento `script` es el [6to elemento de HTML más popular](./markup) en uso (por delante de elementos tales como `p` e `i` entre muchos otros). Utilizamos más de 14 veces más bytes de JavaScript de los que usamos de HTML, los bloques para construir la web, y 6 veces más bytes que los que usamos de CSS.
+Los desarrolladores amamos usar JavaScript. De acuerdo con el capítulo de marcado, el elemento `script` es el [6to elemento de HTML más popular](./markup) en uso (por delante de elementos tales como `p` e `i` entre muchos otros). Utilizamos más de 14 veces más bytes de JavaScript de los que usamos de HTML, los bloques para construir la web, y 6 veces más bytes que los que usamos de CSS.
 
 {{ figure_markup(
   image="../page-weight/bytes-distribution-content-type.png",
@@ -34,46 +34,46 @@ Los desarroladores amamos usar JavaScript. De acuerdo con el capítulo de marcad
   sql_file="../page-weight/bytes_per_type_2020.sql"
 ) }}
 
-Pero nada es gratis y esto aplica eespcialmente para Javascript. Todo ese código tiene un costo. Veamos con más detalle cuánto código usamos, cómo lo usamos y cuáles son los efectos secundarios de este.
+Pero nada es gratis y esto aplica especialmente para Javascript. Todo ese código tiene un costo. Veamos con más detalle cuánto código usamos, cómo lo usamos y cuáles son los efectos secundarios de este.
 
-## How much JavaScript do we use?
+## ¿Cuánto JavaScript usamos?
 
-We mentioned that the `script` tag is the 6th most used HTML element. Let's dig in a bit deeper to see just how much JavaScript that actually amounts to.
+Mencionamos que la etiqueta `script` es el 6to elemento de HTML más usado. Entremos más en detalle para ver cuánto JavaScript es contenido ahí.
 
-The median site (the 50th percentile) sends 444 KB of JavaScript when loaded on a desktop device, and slightly fewer (411 KB) to a mobile device.
+Un sitio ubicado en la mediana (percentil 50) envía 444 KB de JavaScript al ser cargado en un dispositivo de escritorio y un poco menos que eso (411 KB) a un dispositivo móvil.
 
 {{ figure_markup(
   image="bytes-2020.png",
-  caption="Distribution of the amount of JavaScript kilobytes loaded per page.",
-  description="Bar chart showing the distribution of JavaScript bytes per page by about 10%. Desktop pages consistently load more JavaScript bytes than mobile pages. The 10th, 25th, 50th, 75th, and 90th percentiles for desktop are: 87 KB, 209 KB, 444 KB, 826 KB, and 1,322 KB.",
+  caption="Distribución de la cantidad de kilobytes cargados por página.",
+  description="Gráfica de barras mostrando la distribución de bytes de JavaScript por página en intervalos de 10%. Las páginas de escritorio consistentemente cargan más bytes de JavaScript que las páginas móviles. Los percentiles 10, 25, 50, 75 y 90 para escritorio son de: 87 KB, 209 KB, 444 KB, 826 KB y 1,322 KB.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=441749673&format=interactive",
   sheets_gid="2139688512",
   sql_file="bytes_2020.sql"
 ) }}
 
-It's a bit disappointing that there isn't a bigger gap here. While it's dangerous to make too many assumptions about network or processing power based on whether the device in use is a phone or a desktop (or somewhere in between), it's worth noting that [HTTP Archive mobile tests](./methodology#webpagetest) are done by emulating a Moto G4 and a 3G network. In other words, if there was any work being done to adapt to less-than-ideal circumstances by passing down less code, these tests should be showing it.
+Es un poco decepcionante no ver una mayor diferencia. Si bien es peligroso hacer muchas suposiciones sobre la red o el poder de procesamiento basados en si el dispositivo es un teléfono o una computadora de escritorio (o algo intermedio), debemos recalcar que las [pruebas en móviles del <i lang="en">HTTP Archive</i>](./methodology#webpagetest) son hechas emulando un Moto G4 en una red 3G. En otras palabras, si existiese algún trabajo para adaptarse a condiciones no ideales y transmitir menos código estas pruebas deberían demostrarlo.
 
-The trend also seems to be in favor of using more JavaScript, not less. Comparing to [last year's results](../2019/javascript#how-much-javascript-do-we-use), at the median we see a 13.4% increase in JavaScript as tested on a desktop device, and a 14.4% increase in the amount of JavaScript sent to a mobile device.
+La tendencia parece estar a favor de usar más JavaScript, no menos. Comparando con [los resultados del año pasado](../2019/javascript#how-much-javascript-do-we-use), vemos un incremento de 13.4% en la mediana de Javascript al probar en un dispositivo de escritorio y un incremento de 14.4% en la cantidad de JavaScript enviado a un dispositivo móvil.
 
 <figure>
   <table>
     <thead>
       <tr>
-        <th>Client</th>
+        <th>Cliente</th>
         <th>2019</th>
         <th>2020</th>
-        <th>Change</th>
+        <th>Cambio</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <td>Desktop</td>
+        <td>Escritorio</td>
         <td class="numeric">391</td>
         <td class="numeric">444</td>
         <td class="numeric">13.4%</td>
       </tr>
       <tr>
-        <td>Mobile</td>
+        <td>Móvil</td>
         <td class="numeric">359</td>
         <td class="numeric">411</td>
         <td class="numeric">14.4%</td>
@@ -82,35 +82,35 @@ The trend also seems to be in favor of using more JavaScript, not less. Comparin
   </table>
   <figcaption>
     {{ figure_link(
-      caption="Year-over-year change in the median number of JavaScript kilobytes per page.",
+      caption="Cambio año a año en la mediana de kilobytes de JavaScript por página.",
       sheets_gid="86213362",
       sql_file="bytes_2020.sql"
     ) }}
   </figcaption>
 </figure>
 
-At least some of this weight seems to be unnecessary. If we look at a breakdown of how much of that JavaScript is unused on any given page load, we see that the median page is shipping 152 KB of unused JavaScript. That number jumps to 334 KB at the 75th percentile and 567 KB at the 90th percentile.
+Al menos parte de este tamaño parece ser innecesario. Si vemos un desglose de cuanto JavaScript no es usado al cargar una página, podemos ver que una página ubicada en la mediana transmite 152 KB de JavaScript que no es usado. Este número sube a 334 KB en el percentil 75 y a 567 KB en el percentil 90.
 
 {{ figure_markup(
   image="unused-js-bytes-distribution.png",
-  caption="Distribution of the amount of wasted JavaScript bytes per mobile page.",
-  description="Bar chart showing the distribution of amount of wasted JavaScript bytes per page. From the 10, 25, 50, 75, and 90th percentiles, the distribution goes: 0, 57, 153, 335, and 568 KB.",
+  caption="Distribución de la cantidad de bytes de JavaScript desperdiciados por página móvil.",
+  description="Gráfica de barras mostrando la distribución de bytes de JavaScript desperdiciados por página. Para los percentiles 10, 25, 50, 75 y 90 la distribución es: 0, 57, 153, 335 y 568 KB.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=773002950&format=interactive",
   sheets_gid="611267860",
   sql_file="unused_js_bytes_distribution.sql"
 ) }}
 
-As raw numbers, those may or may not jump out at you depending on how much of a performance nut you are, but when you look at it as a percentage of the total JavaScript used on each page, it becomes a bit easier to see just how much waste we're sending.
+Los números sin procesar pueden o no saltar a tu vista dependiendo de que tan aficionado seas a optimizar el desempeño, pero al verlo como un porcentaje del total de JavaScript usado en cada página, se vuelve un poco más fácil ver que tanto código extra se está enviando.
 
 {{ figure_markup(
-  caption="Percent of the median mobile page's JavaScript bytes that are unused.",
+  caption="Porcentaje de los bytes de JavaScript en una página ubicada en la mediana que no son usados.",
   content="37.22%",
   classes="big-number",
   sheets_gid="611267860",
   sql_file="unused_js_bytes_distribution.sql"
 ) }}
 
-That 153 KB equates to ~37% of the total script size that we send down to mobile devices. There's definitely some room for improvement here.
+Esos 153 KB equivalen a ~37% del tamaño total del código que le enviamos a los dispositivos móviles. Esto definitivamente puede mejorar.
 
 ### `module` and `nomodule`
 One mechanism we have to potentially reduce the amount of code we send down is to take advantage of the <a hreflang="en" href="https://web.dev/serve-modern-code-to-modern-browsers/">`module`/`nomodule` pattern</a>. With this pattern, we create two sets of bundles: one bundle intended for modern browsers and one intended for legacy browsers. The bundle intended for modern browsers gets a `type=module` and the bundle intended for legacy browsers gets a `type=nomodule`.

--- a/src/content/es/2020/javascript.md
+++ b/src/content/es/2020/javascript.md
@@ -38,7 +38,7 @@ Pero nada es gratis y esto aplica especialmente para JavaScript. Todo ese códig
 
 ## ¿Cuánto JavaScript usamos?
 
-Mencionamos que la etiqueta `script` es el 6to elemento de HTML más usado. Entremos más en detalle para ver cuánto JavaScript es contenido ahí.
+Mencionamos que la etiqueta `script` es el 6to elemento de HTML más usado. Entremos más en detalle para ver cuánto JavaScript está contenido ahí.
 
 Un sitio ubicado en la mediana (percentil 50) envía 444 KB de JavaScript al ser cargado en un dispositivo de escritorio y un poco menos que eso (411 KB) a un dispositivo móvil.
 
@@ -110,7 +110,7 @@ Los números sin procesar pueden o no saltar a tu vista dependiendo de que tan a
   sql_file="unused_js_bytes_distribution.sql"
 ) }}
 
-Esos 153 KB equivalen a ~37% del tamaño total del código que le enviamos a los dispositivos móviles. Esto definitivamente puede mejorar.
+Esos 153 KB equivalen a alrededor de 37% del tamaño total del código que le enviamos a los dispositivos móviles. Esto definitivamente puede mejorar.
 
 ### `module` y `nomodule`
 Un mecanismo que tenemos que tiene el potencial de reducir la cantidad de código que enviamos es utilizar <a hreflang="en" href="https://web.dev/serve-modern-code-to-modern-browsers/">el patrón `module`/`nomodule`</a>. Con este patrón, creamos dos <i lang="en">bundles</i>: uno para navegadores modernos y otro para navegadores <i lang="en">legacy</i>. Al <i lang="en">bundle</i> para navegadores modernos se le asigna `type=module` y al <i lang="en">bundle</i> para navegadores <i lang="en">legacy</i> se le asigna `type=nomodule`.
@@ -121,7 +121,7 @@ La compatibilidad con `module` y `nomodule` va en aumento pero aún es una estra
 
 ### Conteo de peticiones
 
-Otra manera de ver cuanto JavaScript usamos es explorar cuantas peticiones de JavaScript son hechas por página. Reducir el número de peticiones era fundamental para tener un buen desempeño usando HTTP/1.1, sin embargo, con HTTP/2 aplica lo contrario: dividir el código en JavaScript en <a hreflang="en" href="https://web.dev/granular-chunking-nextjs/">archivos individuales y más pequeños</a> resulta en [un mejor desempeño en general.](../2019/http2#impact-of-http2).
+Otra manera de ver cuánto JavaScript usamos es explorar cuantas peticiones de JavaScript son hechas por página. Reducir el número de peticiones era fundamental para tener un buen desempeño usando HTTP/1.1, sin embargo, con HTTP/2 aplica lo contrario: dividir el código en JavaScript en <a hreflang="en" href="https://web.dev/granular-chunking-nextjs/">archivos individuales y más pequeños</a> resulta en [un mejor desempeño en general.](../2019/http2#impact-of-http2).
 
 {{ figure_markup(
   image="requests-2020.png",
@@ -149,7 +149,7 @@ Una tendencia que posiblemente contribuye al incremento en la cantidad de JavaSc
 
 Veamos esto más a detalle para ver cuantos scripts de terceros estamos enviando.
 
-Justo hasta la mediana, los sitios envían apróximadamente la misma cantidad de scripts propios que de terceros. En la mediana, 9 scripts por página son propios y 10 son de terceros. Desde ese punto, la diferencia crece un poco: mientras más scripts envía un sitio en total, es mayor la probabilidad de que la mayoría de esos scripts sean de terceros.
+Justo hasta la mediana, los sitios envían aproximadamente la misma cantidad de scripts propios que de terceros. En la mediana, 9 scripts por página son propios y 10 son de terceros. Desde ese punto, la diferencia crece un poco: mientras más scripts envía un sitio en total, es mayor la probabilidad de que la mayoría de esos scripts sean de terceros.
 
 {{ figure_markup(
   image="requests-by-3p-desktop.png",
@@ -195,12 +195,12 @@ La manera en la que cargamos JavaScript tiene un impacto significativo en la exp
 
 JavaScript _bloquea al analizador sintáctico_ por defecto. En otras palabras, cuando el navegador encuentra un elemento `script`, debe pausar el análisis del HTML hasta que el script haya sido descargado, analizado y ejecutado. Esto es un cuello de botella significativo y es una causa común de que las páginas se muestren lentamente.
 
-Podemos comenzar a compensar el costo de cargar JavaScript haciendo que los scripts se descarguen asíncronamente (usando el atributo `async`), este atributo sólo detiene el analizador de HTML durante las fases de análisis y ejecución de JavaScript y no durante la de descarga, o diferidamente (usando el atributo `defer`), este atributo no detiene al analizador de HTML nunca. Ambos atributos solo pueden aplicarse a scripts externos, no se pueden aplicar a scripts _inline_.
+Podemos comenzar a compensar el costo de cargar JavaScript haciendo que los scripts se descarguen asíncronamente (usando el atributo `async`), este atributo sólo detiene el analizador de HTML durante las fases de análisis y ejecución de JavaScript y no durante la de descarga, o diferidamente (usando el atributo `defer`), este atributo no detiene al analizador de HTML nunca. Ambos atributos sólo pueden aplicarse a scripts externos, no se pueden aplicar a scripts _inline_.
 
 En móviles, los scripts externos representan el 59.0% de todos los scripts encontrados.
 
 <p class="note">
-  Como nota, cuando hablamos anteriormente acerca de cuanto JavaScript es cargado en una página, ese total no tomaba en cuenta el tamaño de los scripts _inline_. Debido a que son parte del documento HTML, se cuentan como parte del tamaño de marcado. Esto significa que cargamos aún más scripts de lo que los números muestran.
+  Como nota, cuando hablamos anteriormente acerca de cuánto JavaScript es cargado en una página, ese total no tomaba en cuenta el tamaño de los scripts _inline_. Debido a que son parte del documento HTML, se cuentan como parte del tamaño de marcado. Esto significa que cargamos aún más scripts de lo que los números muestran.
 </p>
 
 {{ figure_markup(
@@ -212,7 +212,7 @@ En móviles, los scripts externos representan el 59.0% de todos los scripts enco
   sql_file="breakdown_of_scripts_using_async_defer_module_nomodule.sql"
 ) }}
 
-De los scripts externos, solo el 12.2% son cargados con el atributo `async` y 6.0% son cargados con el atributo `defer`.
+De los scripts externos, sólo el 12.2% son cargados con el atributo `async` y 6.0% son cargados con el atributo `defer`.
 
 {{ figure_markup(
   image="async-defer-mobile.png",
@@ -223,11 +223,11 @@ De los scripts externos, solo el 12.2% son cargados con el atributo `async` y 6.
   sql_file="breakdown_of_scripts_using_async_defer_module_nomodule.sql"
 ) }}
 
-Tomando en consideración que `defer` provee el mejor desempeño al cargar (ya que se asegura que la descarga del script ocurre en paralelo a otras tareas y la execución se realiza hasta después de que la página pueda ser mostrada), desearíamos que el porcentaje de uso fuera mayor. De hecho, el 6.0% anterior esta un poco inflado.
+Tomando en consideración que `defer` provee el mejor desempeño al cargar (ya que se asegura que la descarga del script ocurre en paralelo a otras tareas y la ejecución se realiza hasta después de que la página pueda ser mostrada), desearíamos que el porcentaje de uso fuera mayor. De hecho, el 6.0% anterior está un poco inflado.
 
 Cuando el soporte para IE8 e IE9 era más común, era relativamente común usar _ambos atributos_. Cuando ambos están presentes, cualquier navegador que soporte ambos usará `async`. IE8 e IE9 no soportan `async` entonces usarán `defer`.
 
-En días recientes, este patrón no es necesario para la mayoría de los sitios y cualquier script cargado con este patrón interrumpirá al analizador de HTML cuando debe ser ejecutado, en lugar de diferir hasta que la página haya cargado. Este patrón tiene un uso soprendentement frecuente, 11.4% de las páginas móviles tienen al menos un script con este patrón. En otras palabras, al menos una parte del 6% de scripts que usan `defer` no están obteniendo los beneficios del atributo `defer`.
+En días recientes, este patrón no es necesario para la mayoría de los sitios y cualquier script cargado con este patrón interrumpirá al analizador de HTML cuando debe ser ejecutado, en lugar de diferir hasta que la página haya cargado. Este patrón tiene un uso sorprendentemente frecuente, 11.4% de las páginas móviles tienen al menos un script con este patrón. En otras palabras, al menos una parte del 6% de scripts que usan `defer` no están obteniendo los beneficios del atributo `defer`.
 
 Pero hay una historia alentadora sobre esto.
 
@@ -247,7 +247,7 @@ Globalmente, 16.7% de las páginas móviles usa al menos uno de estos dos _resou
 
 De ese 16.7%, casi todo el uso viene de usar `preload`. Mientras que el 16.6% de las páginas móviles usa al menos un _hint_ de preload para cargar JavaScript, sólo el 0.4% de las páginas móviles usan al menos un _hint_ de `prefetch`.
 
-Existe un riesgo, en particular con `preload`, al usar demasiados _hints_ pues se reduce su eficacia, así que vale la pena analizar las páginas que usan estos _hints_ para ver cuantos usan.
+Existe un riesgo, en particular con `preload`, al usar demasiados _hints_ pues se reduce su eficacia, así que vale la pena analizar las páginas que usan estos _hints_ para ver cuántos usan.
 
 {{ figure_markup(
   image="prefetch-distribution.png",
@@ -273,7 +273,7 @@ En la mediana, las páginas que usan _hints_ de `prefetch` para cargar JavaScrip
 
 Al igual que con otros recursos basados en texto en la web, podemos ahorrar una cantidad significativa de bytes a través de minimización y compresión. Ninguna de estas optimizaciones son nuevas, llevan siendo usadas por mucho tiempo, así que deberíamos verlas usadas frecuentemente.
 
-Una de las auditorías en _[Lighthouse](./methodology#lighthouse)_ revisa si el JavaScript no ha sido minimizado y provee una calificación (0.00 siendo la mínima calificación y 1.00 siendo la máxima) basado en lo que encuentra.
+Una de las auditorías en [Lighthouse](./methodology#lighthouse) revisa si el JavaScript no ha sido minimizado y provee una calificación (0.00 siendo la mínima calificación y 1.00 siendo la máxima) basado en lo que encuentra.
 
 {{ figure_markup(
   image="lighthouse-unminified-js.png",
@@ -284,11 +284,11 @@ Una de las auditorías en _[Lighthouse](./methodology#lighthouse)_ revisa si el 
   sql_file="lighthouse_unminified_js.sql"
 ) }}
 
-La gráfica anterior muestra que la mayor parte de las páginas evaludadas (77%) tienen una calificación de 0.90 o superior, lo que significa que pocos scripts sin minización han sido encontrados.
+La gráfica anterior muestra que la mayor parte de las páginas evaluadas (77%) tienen una calificación de 0.90 o superior, lo que significa que pocos scripts sin minimización han sido encontrados.
 
 En general, sólo el 4.5% de las peticiones de JavaScript medidas no están minimizadas.
 
-Algo interesante es que, si bien hemos sido quisquillosos con las peticiones a terceros, esta es un área donde los scripts de terceros tienen un mejor resultado que los scripts propios. En la página móvil promedio, el 82% de los bytes de JavaScript sin minimizar vienen de código propio.
+Algo interesante es que, si bien hemos sido quisquillosos con las peticiones a terceros, esta es un área donde los scripts de terceros tienen un mejor resultado que los propios. En la página móvil promedio, el 82% de los bytes de JavaScript sin minimizar vienen de código propio.
 
 {{ figure_markup(
   image="lighthouse-unminified-js-by-3p.png",
@@ -312,7 +312,7 @@ Minimizar los scripts es una buena manera de reducir el tamaño de los archivos,
   sql_file="compression_method.sql"
 ) }}
 
-85% de todas las peticiones de JavaScript usan algún tipo de compresion. Gzip ocupa la mayoría de ese porcentaje, con 65% de los scripts siendo comprimidos usando Gzip en comparación a un 20% para Brotli (br). Mientras que el porcentaje de Brotli (qué es más efectivo que Gzip) es bajo tomando en cuenta el soporte que tiene en los navegadores, la tendencia va en la dirección correcta, pues subió 5 puntos porcentuales comparado con el año pasado.
+85% de todas las peticiones de JavaScript usan algún tipo de compresión. Gzip ocupa la mayoría de ese porcentaje, con 65% de los scripts siendo comprimidos usando Gzip en comparación a un 20% para Brotli (br). Mientras que el porcentaje de Brotli (qué es más efectivo que Gzip) es bajo tomando en cuenta el soporte que tiene en los navegadores, la tendencia va en la dirección correcta, pues subió 5 puntos porcentuales comparado con el año pasado.
 
 Una vez más, esta parece ser un área donde los scripts de terceros están haciendo un mejor trabajo que los propios. Si hacemos la comparativa entre los métodos de compresión entre scripts propios y de terceros, podemos ver que el 24% de los scripts de terceros son comprimidos usando Brotli en comparación con un 15% en scripts propios.
 
@@ -337,19 +337,19 @@ Vale la pena ver más de cerca a los scripts que _no_ usan compresión. La compr
   sql_file="compression_none_by_bytes.sql"
 ) }}
 
-Por fortuna, eso es exactamente lo que podemos observar, en paricular para los scripts de terceros donde el 90% de los scripts sin comprimir tiene un tamaño menor a 5 KB. Por otro lado, 49% de los scripts propios son de menos de 5 KB y 37% de los scripts propios sin comprimir son de más de 10 KB. Así que mientras que si vemos una gran cantidad de scripts propios pequeños sin comprimir, aún existen muchos que podrían beneficiarse de la compresión.
+Por fortuna, eso es exactamente lo que podemos observar, en particular para los scripts de terceros donde el 90% de los scripts sin comprimir tiene un tamaño menor a 5 KB. Por otro lado, 49% de los scripts propios son de menos de 5 KB y 37% de los scripts propios sin comprimir son de más de 10 KB. Así que mientras que si vemos una gran cantidad de scripts propios pequeños sin comprimir, aún existen muchos que podrían beneficiarse de la compresión.
 
 ## ¿Qué usamos?
 
 Mientras usamos cada vez más JavaScript para crear nuestros sitios y aplicaciones también se ha incrementado la demanda por librerías y _frameworks open source_ que ayuden a mejorar la productividad de los desarrolladores y hacer más mantenible el código. Los sitios que _no_ usan una de estas librerías son una minoría, solamente jQuery se encuentra en el 85% de las páginas móviles medidas por el HTTP Archive.
 
-Es importante que seamos críticos acerca de las herramientas que usamos al construir la web y cuales son sus pros y contras. Por lo que tiene sentido analizar más de cerca qué usamos hoy en día.
+Es importante que seamos críticos acerca de las herramientas que usamos al construir la web y cuáles son sus pros y contras. Por lo que tiene sentido analizar más de cerca qué usamos hoy en día.
 
 ### Librerías
 
 El HTTP Archive usa [Wappalyzer](./methodology#wappalyzer) para detectar las tecnologías usadas en una página. Wappalyzer revisa tanto las librerías de JavaScript (estas son una colección de fragmentos de código y funciones útiles para hacer facilitar el desarrollo como jQuery) y _frameworks_ de JavaScript (estos son más _scaffolding_ y proveen plantillas y estructuras como React).
 
-Las librerías más populares no cambiaron mucho respecto al año pasado, con jQuery manteniendo un dominio en el uso y sólo una de las librerías en el top 21 bajando posiciones (lazy,js siendo reemplazado por DataTables). De hecho, el porcentaje de las librerías más comunes prácticamente no cambio con respecto al año pasado.
+Las librerías más populares no cambiaron mucho respecto al año pasado, con jQuery manteniendo un dominio en el uso y sólo una de las librerías en el top 21 bajando posiciones (lazy,js siendo reemplazado por DataTables). De hecho, el porcentaje de las librerías más comunes prácticamente no cambió con respecto al año pasado.
 
 {{ figure_markup(
   image="frameworks-libraries.png",
@@ -363,7 +363,7 @@ Las librerías más populares no cambiaron mucho respecto al año pasado, con jQ
 El año pasado [Houssein listó algunas de las razones por las cuales la dominación de jQuery continúa](../2019/javascript#open-source-libraries-and-frameworks):
 
 > WordPress, que es usado en más del 30% de los sitios e incluye jQuery por defecto.
-> Migrar de jQuery a una librería del lado del cliente más nueva puede tomar tiempo dependiendo de que tan grande es la aplicación y muchos sitios consisten de jQuery en conjunto con alguna librería más nueva.
+> Migrar de jQuery a una librería del lado del cliente más nueva puede tomar tiempo dependiendo de qué tan grande es la aplicación y muchos sitios consisten de jQuery en conjunto con alguna librería más nueva.
 
 Ambas son suposiciones bastante sólidas y parece que la situación no ha cambiado mucho en ninguno de los casos.
 
@@ -505,7 +505,7 @@ Cuando observamos las combinaciones más comunes en producción, la mayoría son
   </figcaption>
 </figure>
 
-Tambien podemos ver una cantidad relativamente alta de _frameworks_ "modernos" como React, Vue y Angular usados en conjunto con jQuery, por ejemplo como resultado de una migración o inclusión por terceros.
+También podemos ver una cantidad relativamente alta de _frameworks_ "modernos" como React, Vue y Angular usados en conjunto con jQuery, por ejemplo como resultado de una migración o inclusión por terceros.
 
 <figure>
   <table>
@@ -579,12 +579,12 @@ Es más importante notar que todas estas herramientas usualmente derivan en más
 
 Revisando específicamente los _frameworks_ en uso, vemos que la mediana de bytes de JavaScript por páginas usándolos varía dramáticamente dependiendo de _qué_ está siendo usado.
 
-La gráfica sigueiente muestra la mediana de bytes por páginas donde cualquiera de los 35 frameworks más comunes fueron encontrados dividido por tipo de cliente.
+La gráfica siguiente muestra la mediana de bytes por páginas donde cualquiera de los 35 frameworks más comunes fueron encontrados divididos por tipo de cliente.
 
 {{ figure_markup(
   image="frameworks-bytes.png",
   caption="La mediana de kilobytes de JavaScript por página por framework de JavaScript.",
-  description="Gráfica de barras mostrando la mediana de kilobytes de JavaScript por página dividida y ordenada por popularidad de los frameworks de JavaScript. El framework más popular, React, tiene una mediana de 1,328 en páginas móviles. Otros frameworks como RequireJS y Angular tienen números altos de bytes de JS por página. Páginas con MooTools, Prototype, AMP, RightJS, Alpine.js y Svelte tienen medianas de menos de 500KB por página móvil. Ember.js es un caso aparte con alrededor de 1,800 KB de JS por página móvil.",
+  description="Gráfica de barras mostrando la mediana de kilobytes de JavaScript por página dividida y ordenada por popularidad de los frameworks de JavaScript. El framework más popular, React, tiene una mediana de 1,328 en páginas móviles. Otros frameworks como RequireJS y Angular tienen números altos de bytes de JS por página. Páginas con MooTools, Prototype, AMP, RightJS, Alpine.js y Svelte tienen medianas de menos de 500 KB por página móvil. Ember.js es un caso aparte con alrededor de 1,800 KB de JS por página móvil.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=955720480&format=interactive",
   sheets_gid="1206934500",
   width="600",
@@ -592,7 +592,7 @@ La gráfica sigueiente muestra la mediana de bytes por páginas donde cualquiera
   sql_file="frameworks-bytes-by-framework.sql"
 ) }}
 
-En un lado del espectro están _frameworks_ como React, Angular o Ember, que tienden a resultar en mucho código sin importar el cliente. Por otro lado, observamos que _frameworks_ minimalistas como Alpine.js y Svelte muestran resultados muy prometedores. La configuracíón por defecto es muy importante, y parece ser que, al empezar con una base con un alto desempeño, Svelte y Alpine están teniendo éxito (hasta ahora&hellip; la muestra es bastante pequeña) en crear páginas más ligeras.
+En un lado del espectro están _frameworks_ como React, Angular o Ember, que tienden a resultar en mucho código sin importar el cliente. Por otro lado, observamos que _frameworks_ minimalistas como Alpine.js y Svelte muestran resultados muy prometedores. La configuración por defecto es muy importante, y parece ser que, al empezar con una base con un alto desempeño, Svelte y Alpine están teniendo éxito (hasta ahora&hellip; la muestra es bastante pequeña) en crear páginas más ligeras.
 
 La situación es muy similar cuando tomamos un vistazo al tiempo de ejecución del hilo principal para páginas donde estas herramientas fueron detectadas.
 
@@ -616,7 +616,7 @@ El tiempo de ejecución del hilo principal de Ember destaca tanto que distorsion
   sql_file="main_thread_time_frameworks.sql"
 ) }}
 
-Herramientas como React, GSAP y RequireJS tiended a ocupar mucho del tiempo de ejecución del hilo principal del browser, sin importar si es una página de escritorio o móvil. Las mismas herramientas que dan como resultado una menor cantidad de código—herramientas como Alpine o Svelte—también tienden a tener un menor impacto en el hilo principal.
+Herramientas como React, GSAP y RequireJS tienden a ocupar mucho del tiempo de ejecución del hilo principal del browser, sin importar si es una página de escritorio o móvil. Las mismas herramientas que dan como resultado una menor cantidad de código—herramientas como Alpine o Svelte—también tienden a tener un menor impacto en el hilo principal.
 
 También vale la pena indagar en el intervalo que existe entre la experiencia que un _framework_ provee en escritorio y móvil. El tráfico de dispositivos móviles cada vez se vuelve más dominante y es crítico que nuestras herramientas se desempeñen tan bien como sea posible en móviles. Una gran diferencia en el desempeño en móviles de un _framework_ es una gran alerta roja.
 
@@ -655,7 +655,7 @@ Un sitio de escritorio en la mediana pasa 891 ms en lo que el navegador ejecuta 
 
 ### La correlación entre el uso de JavaScript y la calificación de Lighthouse
 
-Una manera de ver como todo esto se traduce en un impacto en la experiencia de usuario es intentar encontrar una correlación entre algunas de las métricas de JavaScript que identificamos anteriomente con las calificaciones de Lighthouse para diferentes métricas y categorías.
+Una manera de ver cómo todo esto se traduce en un impacto en la experiencia de usuario es intentar encontrar una correlación entre algunas de las métricas de JavaScript que identificamos anteriormente con las calificaciones de Lighthouse para diferentes métricas y categorías.
 
 {{ figure_markup(
   image="correlations.png",
@@ -666,13 +666,13 @@ Una manera de ver como todo esto se traduce en un impacto en la experiencia de u
   sql_file="correlations.sql"
 ) }}
 
-La gráfica anterior utiliza el [coeficiente de correlación de Pearson](https://es.wikipedia.org/wiki/Coeficiente_de_correlaci%C3%B3n_de_Pearson). Hay una larga y relativamente compleja explicación de lo que eso significa, pero en pocas palabras significa que estamos buscando el grado de correlación entre dos números diferentes. Si encontramos un coeficiente de 1.00, tenemos una correlación directa positiva. Una correlación de 0.00 mostraría que no hay conexión entre ambos números. Cualquier cosa menor a 0.00 idica que hay una correlación negativa—en otras palabras, si un número aumenta el otro disminuye.
+La gráfica anterior utiliza el [coeficiente de correlación de Pearson](https://es.wikipedia.org/wiki/Coeficiente_de_correlaci%C3%B3n_de_Pearson). Hay una larga y relativamente compleja explicación de lo que eso significa, pero en pocas palabras significa que estamos buscando el grado de correlación entre dos números diferentes. Si encontramos un coeficiente de 1.00, tenemos una correlación directa positiva. Una correlación de 0.00 mostraría que no hay conexión entre ambos números. Cualquier cosa menor a 0.00 indica que hay una correlación negativa—en otras palabras, si un número aumenta el otro disminuye.
 
-Para empezar, no parece haber una correlación medible entre nuestras métricas de JavaScript y la calificación de accessibilidad de Lighthouse ("LH A11y" en la gráfica). Esto es completamente opuesto a lo que se encontró en otros estudios, especialmente en el <a hreflang="en" href="https://webaim.org/projects/million/#frameworks">estudio anual de WebAIM</a>.
+Para empezar, no parece haber una correlación medible entre nuestras métricas de JavaScript y la calificación de accesibilidad de Lighthouse ("LH A11y" en la gráfica). Esto es completamente opuesto a lo que se encontró en otros estudios, especialmente en el <a hreflang="en" href="https://webaim.org/projects/million/#frameworks">estudio anual de WebAIM</a>.
 
 La explicación más probable para esto es que las pruebas de accesibilidad de Lighthouse (aún) no son tan completas comparadas con otras herramientas enfocadas en accesibilidad, como WebAIM.
 
-Donde si vemos una correlación fuerte es entre la cantidad de bytes de JavaScript ("Bytes") y tanto la calificación general de desempeño de Lighthouse ("LH Perf") como el Tiempo Total de Bloqueo ("TBT").
+Donde sí vemos una correlación fuerte es entre la cantidad de bytes de JavaScript ("Bytes") y tanto la calificación general de desempeño de Lighthouse ("LH Perf") como el Tiempo Total de Bloqueo ("TBT").
 
 La correlación entre los bytes de JavaScript y las calificaciones de desempeño de Lighthouse es de -0.47. En otras palabras, mientras la cantidad de bytes de JS aumenta, la calificación de Lighthouse de desempeño disminuye. La cantidad total de bytes tiene una correlación más fuerte que la cantidad de bytes de terceros ("3P bytes"), lo cual sugiere que si bien los scripts de terceros fungen un rol, no podemos echarles toda la culpa a ellos.
 
@@ -692,7 +692,7 @@ Otra auditoría útil que Lighthouse corre es revisar si existen vulnerabilidade
 
 De acuerdo a la auditoría, 83.5% de las páginas móviles usan una librería o _framework_ con al menos una vulnerabilidad de seguridad conocida.
 
-Esto es a lo que llamamos el efecto jQuery. Anteriormente vismo como jQuery es usado en un 83% de las páginas. Múltiples versiones viejas de jQuery contienen vulnerabilidades conocidas, lo cual constituye la vasta mayoría de las vulnerabilidades que esta auditoría revisó.
+Esto es a lo que llamamos el efecto jQuery. Anteriormente vimos como jQuery es usado en un 83% de las páginas. Múltiples versiones viejas de jQuery contienen vulnerabilidades conocidas, lo cual constituye la vasta mayoría de las vulnerabilidades que esta auditoría revisó.
 
 De las casi 5 millones de páginas móviles que fueron probadas, 81% de ellas contiene una versión vulnerable de jQuery—una delantera considerable contra la segunda librería vulnerable más común—jQuery UI con un 15.6%.
 
@@ -770,8 +770,8 @@ La mayor parte de las vulnerabilidades encontradas cae en la categoría de sever
 
 ## Conclusión
 
-La popularidad de JavaScript está aumentando contínuamente y eso tiene muchos lados positivos. Es increíble considerar todo lo que podemos lograr con la web de hoy gracias a JavaScript que, hasta hace unos años, sería inimaginable.
+La popularidad de JavaScript está aumentando continuamente y eso tiene muchos lados positivos. Es increíble considerar todo lo que podemos lograr con la web de hoy gracias a JavaScript que, hasta hace unos años, sería inimaginable.
 
 Pero es claro que también debemos andar con cuidado. La cantidad de JavaScript aumenta de manera consistente cada año (si el mercado accionario fuera así de predecible todos seríamos increíblemente ricos) y eso tiene sus contras. Mayores cantidades de JavaScript están conectadas a un incremento en el tiempo de procesamiento lo cual afecta negativamente métricas clave como el Tiempo Total de Bloqueo. Y, si descuidamos todas esas librerías sin actualizarlas, corremos el riesgo de exponer a los usuarios a vulnerabilidades de seguridad conocidas.
 
-Nuestras mejores apuestas para asegurar que construyamos una web accesible, con buen desempeño y segura son medir cuidadosamente el costo de los scripts que agregamos a nuestras páginas y estas dispuestos a ver con un ojo crítico a las herramientas que usamos y pedirles que sean mejores.
+Nuestras mejores apuestas para asegurar que construyamos una web accesible, con buen desempeño y segura son medir cuidadosamente el costo de los scripts que agregamos a nuestras páginas y estar dispuestos a ver con un ojo crítico a las herramientas que usamos y pedirles que sean mejores.

--- a/src/content/es/2020/javascript.md
+++ b/src/content/es/2020/javascript.md
@@ -235,24 +235,24 @@ Harry Roberts [hizo un _tweet_ sobre este antipatrón en Twitter](https://twitte
 
 Una de las grandes ventajas sobre lo abierta que es la web es que una observación puede llevar a un cambio significativo como el que vimos aquí.
 
-### Resource hints
+### _Resource hints_
 
-Another tool we have at our disposal for offsetting some of the network costs of loading JavaScript are [resource hints](./resource-hints), specifically, `prefetch` and `preload`.
+Otra herramienta que tenemos a nuestra disposición para compensar algunos de los costos de cargar JavaScript son los [_resource hints_](./resource-hints), específicamente `prefetch` y `preload`.
 
-The `prefetch` hint lets developers signify that a resource will be used on the next page navigation, therefore the browser should try to download it when the browser is idle.
+El _hint_ de `prefetch` permite a los desarrolladores indicar que un recurso será utilizado en la siguiente navegación de página, por ende el navegador deberá intentar descargarlo una vez que se encuentre desocupado.
 
-The `preload` hint signifies that a resource will be used on the current page and that the browser should download it right away at a higher priority.
+El _hint_ de `preload` indica que un recurso será utilizado en la página actual y que el browser lo debería tratar de descargar cuanto antes posible.
 
-Overall, we see 16.7% of mobile pages using at least one of the two resource hints to load JavaScript more proactively.
+Globalmente, 16.7% de las páginas móviles usa al menos uno de estos dos _resource hints_ para cargar JavaScript proactivamente.
 
-Of those, nearly all of the usage is coming from `preload`. While 16.6% of mobile pages use at least one `preload` hint to load JavaScript, only 0.4% of mobile pages use at least one `prefetch` hint.
+De ese 16.7%, casi todo el uso viene de usar `preload`. Mientras que el 16.6% de las páginas móviles usa al menos un _hint_ de preload para cargar JavaScript, sólo el 0.4% de las páginas móviles usan al menos un _hint_ de `prefetch`.
 
-There's a risk, particularly with `preload`, of using too many hints and reducing their effectiveness, so it's worth looking at the pages that do use these hints to see how many they're using.
+Existe un riesgo, en particular con `preload`, al usar demasiados _hints_ pues se reduce su eficacia, así que vale la pena analizar las páginas que usan estos _hints_ para ver cuantos usan.
 
 {{ figure_markup(
   image="prefetch-distribution.png",
-  caption="Distribution of the number `prefetch` hints per page with any `prefetch` hints.",
-  description="Bar chart showing the distribution of prefetch hints per page with any prefetch hints. The 10, 25 and 50th percentiles for desktop and mobile pages is 1, 2, and 3 prefetch hints per page. At the 75th percentile for desktop pages it's 6 and 4 for mobile. At the 90th percentile, desktop pages use 14 prefetch hints per page and 12 for mobile pages.",
+  caption="Distribución del número de _hints_ de `prefetch` por página que tiene dichos _hints_.",
+  description="Gráfica de barras mostrando la distribución de _hints_ de prefetch por página que tiene dichos _hints_. Los percentiles 10, 25 y 50 para páginas de escritorio y móviles es de 1, 2 y 3 _hints_ de prefecth por página. En el percentil 75 el número es 6 para páginas de escritorio y 4 para móviles. En el percentil 90 las páginas de escritorio usan 14 _hints_ de prefetch por página y 12 en páginas móviles.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=1874381460&format=interactive",
   sheets_gid="1910228743",
   sql_file="resource-hints-preload-prefetch-distribution.sql"
@@ -260,14 +260,14 @@ There's a risk, particularly with `preload`, of using too many hints and reducin
 
 {{ figure_markup(
   image="preload-distribution.png",
-  caption="Distribution of the number `preload` hints per page with any `preload` hints.",
-  description="Bar chart showing the distribution of preload hints per page with any preload hints. 75% of desktop and mobile pages that use preload hints use it exactly once. The 90th percentile is 5 preload hints per page for desktop and 7 for mobile.",
+  caption="Distribución del número de _hints_ de `preload` por página que tiene dichos _hints_.",
+  description="Gráfica de barras mostrando la distribución de _hints_ de preload por página que tiene dichos _hints_. 75% de las páginas de escritorio y móviles que usan _hints_ de preload los usan exactamente una vez. En el percentil 90 hay 5 _hints_ de preload por página de escritorio y 7 por página móvil.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=320533828&format=interactive",
   sheets_gid="1910228743",
   sql_file="resource-hints-preload-prefetch-distribution.sql"
 ) }}
 
-At the median, pages that use a `prefetch` hint to load JavaScript use three, while pages that use a `preload` hint only use one. The long tail gets a bit more interesting, with 12 `prefetch` hints used at the 90th percentile and 7 `preload` hints used on the 90th as well. For more detail on resource hints, check out this year's [Resource Hints](./resource-hints) chapter.
+En la mediana, las páginas que usan _hints_ de `prefetch` para cargar JavaScript los usan 3 veces, mientras que las páginas que usan `preload` lo usan sólo una vez. La cola se pone un poco más interesante, en el percentil 90 se usan 12 _hints_ de `prefetch` y 7 _hints_ de `preload`. Para mayor detalle acerca de _resource hints_ vaya al capítulo de [_Resource Hints_](./resource-hints) de este año.
 
 ## How do we serve JavaScript?
 

--- a/src/content/es/2020/javascript.md
+++ b/src/content/es/2020/javascript.md
@@ -653,30 +653,30 @@ Un sitio de escritorio en la mediana pasa 891 ms en lo que el navegador ejecuta 
   sql_file="main_thread_time.sql"
 ) }}
 
-### Correlating JavaScript use to Lighthouse scoring
+### La correlación entre el uso de JavaScript y la calificación de Lighthouse
 
-One way of looking at how this translates into impacting the user experience is to try to correlate some of the JavaScript metrics we've identified earlier with Lighthouse scores for different metrics and categories.
+Una manera de ver como todo esto se traduce en un impacto en la experiencia de usuario es intentar encontrar una correlación entre algunas de las métricas de JavaScript que identificamos anteriomente con las calificaciones de Lighthouse para diferentes métricas y categorías.
 
 {{ figure_markup(
   image="correlations.png",
-  caption="Correlations of JavaScript on various aspects of user experience.",
-  description="Bar chart showing the Pearson coefficient of correlation for various aspects of user experience. The correlation of bytes to the Lighthouse performance score has a coefficient of correlation of -0.47. Bytes and Lighthouse accessibility score: 0.08. Bytes and Total Blocking Time (TBT): 0.55. Third party bytes and Lighthouse performance score: -0.37. Third party bytes and the Lighthouse accessibility score: 0.00. Third party bytes and TBT: 0.48. The number of async scripts per page and Lighthouse performance score: -0.19. Async scripts and Lighthouse accessibility score: 0.08. Async scripts and TBT: 0.36.",
+  caption="Correlaciones de JavaScript en varios aspectos de la experiencia de usuario.",
+  description="Gráfica de barras mostrando el coeficiente de correlación de Pearson para varios aspectos de la experiencia de usuario. La correlación de bytes con la calificación de desempeño de Lighthouse tiene un coeficiente de correlación de -0.47. De bytes con la calificación de Lighthouse de accesibilidad: 0.08. De bytes y el Tiempo Total de Bloqueo (TBT): 0.55. De bytes de terceros y la calificación de desempeño de Lighthouse: -0.37. De bytes de terceros y la calificación de Lighthouse de accesibilidad: 0.00. De bytes de terceros y TBT: 0.48. Del número de scripts async por página y la calificación de desempeño de Lighthouse: -0.19. Scripts async y la calificación de Lighthouse de accesibilidad: 0.08. Scripts async y TBT: 0.36.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=649523941&format=interactive",
   sheets_gid="2035770638",
   sql_file="correlations.sql"
 ) }}
 
-The above chart uses the [Pearson coefficient of correlation](https://en.wikipedia.org/wiki/Pearson_correlation_coefficient). There's a long, kinda complex definition of what that means precisely, but the gist is that we're looking for the strength of the correlation between two different numbers. If we find a coefficient of 1.00, we'd have a direct positive correlation. A correlation of 0.00 would show no connection between two numbers. Anything below 0.00 indicates a negative correlation—in other words, as one number goes up the other one decreases.
+La gráfica anterior utiliza el [coeficiente de correlación de Pearson](https://es.wikipedia.org/wiki/Coeficiente_de_correlaci%C3%B3n_de_Pearson). Hay una larga y relativamente compleja explicación de lo que eso significa, pero en pocas palabras significa que estamos buscando el grado de correlación entre dos números diferentes. Si encontramos un coeficiente de 1.00, tenemos una correlación directa positiva. Una correlación de 0.00 mostraría que no hay conexión entre ambos números. Cualquier cosa menor a 0.00 idica que hay una correlación negativa—en otras palabras, si un número aumenta el otro disminuye.
 
-First, there doesn't seem to be much of a measurable correlation between our JavaScript metrics and the Lighthouse accessibility ("LH A11y" in the chart) score here. That stands in stark opposition to what's been found elsewhere, notably through <a hreflang="en" href="https://webaim.org/projects/million/#frameworks">WebAim's annual research</a>.
+Para empezar, no parece haber una correlación medible entre nuestras métricas de JavaScript y la calificación de accessibilidad de Lighthouse ("LH A11y" en la gráfica). Esto es completamente opuesto a lo que se encontró en otros estudios, especialmente en el <a hreflang="en" href="https://webaim.org/projects/million/#frameworks">estudio anual de WebAIM</a>.
 
-The most likely explanation for this is that Lighthouse's accessibility tests aren't as comprehensive (yet!) as what is available through other tools, like WebAIM, that have accessibility as their primary focus.
+La explicación más probable para esto es que las pruebas de accesibilidad de Lighthouse (aún) no son tan completas comparadas con otras herramientas enfocadas en accesibilidad, como WebAIM.
 
-Where we do see a strong correlation is between the amount of JavaScript bytes ("Bytes") and both the overall Lighthouse performance ("LH Perf") score and Total Blocking Time ("TBT").
+Donde si vemos una correlación fuerte es entre la cantidad de bytes de JavaScript ("Bytes") y tanto la calificación general de desempeño de Lighthouse ("LH Perf") como el Tiempo Total de Bloqueo ("TBT").
 
-The correlation between JavaScript bytes and Lighthouse performance scores is -0.47. In other words, as JS bytes increase, Lighthouse performance scores decrease. The overall bytes has a stronger correlation than the amount of third-party bytes ("3P bytes"), hinting that while they certainly play a role, we can't place all the blame on third-parties.
+La correlación entre los bytes de JavaScript y las calificaciones de desempeño de Lighthouse es de -0.47. En otras palabras, mientras la cantidad de bytes de JS aumenta, la calificación de Lighthouse de desempeño disminuye. La cantidad total de bytes tiene una correlación más fuerte que la cantidad de bytes de terceros ("3P bytes"), lo cual sugiere que si bien los scripts de terceros fungen un rol, no podemos echarles toda la culpa a ellos.
 
-The connection between Total Blocking Time and JavaScript bytes is even more significant (0.55 for overall bytes, 0.48 for third-party bytes). That's not too surprising given what we know about all the work browsers have to do to get JavaScript to run in a page—more bytes means more time.
+La conexión entre el Tiempo Total de Bloqueo y los bytes de JavaScript es aún más significativa (0.55 para bytes totales y 0.48 para bytes de terceros). Esto no es sorpresivo debido a que conocemos todo el trabajo extra que los navegadores deben hacer para hacer que el código JavaScript corra en una página—más bytes significa más tiempo.
 
 ### Security vulnerabilities
 

--- a/src/content/es/2020/javascript.md
+++ b/src/content/es/2020/javascript.md
@@ -632,22 +632,22 @@ También vale la pena indagar en el intervalo que existe entre la experiencia qu
 
 Como era de esperarse, existe un intervalo para todas las herramientas usadas debido al bajo poder de procesamiento del [Moto G4 emulado](methodology#webpagetest). Ember y Polymer parecen ser ejemplos particularmente atroces, mientras que RxJS y Mustache varían muy poco entre escritorio y móvil.
 
-## What's the impact?
+## ¿Cuál es el impacto?
 
-We have a pretty good picture now of how much JavaScript we use, where it comes from, and what we use it for. While that's interesting enough on its own, the real kicker is the "so what?" What impact does all this script actually have on the experience of our pages?
+Ahora tenemos una buena idea de cuanto JavaScript usamos, de donde viene y para que lo usamos. Eso es interesante por su cuenta pero la verdadera pregunta aquí es el "¿Y eso qué?" ¿Qué impacto tiene todo este script que usamos en la experiencia de nuestras páginas?
 
-The first thing we should consider is what happens with all that JavaScript once its been downloaded. Downloading is only the first part of the JavaScript journey. The browser still has to parse all that script, compile it, and eventually execute it. While browsers are constantly on the lookout for ways to offload some of that cost to other threads, much of that work still happens on the main thread, blocking the browser from being able to do layout or paint-related work, as well as from being able to respond to user interaction.
+La primera cosa que debemos considerar es qué ocurre con todo ese JavaScript una vez que ha sido descargado. La descarga es sólo la primera parte del viaje del JavaScript. El navegador aún tiene que analizar ese script, compilarlo y eventualmente ejecutarlo. Mientras que los browsers están en una constante búsqueda de maneras de mover parte de ese costo a otros hilos, mucho de ese trabajo aún ocurre en el hilo principal, lo que impide al navegador realizar trabajo de _layout_ o pintado, así como de responder a interacciones del usuario.
 
-If you recall, there was only a 30 KB difference between what is shipped to a mobile device versus a desktop device. Depending on your point of view, you could be forgiven for not getting too upset about the small gap in the amount of code sent to a desktop browser versus a mobile one—after all, what's an extra 30 KB or so at the median, right?
+Como mencionamos antes, sólo existe una diferencia de 30KB entre lo que se le envía a dispositivos móviles y de escritorio. Dependiendo de tu punto de vista, es entendible si no te molesta mucho la pequeña diferencia entre la cantidad de código enviado a un navegador de escritorio contra uno móvil—después de todo, ¿Qué son 30KB, no?
 
-The biggest problem comes when all of that code gets served to a low-to-middle-end device, something a bit less like the kind of devices most developers are likely to have, and a bit more like the kind of devices you'll see from the majority of people across the world. That relatively small gap between desktop and mobile is much more dramatic when we look at it in terms of processing time.
+El mayor problema viene cuando todo ese código llega a un dispositivo de gama media o baja, algo poco parecido a los dispositivos que la mayoría de los desarrolladores tienden a usar, y un poco más parecido al tipo de dispositivos usados por la mayoría de las personas en el mundo. Esa diferencia relativamente pequeña entre escritorio y móvil es mucho más notoria cuando la medimos en términos de tiempo de procesamiento.
 
-The median desktop site spends 891 ms on the main thread of a browser working with all that JavaScript. The median mobile site, however, spends 1,897 ms—over two times the time spent on the desktop. It's even worse for the long tail of sites. At the 90th percentile, mobile sites spend a staggering 8,921 ms of main thread time dealing with JavaScript, compared to 3,838 ms for desktop sites.
+Un sitio de escritorio en la mediana pasa 891 ms en lo que el navegador ejecuta todo ese JavaScript en el hilo principal. Mientras tanto, un sitio móvil en la mediana pasa 1,897 ms—más del doble de tiempo que en escritorio. Esto es aún peor para el resto de los sitios. En el percentil 90, los sitios móviles tienen un tiempo de ejecución del hilo principal de JavaScript abrumador de 8,921 ms, comparado con 3,838 ms en sitios de escritorio.
 
 {{ figure_markup(
   image="main-thread-time.png",
-  caption="Distribution of main thread time.",
-  description="Bar chart showing the distribution of main thread time for desktop and mobile. Mobile is 2-3 times higher throughout the distribution. The 10, 25, 50, 75, and 90th percentiles for desktop are: 137, 356, 891, 1,988, and 3,838 milliseconds.",
+  caption="Distribución del tiempo de ejecución del hilo principal.",
+  description="Gráfica de barras mostrando la distribución del tiempo de ejecución del hilo principal en escritorio y móvil. El tiempo en móvil es 2-3 veces más alto a lo largo de la distribución. Los percentiles 10, 25, 50, 75 y 90 de escritorio son de: 137, 356, 891, 1,988 y 3,838 milisegundos.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=740020507&format=interactive",
   sheets_gid="2039579122",
   sql_file="main_thread_time.sql"

--- a/src/content/es/2020/javascript.md
+++ b/src/content/es/2020/javascript.md
@@ -34,7 +34,7 @@ Los desarrolladores amamos usar JavaScript. De acuerdo con el capítulo de marca
   sql_file="../page-weight/bytes_per_type_2020.sql"
 ) }}
 
-Pero nada es gratis y esto aplica especialmente para Javascript. Todo ese código tiene un costo. Veamos con más detalle cuánto código usamos, cómo lo usamos y cuáles son los efectos secundarios de este.
+Pero nada es gratis y esto aplica especialmente para JavaScript. Todo ese código tiene un costo. Veamos con más detalle cuánto código usamos, cómo lo usamos y cuáles son los efectos secundarios de este.
 
 ## ¿Cuánto JavaScript usamos?
 
@@ -53,7 +53,7 @@ Un sitio ubicado en la mediana (percentil 50) envía 444 KB de JavaScript al ser
 
 Es un poco decepcionante no ver una mayor diferencia. Si bien es peligroso hacer muchas suposiciones sobre la red o el poder de procesamiento basados en si el dispositivo es un teléfono o una computadora de escritorio (o algo intermedio), debemos recalcar que las [pruebas en móviles del <i lang="en">HTTP Archive</i>](./methodology#webpagetest) son hechas emulando un Moto G4 en una red 3G. En otras palabras, si existiese algún trabajo para adaptarse a condiciones no ideales y transmitir menos código estas pruebas deberían demostrarlo.
 
-La tendencia parece estar a favor de usar más JavaScript, no menos. Comparando con [los resultados del año pasado](../2019/javascript#how-much-javascript-do-we-use), vemos un incremento de 13.4% en la mediana de Javascript al probar en un dispositivo de escritorio y un incremento de 14.4% en la cantidad de JavaScript enviado a un dispositivo móvil.
+La tendencia parece estar a favor de usar más JavaScript, no menos. Comparando con [los resultados del año pasado](../2019/javascript#how-much-javascript-do-we-use), vemos un incremento de 13.4% en la mediana de JavaScript al probar en un dispositivo de escritorio y un incremento de 14.4% en la cantidad de JavaScript enviado a un dispositivo móvil.
 
 <figure>
   <table>
@@ -319,7 +319,7 @@ Una vez más, esta parece ser un área donde los scripts de terceros están haci
 {{ figure_markup(
   image="compression-method-3p.png",
   caption="Distribución del porcentaje de peticiones de JavaScript en móviles por método de compresión y host.",
-  description="Gráfica de barras mostrando la distribución del porcentaje de peticiones de JavaScript en móviles por método de compresión y host. 66% de las peticiones de Javascript propias y 64% de las de terceros usan Gzip. 15% de las peticiones de scripts propios y 24% de las de terceros usan Brotli. Y el 19% de los scripts propios y el 12% de los de terceros no usan ningún método de compresión.",
+  description="Gráfica de barras mostrando la distribución del porcentaje de peticiones de JavaScript en móviles por método de compresión y host. 66% de las peticiones de JavaScript propias y 64% de las de terceros usan Gzip. 15% de las peticiones de scripts propios y 24% de las de terceros usan Brotli. Y el 19% de los scripts propios y el 12% de los de terceros no usan ningún método de compresión.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=1402692197&format=interactive",
   sheets_gid="564760060",
   sql_file="compression_method_by_3p.sql"

--- a/src/content/es/2020/javascript.md
+++ b/src/content/es/2020/javascript.md
@@ -269,31 +269,31 @@ Existe un riesgo, en particular con `preload`, al usar demasiados _hints_ pues s
 
 En la mediana, las páginas que usan _hints_ de `prefetch` para cargar JavaScript los usan 3 veces, mientras que las páginas que usan `preload` lo usan sólo una vez. La cola se pone un poco más interesante, en el percentil 90 se usan 12 _hints_ de `prefetch` y 7 _hints_ de `preload`. Para mayor detalle acerca de _resource hints_ vaya al capítulo de [_Resource Hints_](./resource-hints) de este año.
 
-## How do we serve JavaScript?
+## ¿Cómo servimos JavaScript?
 
-As with any text-based resource on the web, we can save a significant number of bytes through minimization and compression. Neither of these are new optimizations—they've been around for quite awhile—so we should expect to see them applied in more cases than not.
+Al igual que con otros recursos basados en texto en la web, podemos ahorrar una cantidad significativa de bytes a través de minimización y compresión. Ninguna de estas optimizaciones son nuevas, llevan siendo usadas por mucho tiempo, así que deberíamos verlas usadas frecuentemente.
 
-One of the audits in [Lighthouse](./methodology#lighthouse) checks for unminified JavaScript, and provides a score (0.00 being the worst, 1.00 being the best) based on the findings.
+Una de las auditorías en _[Lighthouse](./methodology#lighthouse)_ revisa si el JavaScript no ha sido minimizado y provee una calificación (0.00 siendo la mínima calificación y 1.00 siendo la máxima) basado en lo que encuentra.
 
 {{ figure_markup(
   image="lighthouse-unminified-js.png",
-  caption="Distribution of unminified JavaScript Lighthouse audit scores per mobile page.",
-  description="Bar chart showing 0% of mobile pages getting unminified JavaScript Lighthouse audit scores under 0.25, 4% of pages getting a score between 0.25 and 0.5, 10% of pages between 0.5 and 0.75, 8% of pages between 0.75 and 0.9, and 77% of pages between 0.9 and 1.0.",
+  caption="Distribución de las calificaciones de la auditoría de Lighthouse para JavaScript por página móvil.",
+  description="Gráfica de barras mostrando que 0% de las páginas móviles obtienen una calificación de minimización de JavaScript en Lighthouse por debajo de 0.25, 4% de las páginas obtienen una calificación de entre 0.25 y 0.5, 10% de las páginas están entre 0.5 y 0.75, 8% de las páginas están entre 0.75  y 0.9 y 77% de las páginas están entre 0.9 y 1.0.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=158284816&format=interactive",
   sheets_gid="362705605",
   sql_file="lighthouse_unminified_js.sql"
 ) }}
 
-The chart above shows that most pages tested (77%) get a score of 0.90 or above, meaning that few unminified scripts are found.
+La gráfica anterior muestra que la mayor parte de las páginas evaludadas (77%) tienen una calificación de 0.90 o superior, lo que significa que pocos scripts sin minización han sido encontrados.
 
-Overall, only 4.5% of the JavaScript requests recorded are unminified.
+En general, sólo el 4.5% de las peticiones de JavaScript medidas no están minimizadas.
 
-Interestingly, while we've picked on third-party requests a bit, this is one area where third-party scripts are doing better than first-party scripts. 82% of the average mobile page's unminified JavaScript bytes come from first-party code.
+Algo interesante es que, si bien hemos sido quisquillosos con las peticiones a terceros, esta es un área donde los scripts de terceros tienen un mejor resultado que los scripts propios. En la página móvil promedio, el 82% de los bytes de JavaScript sin minimizar vienen de código propio.
 
 {{ figure_markup(
   image="lighthouse-unminified-js-by-3p.png",
-  caption="Average distribution of unminified JavaScript bytes by host.",
-  description="Pie chart showing that 17.7% of unminified JS bytes are third party scripts and 82.3% are first party scripts.",
+  caption="Distribución promedio de los bytes de JavaScript sin minimizar por host.",
+  description="Gráfica de pie mostrando que el 17.7% de los bytes de JS sin minimizar son de scripts de terceros y el 82.3% son de scripts propios.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=2073491355&format=interactive",
   sheets_gid="1169731612",
   sql_file="lighthouse_unminified_js_by_3p.sql"

--- a/src/content/es/2020/javascript.md
+++ b/src/content/es/2020/javascript.md
@@ -189,51 +189,51 @@ Si bien la cantidad de peticiones de JavaScript es similar en la mediana, el tam
   sql_file="bytes_by_3p.sql"
 ) }}
 
-## How do we load our JavaScript?
+## ¿Cómo cargamos JavaScript?
 
-The way we load JavaScript has a significant impact on the overall experience.
+La manera en la que cargamos JavaScript tiene un impacto significativo en la experiencia en general.
 
-By default, JavaScript is _parser-blocking_. In other words, when the browser discovers a `script` element, it must pause parsing of the HTML until the script has been downloaded, parsed, and executed. It's a significant bottleneck and a common contributor to pages that are slow to render.
+JavaScript _bloquea al analizador sintáctico_ por defecto. En otras palabras, cuando el navegador encuentra un elemento `script`, debe pausar el análisis del HTML hasta que el script haya sido descargado, analizado y ejecutado. Esto es un cuello de botella significativo y es una causa común de que las páginas se muestren lentamente.
 
-We can start to offset some of the cost of loading JavaScript by loading scripts either asynchronously (with the `async` attribute), which only halts the HTML parser during the parse and execution phases and not during the download phase, or deferred (with the `defer` attribute), which doesn't halt the HTML parser at all. Both attributes are only available on external scripts—inline scripts cannot have them applied.
+Podemos comenzar a compensar el costo de cargar JavaScript haciendo que los scripts se descarguen asíncronamente (usando el atributo `async`), este atributo sólo detiene el analizador de HTML durante las fases de análisis y ejecución de JavaScript y no durante la de descarga, o diferidamente (usando el atributo `defer`), este atributo no detiene al analizador de HTML nunca. Ambos atributos solo pueden aplicarse a scripts externos, no se pueden aplicar a scripts _inline_.
 
-On mobile, external scripts comprise 59.0% of all script elements found.
+En móviles, los scripts externos representan el 59.0% de todos los scripts encontrados.
 
 <p class="note">
-  As an aside, when we talked about how much JavaScript is loaded on a page earlier, that total didn't account for the size of these inline scripts—because they're part of the HTML document, they're counted against the markup size. This means we load even more script that the numbers show.
+  Como nota, cuando hablamos anteriormente acerca de cuanto JavaScript es cargado en una página, ese total no tomaba en cuenta el tamaño de los scripts _inline_. Debido a que son parte del documento HTML, se cuentan como parte del tamaño de marcado. Esto significa que cargamos aún más scripts de lo que los números muestran.
 </p>
 
 {{ figure_markup(
   image="external-inline-mobile.png",
-  caption="Distribution of the number of external and inline scripts per mobile page.",
-  description="Pie chart showing 41.0% of mobile scripts are inline and 59.0% are external.",
+  caption="Distribución del número de scripts externos e _inline_ por página móvil.",
+  description="Gráfica de pie mostrando que 41.0% de los scripts en móviles son _inline_ y 59.0% son externos.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=1326937127&format=interactive",
   sheets_gid="1991661912",
   sql_file="breakdown_of_scripts_using_async_defer_module_nomodule.sql"
 ) }}
 
-Of those external scripts, only 12.2% of them are loaded with the `async` attribute and 6.0% of them are loaded with the `defer` attribute.
+De los scripts externos, solo el 12.2% son cargados con el atributo `async` y 6.0% son cargados con el atributo `defer`.
 
 {{ figure_markup(
   image="async-defer-mobile.png",
-  caption="Distribution of the number of `async` and `defer` scripts per mobile page.",
-  description="Pie chart showing 12.2% of external mobile scripts use async, 6.0% use defer, and 81.8% use neither.",
+  caption="Distribución del número de scripts `async` y `defer` por página móvil.",
+  description="Gráfica de pie mostrando que el 12.2% de los script externos en móviles usan async, 6.0% usa defer y 81.8% no usa ninguno de los dos.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=662584253&format=interactive",
   sheets_gid="1991661912",
   sql_file="breakdown_of_scripts_using_async_defer_module_nomodule.sql"
 ) }}
 
-Considering that `defer` provides us with the best loading performance (by ensuring downloading the script happens in parallel to other work, and execution waits until after the page can be displayed), we would hope to see that percentage a bit higher. In fact, as it is that 6.0% is slightly inflated.
+Tomando en consideración que `defer` provee el mejor desempeño al cargar (ya que se asegura que la descarga del script ocurre en paralelo a otras tareas y la execución se realiza hasta después de que la página pueda ser mostrada), desearíamos que el porcentaje de uso fuera mayor. De hecho, el 6.0% anterior esta un poco inflado.
 
-Back when supporting IE8 and IE9 was more common, it was relatively common to use _both_ the `async` and `defer` attributes. With both attributes in place, any browser supporting both will use `async`. IE8 and IE9, which don't support `async` will fall back to `defer`.
+Cuando el soporte para IE8 e IE9 era más común, era relativamente común usar _ambos atributos_. Cuando ambos están presentes, cualquier navegador que soporte ambos usará `async`. IE8 e IE9 no soportan `async` entonces usarán `defer`.
 
-Nowadays, the pattern is unnecessary for the vast majority of sites and any script loaded with the pattern in place will interrupt the HTML parser when it needs to be executed, instead of deferring until the page has loaded. The pattern is still used surprisingly often, with 11.4% of mobile pages serving at least one script with that pattern in place. In other words, at least some of the 6% of scripts that use `defer` aren't getting the full benefits of the `defer` attribute.
+En días recientes, este patrón no es necesario para la mayoría de los sitios y cualquier script cargado con este patrón interrumpirá al analizador de HTML cuando debe ser ejecutado, en lugar de diferir hasta que la página haya cargado. Este patrón tiene un uso soprendentement frecuente, 11.4% de las páginas móviles tienen al menos un script con este patrón. En otras palabras, al menos una parte del 6% de scripts que usan `defer` no están obteniendo los beneficios del atributo `defer`.
 
-There is an encouraging story here, though.
+Pero hay una historia alentadora sobre esto.
 
-Harry Roberts [tweeted about the anti-pattern on Twitter](https://twitter.com/csswizardry/status/1331721659498319873), which is what prompted us to check to see how frequently this was occurring in the wild. [Rick Viscomi checked to see who the top culprits were](https://twitter.com/rick_viscomi/status/1331735748060524551), and it turns out "stats.wp.com" was the source of the most common offenders. @Kraft from Automattic replied, and the pattern will now be [removed going forward](https://twitter.com/Kraft/status/1336772912414601224).
+Harry Roberts [hizo un _tweet_ sobre este antipatrón en Twitter](https://twitter.com/csswizardry/status/1331721659498319873), lo cual fue lo que nos motivó a medir que tan frecuentemente ocurre en realidad. [Rick Viscomi revisó quiénes eran culpables de esto con mayor frecuencia](https://twitter.com/rick_viscomi/status/1331735748060524551), y resultó que "stats.wp.com" era la fuente de los culpables más frecuentes. @Kraft de Automattic respondió y el patrón será [removido de ahora en adelante](https://twitter.com/Kraft/status/1336772912414601224)
 
-One of the great things about the openness of the web is how one observation can lead to meaningful change and that's exactly what happened here.
+Una de las grandes ventajas sobre lo abierta que es la web es que una observación puede llevar a un cambio significativo como el que vimos aquí.
 
 ### Resource hints
 

--- a/src/content/es/2020/javascript.md
+++ b/src/content/es/2020/javascript.md
@@ -339,35 +339,35 @@ Vale la pena ver más de cerca a los scripts que _no_ usan compresión. La compr
 
 Por fortuna, eso es exactamente lo que podemos observar, en paricular para los scripts de terceros donde el 90% de los scripts sin comprimir tiene un tamaño menor a 5 KB. Por otro lado, 49% de los scripts propios son de menos de 5 KB y 37% de los scripts propios sin comprimir son de más de 10 KB. Así que mientras que si vemos una gran cantidad de scripts propios pequeños sin comprimir, aún existen muchos que podrían beneficiarse de la compresión.
 
-## What do we use?
+## ¿Qué usamos?
 
-As we've increasingly used more JavaScript to power our sites and applications, there has also been an increasing demand for open-source libraries and frameworks to help with improving developer productivity and overall code maintainability. Sites that _don't_ wield one of these tools are definitely the minority on today's web—jQuery alone is found on nearly 85% of the mobile pages tracked by HTTP Archive.
+Mientras usamos cada vez más JavaScript para crear nuestros sitios y aplicaciones también se ha incrementado la demanda por librerías y _frameworks open source_ que ayuden a mejorar la productividad de los desarrolladores y hacer más mantenible el código. Los sitios que _no_ usan una de estas librerías son una minoría, solamente jQuery se encuentra en el 85% de las páginas móviles medidas por el HTTP Archive.
 
-It's important that we think critically about the tools we use to build the web and what the trade-offs are, so it makes sense to look closely at what we see in use today.
+Es importante que seamos críticos acerca de las herramientas que usamos al construir la web y cuales son sus pros y contras. Por lo que tiene sentido analizar más de cerca qué usamos hoy en día.
 
-### Libraries
+### Librerías
 
-HTTP Archive uses [Wappalyzer](./methodology#wappalyzer) to detect technologies in use on a given page. Wappalazyer tracks both JavaScript libraries (think of these as a collection of snippets or helper functions to ease development, like jQuery) and JavaScript frameworks (these are more likely scaffolding and provide templating and structure, like React).
+El HTTP Archive usa [Wappalyzer](./methodology#wappalyzer) para detectar las tecnologías usadas en una página. Wappalyzer revisa tanto las librerías de JavaScript (estas son una colección de fragmentos de código y funciones útiles para hacer facilitar el desarrollo como jQuery) y _frameworks_ de JavaScript (estos son más _scaffolding_ y proveen plantillas y estructuras como React).
 
-The popular libraries in use are largely unchanged from last year, with jQuery continuing to dominate usage and only one of the top 21 libraries falling out (lazy.js, replaced by DataTables). In fact, even the percentages of the top libraries has barely changed from last year.
+Las librerías más populares no cambiaron mucho respecto al año pasado, con jQuery manteniendo un dominio en el uso y sólo una de las librerías en el top 21 bajando posiciones (lazy,js siendo reemplazado por DataTables). De hecho, el porcentaje de las librerías más comunes prácticamente no cambio con respecto al año pasado.
 
 {{ figure_markup(
   image="frameworks-libraries.png",
-  caption="Adoption of the top JavaScript frameworks and libraries as a percent of pages.",
-  description="Bar chart showing the adoption of the top frameworks and libraries as a percent of pages (not page views or npm downloads). jQuery is the overwhelming leader, found on 83% of mobile pages. It's followed by jQuery migrate on 30%, jQuery UI on 21%, Modernizr on 15%, FancyBox on 7%, Slick and Lightbox on 6%, and the remaining frameworks and libraries on 4% or 3%: Moment.js, Underscore.js, Lodash, React, GSAP, Select2, RequireJS, and prettyPhoto.",
+  caption="Uso de los frameworks y librerías de JavaScript más comunes en porcentaje de páginas.",
+  description="Gráfica de barras mostrando el uso de los frameworks y librerías de JavaScript más comunes en porcentaje de páginas (no número de vistas o descargas de npm). jQuery es el líder dominante, se encuentra en 83% de las páginas móviles. Lo siguen jQuery migrate con un 30%, jQuery UI con 21%, Modernizr con 15%, FancyBox con 7%, Slick y Lightbox con 6% y el resto de los frameworks y librerías con 4% o 3%: Moment.js, Underscore.js, Lodash, React, GSAP, Select2, RequireJS y prettyPhoto.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=419887153&format=interactive",
   sheets_gid="1654577118",
   sql_file="frameworks_libraries.sql"
 ) }}
 
-Last year, [Houssein posited a few reasons for why jQuery's dominance continues](../2019/javascript#open-source-libraries-and-frameworks):
+El año pasado [Houssein listó algunas de las razones por las cuales la dominación de jQuery continúa](../2019/javascript#open-source-libraries-and-frameworks):
 
-> WordPress, which is used in more than 30% of sites, includes jQuery by default.
-> Switching from jQuery to a newer client-side library can take time depending on how large an application is, and many sites may consist of jQuery in addition to newer client-side libraries.
+> WordPress, que es usado en más del 30% de los sitios e incluye jQuery por defecto.
+> Migrar de jQuery a una librería del lado del cliente más nueva puede tomar tiempo dependiendo de que tan grande es la aplicación y muchos sitios consisten de jQuery en conjunto con alguna librería más nueva.
 
-Both are very sound guesses, and it seems the situation hasn't changed much on either front.
+Ambas son suposiciones bastante sólidas y parece que la situación no ha cambiado mucho en ninguno de los casos.
 
-In fact, the dominance of jQuery is supported even further when you stop to consider that, of the top 10 libraries, 6 of them are either jQuery or require jQuery in order to be used: jQuery UI, jQuery Migrate, FancyBox, Lightbox and Slick.
+De hecho, la dominación de jQuery tiene un mayor respaldo si consideramos que, de las librerías en el top 10, 6 son ya sea jQuery o requieren de jQuery para ser usadas: jQuery UI, jQuery Migrate, FancyBox, Lightbox y Slick.
 
 ### Frameworks
 

--- a/src/content/es/2020/javascript.md
+++ b/src/content/es/2020/javascript.md
@@ -143,18 +143,18 @@ En la mediana, las páginas hacen 20 peticiones de JavaScript. Esto es un increm
   sql_file="requests_2019.sql"
 ) }}
 
-## Where does it come from?
+## ¿De dónde viene el incremento?
 
-One trend that likely contributes to the increase in JavaScript used on our pages is the seemingly ever-increasing amount of third-party scripts that get added to pages to help with everything from client-side A/B testing and analytics, to serving ads and handling personalization.
+Una tendencia que posiblemente contribuye al incremento en la cantidad de JavaScript usado en nuestras páginas es la cantidad cada vez mayor de scripts de terceros que son añadidos a las páginas para ayudar con cosas desde pruebas A/B en el lado del cliente y análiticos hasta commerciales y personalización.
 
-Let's drill into that a bit to see just how much third-party script we're serving up.
+Veamos esto más a detalle para ver cuantos scripts de terceros estamos enviando.
 
-Right up until the median, sites serve roughly the same number of first-party scripts as they do third-party scripts. At the median, 9 scripts per page are first-party, compared to 10 per page from third-parties. From there, the gap widens a bit: the more scripts a site serves in the total, the more likely it is that the majority of those scripts are from third-party sources.
+Justo hasta la mediana, los sitios envían apróximadamente la misma cantidad de scripts propios que de terceros. En la mediana, 9 scripts por página son propios y 10 son de terceros. Desde ese punto, la diferencia crece un poco: mientras más scripts envía un sitio en total, es mayor la probabilidad de que la mayoría de esos scripts sean de terceros.
 
 {{ figure_markup(
   image="requests-by-3p-desktop.png",
-  caption="Distribution of the number of JavaScript requests by host for desktop.",
-  description="Bar chart showing the distribution of JavaScript requests per host for desktop. The 10, 25, 50, 75, and 90th percentiles for first party requests are: 2, 4, 9, 17, and 30 requests per page. The number of third party requests per page is slightly higher in the upper percentiles by 1 to 6 requests.",
+  caption="Distribución del número de peticiones de JavaScript por dominio en escritorio.",
+  description="Gráfica de barras mostrando la distribución de peticiones de JavaScript por dominio para escritorio. Los percentiles 10, 25, 50, 75 y 90 para peticiones propias son de: 2, 4, 9, 17 y 30 peticiones por página. El número de peticiones a terceros es ligeramente mayor en los percentiles altos por desde 1 hasta 6 peticiones.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=1566679225&format=interactive",
   sheets_gid="978380311",
   sql_file="requests_by_3p.sql"
@@ -162,19 +162,19 @@ Right up until the median, sites serve roughly the same number of first-party sc
 
 {{ figure_markup(
   image="requests-by-3p-mobile.png",
-  caption="Distribution of the number of JavaScript requests by host for mobile.",
-  description="Bar chart showing the distribution of JavaScript requests per host for mobile. The 10, 25, 50, 75, and 90th percentiles for first party requests are: 2, 4, 9, 17, and 30 requests per page. This is the same as for desktop. The number of third party requests per page is slightly higher in the upper percentiles by 1 to 5 requests, similar to desktop.",
+  caption="Distribución del número de peticiones de JavaScript por dominio en móviles.",
+  description="Gráfica de barras mostrando la distribución de peticiones de JavaScript por dominio para escritorio. Los percentiles 10, 25, 50, 75 y 90 para peticiones propias son de: 2, 4, 9, 17 y 30 peticiones por página. Estos números son iguales a los de escritorio. El número de peticiones a terceros es ligeramente mayor en los percentiles altos por desde 1 hasta 5 peticiones, una situación similar a la de escritorio.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=1465647946&format=interactive",
   sheets_gid="978380311",
   sql_file="requests_by_3p.sql"
 ) }}
 
-While the amount of JavaScript requests are similar at the median, the actual size of those scripts is weighted (pun intended) a bit more heavily toward third-party sources. The median site sends 267 KB of JavaScript from third-parties to desktop devices ,compared to 147 KB from first-parties. The situation is very similar on mobile, where the median site ships 255 KB of third-party scripts compared to 134 KB of first-party scripts.
+Si bien la cantidad de peticiones de JavaScript es similar en la mediana, el tamaño real de esos scripts está cargado hacia los scripts de terceros. Un sitio en la mediana envía 267 KB de JavaScript de terceros a dispositivos de escritorio, comparado a 147 KB de scripts propios. La situación es similar en móviles, donde un sitio en la mediana envía 255 KB de scripts de terceros contra 134 KB de scripts propios.
 
 {{ figure_markup(
   image="bytes-by-3p-desktop.png",
-  caption="Distribution of the number of JavaScript bytes by host for desktop.",
-  description="Bar chart showing the distribution of JavaScript bytes per host for desktop. The 10, 25, 50, 75, and 90th percentiles for first party bytes are: 21, 67, 147, 296, and 599 KB per page. The number of third party requests per page grows much higher in the upper percentiles by up to 343 KB.",
+  caption="Distribución de la cantidad de bytes de JavaScript por dominio para escritorio.",
+  description="Gráfica de barras mostrando la distribución de la cantidad de bytes de JavaScript por dominio para escritorio. Los percentiles 10, 25, 50, 75 y 90 para scripts propios son: 21, 67, 147, 296 y 599 KB por página. La cantidad de bytes de scripts de terceros por página aumenta en cantidades mucho mayores en percentiles altos por hasta 343 KB.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=1749995505&format=interactive",
   sheets_gid="1145367011",
   sql_file="bytes_by_3p.sql"
@@ -182,8 +182,8 @@ While the amount of JavaScript requests are similar at the median, the actual si
 
 {{ figure_markup(
   image="bytes-by-3p-mobile.png",
-  caption="Distribution of the number of JavaScript bytes by host for mobile.",
-  description="Bar chart showing the distribution of JavaScript bytes per host for mobile. The 10, 25, 50, 75, and 90th percentiles for first party bytes are: 18, 60, 134, 275, and 560 KB. These values are consistently smaller than the desktop values, but only by 10-30 KB. Similar to desktop, the third party bytes are higher than first party, on mobile this difference is not as wide, only up to 328 KB at the 90th percentile.",
+  caption="Distribución de la cantidad de bytes de JavaScript por dominio para móviles.",
+  description="Gráfica de barras mostrando la distribución de la cantidad de bytes de JavaScript por dominio para móviles. Los percentiles 10, 25, 50, 75 y 90 para scripts propios son: 18, 60, 134, 275 y 560 KB por página. Estos números son consistentemente menores que los de escritorio, pero sólo por 10-30 KB. Al igual que en escritorio, la cantidad de bytes de scripts de terceros por página aumenta, en móviles la diferencia no es tan amplia, es de 328 KB en el percentil 90.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=231883913&format=interactive",
   sheets_gid="1145367011",
   sql_file="bytes_by_3p.sql"

--- a/src/content/es/2020/javascript.md
+++ b/src/content/es/2020/javascript.md
@@ -117,27 +117,27 @@ Un mecanismo que tenemos que tiene el potencial de reducir la cantidad de códig
 
 Esta estrategia nos permite crear <i lang="en">bundles</i> más pequeños utilizando sintaxis moderna optimizada para los browsers que son compatibles, mientras tanto, también proveemos <i lang="en">polyfills</i> cargados condicionalmente y una sintaxis diferente para los que no son compatibles.
 
-La compatibilidad con `module` y `nomodule` va en aumento pero aún es una estrategia relativamente nueva. Como resultado, la adopción aún es baja. Solo 3.6% de las páginas móviles usa al menos un script con `type=module` y solo 0.7% de las páginas móviles usa al menos un script con `type=nomodule` para ser compatible con navegadores <i lang="en">legacy</i>.
+La compatibilidad con `module` y `nomodule` va en aumento pero aún es una estrategia relativamente nueva. Como resultado, la adopción aún es baja. Sólo 3.6% de las páginas móviles usa al menos un script con `type=module` y sólo 0.7% de las páginas móviles usa al menos un script con `type=nomodule` para ser compatible con navegadores <i lang="en">legacy</i>.
 
-### Request count
+### Conteo de peticiones
 
-Another way of looking at how much JavaScript we use is to explore how many JavaScript requests are made on each page. While reducing the number of requests was paramount to maintaining good performance with HTTP/1.1, with HTTP/2 the opposite is the case: breaking JavaScript down into <a hreflang="en" href="https://web.dev/granular-chunking-nextjs/">smaller, individual files</a> is [typically better for performance](../2019/http2#impact-of-http2).
+Otra manera de ver cuanto JavaScript usamos es explorar cuantas peticiones de JavaScript son hechas por página. Reducir el número de peticiones era fundamental para tener un buen desempeño usando HTTP/1.1, sin embargo, con HTTP/2 aplica lo contrario: dividir el código en JavaScript en <a hreflang="en" href="https://web.dev/granular-chunking-nextjs/">archivos individuales y más pequeños</a> resulta en [un mejor desempeño en general.](../2019/http2#impact-of-http2).
 
 {{ figure_markup(
   image="requests-2020.png",
-  caption="Distribution of JavaScript requests per page.",
-  description="Bar chart showing the distribution of JavaScript requests per page in 2020. The 10, 25, 50, 75, and 90th percentiles for mobile pages are: 4, 10, 19, 34, and 55. Desktop pages only tend to have 0 or 1 more JavaScript request per page.",
+  caption="Distribución de peticiones de JavaScript por página.",
+  description="Gráfica de barras mostrando la distribución de peticiones de JavaScript por página en 2020. Los percentiles 10, 25, 50, 75 y 90 para páginas móviles son: 4, 10, 19, 34 y 55. Las páginas de escritorio tienden a tener 0 o 1 petición más por página.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=153746548&format=interactive",
   sheets_gid="1804671297",
   sql_file="requests_2020.sql"
 ) }}
 
-At the median, pages make 20 JavaScript requests. That's only a minor increase over last year, when the median page made 19 JavaScript requests.
+En la mediana, las páginas hacen 20 peticiones de JavaScript. Esto es un incremento menor con respecto al año pasado cuando una página en la mediana hacía 19 peticiones de JavaScript.
 
 {{ figure_markup(
   image="requests-2019.png",
-  caption="Distribution of JavaScript requests per page in 2019.",
-  description="Bar chart showing the distribution of JavaScript requests per page in 2019. The 10, 25, 50, 75, and 90th percentiles for mobile pages are: 4, 9, 18, 32, and 52. Similar to the 2020 results, desktop pages only tend to have 0 or 1 more request per page. These results are slightly lower than the 2020 results.",
+  caption="Distribución de peticiones de JavaScript por página en 2019.",
+  description="Gráfica de barras mostrando la distribución de peticiones de JavaScript por página en 2020. Los percentiles 10, 25, 50, 75 y 90 para páginas móviles son: 4, 9, 18, 32 y 52. Los resultados son ligeramente menores a los resultados de 2020.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=528431485&format=interactive",
   sheets_gid="1983394384",
   sql_file="requests_2019.sql"

--- a/src/content/es/2020/javascript.md
+++ b/src/content/es/2020/javascript.md
@@ -1,0 +1,777 @@
+---
+#See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
+title: JavaScript
+description: Capítulo sobre JavaScript del Web Almanac 2020 que cubre cuánto JavaScript usamos en la web, compresión, librerías y <i lang="en">frameworks</i>, cargado y <i lang="en">source maps</i>.
+authors: [tkadlec]
+reviewers: [ibnesayeed, denar90]
+analysts: [rviscomi, paulcalvano]
+editors: [rviscomi]
+translators: [alangdm]
+tkadlec_bio: Tim es un consultor y entrenador sobre desempeño web enfocado en crear una web que todos podamos usar. El es autor de <i lang="en">High Performance Images</i> (O'Reilly, 2016) y <i lang="en">Implementing Responsive Design</i> (New Riders, 2012). El escribe sobre la web en general en <a hreflang="en" href="https://timkadlec.com/">timkadlec.com</a>. Puedes encontrarlo compartiendo sus opiniones en un formato más breve en Twitter con el usuario <a href="https://twitter.com/tkadlec">@tkadlec</a>.
+discuss: 2038
+results: https://docs.google.com/spreadsheets/d/1cgXJrFH02SHPKDGD0AelaXAdB3UI7PIb5dlS0dxVtfY/
+featured_quote: JavaScript ha avanzado mucho desde su origen humilde hasta ser considerado el tercer pilar de la web junto con CSS y HTML. Hoy en día, JavaScript ha comenzado a invadir un amplio espectro del <i lang="en">stack</i> técnico. JavaScript ya no se encuentra limitado al lado del cliente y se ha convertido en una elección cada vez más popular para crear herramientas de construcción y <i lang="en">scripting</i> del lado del servidor. JavaScript también se ha adentrado en la capa de CDN gracias a soluciones de <i lang="en">edge computing</i>.
+featured_stat_1: 1,897ms
+featured_stat_label_1: Mediana de tiempo de ejecución del hilo principal de JS en móviles
+featured_stat_2: 37.22%
+featured_stat_label_2: Porcentaje de JS sin usar en móviles
+featured_stat_3: 12.2%
+featured_stat_label_3: Porcentaje de <i lang="en">scripts</i> cargados asíncronamente
+---
+
+## Introducción
+
+JavaScript ha avanzado mucho desde su origen humilde hasta ser considerado el tercer pilar de la web junto con CSS y HTML. Hoy en día, JavaScript ha comenzado a invadir un amplio espectro del <i lang="en">stack</i> técnico. JavaScript ya no se encuentra limitado al lado del cliente y se ha convertido en una elección cada vez más popular para crear herramientas de construcción y <i lang="en">scripting</i> del lado del servidor. JavaScript también se ha adentrado en la capa de CDN gracias a soluciones de <i lang="en">edge computing</i>.
+
+Los desarroladores amamos usar JavaScript. De acuerdo con el capítulo de marcado, el elemento `script` es el [6to elemento de HTML más popular](./markup) en uso (por delante de elementos tales como `p` e `i` entre muchos otros). Utilizamos más de 14 veces más bytes de JavaScript de los que usamos de HTML, los bloques para construir la web, y 6 veces más bytes que los que usamos de CSS.
+
+{{ figure_markup(
+  image="../page-weight/bytes-distribution-content-type.png",
+  caption="Mediana de tamaño de página por tipo de contenido.",
+  description="Gráfica de barras mostrando la mediana de tamaño de página para páginas móviles y de escritorio dividida en imágenes, JS, CSS y HTML. La mediana de bytes para cada tipo de contenido en páginas móviles es de: 916 KB de imágenes, 411 KB de JS, 62 KB de CSS y 25 KB de HTML. Las páginas de escritorio tienden a tener imágenes de mayor tamaño (alrededor de 1000 KB) y una ligera mayor cantidad de JS (alrededor de 450 KB).",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vQlN4Clqeb8aPc63h0J58WfBxoJluSFT6kXn45JGPghw1LGU28hzabMYAATXNY5st9TtjKrr2HnbfGd/pubchart?oid=1147150650&format=interactive",
+  sheets_gid="https://docs.google.com/spreadsheets/d/1wG4u0LV5PT9aN-XB1hixSFtI8KIDARTOCX0sp7ZT3h0/#378779486",
+  sql_file="../page-weight/bytes_per_type_2020.sql"
+) }}
+
+Pero nada es gratis y esto aplica eespcialmente para Javascript. Todo ese código tiene un costo. Veamos con más detalle cuánto código usamos, cómo lo usamos y cuáles son los efectos secundarios de este.
+
+## How much JavaScript do we use?
+
+We mentioned that the `script` tag is the 6th most used HTML element. Let's dig in a bit deeper to see just how much JavaScript that actually amounts to.
+
+The median site (the 50th percentile) sends 444 KB of JavaScript when loaded on a desktop device, and slightly fewer (411 KB) to a mobile device.
+
+{{ figure_markup(
+  image="bytes-2020.png",
+  caption="Distribution of the amount of JavaScript kilobytes loaded per page.",
+  description="Bar chart showing the distribution of JavaScript bytes per page by about 10%. Desktop pages consistently load more JavaScript bytes than mobile pages. The 10th, 25th, 50th, 75th, and 90th percentiles for desktop are: 87 KB, 209 KB, 444 KB, 826 KB, and 1,322 KB.",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=441749673&format=interactive",
+  sheets_gid="2139688512",
+  sql_file="bytes_2020.sql"
+) }}
+
+It's a bit disappointing that there isn't a bigger gap here. While it's dangerous to make too many assumptions about network or processing power based on whether the device in use is a phone or a desktop (or somewhere in between), it's worth noting that [HTTP Archive mobile tests](./methodology#webpagetest) are done by emulating a Moto G4 and a 3G network. In other words, if there was any work being done to adapt to less-than-ideal circumstances by passing down less code, these tests should be showing it.
+
+The trend also seems to be in favor of using more JavaScript, not less. Comparing to [last year's results](../2019/javascript#how-much-javascript-do-we-use), at the median we see a 13.4% increase in JavaScript as tested on a desktop device, and a 14.4% increase in the amount of JavaScript sent to a mobile device.
+
+<figure>
+  <table>
+    <thead>
+      <tr>
+        <th>Client</th>
+        <th>2019</th>
+        <th>2020</th>
+        <th>Change</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Desktop</td>
+        <td class="numeric">391</td>
+        <td class="numeric">444</td>
+        <td class="numeric">13.4%</td>
+      </tr>
+      <tr>
+        <td>Mobile</td>
+        <td class="numeric">359</td>
+        <td class="numeric">411</td>
+        <td class="numeric">14.4%</td>
+      </tr>
+    </tbody>
+  </table>
+  <figcaption>
+    {{ figure_link(
+      caption="Year-over-year change in the median number of JavaScript kilobytes per page.",
+      sheets_gid="86213362",
+      sql_file="bytes_2020.sql"
+    ) }}
+  </figcaption>
+</figure>
+
+At least some of this weight seems to be unnecessary. If we look at a breakdown of how much of that JavaScript is unused on any given page load, we see that the median page is shipping 152 KB of unused JavaScript. That number jumps to 334 KB at the 75th percentile and 567 KB at the 90th percentile.
+
+{{ figure_markup(
+  image="unused-js-bytes-distribution.png",
+  caption="Distribution of the amount of wasted JavaScript bytes per mobile page.",
+  description="Bar chart showing the distribution of amount of wasted JavaScript bytes per page. From the 10, 25, 50, 75, and 90th percentiles, the distribution goes: 0, 57, 153, 335, and 568 KB.",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=773002950&format=interactive",
+  sheets_gid="611267860",
+  sql_file="unused_js_bytes_distribution.sql"
+) }}
+
+As raw numbers, those may or may not jump out at you depending on how much of a performance nut you are, but when you look at it as a percentage of the total JavaScript used on each page, it becomes a bit easier to see just how much waste we're sending.
+
+{{ figure_markup(
+  caption="Percent of the median mobile page's JavaScript bytes that are unused.",
+  content="37.22%",
+  classes="big-number",
+  sheets_gid="611267860",
+  sql_file="unused_js_bytes_distribution.sql"
+) }}
+
+That 153 KB equates to ~37% of the total script size that we send down to mobile devices. There's definitely some room for improvement here.
+
+### `module` and `nomodule`
+One mechanism we have to potentially reduce the amount of code we send down is to take advantage of the <a hreflang="en" href="https://web.dev/serve-modern-code-to-modern-browsers/">`module`/`nomodule` pattern</a>. With this pattern, we create two sets of bundles: one bundle intended for modern browsers and one intended for legacy browsers. The bundle intended for modern browsers gets a `type=module` and the bundle intended for legacy browsers gets a `type=nomodule`.
+
+This approach lets us create smaller bundles with modern syntax optimized for the browsers that support it, while providing conditionally loaded polyfills and different syntax to the browsers that don't.
+
+Support for `module` and `nomodule` is broadening, but still relatively new. As a result, adoption is still a bit low. Only 3.6% of mobile pages use at least one script with `type=module` and only 0.7% of mobile pages use at least one script with `type=nomodule` to support legacy browsers.
+
+### Request count
+
+Another way of looking at how much JavaScript we use is to explore how many JavaScript requests are made on each page. While reducing the number of requests was paramount to maintaining good performance with HTTP/1.1, with HTTP/2 the opposite is the case: breaking JavaScript down into <a hreflang="en" href="https://web.dev/granular-chunking-nextjs/">smaller, individual files</a> is [typically better for performance](../2019/http2#impact-of-http2).
+
+{{ figure_markup(
+  image="requests-2020.png",
+  caption="Distribution of JavaScript requests per page.",
+  description="Bar chart showing the distribution of JavaScript requests per page in 2020. The 10, 25, 50, 75, and 90th percentiles for mobile pages are: 4, 10, 19, 34, and 55. Desktop pages only tend to have 0 or 1 more JavaScript request per page.",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=153746548&format=interactive",
+  sheets_gid="1804671297",
+  sql_file="requests_2020.sql"
+) }}
+
+At the median, pages make 20 JavaScript requests. That's only a minor increase over last year, when the median page made 19 JavaScript requests.
+
+{{ figure_markup(
+  image="requests-2019.png",
+  caption="Distribution of JavaScript requests per page in 2019.",
+  description="Bar chart showing the distribution of JavaScript requests per page in 2019. The 10, 25, 50, 75, and 90th percentiles for mobile pages are: 4, 9, 18, 32, and 52. Similar to the 2020 results, desktop pages only tend to have 0 or 1 more request per page. These results are slightly lower than the 2020 results.",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=528431485&format=interactive",
+  sheets_gid="1983394384",
+  sql_file="requests_2019.sql"
+) }}
+
+## Where does it come from?
+
+One trend that likely contributes to the increase in JavaScript used on our pages is the seemingly ever-increasing amount of third-party scripts that get added to pages to help with everything from client-side A/B testing and analytics, to serving ads and handling personalization.
+
+Let's drill into that a bit to see just how much third-party script we're serving up.
+
+Right up until the median, sites serve roughly the same number of first-party scripts as they do third-party scripts. At the median, 9 scripts per page are first-party, compared to 10 per page from third-parties. From there, the gap widens a bit: the more scripts a site serves in the total, the more likely it is that the majority of those scripts are from third-party sources.
+
+{{ figure_markup(
+  image="requests-by-3p-desktop.png",
+  caption="Distribution of the number of JavaScript requests by host for desktop.",
+  description="Bar chart showing the distribution of JavaScript requests per host for desktop. The 10, 25, 50, 75, and 90th percentiles for first party requests are: 2, 4, 9, 17, and 30 requests per page. The number of third party requests per page is slightly higher in the upper percentiles by 1 to 6 requests.",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=1566679225&format=interactive",
+  sheets_gid="978380311",
+  sql_file="requests_by_3p.sql"
+) }}
+
+{{ figure_markup(
+  image="requests-by-3p-mobile.png",
+  caption="Distribution of the number of JavaScript requests by host for mobile.",
+  description="Bar chart showing the distribution of JavaScript requests per host for mobile. The 10, 25, 50, 75, and 90th percentiles for first party requests are: 2, 4, 9, 17, and 30 requests per page. This is the same as for desktop. The number of third party requests per page is slightly higher in the upper percentiles by 1 to 5 requests, similar to desktop.",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=1465647946&format=interactive",
+  sheets_gid="978380311",
+  sql_file="requests_by_3p.sql"
+) }}
+
+While the amount of JavaScript requests are similar at the median, the actual size of those scripts is weighted (pun intended) a bit more heavily toward third-party sources. The median site sends 267 KB of JavaScript from third-parties to desktop devices ,compared to 147 KB from first-parties. The situation is very similar on mobile, where the median site ships 255 KB of third-party scripts compared to 134 KB of first-party scripts.
+
+{{ figure_markup(
+  image="bytes-by-3p-desktop.png",
+  caption="Distribution of the number of JavaScript bytes by host for desktop.",
+  description="Bar chart showing the distribution of JavaScript bytes per host for desktop. The 10, 25, 50, 75, and 90th percentiles for first party bytes are: 21, 67, 147, 296, and 599 KB per page. The number of third party requests per page grows much higher in the upper percentiles by up to 343 KB.",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=1749995505&format=interactive",
+  sheets_gid="1145367011",
+  sql_file="bytes_by_3p.sql"
+) }}
+
+{{ figure_markup(
+  image="bytes-by-3p-mobile.png",
+  caption="Distribution of the number of JavaScript bytes by host for mobile.",
+  description="Bar chart showing the distribution of JavaScript bytes per host for mobile. The 10, 25, 50, 75, and 90th percentiles for first party bytes are: 18, 60, 134, 275, and 560 KB. These values are consistently smaller than the desktop values, but only by 10-30 KB. Similar to desktop, the third party bytes are higher than first party, on mobile this difference is not as wide, only up to 328 KB at the 90th percentile.",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=231883913&format=interactive",
+  sheets_gid="1145367011",
+  sql_file="bytes_by_3p.sql"
+) }}
+
+## How do we load our JavaScript?
+
+The way we load JavaScript has a significant impact on the overall experience.
+
+By default, JavaScript is _parser-blocking_. In other words, when the browser discovers a `script` element, it must pause parsing of the HTML until the script has been downloaded, parsed, and executed. It's a significant bottleneck and a common contributor to pages that are slow to render.
+
+We can start to offset some of the cost of loading JavaScript by loading scripts either asynchronously (with the `async` attribute), which only halts the HTML parser during the parse and execution phases and not during the download phase, or deferred (with the `defer` attribute), which doesn't halt the HTML parser at all. Both attributes are only available on external scripts—inline scripts cannot have them applied.
+
+On mobile, external scripts comprise 59.0% of all script elements found.
+
+<p class="note">
+  As an aside, when we talked about how much JavaScript is loaded on a page earlier, that total didn't account for the size of these inline scripts—because they're part of the HTML document, they're counted against the markup size. This means we load even more script that the numbers show.
+</p>
+
+{{ figure_markup(
+  image="external-inline-mobile.png",
+  caption="Distribution of the number of external and inline scripts per mobile page.",
+  description="Pie chart showing 41.0% of mobile scripts are inline and 59.0% are external.",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=1326937127&format=interactive",
+  sheets_gid="1991661912",
+  sql_file="breakdown_of_scripts_using_async_defer_module_nomodule.sql"
+) }}
+
+Of those external scripts, only 12.2% of them are loaded with the `async` attribute and 6.0% of them are loaded with the `defer` attribute.
+
+{{ figure_markup(
+  image="async-defer-mobile.png",
+  caption="Distribution of the number of `async` and `defer` scripts per mobile page.",
+  description="Pie chart showing 12.2% of external mobile scripts use async, 6.0% use defer, and 81.8% use neither.",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=662584253&format=interactive",
+  sheets_gid="1991661912",
+  sql_file="breakdown_of_scripts_using_async_defer_module_nomodule.sql"
+) }}
+
+Considering that `defer` provides us with the best loading performance (by ensuring downloading the script happens in parallel to other work, and execution waits until after the page can be displayed), we would hope to see that percentage a bit higher. In fact, as it is that 6.0% is slightly inflated.
+
+Back when supporting IE8 and IE9 was more common, it was relatively common to use _both_ the `async` and `defer` attributes. With both attributes in place, any browser supporting both will use `async`. IE8 and IE9, which don't support `async` will fall back to `defer`.
+
+Nowadays, the pattern is unnecessary for the vast majority of sites and any script loaded with the pattern in place will interrupt the HTML parser when it needs to be executed, instead of deferring until the page has loaded. The pattern is still used surprisingly often, with 11.4% of mobile pages serving at least one script with that pattern in place. In other words, at least some of the 6% of scripts that use `defer` aren't getting the full benefits of the `defer` attribute.
+
+There is an encouraging story here, though.
+
+Harry Roberts [tweeted about the anti-pattern on Twitter](https://twitter.com/csswizardry/status/1331721659498319873), which is what prompted us to check to see how frequently this was occurring in the wild. [Rick Viscomi checked to see who the top culprits were](https://twitter.com/rick_viscomi/status/1331735748060524551), and it turns out "stats.wp.com" was the source of the most common offenders. @Kraft from Automattic replied, and the pattern will now be [removed going forward](https://twitter.com/Kraft/status/1336772912414601224).
+
+One of the great things about the openness of the web is how one observation can lead to meaningful change and that's exactly what happened here.
+
+### Resource hints
+
+Another tool we have at our disposal for offsetting some of the network costs of loading JavaScript are [resource hints](./resource-hints), specifically, `prefetch` and `preload`.
+
+The `prefetch` hint lets developers signify that a resource will be used on the next page navigation, therefore the browser should try to download it when the browser is idle.
+
+The `preload` hint signifies that a resource will be used on the current page and that the browser should download it right away at a higher priority.
+
+Overall, we see 16.7% of mobile pages using at least one of the two resource hints to load JavaScript more proactively.
+
+Of those, nearly all of the usage is coming from `preload`. While 16.6% of mobile pages use at least one `preload` hint to load JavaScript, only 0.4% of mobile pages use at least one `prefetch` hint.
+
+There's a risk, particularly with `preload`, of using too many hints and reducing their effectiveness, so it's worth looking at the pages that do use these hints to see how many they're using.
+
+{{ figure_markup(
+  image="prefetch-distribution.png",
+  caption="Distribution of the number `prefetch` hints per page with any `prefetch` hints.",
+  description="Bar chart showing the distribution of prefetch hints per page with any prefetch hints. The 10, 25 and 50th percentiles for desktop and mobile pages is 1, 2, and 3 prefetch hints per page. At the 75th percentile for desktop pages it's 6 and 4 for mobile. At the 90th percentile, desktop pages use 14 prefetch hints per page and 12 for mobile pages.",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=1874381460&format=interactive",
+  sheets_gid="1910228743",
+  sql_file="resource-hints-preload-prefetch-distribution.sql"
+) }}
+
+{{ figure_markup(
+  image="preload-distribution.png",
+  caption="Distribution of the number `preload` hints per page with any `preload` hints.",
+  description="Bar chart showing the distribution of preload hints per page with any preload hints. 75% of desktop and mobile pages that use preload hints use it exactly once. The 90th percentile is 5 preload hints per page for desktop and 7 for mobile.",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=320533828&format=interactive",
+  sheets_gid="1910228743",
+  sql_file="resource-hints-preload-prefetch-distribution.sql"
+) }}
+
+At the median, pages that use a `prefetch` hint to load JavaScript use three, while pages that use a `preload` hint only use one. The long tail gets a bit more interesting, with 12 `prefetch` hints used at the 90th percentile and 7 `preload` hints used on the 90th as well. For more detail on resource hints, check out this year's [Resource Hints](./resource-hints) chapter.
+
+## How do we serve JavaScript?
+
+As with any text-based resource on the web, we can save a significant number of bytes through minimization and compression. Neither of these are new optimizations—they've been around for quite awhile—so we should expect to see them applied in more cases than not.
+
+One of the audits in [Lighthouse](./methodology#lighthouse) checks for unminified JavaScript, and provides a score (0.00 being the worst, 1.00 being the best) based on the findings.
+
+{{ figure_markup(
+  image="lighthouse-unminified-js.png",
+  caption="Distribution of unminified JavaScript Lighthouse audit scores per mobile page.",
+  description="Bar chart showing 0% of mobile pages getting unminified JavaScript Lighthouse audit scores under 0.25, 4% of pages getting a score between 0.25 and 0.5, 10% of pages between 0.5 and 0.75, 8% of pages between 0.75 and 0.9, and 77% of pages between 0.9 and 1.0.",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=158284816&format=interactive",
+  sheets_gid="362705605",
+  sql_file="lighthouse_unminified_js.sql"
+) }}
+
+The chart above shows that most pages tested (77%) get a score of 0.90 or above, meaning that few unminified scripts are found.
+
+Overall, only 4.5% of the JavaScript requests recorded are unminified.
+
+Interestingly, while we've picked on third-party requests a bit, this is one area where third-party scripts are doing better than first-party scripts. 82% of the average mobile page's unminified JavaScript bytes come from first-party code.
+
+{{ figure_markup(
+  image="lighthouse-unminified-js-by-3p.png",
+  caption="Average distribution of unminified JavaScript bytes by host.",
+  description="Pie chart showing that 17.7% of unminified JS bytes are third party scripts and 82.3% are first party scripts.",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=2073491355&format=interactive",
+  sheets_gid="1169731612",
+  sql_file="lighthouse_unminified_js_by_3p.sql"
+) }}
+
+### Compression
+
+Minification is a great way to help reduce file size, but compression is even more effective and, therefore, more important—it provides the bulk of network savings more often than not.
+
+{{ figure_markup(
+  image="compression-method-request.png",
+  caption="Distribution of the percent of JavaScript requests by compression method.",
+  description="Bar chart showing the distribution of the percent of JavaScript requests by compression method. Desktop and mobile values are very similar. 65% of JavaScript requests use Gzip compression, 20% use br (Brotli), 15% don't use any compression, and deflate, UTF-8, identity, and none appear as having 0%",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=263239275&format=interactive",
+  sheets_gid="1270710983",
+  sql_file="compression_method.sql"
+) }}
+
+85% of all JavaScript requests have some level of network compression applied. Gzip makes up the majority of that, with 65% of scripts having Gzip compression applied compared to 20% for Brotli (br). While the percentage of Brotli (which is more effective than Gzip) is low compared to its browser support, it's trending in the right direction, increasing by 5 percentage points in the last year.
+
+Once again, this appears to be an area where third-party scripts are actually doing better than first-party scripts. If we break the compression methods out by first- and third-party, we see that 24% of third-party scripts have Brotli applied, compared to only 15% of first-party scripts.
+
+{{ figure_markup(
+  image="compression-method-3p.png",
+  caption="Distribution of the percent of mobile JavaScript requests by compression method and host.",
+  description="Bar chart showing the distribution of the percent of mobile JavaScript requests by compression method and host. 66% and 64% of first and third party JavaScript requests use Gzip. 15% of first party and 24% of third party scripts requests use Brotli. And 19% of first party and 12% of third party scripts do not have a compression method set.",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=1402692197&format=interactive",
+  sheets_gid="564760060",
+  sql_file="compression_method_by_3p.sql"
+) }}
+
+Third-party scripts are also least likely to be served without any compression at all: 12% of third-party scripts have neither Gzip nor Brotli applied, compared to 19% of first-party scripts.
+
+It's worth taking a closer look at those scripts that _don't_ have compression applied. Compression becomes more efficient in terms of savings the more content it has to work with. In other words, if the file is tiny, sometimes the cost of compressing the file doesn't outweight the miniscule reduction in file size.
+
+{{ figure_markup(
+  caption="Percent of uncompressed third-party JavaScript requests under 5 KB.",
+  content="90.25%",
+  classes="big-number",
+  sheets_gid="347926930",
+  sql_file="compression_none_by_bytes.sql"
+) }}
+
+Thankfully, that's exactly what we see, particularly in third-party scripts where 90% of uncompressed scripts are less than 5 KB in size. On the other hand, 49% of uncompressed first-party scripts are less than 5 KB and 37% of uncompressed first-party scripts are over 10 KB. So while we do see a lot of small uncompressed first-party scripts, there are still quite a few that would benefit from some compression.
+
+## What do we use?
+
+As we've increasingly used more JavaScript to power our sites and applications, there has also been an increasing demand for open-source libraries and frameworks to help with improving developer productivity and overall code maintainability. Sites that _don't_ wield one of these tools are definitely the minority on today's web—jQuery alone is found on nearly 85% of the mobile pages tracked by HTTP Archive.
+
+It's important that we think critically about the tools we use to build the web and what the trade-offs are, so it makes sense to look closely at what we see in use today.
+
+### Libraries
+
+HTTP Archive uses [Wappalyzer](./methodology#wappalyzer) to detect technologies in use on a given page. Wappalazyer tracks both JavaScript libraries (think of these as a collection of snippets or helper functions to ease development, like jQuery) and JavaScript frameworks (these are more likely scaffolding and provide templating and structure, like React).
+
+The popular libraries in use are largely unchanged from last year, with jQuery continuing to dominate usage and only one of the top 21 libraries falling out (lazy.js, replaced by DataTables). In fact, even the percentages of the top libraries has barely changed from last year.
+
+{{ figure_markup(
+  image="frameworks-libraries.png",
+  caption="Adoption of the top JavaScript frameworks and libraries as a percent of pages.",
+  description="Bar chart showing the adoption of the top frameworks and libraries as a percent of pages (not page views or npm downloads). jQuery is the overwhelming leader, found on 83% of mobile pages. It's followed by jQuery migrate on 30%, jQuery UI on 21%, Modernizr on 15%, FancyBox on 7%, Slick and Lightbox on 6%, and the remaining frameworks and libraries on 4% or 3%: Moment.js, Underscore.js, Lodash, React, GSAP, Select2, RequireJS, and prettyPhoto.",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=419887153&format=interactive",
+  sheets_gid="1654577118",
+  sql_file="frameworks_libraries.sql"
+) }}
+
+Last year, [Houssein posited a few reasons for why jQuery's dominance continues](../2019/javascript#open-source-libraries-and-frameworks):
+
+> WordPress, which is used in more than 30% of sites, includes jQuery by default.
+> Switching from jQuery to a newer client-side library can take time depending on how large an application is, and many sites may consist of jQuery in addition to newer client-side libraries.
+
+Both are very sound guesses, and it seems the situation hasn't changed much on either front.
+
+In fact, the dominance of jQuery is supported even further when you stop to consider that, of the top 10 libraries, 6 of them are either jQuery or require jQuery in order to be used: jQuery UI, jQuery Migrate, FancyBox, Lightbox and Slick.
+
+### Frameworks
+
+When we look at the frameworks, we also don't see much of a dramatic change in terms of adoption in the main frameworks that were highlighted last year. Vue.js has seen a significant increase, and AMP grew a bit, but most of them are more or less where they were a year ago.
+
+It's worth noting that the <a hreflang="en" href="https://github.com/AliasIO/wappalyzer/issues/2450">detection issue that was noted last year still applies</a>, and still impacts the results here. It's possible that there _has_ been a significant change in popularity for a few more of these tools, but we just don't see it with the way the data is currently collected.
+
+### What it all means
+
+More interesting to us than the popularity of the tools themselves is the impact they have on the things we build.
+
+First, it's worth noting that while we may think of the usage of one tool versus another, in reality, we rarely only use a single library or framework in production. Only 21% of pages analyzed report only one library or framework. Two or three frameworks are pretty common, and the long-tail gets very long, very quickly.
+
+When we look at the common combinations that we see in production, most of them are to be expected. Knowing jQuery's dominance, it's unsurprising that most of the popular combinations include jQuery and any number of jQuery-related plugins.
+
+<figure>
+  <table>
+    <thead>
+      <tr>
+        <th>Combinations</th>
+        <th>Pages</th>
+        <th>(%)</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>jQuery</td>
+        <td class="numeric">1,312,601</td>
+        <td class="numeric">20.7%</td>
+      </tr>
+      <tr>
+        <td>jQuery, jQuery Migrate</td>
+        <td class="numeric">658,628</td>
+        <td class="numeric">10.4%</td>
+      </tr>
+      <tr>
+        <td>jQuery, jQuery UI</td>
+        <td class="numeric">289,074</td>
+        <td class="numeric">4.6%</td>
+      </tr>
+      <tr>
+        <td>Modernizr, jQuery</td>
+        <td class="numeric">155,082</td>
+        <td class="numeric">2.4%</td>
+      </tr>
+      <tr>
+        <td>jQuery, jQuery Migrate, jQuery UI</td>
+        <td class="numeric">140,466</td>
+        <td class="numeric">2.2%</td>
+      </tr>
+      <tr>
+        <td>Modernizr, jQuery, jQuery Migrate</td>
+        <td class="numeric">85,296</td>
+        <td class="numeric">1.3%</td>
+      </tr>
+      <tr>
+        <td>FancyBox, jQuery</td>
+        <td class="numeric">84,392</td>
+        <td class="numeric">1.3%</td>
+      </tr>
+      <tr>
+        <td>Slick, jQuery</td>
+        <td class="numeric">72,591</td>
+        <td class="numeric">1.1%</td>
+      </tr>
+      <tr>
+        <td>GSAP, Lodash, React, RequireJS, Zepto</td>
+        <td class="numeric">61,935</td>
+        <td class="numeric">1.0%</td>
+      </tr>
+      <tr>
+        <td>Modernizr, jQuery, jQuery UI</td>
+        <td class="numeric">61,152</td>
+        <td class="numeric">1.0%</td>
+      </tr>
+      <tr>
+        <td>Lightbox, jQuery</td>
+        <td class="numeric">60,395</td>
+        <td class="numeric">1.0%</td>
+      </tr>
+      <tr>
+        <td>Modernizr, jQuery, jQuery Migrate, jQuery UI</td>
+        <td class="numeric">53,924</td>
+        <td class="numeric">0.8%</td>
+      </tr>
+      <tr>
+        <td>Slick, jQuery, jQuery Migrate</td>
+        <td class="numeric">51,686</td>
+        <td class="numeric">0.8%</td>
+      </tr>
+      <tr>
+        <td>Lightbox, jQuery, jQuery Migrate</td>
+        <td class="numeric">50,557</td>
+        <td class="numeric">0.8%</td>
+      </tr>
+      <tr>
+        <td>FancyBox, jQuery, jQuery UI</td>
+        <td class="numeric">44,193</td>
+        <td class="numeric">0.7%</td>
+      </tr>
+      <tr>
+        <td>Modernizr, YUI</td>
+        <td class="numeric">42,489</td>
+        <td class="numeric">0.7%</td>
+      </tr>
+      <tr>
+        <td>React, jQuery</td>
+        <td class="numeric">37,753</td>
+        <td class="numeric">0.6%</td>
+      </tr>
+      <tr>
+        <td>Moment.js, jQuery</td>
+        <td class="numeric">32,793</td>
+        <td class="numeric">0.5%</td>
+      </tr>
+      <tr>
+        <td>FancyBox, jQuery, jQuery Migrate</td>
+        <td class="numeric">31,259</td>
+        <td class="numeric">0.5%</td>
+      </tr>
+      <tr>
+        <td>MooTools, jQuery, jQuery Migrate</td>
+        <td class="numeric">28,795</td>
+        <td class="numeric">0.5%</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <figcaption>
+    {{ figure_link(
+      caption="The most popular combinations of libraries and frameworks on mobile pages.",
+      sheets_gid="795160444",
+      sql_file="frameworks_libraries_combos.sql"
+    ) }}
+  </figcaption>
+</figure>
+
+We do also see a fair amount of more "modern" frameworks like React, Vue, and Angular paired with jQuery, for example as a result of migration or inclusion by third-parties.
+
+<figure>
+  <table>
+    <thead>
+      <tr>
+        <th scope="col">Combination</th>
+        <th scope="col">Without jQuery</th>
+        <th scope="col">With jQuery</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>GSAP, Lodash, React, RequireJS, Zepto</td>
+        <td class="numeric">1.0%</td>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
+        <td>React, jQuery</td>
+        <td>&nbsp;</td>
+        <td class="numeric">0.6%</td>
+      </tr>
+      <tr>
+        <td>React</td>
+        <td class="numeric">0.4%</td>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
+        <td>React, jQuery, jQuery Migrate</td>
+        <td>&nbsp;</td>
+        <td class="numeric">0.4%</td>
+      </tr>
+      <tr>
+        <td>Vue.js, jQuery</td>
+        <td>&nbsp;</td>
+        <td class="numeric">0.3%</td>
+      </tr>
+      <tr>
+        <td>Vue.js</td>
+        <td class="numeric">0.2%</td>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
+        <td>AngularJS, jQuery</td>
+        <td>&nbsp;</td>
+        <td class="numeric">0.2%</td>
+      </tr>
+      <tr>
+        <td>GSAP, Hammer.js, Lodash, React, RequireJS, Zepto</td>
+        <td class="numeric">0.2%</td>
+        <td>&nbsp;</td>
+      </tr>
+    </tbody>
+    <tfoot>
+      <tr>
+        <th scope="col">Grand Total</th>
+        <th scope="col" class="numeric">1.7%</th>
+        <th scope="col" class="numeric">1.4%</th>
+      </tr>
+    </tfoot>
+  </table>
+  <figcaption>
+    {{ figure_link(
+      caption="The most popular combinations of React, Angular, and Vue with and without jQuery.",
+      sheets_gid="795160444",
+      sql_file="frameworks_libraries_combos.sql"
+    ) }}
+  </figcaption>
+</figure>
+
+More importantly, all these tools typically mean more code and more processing time.
+
+Looking specifically at the frameworks in use, we see that the median JavaScript bytes for pages using them varies dramatically depending on _what_ is being used.
+
+The graph below shows the median bytes for pages where any of the top 35 most commonly detected frameworks were found, broken down by client.
+
+{{ figure_markup(
+  image="frameworks-bytes.png",
+  caption="The median number of JavaScript kilobytes per page by JavaScript framework.",
+  description="Bar chart showing the median number of JavaScript kilobytes per page broken down and sorted by JavaScript framework popularity. The most popular framework, React, has a median amount of JS at 1,328 on mobile pages. Other frameworks like RequireJS and Angular have high numbers of median JS bytes per page. Pages with MooTools, Prototype, AMP, RightJS, Alpine.js, and Svelte have medians under 500 KB per mobile page. Ember.js has an outlier of about 1,800 KB of median JS per mobile page.",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=955720480&format=interactive",
+  sheets_gid="1206934500",
+  width="600",
+  height="835",
+  sql_file="frameworks-bytes-by-framework.sql"
+) }}
+
+On one of the spectrum are frameworks like React or Angular or Ember, which tend to ship a lot of code regardless of the client. On the other end, we see minimalist frameworks like Alpine.js and Svelte showing very promising results. Defaults are very important, and it seems that by starting with highly performant defaults, Svelte and Alpine are both succeeding (so far&hellip; the sample size is pretty small) in creating a lighter set of pages.
+
+We get a very similar picture when looking at main thread time for pages where these tools were detected.
+
+{{ figure_markup(
+  image="frameworks-main-thread.png",
+  caption="The median main thread time per page by JavaScript framework.",
+  description="Bar chart showing the median main thread time by framework. It's hard to notice anything other than Ember.js, whose median mobile main thread time is over 20,000 milliseconds (20 seconds). The rest of the frameworks are tiny by comparison.",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=691531699&format=interactive",
+  sheets_gid="160832134",
+  sql_file="main_thread_time_frameworks.sql"
+) }}
+
+Ember's mobile main thread time jumps out and kind of distorts the graph with how long it takes. (I spent some more time looking into this and it appears to be heavily influenced <a hreflang="en" href="https://timkadlec.com/remembers/2021-01-26-what-about-ember/">by one particular platform using this framework inefficiently</a>, rather than an underlying problem with Ember itself.) Pulling it out makes the picture a bit easier to understand.
+
+{{ figure_markup(
+  image="frameworks-main-thread-no-ember.png",
+  caption="The median main thread time per page by JavaScript framework, excluding Ember.js.",
+  description="Bar chart showing the median main thread time by framework, excluding Ember.js. Mobile main thread times are all higher due to the testing methodology of using slower CPU speeds for mobile. The most popular frameworks like React, GSAP, and RequireJS have high main thread times around 2-3 seconds for desktop and 5-7 seconds for mobile. Polymer also sticks out further down the popularity list. MooToos, Prototype, Alpine.js, and Svelte tend to have lower main thread times, under 2 seconds.",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=77448759&format=interactive",
+  sheets_gid="160832134",
+  sql_file="main_thread_time_frameworks.sql"
+) }}
+
+Tools like React, GSAP, and RequireJS tend to spend a lot of time on the main thread of the browser, regardless of whether it's a desktop or mobile page view. The same tools that tend to lead to less code overall—tools like Alpine and Svelte—also tend to lead to lower impact on the main thread.
+
+The gap between the experience a framework provides for desktop and mobile is also worth digging into. Mobile traffic is becoming increasingly dominant, and it's critical that our tools perform as well as possible for mobile pageviews. The bigger the gap we see between desktop and mobile performance for a framework, the bigger the red flag.
+
+{{ figure_markup(
+  image="frameworks-main-thread-no-ember-diff.png",
+  caption="Difference between desktop and mobile median main thread time per page by JavaScript framework, excluding Ember.js.",
+  description="Bar chart showing the absolute and relative differences between desktop and mobile's median main thread time per page by JavaScript framework, excluding Ember.js. Polymer jumps out later in the popularity list as having a high difference: about 5 seconds and 250% slower median main thread time on mobile pages than desktop pages. Other frameworks that stand out are GSAP and RequireJS has having a 4 second or 150% difference. Frameworks with the lowest difference are Mustache and RxJS, which are only about 20-30% slower on mobile.",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=1758266664&format=interactive",
+  sheets_gid="160832134",
+  sql_file="main_thread_time_frameworks.sql"
+) }}
+
+As you would expect, there's a gap for all tools in use due to the lower processing power of the [emulated Moto G4](methodology#webpagetest). Ember and Polymer seem to jump out as particularly egregious examples, while tools like RxJS and Mustache vary only minorly from desktop to mobile.
+
+## What's the impact?
+
+We have a pretty good picture now of how much JavaScript we use, where it comes from, and what we use it for. While that's interesting enough on its own, the real kicker is the "so what?" What impact does all this script actually have on the experience of our pages?
+
+The first thing we should consider is what happens with all that JavaScript once its been downloaded. Downloading is only the first part of the JavaScript journey. The browser still has to parse all that script, compile it, and eventually execute it. While browsers are constantly on the lookout for ways to offload some of that cost to other threads, much of that work still happens on the main thread, blocking the browser from being able to do layout or paint-related work, as well as from being able to respond to user interaction.
+
+If you recall, there was only a 30 KB difference between what is shipped to a mobile device versus a desktop device. Depending on your point of view, you could be forgiven for not getting too upset about the small gap in the amount of code sent to a desktop browser versus a mobile one—after all, what's an extra 30 KB or so at the median, right?
+
+The biggest problem comes when all of that code gets served to a low-to-middle-end device, something a bit less like the kind of devices most developers are likely to have, and a bit more like the kind of devices you'll see from the majority of people across the world. That relatively small gap between desktop and mobile is much more dramatic when we look at it in terms of processing time.
+
+The median desktop site spends 891 ms on the main thread of a browser working with all that JavaScript. The median mobile site, however, spends 1,897 ms—over two times the time spent on the desktop. It's even worse for the long tail of sites. At the 90th percentile, mobile sites spend a staggering 8,921 ms of main thread time dealing with JavaScript, compared to 3,838 ms for desktop sites.
+
+{{ figure_markup(
+  image="main-thread-time.png",
+  caption="Distribution of main thread time.",
+  description="Bar chart showing the distribution of main thread time for desktop and mobile. Mobile is 2-3 times higher throughout the distribution. The 10, 25, 50, 75, and 90th percentiles for desktop are: 137, 356, 891, 1,988, and 3,838 milliseconds.",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=740020507&format=interactive",
+  sheets_gid="2039579122",
+  sql_file="main_thread_time.sql"
+) }}
+
+### Correlating JavaScript use to Lighthouse scoring
+
+One way of looking at how this translates into impacting the user experience is to try to correlate some of the JavaScript metrics we've identified earlier with Lighthouse scores for different metrics and categories.
+
+{{ figure_markup(
+  image="correlations.png",
+  caption="Correlations of JavaScript on various aspects of user experience.",
+  description="Bar chart showing the Pearson coefficient of correlation for various aspects of user experience. The correlation of bytes to the Lighthouse performance score has a coefficient of correlation of -0.47. Bytes and Lighthouse accessibility score: 0.08. Bytes and Total Blocking Time (TBT): 0.55. Third party bytes and Lighthouse performance score: -0.37. Third party bytes and the Lighthouse accessibility score: 0.00. Third party bytes and TBT: 0.48. The number of async scripts per page and Lighthouse performance score: -0.19. Async scripts and Lighthouse accessibility score: 0.08. Async scripts and TBT: 0.36.",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=649523941&format=interactive",
+  sheets_gid="2035770638",
+  sql_file="correlations.sql"
+) }}
+
+The above chart uses the [Pearson coefficient of correlation](https://en.wikipedia.org/wiki/Pearson_correlation_coefficient). There's a long, kinda complex definition of what that means precisely, but the gist is that we're looking for the strength of the correlation between two different numbers. If we find a coefficient of 1.00, we'd have a direct positive correlation. A correlation of 0.00 would show no connection between two numbers. Anything below 0.00 indicates a negative correlation—in other words, as one number goes up the other one decreases.
+
+First, there doesn't seem to be much of a measurable correlation between our JavaScript metrics and the Lighthouse accessibility ("LH A11y" in the chart) score here. That stands in stark opposition to what's been found elsewhere, notably through <a hreflang="en" href="https://webaim.org/projects/million/#frameworks">WebAim's annual research</a>.
+
+The most likely explanation for this is that Lighthouse's accessibility tests aren't as comprehensive (yet!) as what is available through other tools, like WebAIM, that have accessibility as their primary focus.
+
+Where we do see a strong correlation is between the amount of JavaScript bytes ("Bytes") and both the overall Lighthouse performance ("LH Perf") score and Total Blocking Time ("TBT").
+
+The correlation between JavaScript bytes and Lighthouse performance scores is -0.47. In other words, as JS bytes increase, Lighthouse performance scores decrease. The overall bytes has a stronger correlation than the amount of third-party bytes ("3P bytes"), hinting that while they certainly play a role, we can't place all the blame on third-parties.
+
+The connection between Total Blocking Time and JavaScript bytes is even more significant (0.55 for overall bytes, 0.48 for third-party bytes). That's not too surprising given what we know about all the work browsers have to do to get JavaScript to run in a page—more bytes means more time.
+
+### Security vulnerabilities
+
+One other helpful audit that Lighthouse runs is to check for known security vulnerabilities in third-party libraries. It does this by detecting which libraries and frameworks are used on a given page, and what version is used of each. Then it checks <a hreflang="en" href="https://snyk.io/vuln?type=npm">Snyk's open-source vulnerability database</a> to see what vulnerabilities have been discovered in the identified tools.
+
+{{ figure_markup(
+  caption="Percent of mobile pages contain at least one vulnerable JavaScript library.",
+  content="83.50%",
+  classes="big-number",
+  sheets_gid="1326928130",
+  sql_file="lighthouse_vulnerabilities.sql"
+) }}
+
+According to the audit, 83.5% of mobile pages use a JavaScript library or framework with at least one known security vulnerability.
+
+This is what we call the jQuery effect. Remember how we saw that jQuery is used on a whopping 83% of pages? Several older versions of jQuery contain known vulnerabilities, which comprises the vast majority of the vulnerabilities this audit checks.
+
+Of the roughly 5 million or so mobile pages that are tested against, 81% of them contain a vulnerable version of jQuery—a sizeable lead over the second most commonly found vulnerable library—jQuery UI at 15.6%.
+
+<figure>
+  <table>
+    <thead>
+      <tr>
+        <th>Library</th>
+        <th>Vulnerable pages</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>jQuery</td>
+        <td class="numeric">80.86%</td>
+      </tr>
+      <tr>
+        <td>jQuery UI</td>
+        <td class="numeric">15.61%</td>
+      </tr>
+      <tr>
+        <td>Bootstrap</td>
+        <td class="numeric">13.19%</td>
+      </tr>
+      <tr>
+        <td>Lodash</td>
+        <td class="numeric">4.90%</td>
+      </tr>
+      <tr>
+        <td>Moment.js</td>
+        <td class="numeric">2.61%</td>
+      </tr>
+      <tr>
+        <td>Handlebars</td>
+        <td class="numeric">1.38%</td>
+      </tr>
+      <tr>
+        <td>AngularJS</td>
+        <td class="numeric">1.26%</td>
+      </tr>
+      <tr>
+        <td>Mustache</td>
+        <td class="numeric">0.77%</td>
+      </tr>
+      <tr>
+        <td>Dojo</td>
+        <td class="numeric">0.58%</td>
+      </tr>
+      <tr>
+        <td>jQuery Mobile</td>
+        <td class="numeric">0.53%</td>
+      </tr>
+    </tbody>
+  </table>
+  <figcaption>
+    {{ figure_link(
+      caption="Top 10 libraries contributing to the highest numbers of vulnerable mobile pages according to Lighthouse.",
+      sheets_gid="1803013938",
+      sql_file="lighthouse_vulnerable_libraries.sql"
+    ) }}
+  </figcaption>
+</figure>
+
+In other words, if we can get folks to migrate away from those outdated, vulnerable versions of jQuery, we would see the number of sites with known vulnerabilities plummet (at least, until we start finding some in the newer frameworks).
+
+The bulk of the vulnerabilities found fall into the "medium" severity category.
+
+{{ figure_markup(
+  image="vulnerabilities-by-severity.png",
+  caption="Distribution of the percent of mobile pages having JavaScript vulnerabilities by severity.",
+  description="Pie chart showing 13.7% of mobile pages having no JavaScript vulnerabilities, 0.7% having low severity vulnerabilities, 69.1% having medium severity, and 16.4% having high severity.",
+  chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=1932740277&format=interactive",
+  sheets_gid="1409147642",
+  sql_file="lighthouse_vulnerabilities_by_severity.sql"
+) }}
+
+## Conclusion
+
+JavaScript is steadily rising in popularity, and there's a lot that's positive about that. It's incredible to consider what we're able to accomplish on today's web thanks to JavaScript that, even a few years ago, would have been unimaginable.
+
+But it's clear we've also got to tread carefully. The amount of JavaScript consistently rises each year (if the stock market were that predictable, we'd all be incredibly wealthy), and that comes with trade-offs. More JavaScript is connected to an increase in processing time which negatively impacts key metrics like Total Blocking Time. And, if we let those libraries languish without keeping them updated, they carry the risk of exposing users through known security vulnerabilities.
+
+Carefully weighing the cost of the scripts we add to our pages and being willing to place a critical eye on our tools and ask more of them are our best bets for ensuring that we build a web that is accessible, performant, and safe.

--- a/src/content/es/2020/javascript.md
+++ b/src/content/es/2020/javascript.md
@@ -592,44 +592,45 @@ La gráfica sigueiente muestra la mediana de bytes por páginas donde cualquiera
   sql_file="frameworks-bytes-by-framework.sql"
 ) }}
 
-On one of the spectrum are frameworks like React or Angular or Ember, which tend to ship a lot of code regardless of the client. On the other end, we see minimalist frameworks like Alpine.js and Svelte showing very promising results. Defaults are very important, and it seems that by starting with highly performant defaults, Svelte and Alpine are both succeeding (so far&hellip; the sample size is pretty small) in creating a lighter set of pages.
+En un lado del espectro están _frameworks_ como React, Angular o Ember, que tienden a resultar en mucho código sin importar el cliente. Por otro lado, observamos que _frameworks_ minimalistas como Alpine.js y Svelte muestran resultados muy prometedores. La configuracíón por defecto es muy importante, y parece ser que, al empezar con una base con un alto desempeño, Svelte y Alpine están teniendo éxito (hasta ahora&hellip; la muestra es bastante pequeña) en crear páginas más ligeras.
 
-We get a very similar picture when looking at main thread time for pages where these tools were detected.
+La situación es muy similar cuando tomamos un vistazo al tiempo de ejecución del hilo principal para páginas donde estas herramientas fueron detectadas.
 
 {{ figure_markup(
   image="frameworks-main-thread.png",
-  caption="The median main thread time per page by JavaScript framework.",
-  description="Bar chart showing the median main thread time by framework. It's hard to notice anything other than Ember.js, whose median mobile main thread time is over 20,000 milliseconds (20 seconds). The rest of the frameworks are tiny by comparison.",
+  caption="La mediana de tiempo de ejecución del hilo principal por página por framework de JavaScript.",
+  description="Gráfica de barras mostrando la mediana de tiempo de ejecución del hilo principal por framework. Es difícil notar algo que no sea Ember.js, cuya mediana de tiempo de ejecución del hilo principal en móviles es de más de 20,000 milisegundos (20 segundos). El resto de los frameworks tienen números pequeños en comparación.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=691531699&format=interactive",
   sheets_gid="160832134",
   sql_file="main_thread_time_frameworks.sql"
 ) }}
 
-Ember's mobile main thread time jumps out and kind of distorts the graph with how long it takes. (I spent some more time looking into this and it appears to be heavily influenced <a hreflang="en" href="https://timkadlec.com/remembers/2021-01-26-what-about-ember/">by one particular platform using this framework inefficiently</a>, rather than an underlying problem with Ember itself.) Pulling it out makes the picture a bit easier to understand.
+El tiempo de ejecución del hilo principal de Ember destaca tanto que distorsiona la gráfica por tanto tiempo que tarda en ejecutarse. (Pasé algo de tiempo extra investigando esto y parece haber una gran influencia <a hreflang="en" href="https://timkadlec.com/remembers/2021-01-26-what-about-ember/">de una cierta plataforma usando este _framework_ de manera poco eficiente</a> en vez de ser un problema con Ember en sí.) Quitar Ember de la gráfica la hace un poco más fácil de entender.
 
 {{ figure_markup(
   image="frameworks-main-thread-no-ember.png",
-  caption="The median main thread time per page by JavaScript framework, excluding Ember.js.",
-  description="Bar chart showing the median main thread time by framework, excluding Ember.js. Mobile main thread times are all higher due to the testing methodology of using slower CPU speeds for mobile. The most popular frameworks like React, GSAP, and RequireJS have high main thread times around 2-3 seconds for desktop and 5-7 seconds for mobile. Polymer also sticks out further down the popularity list. MooToos, Prototype, Alpine.js, and Svelte tend to have lower main thread times, under 2 seconds.",
+  caption="La mediana de tiempo de ejecución del hilo principal por página por framework de JavaScript, sin contar a Ember.js.",
+  description="Gráfica de barras mostrando la mediana de tiempo de ejecución del hilo principal por framework, sin contar Ember.js. Los tiempos de ejecución del hilo principal son todos altos debido a que en la metodología de pruebas se usaron velocidades bajas de CPU para móviles. Los frameworks más populares como React, GSAP y RequireJS tienen tiempos de ejecución de hilo principal altos de alrededor de 2-3 segundos en escritorio y 5-7 segundos en móviles. Polymer también sobresale en la parte baja de la lista de popularidad. MooToos, Prototype, Alpine.js y Svelte tienden a tener tiempos de ejecución de hilo principal más bajos, por debajo de los 2 segundos.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=77448759&format=interactive",
   sheets_gid="160832134",
   sql_file="main_thread_time_frameworks.sql"
 ) }}
 
-Tools like React, GSAP, and RequireJS tend to spend a lot of time on the main thread of the browser, regardless of whether it's a desktop or mobile page view. The same tools that tend to lead to less code overall—tools like Alpine and Svelte—also tend to lead to lower impact on the main thread.
+Herramientas como React, GSAP y RequireJS tiended a ocupar mucho del tiempo de ejecución del hilo principal del browser, sin importar si es una página de escritorio o móvil. Las mismas herramientas que dan como resultado una menor cantidad de código—herramientas como Alpine o Svelte—también tienden a tener un menor impacto en el hilo principal.
 
-The gap between the experience a framework provides for desktop and mobile is also worth digging into. Mobile traffic is becoming increasingly dominant, and it's critical that our tools perform as well as possible for mobile pageviews. The bigger the gap we see between desktop and mobile performance for a framework, the bigger the red flag.
+También vale la pena indagar en el intervalo que existe entre la experiencia que un _framework_ provee en escritorio y móvil. El tráfico de dispositivos móviles cada vez se vuelve más dominante y es crítico que nuestras herramientas se desempeñen tan bien como sea posible en móviles. Una gran diferencia en el desempeño en móviles de un _framework_ es una gran alerta roja.
+
 
 {{ figure_markup(
   image="frameworks-main-thread-no-ember-diff.png",
-  caption="Difference between desktop and mobile median main thread time per page by JavaScript framework, excluding Ember.js.",
-  description="Bar chart showing the absolute and relative differences between desktop and mobile's median main thread time per page by JavaScript framework, excluding Ember.js. Polymer jumps out later in the popularity list as having a high difference: about 5 seconds and 250% slower median main thread time on mobile pages than desktop pages. Other frameworks that stand out are GSAP and RequireJS has having a 4 second or 150% difference. Frameworks with the lowest difference are Mustache and RxJS, which are only about 20-30% slower on mobile.",
+  caption="Diferencia entre la mediana del tiempo de ejecución del hilo principal por página por framework de JavaScript, sin contar Ember.js.",
+  description="Gráfica de barras mostrando la diferencia absoluta y relativa entre la mediana del tiempo de ejecución del hilo principal por página por framework de JavaScript entre escritorio y móvil, sin contar Ember.js. Polymer destaca hacia el final de la lista de popularidad teniendo una gran diferencia: alrededor de 5 segundos y un tiempo de ejecución del hilo principal 250% más lento en páginas móviles que en páginas de escritorio. Otros frameworks que saltan a la vista son GSAP y RequireJS teniendo una diferencia de 4 segundos o 150%. Los frameworks con menor diferencia son Mustache y RxJS que sólo son 20-30% más lentos en móviles.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vRn1IaMxnTl0jhdC-C-vC5VLN_boJfLAaOfGJ968IalK1vPc8-dz0OkVmNY0LjMxZ6BIwSRB7xtRmIE/pubchart?oid=1758266664&format=interactive",
   sheets_gid="160832134",
   sql_file="main_thread_time_frameworks.sql"
 ) }}
 
-As you would expect, there's a gap for all tools in use due to the lower processing power of the [emulated Moto G4](methodology#webpagetest). Ember and Polymer seem to jump out as particularly egregious examples, while tools like RxJS and Mustache vary only minorly from desktop to mobile.
+Como era de esperarse, existe un intervalo para todas las herramientas usadas debido al bajo poder de procesamiento del [Moto G4 emulado](methodology#webpagetest). Ember y Polymer parecen ser ejemplos particularmente atroces, mientras que RxJS y Mustache varían muy poco entre escritorio y móvil.
 
 ## What's the impact?
 


### PR DESCRIPTION
Makes progress into #498 

It took me a bit longer than I originally expected but here's the full Spanish translation for the 2020 JavaScript section.

Any comments or corrections are welcome.