### PR TITLE
Remove modern image formats Lighthouse check

### DIFF
--- a/.github/lighthouse/lighthouse-config-dev.json
+++ b/.github/lighthouse/lighthouse-config-dev.json
@@ -20,6 +20,7 @@
         "mainthread-work-breakdown": "off",
         "maskable-icon": "off",
         "max-potential-fid": "off",
+        "modern-image-formats": "off",
         "render-blocking-resources": "off",
         "server-response-time": "off",
         "service-worker": "off",

--- a/.github/lighthouse/lighthouse-config-prod.json
+++ b/.github/lighthouse/lighthouse-config-prod.json
@@ -20,6 +20,7 @@
         "mainthread-work-breakdown": "off",
         "maskable-icon": "off",
         "max-potential-fid": "off",
+        "modern-image-formats": "off",
         "render-blocking-resources": "off",
         "server-response-time": "off",
         "service-worker": "off",


### PR DESCRIPTION
We do use WebP and AVIF but only on chapter pages and not on other pages so this warning is just noise.