### PR TITLE
Stop testing website for SQL only changes

### DIFF
--- a/.github/workflows/test_website.yml
+++ b/.github/workflows/test_website.yml
@@ -9,6 +9,8 @@ name: Test Website
 on:
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - 'sql/**'
 jobs:
   build:
     name: Build and Test Website


### PR DESCRIPTION
No point in running website checks if the only changes are in SQL directory so exclude that, as a waste of our time and GitHub's time!