### PR TITLE
More SQL Linting fixes

### DIFF
--- a/sql/.sqlfluff
+++ b/sql/.sqlfluff
@@ -12,9 +12,9 @@ exclude_rules = L003,L007,L011,L014,L016,L020,L026,L027,L028,L029,L030,L031,L032
 # L016 - We allow longer lines as some of our queries are complex. Maybe should limit in future?
 # L020 - Asks for unique table aliases meaning it complains if selecting from two 2021_07_01 tables as implicit alias is table name (not fully qualified) so same.
 # L026 - BigQuery uses arrays and functions which looks like incorrect references
-# L027 - Asks for qualified columns for ambiguous. Really should enable this but a lot to clean up. TODO
+# L027 - Asks for qualified columns for ambiguous one. Really should enable this but a lot to clean up. TODO
 # L028 - Insists on references in column names even if not ambiguous. Bit OTT.
-# L029 - Avoids keywords as identifiers but has some common ones we use (e.g. count, element).
+# L029 - Avoids keywords as identifiers but we use this a lot (e.g. AS count, AS max...etc.)
 # L030 - Function names will be mixed case so don't enforce case
 # L031 - Avoid aliases in from and join - why?
 # L032 - Uses joins instead of USING - why?
@@ -37,6 +37,7 @@ sql_file_exts = .sql,.sql.j2,.dml,.ddl
 
 [sqlfluff:indentation]
 indented_joins = False
+indented_using_on = False
 template_blocks_indent = True
 
 [sqlfluff:templater]
@@ -67,6 +68,9 @@ unquoted_identifiers_policy = all
 [sqlfluff:rules:L003]
 lint_templated_tokens = True
 
+[sqlfluff:rules:L007]
+operator_new_lines = before
+
 [sqlfluff:rules:L010]  # Keywords
 capitalisation_policy = upper
 
@@ -94,3 +98,4 @@ forbid_subquery_in = join
 
 [sqlfluff:rules:L047]  # Consistent syntax to count all rows
 prefer_count_1 = False
+prefer_count_0 = True

--- a/sql/2019/accessibility/09_03.sql
+++ b/sql/2019/accessibility/09_03.sql
@@ -32,5 +32,4 @@ GROUP BY
 ORDER BY
   pages / total DESC,
   client
-LIMIT
-  10000
+LIMIT 10000

--- a/sql/2019/accessibility/09_05.sql
+++ b/sql/2019/accessibility/09_05.sql
@@ -22,5 +22,4 @@ GROUP BY
   role
 ORDER BY
   pages / total DESC
-LIMIT
-  1000
+LIMIT 1000

--- a/sql/2019/cdn/17_01.sql
+++ b/sql/2019/cdn/17_01.sql
@@ -16,14 +16,14 @@ SELECT
   SUM(COUNT(0)) OVER (PARTITION BY client) AS totalHits,
   ROUND((COUNT(0) * 100 / (0.001 + SUM(COUNT(0)) OVER (PARTITION BY client))), 2) AS hitsPct
 FROM
-(
-  SELECT
-    client, page, url, firstHtml, respBodySize,
-    IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') AS cdn, # sometimes _cdn provider detection includes multiple entries. we bias for the DNS detected entry which is the first entry
-    IF(NET.HOST(url) = NET.HOST(page), TRUE, FALSE) AS sameHost,
-    IF(NET.HOST(url) = NET.HOST(page) OR NET.REG_DOMAIN(url) = NET.REG_DOMAIN(page), TRUE, FALSE) AS sameDomain # if toplevel reg_domain will return NULL so we group this as sameDomain
-  FROM `httparchive.almanac.requests3`
-)
+  (
+    SELECT
+      client, page, url, firstHtml, respBodySize,
+      IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') AS cdn, # sometimes _cdn provider detection includes multiple entries. we bias for the DNS detected entry which is the first entry
+      IF(NET.HOST(url) = NET.HOST(page), TRUE, FALSE) AS sameHost,
+      IF(NET.HOST(url) = NET.HOST(page) OR NET.REG_DOMAIN(url) = NET.REG_DOMAIN(page), TRUE, FALSE) AS sameDomain # if toplevel reg_domain will return NULL so we group this as sameDomain
+    FROM `httparchive.almanac.requests3`
+  )
 GROUP BY
   client,
   cdn

--- a/sql/2019/cdn/17_02.sql
+++ b/sql/2019/cdn/17_02.sql
@@ -1,32 +1,32 @@
 #standardSQL
 # 17_02: Percentage of the sites which use a CDN for any resource
 SELECT
-    client,
-    COUNTIF(firstHtml) AS htmlHits,
-    COUNTIF(NOT firstHtml AND sameHost) AS domainHits,
-    COUNTIF(NOT sameHost AND sameDomain) AS subdomainHits,
-    COUNTIF(NOT sameHost AND NOT sameDomain) AS thirdPartyHits,
-    COUNT(0) AS hits,
-    SUM(IF(firstHtml, respBodySize, 0)) AS htmlBytes,
-    SUM(IF(NOT firstHtml AND sameHost, respBodySize, 0)) AS domainBytes,
-    SUM(IF(NOT sameHost AND sameDomain, respBodySize, 0)) AS subdomainBytes,
-    SUM(IF(NOT sameHost AND NOT sameDomain, respBodySize, 0)) AS thirdPartyBytes,
-    SUM(respBodySize) AS bytes,
+  client,
+  COUNTIF(firstHtml) AS htmlHits,
+  COUNTIF(NOT firstHtml AND sameHost) AS domainHits,
+  COUNTIF(NOT sameHost AND sameDomain) AS subdomainHits,
+  COUNTIF(NOT sameHost AND NOT sameDomain) AS thirdPartyHits,
+  COUNT(0) AS hits,
+  SUM(IF(firstHtml, respBodySize, 0)) AS htmlBytes,
+  SUM(IF(NOT firstHtml AND sameHost, respBodySize, 0)) AS domainBytes,
+  SUM(IF(NOT sameHost AND sameDomain, respBodySize, 0)) AS subdomainBytes,
+  SUM(IF(NOT sameHost AND NOT sameDomain, respBodySize, 0)) AS thirdPartyBytes,
+  SUM(respBodySize) AS bytes,
 
-    COUNTIF(cdn != 'ORIGIN') AS cdnHits,
-    ROUND((COUNTIF(cdn != 'ORIGIN') * 100) / COUNT(0), 2) AS hitsPct,
-    SUM(CASE WHEN cdn != 'ORIGIN' THEN respBodySize ELSE 0 END) AS cdnBytes,
-    ROUND((SUM(CASE WHEN _cdn_provider != '' THEN respBodySize ELSE 0 END) * 100) / SUM(respBodySize), 2) AS bytesPct
-  FROM
-    (
-      SELECT
-        client, page, url, firstHtml, respBodySize,
-        IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') AS cdn,
-        CASE WHEN NET.HOST(url) = NET.HOST(page) THEN TRUE ELSE FALSE END AS sameHost,
-        CASE WHEN NET.HOST(url) = NET.HOST(page) OR NET.REG_DOMAIN(url) = NET.REG_DOMAIN(page) THEN TRUE ELSE FALSE END AS sameDomain # if toplevel reg_domain will return NULL so we group this as sameDomain
-      FROM `httparchive.almanac.requests3`
-      --GROUP BY client, pageid, requestid, page, url, firstHtml, _cdn_provider, respBodySize
-    )
-  GROUP BY
-    client,
-    hits
+  COUNTIF(cdn != 'ORIGIN') AS cdnHits,
+  ROUND((COUNTIF(cdn != 'ORIGIN') * 100) / COUNT(0), 2) AS hitsPct,
+  SUM(CASE WHEN cdn != 'ORIGIN' THEN respBodySize ELSE 0 END) AS cdnBytes,
+  ROUND((SUM(CASE WHEN _cdn_provider != '' THEN respBodySize ELSE 0 END) * 100) / SUM(respBodySize), 2) AS bytesPct
+FROM
+  (
+    SELECT
+      client, page, url, firstHtml, respBodySize,
+      IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') AS cdn,
+      CASE WHEN NET.HOST(url) = NET.HOST(page) THEN TRUE ELSE FALSE END AS sameHost,
+      CASE WHEN NET.HOST(url) = NET.HOST(page) OR NET.REG_DOMAIN(url) = NET.REG_DOMAIN(page) THEN TRUE ELSE FALSE END AS sameDomain # if toplevel reg_domain will return NULL so we group this as sameDomain
+    FROM `httparchive.almanac.requests3`
+  --GROUP BY client, pageid, requestid, page, url, firstHtml, _cdn_provider, respBodySize
+  )
+GROUP BY
+  client,
+  hits

--- a/sql/2019/cdn/17_02f.sql
+++ b/sql/2019/cdn/17_02f.sql
@@ -7,27 +7,27 @@ SELECT
   COUNT(0) AS hits,
   ROUND(100 * COUNTIF(jscdnHits > 0 ) / COUNT(0), 2) AS pct
 FROM
-(
-  SELECT
-    client,
-    page,
-    COUNTIF(
-      NET.HOST(url) IN ('unpkg.com',
-        'www.jsdelivr.net',
-        'cdnjs.cloudflare.com',
-        'ajax.aspnetcdn.com',
-        'ajax.googleapis.com',
-        'stackpath.bootstrapcdn.com',
-        'maxcdn.bootstrapcdn.com',
-        'use.fontawesome.com',
-        'code.jquery.com',
-        'fonts.googleapis.com')
-        ) AS jscdnHits
-  FROM `httparchive.almanac.requests3`
-  GROUP BY
-    client,
-    page
-)
+  (
+    SELECT
+      client,
+      page,
+      COUNTIF(
+        NET.HOST(url) IN ('unpkg.com',
+          'www.jsdelivr.net',
+          'cdnjs.cloudflare.com',
+          'ajax.aspnetcdn.com',
+          'ajax.googleapis.com',
+          'stackpath.bootstrapcdn.com',
+          'maxcdn.bootstrapcdn.com',
+          'use.fontawesome.com',
+          'code.jquery.com',
+          'fonts.googleapis.com')
+      ) AS jscdnHits
+    FROM `httparchive.almanac.requests3`
+    GROUP BY
+      client,
+      page
+  )
 GROUP BY
   client
 ORDER BY

--- a/sql/2019/cdn/17_02g.sql
+++ b/sql/2019/cdn/17_02g.sql
@@ -4,17 +4,17 @@ SELECT
   *,
   ROUND(100 * pageUseCount / totalPagesCount, 2) AS Pct # doing the Pct calc causes memory problems with bigquery
 FROM
-(
-  SELECT
-    client,
-    IF(respBodySize > 0 AND REGEXP_CONTAINS(resp_content_type, r'javascript|css|font'), NET.HOST(url), NULL) AS host,
-    COUNT(DISTINCT page) AS pageUseCount,
-    SUM(COUNTIF(firstHtml)) OVER (PARTITION BY client) AS totalPagesCount
+  (
+    SELECT
+      client,
+      IF(respBodySize > 0 AND REGEXP_CONTAINS(resp_content_type, r'javascript|css|font'), NET.HOST(url), NULL) AS host,
+      COUNT(DISTINCT page) AS pageUseCount,
+      SUM(COUNTIF(firstHtml)) OVER (PARTITION BY client) AS totalPagesCount
     FROM `httparchive.almanac.requests3`
-  GROUP BY
-    client,
-    host
-)
+    GROUP BY
+      client,
+      host
+  )
 WHERE host IS NOT NULL AND pageUseCount > 1000
 ORDER BY
   client DESC,

--- a/sql/2019/cdn/17_02h.sql
+++ b/sql/2019/cdn/17_02h.sql
@@ -5,26 +5,26 @@ SELECT
   *,
   ROUND(100 * pageUseCount / totalPagesCount, 2) AS Pct
 FROM
-(
-  SELECT
-    client,
-    IF(NET.HOST(url) IN ('unpkg.com',
-        'cdn.jsdelivr.net',
-        'cdnjs.cloudflare.com',
-        'ajax.aspnetcdn.com',
-        'ajax.googleapis.com',
-        'stackpath.bootstrapcdn.com',
-        'maxcdn.bootstrapcdn.com',
-        'use.fontawesome.com',
-        'code.jquery.com',
-        'fonts.googleapis.com'), NET.HOST(url), 'OTHER') AS jsCDN,
-    COUNT(DISTINCT page) AS pageUseCount,
-    SUM(COUNTIF(firstHtml)) OVER (PARTITION BY client) AS totalPagesCount
+  (
+    SELECT
+      client,
+      IF(NET.HOST(url) IN ('unpkg.com',
+          'cdn.jsdelivr.net',
+          'cdnjs.cloudflare.com',
+          'ajax.aspnetcdn.com',
+          'ajax.googleapis.com',
+          'stackpath.bootstrapcdn.com',
+          'maxcdn.bootstrapcdn.com',
+          'use.fontawesome.com',
+          'code.jquery.com',
+          'fonts.googleapis.com'), NET.HOST(url), 'OTHER') AS jsCDN,
+      COUNT(DISTINCT page) AS pageUseCount,
+      SUM(COUNTIF(firstHtml)) OVER (PARTITION BY client) AS totalPagesCount
     FROM `httparchive.almanac.requests3`
-  GROUP BY
-    client,
-    jsCDN
-)
+    GROUP BY
+      client,
+      jsCDN
+  )
 ORDER BY
   client DESC,
   pageUseCount DESC

--- a/sql/2019/cdn/17_13.sql
+++ b/sql/2019/cdn/17_13.sql
@@ -16,7 +16,7 @@ FROM (
       IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') AS cdn, # sometimes _cdn provider detection includes multiple entries. we bias for the DNS detected entry which is the first entry
       CAST(JSON_EXTRACT(payload, "$.timings.ssl") AS INT64) AS tlstime,
       ARRAY_LENGTH(split(JSON_EXTRACT(payload, '$._securityDetails.sanList'), "")) AS sanLength,
---       length(FROM_BASE64(REPLACE(REGEXP_REPLACE(JSON_EXTRACT_SCALAR(payload, '$._certificates[0]'), ""-----(BEGIN|END) CERTIFICATE-----"", """"), ""\n"", """"))) AS tlscertsize,
+      --       length(FROM_BASE64(REPLACE(REGEXP_REPLACE(JSON_EXTRACT_SCALAR(payload, '$._certificates[0]'), ""-----(BEGIN|END) CERTIFICATE-----"", """"), ""\n"", """"))) AS tlscertsize,
       IF(NET.HOST(url) = NET.HOST(page), TRUE, FALSE) AS sameHost,
       IF(NET.HOST(url) = NET.HOST(page) OR NET.REG_DOMAIN(url) = NET.REG_DOMAIN(page), TRUE, FALSE) AS sameDomain # if toplevel reg_domain will return NULL so we group this as sameDomain
     FROM `httparchive.almanac.requests`
@@ -27,8 +27,8 @@ WHERE
   tlstime != -1 AND
   sanLength IS NOT NULL
 GROUP BY
- client,
- cdn,
+  client,
+  cdn,
   firstHtml
 ORDER BY
   requests DESC

--- a/sql/2019/cdn/17_19.sql
+++ b/sql/2019/cdn/17_19.sql
@@ -16,40 +16,41 @@ SELECT
   ROUND(100 * COUNTIF(isSecure OR IFNULL(a.protocol, b.protocol) = 'HTTP/2') / COUNT(0), 2) AS tls_pct,
   COUNT(0) AS total
 FROM
-(
-  SELECT
-    client, page, url, firstHtml,
-    # WPT is inconsistent with protocol population.
-    upper(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("HTTP/", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/')))) AS protocol,
-    JSON_EXTRACT_SCALAR(payload, '$._tls_version') AS tlsVersion,
+  (
+    SELECT
+      client, page, url, firstHtml,
+      # WPT is inconsistent with protocol population.
+      upper(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("HTTP/", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/')))) AS protocol,
+      JSON_EXTRACT_SCALAR(payload, '$._tls_version') AS tlsVersion,
 
-    # WPT joins CDN detection but we bias to the DNS detection which is the first entry
-    IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') AS cdn,
-    CAST(JSON_EXTRACT(payload, "$.timings.ssl") AS INT64) AS tlstime,
+      # WPT joins CDN detection but we bias to the DNS detection which is the first entry
+      IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') AS cdn,
+      CAST(JSON_EXTRACT(payload, "$.timings.ssl") AS INT64) AS tlstime,
 
-    # isSecure reports what the browser thought it was going to use, but it can get upgraded with STS OR UpgradeInsecure: 1
-    IF(STARTS_WITH(url, 'https') OR JSON_EXTRACT_SCALAR(payload, '$._tls_version') IS NOT NULL OR CAST(JSON_EXTRACT(payload, '$._is_secure') AS INT64) = 1, TRUE, FALSE) AS isSecure,
-    CAST(jSON_EXTRACT(payload, "$._socket") AS INT64) AS socket
-  FROM
-    `httparchive.almanac.requests3`
-  WHERE
-    # WPT changes the response fields based on a redirect (url becomes the Location path instead of the original) causing insonsistencies in the counts, so we ignore them
-    resp_location = '' OR resp_location IS NULL
-) a
-LEFT JOIN (
-  SELECT
-    client, page,
-    CAST(jSON_EXTRACT(payload, "$._socket") AS INT64) AS socket,
-    ANY_VALUE(upper(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("HTTP/", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/'))))) AS protocol,
-    ANY_VALUE(JSON_EXTRACT_SCALAR(payload, '$._tls_version')) AS tlsVersion
-  FROM
-    `httparchive.almanac.requests3`
-  WHERE
-    JSON_EXTRACT_SCALAR(payload, '$._tls_version') IS NOT NULL AND
-    IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("HTTP/", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/'))) IS NOT NULL AND
-    jSON_EXTRACT(payload, "$._socket") IS NOT NULL
-  GROUP BY client, page, socket
-) b ON (a.client = b.client AND a.page = b.page AND a.socket = b.socket)
+      # isSecure reports what the browser thought it was going to use, but it can get upgraded with STS OR UpgradeInsecure: 1
+      IF(STARTS_WITH(url, 'https') OR JSON_EXTRACT_SCALAR(payload, '$._tls_version') IS NOT NULL OR CAST(JSON_EXTRACT(payload, '$._is_secure') AS INT64) = 1, TRUE, FALSE) AS isSecure,
+      CAST(jSON_EXTRACT(payload, "$._socket") AS INT64) AS socket
+    FROM
+      `httparchive.almanac.requests3`
+    WHERE
+      # WPT changes the response fields based on a redirect (url becomes the Location path instead of the original) causing insonsistencies in the counts, so we ignore them
+      resp_location = '' OR resp_location IS NULL
+  ) a
+LEFT JOIN
+  (
+    SELECT
+      client, page,
+      CAST(jSON_EXTRACT(payload, "$._socket") AS INT64) AS socket,
+      ANY_VALUE(upper(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("HTTP/", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/'))))) AS protocol,
+      ANY_VALUE(JSON_EXTRACT_SCALAR(payload, '$._tls_version')) AS tlsVersion
+    FROM
+      `httparchive.almanac.requests3`
+    WHERE
+      JSON_EXTRACT_SCALAR(payload, '$._tls_version') IS NOT NULL AND
+      IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("HTTP/", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/'))) IS NOT NULL AND
+      jSON_EXTRACT(payload, "$._socket") IS NOT NULL
+    GROUP BY client, page, socket
+  ) b ON (a.client = b.client AND a.page = b.page AND a.socket = b.socket)
 
 GROUP BY
   client,

--- a/sql/2019/cdn/17_19b.sql
+++ b/sql/2019/cdn/17_19b.sql
@@ -12,26 +12,26 @@ SELECT
   ROUND(100 * COUNTIF(IFNULL(a.tlsVersion, b.tlsVersion) = 'TLS 1.3') / COUNT(0), 2) AS tls13_pct,
   COUNT(0) AS total
 FROM
-(
-  SELECT
-    client, page, url, firstHtml,
-    # WPT is inconsistent with protocol population.
-    upper(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("TLS ", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'TLS ')))) AS protocol,
-    JSON_EXTRACT_SCALAR(payload, '$._tls_version') AS tlsVersion,
+  (
+    SELECT
+      client, page, url, firstHtml,
+      # WPT is inconsistent with protocol population.
+      upper(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("TLS ", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'TLS ')))) AS protocol,
+      JSON_EXTRACT_SCALAR(payload, '$._tls_version') AS tlsVersion,
 
-    # WPT joins CDN detection but we bias to the DNS detection which is the first entry
-    IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') AS cdn,
-    CAST(JSON_EXTRACT(payload, "$.timings.ssl") AS INT64) AS tlstime,
+      # WPT joins CDN detection but we bias to the DNS detection which is the first entry
+      IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') AS cdn,
+      CAST(JSON_EXTRACT(payload, "$.timings.ssl") AS INT64) AS tlstime,
 
-    # isSecure reports what the browser thought it was going to use, but it can get upgraded with STS OR UpgradeInsecure: 1
-    IF(STARTS_WITH(url, 'https') OR JSON_EXTRACT_SCALAR(payload, '$._tls_version') IS NOT NULL OR CAST(JSON_EXTRACT(payload, '$._is_secure') AS INT64) = 1, TRUE, FALSE) AS isSecure,
-    CAST(jSON_EXTRACT(payload, "$._socket") AS INT64) AS socket
-  FROM
-    `httparchive.almanac.requests3`
-  WHERE
-    # WPT changes the response fields based on a redirect (url becomes the Location path instead of the original) causing insonsistencies in the counts, so we ignore them
-    resp_location = '' OR resp_location IS NULL
-) a
+      # isSecure reports what the browser thought it was going to use, but it can get upgraded with STS OR UpgradeInsecure: 1
+      IF(STARTS_WITH(url, 'https') OR JSON_EXTRACT_SCALAR(payload, '$._tls_version') IS NOT NULL OR CAST(JSON_EXTRACT(payload, '$._is_secure') AS INT64) = 1, TRUE, FALSE) AS isSecure,
+      CAST(jSON_EXTRACT(payload, "$._socket") AS INT64) AS socket
+    FROM
+      `httparchive.almanac.requests3`
+    WHERE
+      # WPT changes the response fields based on a redirect (url becomes the Location path instead of the original) causing insonsistencies in the counts, so we ignore them
+      resp_location = '' OR resp_location IS NULL
+  ) a
 LEFT JOIN (
   SELECT
     client, page,
@@ -39,7 +39,7 @@ LEFT JOIN (
     ANY_VALUE(upper(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("TLS ", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'TLS '))))) AS protocol,
     ANY_VALUE(JSON_EXTRACT_SCALAR(payload, '$._tls_version')) AS tlsVersion
   FROM `httparchive.almanac.requests3`
-    WHERE
+  WHERE
     JSON_EXTRACT_SCALAR(payload, '$._tls_version') IS NOT NULL AND
     IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("TLS ", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'TLS '))) IS NOT NULL AND
     jSON_EXTRACT(payload, "$._socket") IS NOT NULL

--- a/sql/2019/cdn/17_19c.sql
+++ b/sql/2019/cdn/17_19c.sql
@@ -5,39 +5,40 @@ SELECT
   isSecure,
   COUNT(0) AS total
 FROM
-(
-  SELECT
-    client, page, url, firstHtml,
-    # WPT is inconsistent with protocol population.
-    upper(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("HTTP/", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/')))) AS protocol,
-    JSON_EXTRACT_SCALAR(payload, '$._tls_version') AS tlsVersion,
+  (
+    SELECT
+      client, page, url, firstHtml,
+      # WPT is inconsistent with protocol population.
+      upper(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("HTTP/", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/')))) AS protocol,
+      JSON_EXTRACT_SCALAR(payload, '$._tls_version') AS tlsVersion,
 
-    # WPT joins CDN detection but we bias to the DNS detection which is the first entry
-    IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') AS cdn,
-    CAST(JSON_EXTRACT(payload, "$.timings.ssl") AS INT64) AS tlstime,
+      # WPT joins CDN detection but we bias to the DNS detection which is the first entry
+      IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') AS cdn,
+      CAST(JSON_EXTRACT(payload, "$.timings.ssl") AS INT64) AS tlstime,
 
-    # isSecure reports what the browser thought it was going to use, but it can get upgraded with STS OR UpgradeInsecure: 1
-    IF(STARTS_WITH(url, 'https') OR JSON_EXTRACT_SCALAR(payload, '$._tls_version') IS NOT NULL OR CAST(JSON_EXTRACT(payload, '$._is_secure') AS INT64) = 1, TRUE, FALSE) AS isSecure,
-    CAST(jSON_EXTRACT(payload, "$._socket") AS INT64) AS socket
-  FROM
-    `httparchive.almanac.requests3`
-  WHERE
-    # WPT changes the response fields based on a redirect (url becomes the Location path instead of the original) causing insonsistencies in the counts, so we ignore them
-    resp_location = '' OR resp_location IS NULL
-) a
-LEFT JOIN (
-  SELECT
-    client, page,
-    CAST(jSON_EXTRACT(payload, "$._socket") AS INT64) AS socket,
-    ANY_VALUE(upper(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("HTTP/", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/'))))) AS protocol,
-    ANY_VALUE(JSON_EXTRACT_SCALAR(payload, '$._tls_version')) AS tlsVersion
-  FROM `httparchive.almanac.requests3`
+      # isSecure reports what the browser thought it was going to use, but it can get upgraded with STS OR UpgradeInsecure: 1
+      IF(STARTS_WITH(url, 'https') OR JSON_EXTRACT_SCALAR(payload, '$._tls_version') IS NOT NULL OR CAST(JSON_EXTRACT(payload, '$._is_secure') AS INT64) = 1, TRUE, FALSE) AS isSecure,
+      CAST(jSON_EXTRACT(payload, "$._socket") AS INT64) AS socket
+    FROM
+      `httparchive.almanac.requests3`
     WHERE
-    JSON_EXTRACT_SCALAR(payload, '$._tls_version') IS NOT NULL AND
-    IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("HTTP/", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/'))) IS NOT NULL AND
-    jSON_EXTRACT(payload, "$._socket") IS NOT NULL
-  GROUP BY client, page, socket
-) b ON (a.client = b.client AND a.page = b.page AND a.socket = b.socket)
+      # WPT changes the response fields based on a redirect (url becomes the Location path instead of the original) causing insonsistencies in the counts, so we ignore them
+      resp_location = '' OR resp_location IS NULL
+  ) a
+LEFT JOIN
+  (
+    SELECT
+      client, page,
+      CAST(jSON_EXTRACT(payload, "$._socket") AS INT64) AS socket,
+      ANY_VALUE(upper(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("HTTP/", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/'))))) AS protocol,
+      ANY_VALUE(JSON_EXTRACT_SCALAR(payload, '$._tls_version')) AS tlsVersion
+    FROM `httparchive.almanac.requests3`
+    WHERE
+      JSON_EXTRACT_SCALAR(payload, '$._tls_version') IS NOT NULL AND
+      IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("HTTP/", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/'))) IS NOT NULL AND
+      jSON_EXTRACT(payload, "$._socket") IS NOT NULL
+    GROUP BY client, page, socket
+  ) b ON (a.client = b.client AND a.page = b.page AND a.socket = b.socket)
 
 GROUP BY
   client,

--- a/sql/2019/cms/14_13.sql
+++ b/sql/2019/cms/14_13.sql
@@ -10,7 +10,7 @@ FROM
 JOIN
   `httparchive.technologies.2019_07_01_*`
 USING (_TABLE_SUFFIX, url),
-UNNEST([10, 25, 50, 75, 90]) AS percentile
+  UNNEST([10, 25, 50, 75, 90])
 WHERE
   category = 'CMS'
 GROUP BY

--- a/sql/2019/cms/14_13c.sql
+++ b/sql/2019/cms/14_13c.sql
@@ -21,8 +21,8 @@ FROM
 JOIN
   `httparchive.technologies.2019_07_01_*`
 USING (_TABLE_SUFFIX, url),
-UNNEST(getImageDimensions(payload)) AS image,
-UNNEST([10, 25, 50, 75, 90]) AS percentile
+  UNNEST(getImageDimensions(payload)) AS image,
+  UNNEST([10, 25, 50, 75, 90])
 WHERE
   category = 'CMS'
 GROUP BY

--- a/sql/2019/cms/14_13d.sql
+++ b/sql/2019/cms/14_13d.sql
@@ -12,7 +12,7 @@ FROM
 JOIN
   `httparchive.technologies.2019_07_01_*`
 USING (_TABLE_SUFFIX, url),
-UNNEST([10, 25, 50, 75, 90]) AS percentile
+  UNNEST([10, 25, 50, 75, 90])
 WHERE
   category = 'CMS'
 GROUP BY

--- a/sql/2019/cms/14_15.sql
+++ b/sql/2019/cms/14_15.sql
@@ -24,7 +24,7 @@ FROM (
   GROUP BY
     client,
     page),
-UNNEST([10, 25, 50, 75, 90]) AS percentile
+  UNNEST([10, 25, 50, 75, 90])
 GROUP BY
   percentile,
   client

--- a/sql/2019/cms/14_15b.sql
+++ b/sql/2019/cms/14_15b.sql
@@ -28,7 +28,7 @@ FROM (
     client,
     app,
     page),
-UNNEST([10, 25, 50, 75, 90]) AS percentile
+  UNNEST([10, 25, 50, 75, 90])
 GROUP BY
   client,
   app,

--- a/sql/2019/cms/14_15c.sql
+++ b/sql/2019/cms/14_15c.sql
@@ -31,7 +31,7 @@ FROM (
     client,
     category,
     page),
-UNNEST([10, 25, 50, 75, 90]) AS percentile
+  UNNEST([10, 25, 50, 75, 90])
 GROUP BY
   percentile,
   client,

--- a/sql/2019/cms/14_15d.sql
+++ b/sql/2019/cms/14_15d.sql
@@ -23,7 +23,7 @@ FROM (
   GROUP BY
     client,
     page),
-UNNEST([10, 25, 50, 75, 90]) AS percentile
+  UNNEST([10, 25, 50, 75, 90])
 GROUP BY
   percentile,
   client

--- a/sql/2019/cms/14_15e.sql
+++ b/sql/2019/cms/14_15e.sql
@@ -26,7 +26,7 @@ FROM (
     client,
     type,
     page),
-UNNEST([10, 25, 50, 75, 90]) AS percentile
+  UNNEST([10, 25, 50, 75, 90])
 GROUP BY
   percentile,
   client,

--- a/sql/2019/css/02_06.sql
+++ b/sql/2019/css/02_06.sql
@@ -74,8 +74,8 @@ FROM (
       getColorFormats(css) AS color
     FROM
       `httparchive.almanac.parsed_css`
-  WHERE
-    date = '2019-07-01')
+    WHERE
+      date = '2019-07-01')
   GROUP BY
     client,
     page)

--- a/sql/2019/css/02_08.sql
+++ b/sql/2019/css/02_08.sql
@@ -48,8 +48,8 @@ FROM (
       getSelectorType(css) AS type
     FROM
       `httparchive.almanac.parsed_css`
-  WHERE
-    date = '2019-07-01')
+    WHERE
+      date = '2019-07-01')
   GROUP BY
     client,
     page)

--- a/sql/2019/css/02_15.sql
+++ b/sql/2019/css/02_15.sql
@@ -37,5 +37,4 @@ GROUP BY
   snap_point
 ORDER BY
   freq / total DESC
-LIMIT
-  1000
+LIMIT 1000

--- a/sql/2019/css/02_20.sql
+++ b/sql/2019/css/02_20.sql
@@ -19,5 +19,4 @@ GROUP BY
   filename
 ORDER BY
   freq / total DESC
-LIMIT
-  100
+LIMIT 100

--- a/sql/2019/ecommerce/13_06.sql
+++ b/sql/2019/ecommerce/13_06.sql
@@ -10,7 +10,7 @@ FROM
 JOIN
   `httparchive.technologies.2019_07_01_*`
 USING (_TABLE_SUFFIX, url),
-UNNEST([10, 25, 50, 75, 90]) AS percentile
+  UNNEST([10, 25, 50, 75, 90])
 WHERE
   category = 'Ecommerce'
 GROUP BY

--- a/sql/2019/ecommerce/13_06c.sql
+++ b/sql/2019/ecommerce/13_06c.sql
@@ -21,8 +21,8 @@ FROM
 JOIN
   `httparchive.technologies.2019_07_01_*`
 USING (_TABLE_SUFFIX, url),
-UNNEST(getImageDimensions(payload)) AS image,
-UNNEST([10, 25, 50, 75, 90]) AS percentile
+  UNNEST(getImageDimensions(payload)) AS image,
+  UNNEST([10, 25, 50, 75, 90])
 WHERE
   category = 'Ecommerce'
 GROUP BY

--- a/sql/2019/ecommerce/13_09.sql
+++ b/sql/2019/ecommerce/13_09.sql
@@ -24,7 +24,7 @@ FROM (
   GROUP BY
     client,
     page),
-UNNEST([10, 25, 50, 75, 90]) AS percentile
+  UNNEST([10, 25, 50, 75, 90])
 GROUP BY
   percentile,
   client

--- a/sql/2019/ecommerce/13_09b.sql
+++ b/sql/2019/ecommerce/13_09b.sql
@@ -28,7 +28,7 @@ FROM (
     client,
     app,
     page),
-UNNEST([10, 25, 50, 75, 90]) AS percentile
+  UNNEST([10, 25, 50, 75, 90])
 GROUP BY
   client,
   app,

--- a/sql/2019/ecommerce/13_09c.sql
+++ b/sql/2019/ecommerce/13_09c.sql
@@ -31,7 +31,7 @@ FROM (
     client,
     category,
     page),
-UNNEST([10, 25, 50, 75, 90]) AS percentile
+  UNNEST([10, 25, 50, 75, 90])
 GROUP BY
   percentile,
   client,

--- a/sql/2019/ecommerce/13_09d.sql
+++ b/sql/2019/ecommerce/13_09d.sql
@@ -23,7 +23,7 @@ FROM (
   GROUP BY
     client,
     page),
-UNNEST([10, 25, 50, 75, 90]) AS percentile
+  UNNEST([10, 25, 50, 75, 90])
 GROUP BY
   percentile,
   client

--- a/sql/2019/ecommerce/13_09e.sql
+++ b/sql/2019/ecommerce/13_09e.sql
@@ -26,7 +26,7 @@ FROM (
     client,
     type,
     page),
-UNNEST([10, 25, 50, 75, 90]) AS percentile
+  UNNEST([10, 25, 50, 75, 90])
 GROUP BY
   percentile,
   client,

--- a/sql/2019/fonts/06_09a.sql
+++ b/sql/2019/fonts/06_09a.sql
@@ -5,7 +5,7 @@ SELECT
   _TABLE_SUFFIX AS client,
   APPROX_QUANTILES(reqFont, 1000)[OFFSET(percentile * 10)] AS fonts
 FROM
- `httparchive.summary_pages.2019_07_01_*`,
+  `httparchive.summary_pages.2019_07_01_*`,
   UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   percentile,

--- a/sql/2019/fonts/06_14b.sql
+++ b/sql/2019/fonts/06_14b.sql
@@ -38,7 +38,7 @@ FROM
   `httparchive.almanac.parsed_css`,
   UNNEST(getFonts(css)) AS unicode_range
 WHERE
-    date = '2019-07-01'
+  date = '2019-07-01'
 GROUP BY
   client,
   unicode_range

--- a/sql/2019/fonts/06_32.sql
+++ b/sql/2019/fonts/06_32.sql
@@ -19,5 +19,4 @@ FROM (
     host
   ORDER BY
     freq / total DESC)
-LIMIT
-  100
+LIMIT 100

--- a/sql/2019/fonts/06_39.sql
+++ b/sql/2019/fonts/06_39.sql
@@ -37,7 +37,7 @@ FROM
   `httparchive.almanac.parsed_css`,
   UNNEST(getFontFormats(css)) AS formats
 WHERE
-    date = '2019-07-01'
+  date = '2019-07-01'
 GROUP BY
   client,
   formats

--- a/sql/2019/http2/20_02.sql
+++ b/sql/2019/http2/20_02.sql
@@ -9,10 +9,10 @@ SELECT
   ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (PARTITION BY client), 2) AS pct_pages,
   ROUND(COUNTIF(url LIKE "https://%") * 100 / SUM(COUNT(0)) OVER (PARTITION BY client), 2) AS pct_https
 FROM
-   `httparchive.almanac.requests`
+  `httparchive.almanac.requests`
 WHERE
-   date = '2019-07-01' AND
-   firstHtml
+  date = '2019-07-01' AND
+  firstHtml
 GROUP BY
   client,
   protocol

--- a/sql/2019/http2/20_11.sql
+++ b/sql/2019/http2/20_11.sql
@@ -7,7 +7,7 @@ SELECT
   ROUND(AVG(kb_transfered), 2) AS avg_kb_transfered
 FROM (
 
-SELECT
+  SELECT
     client,
     page,
     SUM(CAST(JSON_EXTRACT_SCALAR(payload, "$._bytesIn") AS INT64) / 1024) AS kb_transfered,

--- a/sql/2019/http2/20_12.sql
+++ b/sql/2019/http2/20_12.sql
@@ -8,7 +8,7 @@ SELECT
   ROUND(AVG(kb_transfered), 2) AS avg_kb_transfered
 FROM (
 
-SELECT
+  SELECT
     client,
     page,
     JSON_EXTRACT_SCALAR(payload, "$._contentType") AS content_type,

--- a/sql/2019/http2/20_13.sql
+++ b/sql/2019/http2/20_13.sql
@@ -26,7 +26,7 @@ FROM (
     firstHtml,
     getLinkHeaders(payload) AS link_headers
   FROM
-   `httparchive.almanac.requests`
+    `httparchive.almanac.requests`
   WHERE
     date = '2019-07-01'
 )

--- a/sql/2019/markup/03_02a.sql
+++ b/sql/2019/markup/03_02a.sql
@@ -12,7 +12,7 @@ try {
 }
 ''';
 
- SELECT
+SELECT
   _TABLE_SUFFIX AS client,
   element,
   COUNT(DISTINCT url) AS pages,

--- a/sql/2019/markup/03_02b.sql
+++ b/sql/2019/markup/03_02b.sql
@@ -27,5 +27,4 @@ GROUP BY
 ORDER BY
   freq / total DESC,
   client
-LIMIT
-  10000
+LIMIT 10000

--- a/sql/2019/markup/03_03c.sql
+++ b/sql/2019/markup/03_03c.sql
@@ -12,7 +12,7 @@ try {
 }
 ''';
 
- SELECT
+SELECT
   _TABLE_SUFFIX AS client,
   element,
   COUNT(DISTINCT url) AS pages,

--- a/sql/2019/media/04_01b.sql
+++ b/sql/2019/media/04_01b.sql
@@ -19,17 +19,17 @@ SELECT
   APPROX_QUANTILES(ROUND(100 * offScreenImagesBytes / (totalImageBytes + 0.1), 2), 1000)[OFFSET(750)] AS pctImageBytes_p75,
   APPROX_QUANTILES(ROUND(100 * offScreenImagesBytes / (totalImageBytes + 0.1), 2), 1000)[OFFSET(900)] AS pctImageBytes_p90
 FROM
-(
-  SELECT
-    url,
-    CAST(JSON_EXTRACT_SCALAR(report, '$.audits.resource-summary.details.items[0].size') AS INT64) AS totalBytes,
-    CAST(JSON_EXTRACT_SCALAR(report, '$.audits.resource-summary.details.items[1].size') AS INT64) AS totalImageBytes,
-    CAST(JSON_EXTRACT_SCALAR(report, '$.audits.offscreen-images.details.overallSavingsBytes') AS INT64) AS offScreenImagesBytes,
-    IF(REGEX_CONTAINS(JSON_EXTRACT(report, '$.audits.offscreen-images.details.items'), ','),
-      ARRAY_LENGTH(split(JSON_EXTRACT(report, '$.audits.offscreen-images.details.items'), ',')), 0) AS offScreenImagesCount,
-    CAST(JSON_EXTRACT_SCALAR(report, '$.audits.uses-optimized-images.details.overallSavingsBytes') AS INT64) AS unoptimizedImagesBytes,
-    IF(REGEX_CONTAINS(JSON_EXTRACT(report, '$.audits.uses-optimized-images.details.items'), ','),
-      ARRAY_LENGTH(split(JSON_EXTRACT(report, '$.audits.uses-optimized-images.details.items'), ',')), 0) AS unoptimizedImagesCount
-  FROM
-    `httparchive.lighthouse.2019_07_01_mobile`
-)
+  (
+    SELECT
+      url,
+      CAST(JSON_EXTRACT_SCALAR(report, '$.audits.resource-summary.details.items[0].size') AS INT64) AS totalBytes,
+      CAST(JSON_EXTRACT_SCALAR(report, '$.audits.resource-summary.details.items[1].size') AS INT64) AS totalImageBytes,
+      CAST(JSON_EXTRACT_SCALAR(report, '$.audits.offscreen-images.details.overallSavingsBytes') AS INT64) AS offScreenImagesBytes,
+      IF(REGEX_CONTAINS(JSON_EXTRACT(report, '$.audits.offscreen-images.details.items'), ','),
+        ARRAY_LENGTH(split(JSON_EXTRACT(report, '$.audits.offscreen-images.details.items'), ',')), 0) AS offScreenImagesCount,
+      CAST(JSON_EXTRACT_SCALAR(report, '$.audits.uses-optimized-images.details.overallSavingsBytes') AS INT64) AS unoptimizedImagesBytes,
+      IF(REGEX_CONTAINS(JSON_EXTRACT(report, '$.audits.uses-optimized-images.details.items'), ','),
+        ARRAY_LENGTH(split(JSON_EXTRACT(report, '$.audits.uses-optimized-images.details.items'), ',')), 0) AS unoptimizedImagesCount
+    FROM
+      `httparchive.lighthouse.2019_07_01_mobile`
+  )

--- a/sql/2019/media/04_01c.sql
+++ b/sql/2019/media/04_01c.sql
@@ -24,15 +24,15 @@ SELECT
   APPROX_QUANTILES(unoptimizedImagesSavingsMs, 1000)[OFFSET(750)] AS ms_p75,
   APPROX_QUANTILES(unoptimizedImagesSavingsMs, 1000)[OFFSET(900)] AS ms_p90
 FROM
-(
-  SELECT
-    url,
-    CAST(JSON_EXTRACT_SCALAR(report, '$.audits.resource-summary.details.items[0].size') AS INT64) AS totalBytes,
-    CAST(JSON_EXTRACT_SCALAR(report, '$.audits.resource-summary.details.items[1].size') AS INT64) AS totalImageBytes,
-    CAST(JSON_EXTRACT_SCALAR(report, '$.audits.uses-optimized-images.details.overallSavingsMs') AS INT64) AS unoptimizedImagesSavingsMs,
-    CAST(JSON_EXTRACT_SCALAR(report, '$.audits.uses-optimized-images.details.overallSavingsBytes') AS INT64) AS unoptimizedImagesBytes,
-    IF(REGEX_CONTAINS(JSON_EXTRACT(report, '$.audits.uses-optimized-images.details.items'), ','),
-      ARRAY_LENGTH(split(JSON_EXTRACT(report, '$.audits.uses-optimized-images.details.items'), ',')), 0) AS unoptimizedImagesCount
-  FROM
-    `httparchive.lighthouse.2019_07_01_mobile`
-)
+  (
+    SELECT
+      url,
+      CAST(JSON_EXTRACT_SCALAR(report, '$.audits.resource-summary.details.items[0].size') AS INT64) AS totalBytes,
+      CAST(JSON_EXTRACT_SCALAR(report, '$.audits.resource-summary.details.items[1].size') AS INT64) AS totalImageBytes,
+      CAST(JSON_EXTRACT_SCALAR(report, '$.audits.uses-optimized-images.details.overallSavingsMs') AS INT64) AS unoptimizedImagesSavingsMs,
+      CAST(JSON_EXTRACT_SCALAR(report, '$.audits.uses-optimized-images.details.overallSavingsBytes') AS INT64) AS unoptimizedImagesBytes,
+      IF(REGEX_CONTAINS(JSON_EXTRACT(report, '$.audits.uses-optimized-images.details.items'), ','),
+        ARRAY_LENGTH(split(JSON_EXTRACT(report, '$.audits.uses-optimized-images.details.items'), ',')), 0) AS unoptimizedImagesCount
+    FROM
+      `httparchive.lighthouse.2019_07_01_mobile`
+  )

--- a/sql/2019/media/04_01d.sql
+++ b/sql/2019/media/04_01d.sql
@@ -19,14 +19,14 @@ SELECT
   APPROX_QUANTILES(ROUND(100 * respImagesBytes / (totalImageBytes + 0.1), 2), 1000)[OFFSET(750)] AS pctImageBytes_p75,
   APPROX_QUANTILES(ROUND(100 * respImagesBytes / (totalImageBytes + 0.1), 2), 1000)[OFFSET(900)] AS pctImageBytes_p90
 FROM
-(
-  SELECT
-    url,
-    CAST(JSON_EXTRACT_SCALAR(report, '$.audits.resource-summary.details.items[0].size') AS INT64) AS totalBytes,
-    CAST(JSON_EXTRACT_SCALAR(report, '$.audits.resource-summary.details.items[1].size') AS INT64) AS totalImageBytes,
-    CAST(JSON_EXTRACT_SCALAR(report, '$.audits.uses-responsive-images.details.overallSavingsBytes') AS INT64) AS respImagesBytes,
-    IF(REGEX_CONTAINS(JSON_EXTRACT(report, '$.audits.uses-responsive-images.details.items'), ','),
-      ARRAY_LENGTH(split(JSON_EXTRACT(report, '$.audits.uses-responsive-images.details.items'), ',')), 0) AS respImagesCount
-  FROM
-    `httparchive.lighthouse.2019_07_01_mobile`
-)
+  (
+    SELECT
+      url,
+      CAST(JSON_EXTRACT_SCALAR(report, '$.audits.resource-summary.details.items[0].size') AS INT64) AS totalBytes,
+      CAST(JSON_EXTRACT_SCALAR(report, '$.audits.resource-summary.details.items[1].size') AS INT64) AS totalImageBytes,
+      CAST(JSON_EXTRACT_SCALAR(report, '$.audits.uses-responsive-images.details.overallSavingsBytes') AS INT64) AS respImagesBytes,
+      IF(REGEX_CONTAINS(JSON_EXTRACT(report, '$.audits.uses-responsive-images.details.items'), ','),
+        ARRAY_LENGTH(split(JSON_EXTRACT(report, '$.audits.uses-responsive-images.details.items'), ',')), 0) AS respImagesCount
+    FROM
+      `httparchive.lighthouse.2019_07_01_mobile`
+  )

--- a/sql/2019/media/04_03b.sql
+++ b/sql/2019/media/04_03b.sql
@@ -22,50 +22,50 @@ SELECT
   APPROX_QUANTILES(bytes, 1000)[OFFSET(900)] AS bytes_p90,
   APPROX_QUANTILES(bytes, 1000)[OFFSET(990)] AS bytes_p99
 FROM
-(
-  SELECT
-    client,
-    page,
-    webImageType,
-    SUM(IF(LOWER(imageType) = LOWER(webImageType), hits, 0)) AS hits,
-    SUM(IF(LOWER(webImageType) = LOWER(imageType), bytes, 0)) AS bytes
-  FROM
   (
     SELECT
       client,
       page,
-      NULLIF(IF(REGEX_CONTAINS(mimetype, r'(?i)^application|^applicaton|^binary|^image$|^multipart|^media|^$|^text/html|^text/plain|\d|array|unknown|undefined|\*|string|^img|^images|^text|\%2f|\(|ipg$|jpe$|jfif'), format, LOWER(REGEXP_REPLACE(REGEXP_REPLACE(mimetype, r'(?is).*image[/\\](?:x-)?|[\."]|[ +,;]+.*$', ''), r'(?i)pjpeg|jpeg', 'jpg'))), '') AS imageType,
-      COUNT(0) AS hits,
-      SUM(respSize) AS bytes
-    FROM `httparchive.almanac.requests3`
+      webImageType,
+      SUM(IF(LOWER(imageType) = LOWER(webImageType), hits, 0)) AS hits,
+      SUM(IF(LOWER(webImageType) = LOWER(imageType), bytes, 0)) AS bytes
+    FROM
+      (
+        SELECT
+          client,
+          page,
+          NULLIF(IF(REGEX_CONTAINS(mimetype, r'(?i)^application|^applicaton|^binary|^image$|^multipart|^media|^$|^text/html|^text/plain|\d|array|unknown|undefined|\*|string|^img|^images|^text|\%2f|\(|ipg$|jpe$|jfif'), format, LOWER(REGEXP_REPLACE(REGEXP_REPLACE(mimetype, r'(?is).*image[/\\](?:x-)?|[\."]|[ +,;]+.*$', ''), r'(?i)pjpeg|jpeg', 'jpg'))), '') AS imageType,
+          COUNT(0) AS hits,
+          SUM(respSize) AS bytes
+        FROM `httparchive.almanac.requests3`
 
-    WHERE
-      # many 404s ANDredirects show up as image/gif
-      status = 200 AND
+        WHERE
+          # many 404s ANDredirects show up as image/gif
+          status = 200 AND
 
-      # we are trying to catch images. WPO populates the format for media but it uses a file extension guess.
-      #So we exclude mimetypes that aren't image or where the format couldn't be guessed by WPO
-      (format <> '' OR mimetype LIKE 'image%') AND
+        # we are trying to catch images. WPO populates the format for media but it uses a file extension guess.
+          #So we exclude mimetypes that aren't image or where the format couldn't be guessed by WPO
+          (format <> '' OR mimetype LIKE 'image%') AND
 
-      # many image/gifs are really beacons with 1x1 pixel, but svgs can get caught in the mix
-      (respSize > 1500 OR REGEXP_CONTAINS(mimetype, r'svg')) AND
+          # many image/gifs are really beacons with 1x1 pixel, but svgs can get caught in the mix
+          (respSize > 1500 OR REGEXP_CONTAINS(mimetype, r'svg')) AND
 
-      # strip favicon requests
-      format <> 'ico' AND
+          # strip favicon requests
+          format <> 'ico' AND
 
-      # strip video mimetypes ANDother favicons
-      NOT REGEXP_CONTAINS(mimetype, r'video|ico')
+          # strip video mimetypes ANDother favicons
+          NOT REGEXP_CONTAINS(mimetype, r'video|ico')
+        GROUP BY
+          client,
+          page,
+          imageType
+      )
+    CROSS JOIN UNNEST(['jpg', 'png', 'webp', 'gif', 'svg']) AS webImageType
     GROUP BY
       client,
       page,
-      imageType
+      webImageType
   )
-  CROSS JOIN UNNEST(['jpg', 'png', 'webp', 'gif', 'svg']) AS webImageType
-  GROUP BY
-    client,
-    page,
-    webImageType
-)
 GROUP BY
   client,
   imageType

--- a/sql/2019/media/04_09a.sql
+++ b/sql/2019/media/04_09a.sql
@@ -11,17 +11,17 @@ SELECT client,
   ROUND(100 * COUNTIF( chHTML AND chHeader) / COUNT(0), 2) AS chBothPct,
   ROUND(100 * COUNTIF( chHTML OR chHeader) / COUNT(0), 2) AS chEitherPct
 FROM
-(
-  SELECT
-    client,
-    page,
-    REGEXP_CONTAINS(body, r'(?is)<meta[^><]*Accept-CH\b') AS chHTML,
-    REGEXP_CONTAINS(respOtherHeaders, r'(?is)Accept-CH = ') AS chHeader
-  FROM
-    `httparchive.almanac.summary_response_bodies`
-  WHERE
-    date = '2019-07-01' AND
-    firstHtml
-)
+  (
+    SELECT
+      client,
+      page,
+      REGEXP_CONTAINS(body, r'(?is)<meta[^><]*Accept-CH\b') AS chHTML,
+      REGEXP_CONTAINS(respOtherHeaders, r'(?is)Accept-CH = ') AS chHeader
+    FROM
+      `httparchive.almanac.summary_response_bodies`
+    WHERE
+      date = '2019-07-01' AND
+      firstHtml
+  )
 GROUP BY
   client

--- a/sql/2019/media/04_09b.sql
+++ b/sql/2019/media/04_09b.sql
@@ -6,19 +6,19 @@ SELECT
   chHeader,
   COUNT(0) AS hits
 FROM
-(
-  SELECT
-    client,
-    page,
-    replace(regexp_extract(regexp_extract(body, r'(?is)<meta[^><]*Accept-CH\b[^><]*'), r'(?im).*content=[&quot;#32"\']*([^\'"><]*)'), "#32;", '') AS chHTML,
-    regexp_extract(regexp_extract(respOtherHeaders, r'(?is)Accept-CH = (.*)'), r'(?im)^([^=]*?)(?:, [a-z-]+ = .*)') AS chHeader
-  FROM `httparchive.almanac.summary_response_bodies`
-  WHERE
-    date = '2019-07-01' AND
-    firstHtml AND
-    ( REGEXP_CONTAINS(body, r'(?is)<meta[^><]*Accept-CH\b') OR
-      REGEXP_CONTAINS(respOtherHeaders, r'(?is)Accept-CH = ') )
-)
+  (
+    SELECT
+      client,
+      page,
+      replace(regexp_extract(regexp_extract(body, r'(?is)<meta[^><]*Accept-CH\b[^><]*'), r'(?im).*content=[&quot;#32"\']*([^\'"><]*)'), "#32;", '') AS chHTML,
+      regexp_extract(regexp_extract(respOtherHeaders, r'(?is)Accept-CH = (.*)'), r'(?im)^([^=]*?)(?:, [a-z-]+ = .*)') AS chHeader
+    FROM `httparchive.almanac.summary_response_bodies`
+    WHERE
+      date = '2019-07-01' AND
+      firstHtml AND
+      ( REGEXP_CONTAINS(body, r'(?is)<meta[^><]*Accept-CH\b') OR
+        REGEXP_CONTAINS(respOtherHeaders, r'(?is)Accept-CH = ') )
+  )
 GROUP BY
   client,
   chHTML,

--- a/sql/2019/media/04_09c.sql
+++ b/sql/2019/media/04_09c.sql
@@ -3,31 +3,31 @@
 SELECT
   client, ch, SUM(hits) AS hits
 FROM
-(
-  SELECT
-    client,
-    REGEXP_REPLACE(concat(IFNULL(chHTML, ''), ',', IFNULL(chHeader, '')), r'^,|,$| ', '') AS acceptCH,
-    COUNT(0) AS hits
-  FROM
   (
     SELECT
       client,
-      page,
-      replace(regexp_extract(regexp_extract(body, r'(?is)<meta[^><]*Accept-CH\b[^><]*'), r'(?im).*content=[&quot;#32"\']*([^\'"><]*)'), "&#32;", '') AS chHTML,
-      regexp_extract(regexp_extract(respOtherHeaders, r'(?is)Accept-CH = (.*)'), r'(?im)^([^=]*?)(?:, [a-z-]+ = .*)') AS chHeader
+      REGEXP_REPLACE(concat(IFNULL(chHTML, ''), ',', IFNULL(chHeader, '')), r'^,|,$| ', '') AS acceptCH,
+      COUNT(0) AS hits
     FROM
-      `httparchive.almanac.summary_response_bodies`
-    WHERE
-      date = '2019-07-01' AND
-      firstHtml AND
-      ( REGEXP_CONTAINS(body, r'(?im)<meta[^><]*Accept-CH\b') OR
-        REGEXP_CONTAINS(respOtherHeaders, r'(?im)Accept-CH = ') )
+      (
+        SELECT
+          client,
+          page,
+          replace(regexp_extract(regexp_extract(body, r'(?is)<meta[^><]*Accept-CH\b[^><]*'), r'(?im).*content=[&quot;#32"\']*([^\'"><]*)'), "&#32;", '') AS chHTML,
+          regexp_extract(regexp_extract(respOtherHeaders, r'(?is)Accept-CH = (.*)'), r'(?im)^([^=]*?)(?:, [a-z-]+ = .*)') AS chHeader
+        FROM
+          `httparchive.almanac.summary_response_bodies`
+        WHERE
+          date = '2019-07-01' AND
+          firstHtml AND
+          ( REGEXP_CONTAINS(body, r'(?im)<meta[^><]*Accept-CH\b') OR
+            REGEXP_CONTAINS(respOtherHeaders, r'(?im)Accept-CH = ') )
+      )
+    GROUP BY
+      client,
+      chHTML,
+      chHeader
   )
-  GROUP BY
-    client,
-    chHTML,
-    chHeader
-)
 CROSS JOIN UNNEST(SPLIT(LOWER(acceptCH), ',')) AS ch
 GROUP BY
   client,

--- a/sql/2019/media/04_11a.sql
+++ b/sql/2019/media/04_11a.sql
@@ -30,27 +30,27 @@ SELECT
   APPROX_QUANTILES(ROUND(bytes / IF(imageType = 'svg' AND pixels > 0, pixels, naturalPixels), 4), 1000)[OFFSET(750)] AS bpp_p75,
   APPROX_QUANTILES(ROUND(bytes / IF(imageType = 'svg' AND pixels > 0, pixels, naturalPixels), 4), 1000)[OFFSET(900)] AS bpp_p90
 FROM
-(
-  SELECT
-    _TABLE_SUFFIX AS client,
-    p.url AS page,
-    image.url AS url,
-    image.width AS width,
-    image.height AS height,
-    image.naturalWidth AS naturalWidth,
-    image.naturalHeight AS naturalHeight,
-    IFNULL(image.width, 0) * IFNULL(image.height, 0) AS pixels,
-    IFNULL(image.naturalWidth, 0) * IFNULL(image.naturalHeight, 0) AS naturalPixels
-  FROM
-    `httparchive.pages.2019_07_01_*` p
+  (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      p.url AS page,
+      image.url AS url,
+      image.width AS width,
+      image.height AS height,
+      image.naturalWidth AS naturalWidth,
+      image.naturalHeight AS naturalHeight,
+      IFNULL(image.width, 0) * IFNULL(image.height, 0) AS pixels,
+      IFNULL(image.naturalWidth, 0) * IFNULL(image.naturalHeight, 0) AS naturalPixels
+    FROM
+      `httparchive.pages.2019_07_01_*` p
     CROSS JOIN UNNEST(getImages(payload)) AS image
-  WHERE
-    image.naturalHeight > 0 AND
-    image.naturalWidth > 0
---  LIMIT 1000
-) a
+    WHERE
+      image.naturalHeight > 0 AND
+      image.naturalWidth > 0
+  --  LIMIT 1000
+  ) a
 LEFT JOIN
-(
+  (
     SELECT
       client,
       page,
@@ -63,7 +63,7 @@ LEFT JOIN
       # many 404s and redirects show up as image/gif
       status = 200 AND
 
-      # we are trying to catch images. WPO populates the format for media but it uses a file extension guess.
+        # we are trying to catch images. WPO populates the format for media but it uses a file extension guess.
       #So we exclude mimetypes that aren't image or where the format couldn't be guessed by WPO
       (format <> '' OR mimetype LIKE 'image%') AND
 
@@ -75,8 +75,8 @@ LEFT JOIN
 
       # strip video mimetypes and other favicons
       NOT REGEXP_CONTAINS(mimetype, r'video|ico')
--- limit 1000
-)
+  -- limit 1000
+  )
 ON (b.client = a.client AND a.page = b.page AND a.url = b.url)
 
 WHERE

--- a/sql/2019/media/04_11b.sql
+++ b/sql/2019/media/04_11b.sql
@@ -43,22 +43,22 @@ SELECT
   Round(APPROX_QUANTILES(naturalPixels, 1000)[OFFSET(750)] / (any_value(viewportHeight) * any_value(viewportWidth)), 2) AS pct_p75,
   Round(APPROX_QUANTILES(naturalPixels, 1000)[OFFSET(900)] / (any_value(viewportHeight) * any_value(viewportWidth)), 2) AS pct_p90
 FROM
-(
-  SELECT
-    _TABLE_SUFFIX AS client,
-    url AS page,
-    getCssPixels(json_extract_scalar(payload, '$._Images')) AS cssPixels,
-    getNaturalPixels(json_extract_scalar(payload, '$._Images')) AS naturalPixels,
-    CAST(json_extract_scalar(payload, '$._smallImageCount') AS Int64) AS smallImageCount,
-    CAST(json_extract_scalar(payload, '$._bigImageCount') AS Int64) AS bigImageCount,
-    CAST(json_extract_scalar(payload, '$._image_total') AS Int64) AS imageBytes,
-    CAST(json_extract_scalar(json_extract_scalar(payload, '$._Dpi'), '$.dppx') AS Float64) AS dpr,
-    CAST(json_extract_scalar(json_extract_scalar(payload, '$._Resolution'), '$.absolute.height') AS Int64) AS viewportHeight,
-    CAST(json_extract_scalar(json_extract_scalar(payload, '$._Resolution'), '$.absolute.width') AS Int64) AS viewportWidth
-  FROM
-    `httparchive.pages.2019_07_01_*`
---  LIMIT 1000
-)
+  (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      url AS page,
+      getCssPixels(json_extract_scalar(payload, '$._Images')) AS cssPixels,
+      getNaturalPixels(json_extract_scalar(payload, '$._Images')) AS naturalPixels,
+      CAST(json_extract_scalar(payload, '$._smallImageCount') AS Int64) AS smallImageCount,
+      CAST(json_extract_scalar(payload, '$._bigImageCount') AS Int64) AS bigImageCount,
+      CAST(json_extract_scalar(payload, '$._image_total') AS Int64) AS imageBytes,
+      CAST(json_extract_scalar(json_extract_scalar(payload, '$._Dpi'), '$.dppx') AS Float64) AS dpr,
+      CAST(json_extract_scalar(json_extract_scalar(payload, '$._Resolution'), '$.absolute.height') AS Int64) AS viewportHeight,
+      CAST(json_extract_scalar(json_extract_scalar(payload, '$._Resolution'), '$.absolute.width') AS Int64) AS viewportWidth
+    FROM
+      `httparchive.pages.2019_07_01_*`
+  --  LIMIT 1000
+  )
 WHERE
   # it appears the _Images array is populated only from <img> tag requests and not CSS or favicon
   # likewise the bigImageCount and smallImageCount only track images > 100,000 and < 10,000 respectively.

--- a/sql/2019/media/04_14.sql
+++ b/sql/2019/media/04_14.sql
@@ -23,7 +23,7 @@ FROM
   `httparchive.almanac.requests`,
   UNNEST([10, 25, 50, 75, 90]) AS percentile
 WHERE
-    date = '2019-07-01' AND
+  date = '2019-07-01' AND
   type = 'image'
 GROUP BY
   percentile,

--- a/sql/2019/mobile-web/12_01.sql
+++ b/sql/2019/mobile-web/12_01.sql
@@ -4,9 +4,9 @@
 # score is not binary
 
 SELECT
-    COUNT(url) AS total,
-    COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.tap-targets.score') AS NUMERIC) = 1) AS score_sum,
-    AVG(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.tap-targets.score') AS NUMERIC)) AS score_average,
-    ROUND(COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.tap-targets.score') AS NUMERIC) = 1) * 100 / COUNT(url), 2) AS score_percentage
+  COUNT(url) AS total,
+  COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.tap-targets.score') AS NUMERIC) = 1) AS score_sum,
+  AVG(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.tap-targets.score') AS NUMERIC)) AS score_average,
+  ROUND(COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.tap-targets.score') AS NUMERIC) = 1) * 100 / COUNT(url), 2) AS score_percentage
 FROM
-    `httparchive.lighthouse.2019_07_01_mobile`
+  `httparchive.lighthouse.2019_07_01_mobile`

--- a/sql/2019/mobile-web/12_02.sql
+++ b/sql/2019/mobile-web/12_02.sql
@@ -4,9 +4,9 @@
 # score is not binary
 
 SELECT
-    COUNT(url) AS total,
-    COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.font-size.score') AS NUMERIC) = 1) AS score_sum,
-    AVG(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.font-size.score') AS NUMERIC)) AS score_average,
-    ROUND(COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.font-size.score') AS NUMERIC) = 1) * 100 / COUNT(url), 2) AS score_percentage
+  COUNT(url) AS total,
+  COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.font-size.score') AS NUMERIC) = 1) AS score_sum,
+  AVG(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.font-size.score') AS NUMERIC)) AS score_average,
+  ROUND(COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.font-size.score') AS NUMERIC) = 1) * 100 / COUNT(url), 2) AS score_percentage
 FROM
-    `httparchive.lighthouse.2019_07_01_mobile`
+  `httparchive.lighthouse.2019_07_01_mobile`

--- a/sql/2019/mobile-web/12_03.sql
+++ b/sql/2019/mobile-web/12_03.sql
@@ -4,9 +4,9 @@
 # score is not binary
 
 SELECT
-    COUNT(url) AS total,
-    COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.color-contrast.score') AS NUMERIC) = 1) AS score_sum,
-    AVG(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.color-contrast.score') AS NUMERIC)) AS score_average,
-    ROUND(COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.color-contrast.score') AS NUMERIC) = 1) * 100 / COUNT(url), 2) AS score_percentage
+  COUNT(url) AS total,
+  COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.color-contrast.score') AS NUMERIC) = 1) AS score_sum,
+  AVG(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.color-contrast.score') AS NUMERIC)) AS score_average,
+  ROUND(COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.color-contrast.score') AS NUMERIC) = 1) * 100 / COUNT(url), 2) AS score_percentage
 FROM
-    `httparchive.lighthouse.2019_07_01_mobile`
+  `httparchive.lighthouse.2019_07_01_mobile`

--- a/sql/2019/mobile-web/12_05.sql
+++ b/sql/2019/mobile-web/12_05.sql
@@ -3,8 +3,8 @@
 # <meta viewport> exists and valid
 
 SELECT
-    COUNT(url) AS total,
-    COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.viewport.score') AS NUMERIC) = 1) AS score_sum,
-    ROUND(COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.viewport.score') AS NUMERIC) = 1) * 100 / COUNT(url), 2) AS score_percentage
+  COUNT(url) AS total,
+  COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.viewport.score') AS NUMERIC) = 1) AS score_sum,
+  ROUND(COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.viewport.score') AS NUMERIC) = 1) * 100 / COUNT(url), 2) AS score_percentage
 FROM
-    `httparchive.lighthouse.2019_07_01_mobile`
+  `httparchive.lighthouse.2019_07_01_mobile`

--- a/sql/2019/mobile-web/12_08.sql
+++ b/sql/2019/mobile-web/12_08.sql
@@ -3,15 +3,16 @@
 # password-inputs-can-be-pasted-into
 
 SELECT
-    COUNT(0) AS total_pages,
-    COUNTIF(password_score IS NOT NULL) AS applicable_pages,
+  COUNT(0) AS total_pages,
+  COUNTIF(password_score IS NOT NULL) AS applicable_pages,
 
-    COUNTIF(CAST(password_score AS NUMERIC) = 1) AS total_allowing,
-    ROUND(COUNTIF(CAST(password_score AS NUMERIC) = 1) * 100 / COUNTIF(password_score IS NOT NULL), 2) AS perc_allowing
-FROM (
+  COUNTIF(CAST(password_score AS NUMERIC) = 1) AS total_allowing,
+  ROUND(COUNTIF(CAST(password_score AS NUMERIC) = 1) * 100 / COUNTIF(password_score IS NOT NULL), 2) AS perc_allowing
+FROM
+  (
     SELECT
-        url,
-        JSON_EXTRACT_SCALAR(report, '$.audits.password-inputs-can-be-pasted-into.score') AS password_score
+      url,
+      JSON_EXTRACT_SCALAR(report, '$.audits.password-inputs-can-be-pasted-into.score') AS password_score
     FROM
-        `httparchive.lighthouse.2019_07_01_mobile`
-)
+      `httparchive.lighthouse.2019_07_01_mobile`
+  )

--- a/sql/2019/mobile-web/12_09.sql
+++ b/sql/2019/mobile-web/12_09.sql
@@ -3,8 +3,8 @@
 # notification-on-start
 
 SELECT
-    COUNT(url) AS total,
-    COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.notification-on-start.score') AS NUMERIC) = 1) AS score_sum,
-    ROUND(COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.notification-on-start.score') AS NUMERIC) = 1) * 100 / COUNT(url), 2) AS score_percentage
+  COUNT(url) AS total,
+  COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.notification-on-start.score') AS NUMERIC) = 1) AS score_sum,
+  ROUND(COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.notification-on-start.score') AS NUMERIC) = 1) * 100 / COUNT(url), 2) AS score_percentage
 FROM
-    `httparchive.lighthouse.2019_07_01_mobile`
+  `httparchive.lighthouse.2019_07_01_mobile`

--- a/sql/2019/mobile-web/12_11.sql
+++ b/sql/2019/mobile-web/12_11.sql
@@ -17,7 +17,7 @@ RETURNS BOOL LANGUAGE js AS '''
 ''';
 
 SELECT
-    COUNT(url) AS total,
-    ROUND(COUNTIF(hasButtonIconSet(payload)) * 100 / COUNT(0), 2) AS pct_has_icon_button
+  COUNT(url) AS total,
+  ROUND(COUNTIF(hasButtonIconSet(payload)) * 100 / COUNT(0), 2) AS pct_has_icon_button
 FROM
-    `httparchive.pages.2019_07_01_mobile`
+  `httparchive.pages.2019_07_01_mobile`

--- a/sql/2019/mobile-web/12_12.sql
+++ b/sql/2019/mobile-web/12_12.sql
@@ -14,15 +14,15 @@ RETURNS ARRAY<STRING> LANGUAGE js AS '''
 ''';
 
 SELECT
-    input_type,
-    COUNT(input_type) AS occurence,
-    ROUND(COUNT(input_type) * 100 / SUM(COUNT(0)) OVER (PARTITION BY 0), 2) AS occurence_perc,
-    COUNT(DISTINCT url) AS pages,
-    total AS total_pages,
-    ROUND(COUNT(DISTINCT url) * 100 / total, 2) AS pages_perc
+  input_type,
+  COUNT(input_type) AS occurence,
+  ROUND(COUNT(input_type) * 100 / SUM(COUNT(0)) OVER (PARTITION BY 0), 2) AS occurence_perc,
+  COUNT(DISTINCT url) AS pages,
+  total AS total_pages,
+  ROUND(COUNT(DISTINCT url) * 100 / total, 2) AS pages_perc
 FROM
-    `httparchive.pages.2019_07_01_mobile`,
-    (SELECT COUNT(0) AS total FROM `httparchive.summary_pages.2019_07_01_mobile`),
-    UNNEST(getInputTypes(payload)) AS input_type
+  `httparchive.pages.2019_07_01_mobile`,
+  (SELECT COUNT(0) AS total FROM `httparchive.summary_pages.2019_07_01_mobile`),
+  UNNEST(getInputTypes(payload))
 GROUP BY input_type, total
 ORDER BY occurence DESC

--- a/sql/2019/mobile-web/12_13.sql
+++ b/sql/2019/mobile-web/12_13.sql
@@ -26,11 +26,11 @@ RETURNS STRUCT<found_advanced_types BOOLEAN, total_inputs INT64> LANGUAGE js AS 
 ''';
 
 SELECT
-    COUNT(0) AS count,
-    COUNTIF(input_stats.total_inputs > 0) AS total_applicable,
+  COUNT(0) AS count,
+  COUNTIF(input_stats.total_inputs > 0) AS total_applicable,
 
-    COUNTIF(input_stats.found_advanced_types) AS total_pages_using,
-    ROUND(COUNTIF(input_stats.found_advanced_types) * 100 / COUNTIF(input_stats.total_inputs > 0), 2) AS occurence_perc
+  COUNTIF(input_stats.found_advanced_types) AS total_pages_using,
+  ROUND(COUNTIF(input_stats.found_advanced_types) * 100 / COUNTIF(input_stats.total_inputs > 0), 2) AS occurence_perc
 FROM (
   SELECT
     getInputStats(payload) AS input_stats

--- a/sql/2019/mobile-web/12_14.sql
+++ b/sql/2019/mobile-web/12_14.sql
@@ -36,18 +36,18 @@ RETURNS BOOLEAN LANGUAGE js AS '''
 ''';
 
 SELECT
-    total_pages_with_inputs,
-    SUM(COUNT(0)) OVER (PARTITION BY 0) AS total_inputs,
-    input_attributes,
+  total_pages_with_inputs,
+  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total_inputs,
+  input_attributes,
 
-    COUNT(input_attributes) AS occurence,
-    COUNT(DISTINCT url) AS total_pages_using,
-    ROUND(COUNT(input_attributes) * 100 / SUM(COUNT(0)) OVER (PARTITION BY 0), 2) AS occurence_perc,
-    ROUND(COUNT(DISTINCT url) * 100 / total_pages_with_inputs, 2) AS perc_of_pages_using
+  COUNT(input_attributes) AS occurence,
+  COUNT(DISTINCT url) AS total_pages_using,
+  ROUND(COUNT(input_attributes) * 100 / SUM(COUNT(0)) OVER (PARTITION BY 0), 2) AS occurence_perc,
+  ROUND(COUNT(DISTINCT url) * 100 / total_pages_with_inputs, 2) AS perc_of_pages_using
 FROM
-    `httparchive.pages.2019_07_01_mobile`,
-    UNNEST(getInputAttributes(payload)) AS input_attributes,
-    (SELECT COUNTIF(hasInputs(payload)) AS total_pages_with_inputs FROM `httparchive.pages.2019_07_01_mobile`)
+  `httparchive.pages.2019_07_01_mobile`,
+  UNNEST(getInputAttributes(payload)),
+  (SELECT COUNTIF(hasInputs(payload)) AS total_pages_with_inputs FROM `httparchive.pages.2019_07_01_mobile`)
 GROUP BY input_attributes, total_pages_with_inputs
 ORDER BY perc_of_pages_using DESC
 LIMIT 1000

--- a/sql/2019/mobile-web/12_15.sql
+++ b/sql/2019/mobile-web/12_15.sql
@@ -30,11 +30,11 @@ RETURNS STRUCT<has_advanced_attributes BOOLEAN, total_inputs INT64> LANGUAGE js 
 ''';
 
 SELECT
-    COUNT(0) AS count,
-    COUNTIF(input_stats.total_inputs > 0) AS total_applicable,
+  COUNT(0) AS count,
+  COUNTIF(input_stats.total_inputs > 0) AS total_applicable,
 
-    COUNTIF(input_stats.has_advanced_attributes) AS total_pages_using,
-    ROUND(COUNTIF(input_stats.has_advanced_attributes) * 100 / COUNTIF(input_stats.total_inputs > 0), 2) AS occurence_perc
+  COUNTIF(input_stats.has_advanced_attributes) AS total_pages_using,
+  ROUND(COUNTIF(input_stats.has_advanced_attributes) * 100 / COUNTIF(input_stats.total_inputs > 0), 2) AS occurence_perc
 FROM (
   SELECT
     getInputStats(payload) AS input_stats

--- a/sql/2019/mobile-web/12_18.sql
+++ b/sql/2019/mobile-web/12_18.sql
@@ -3,8 +3,8 @@
 # <link rel="manifest"> and if valid
 
 SELECT
-    COUNT(url) AS total,
-    COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.installable-manifest.score') AS NUMERIC) = 1) AS score_sum,
-    ROUND(COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.installable-manifest.score') AS NUMERIC) = 1) * 100 / COUNT(url), 2) AS score_percentage
+  COUNT(url) AS total,
+  COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.installable-manifest.score') AS NUMERIC) = 1) AS score_sum,
+  ROUND(COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.installable-manifest.score') AS NUMERIC) = 1) * 100 / COUNT(url), 2) AS score_percentage
 FROM
-    `httparchive.lighthouse.2019_07_01_mobile`
+  `httparchive.lighthouse.2019_07_01_mobile`

--- a/sql/2019/mobile-web/12_19.sql
+++ b/sql/2019/mobile-web/12_19.sql
@@ -3,8 +3,8 @@
 # registers service worker
 
 SELECT
-    COUNT(url) AS total,
-    COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.service-worker.score') AS NUMERIC) = 1) AS score_sum,
-    ROUND(COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.service-worker.score') AS NUMERIC) = 1) * 100 / COUNT(url), 2) AS score_percentage
+  COUNT(url) AS total,
+  COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.service-worker.score') AS NUMERIC) = 1) AS score_sum,
+  ROUND(COUNTIF(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.service-worker.score') AS NUMERIC) = 1) * 100 / COUNT(url), 2) AS score_percentage
 FROM
-    `httparchive.lighthouse.2019_07_01_mobile`
+  `httparchive.lighthouse.2019_07_01_mobile`

--- a/sql/2019/performance/07_04d.sql
+++ b/sql/2019/performance/07_04d.sql
@@ -247,18 +247,20 @@ SELECT
   ROUND(COUNTIF(fast_fid >= .95) * 100 / COUNT(0), 2) AS pct_fast_fid,
   ROUND(COUNTIF(NOT(slow_fid >= .05) AND NOT(fast_fid >= .95)) * 100 / COUNT(0), 2) AS pct_avg_fid,
   ROUND(COUNTIF(slow_fid >= .05) * 100 / COUNT(0), 2) AS pct_slow_fid
-FROM (
-  SELECT
-    geo,
-    ROUND(SAFE_DIVIDE(SUM(IF(bin.start < 100, bin.density, 0)), SUM(bin.density)), 4) AS fast_fid,
-    ROUND(SAFE_DIVIDE(SUM(IF(bin.start >= 100 AND bin.start < 300, bin.density, 0)), SUM(bin.density)), 4) AS avg_fid,
-    ROUND(SAFE_DIVIDE(SUM(IF(bin.start >= 300, bin.density, 0)), SUM(bin.density)), 4) AS slow_fid
-  FROM
-    geos,
-    UNNEST(experimental.first_input_delay.histogram.bin) AS bin
-  GROUP BY
-    origin,
-    geo)
+FROM
+  (
+    SELECT
+      geo,
+      ROUND(SAFE_DIVIDE(SUM(IF(bin.start < 100, bin.density, 0)), SUM(bin.density)), 4) AS fast_fid,
+      ROUND(SAFE_DIVIDE(SUM(IF(bin.start >= 100 AND bin.start < 300, bin.density, 0)), SUM(bin.density)), 4) AS avg_fid,
+      ROUND(SAFE_DIVIDE(SUM(IF(bin.start >= 300, bin.density, 0)), SUM(bin.density)), 4) AS slow_fid
+    FROM
+      geos,
+      UNNEST(experimental.first_input_delay.histogram.bin) AS bin
+    GROUP BY
+      origin,
+      geo
+  )
 GROUP BY
   geo
 ORDER BY

--- a/sql/2019/performance/07_13.sql
+++ b/sql/2019/performance/07_13.sql
@@ -5,13 +5,13 @@ SELECT
   client,
   ROUND(APPROX_QUANTILES(largest_bg_image, 1000)[OFFSET(percentile * 10)] / 1000, 2) AS largest_bg_image
 FROM
-(
-  SELECT
-    _TABLE_SUFFIX AS client,
-    CAST(JSON_EXTRACT(payload, "$['_heroElementTimes.BackgroundImage']") AS INT64) AS largest_bg_image
-  FROM
-    `httparchive.pages.2019_07_01_*`),
-  UNNEST([10, 25, 50, 75, 90]) AS percentile
+  (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      CAST(JSON_EXTRACT(payload, "$['_heroElementTimes.BackgroundImage']") AS INT64) AS largest_bg_image
+    FROM
+      `httparchive.pages.2019_07_01_*`),
+UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   percentile,
   client

--- a/sql/2019/pwa/11_04.sql
+++ b/sql/2019/pwa/11_04.sql
@@ -32,5 +32,4 @@ GROUP BY
   property
 ORDER BY
   freq / total DESC
-LIMIT
-  500
+LIMIT 500

--- a/sql/2019/seo/10_04b.sql
+++ b/sql/2019/seo/10_04b.sql
@@ -16,5 +16,4 @@ GROUP BY
   hreflang
 ORDER BY
   freq / total DESC
-LIMIT
-  10000
+LIMIT 10000

--- a/sql/2019/third-parties/05_03.sql
+++ b/sql/2019/third-parties/05_03.sql
@@ -8,21 +8,21 @@ SELECT
   ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (PARTITION BY 0), 4) AS percentRequests
 FROM (
   SELECT
-      client,
-      type AS contentType,
-      IFNULL(ThirdPartyTable.category,
-        IF(DomainsOver50Table.requestDomain IS NULL, 'first-party', 'other')
-      ) AS thirdPartyCategory
-    FROM
-      `httparchive.almanac.summary_requests`
-    LEFT JOIN
-      `lighthouse-infrastructure.third_party_web.2019_07_01` AS ThirdPartyTable
-    ON NET.HOST(url) = ThirdPartyTable.domain
-    LEFT JOIN
-      `lighthouse-infrastructure.third_party_web.2019_07_01_all_observed_domains` AS DomainsOver50Table
-    ON NET.HOST(url) = DomainsOver50Table.requestDomain
-    WHERE
-      date = '2019-07-01'
+     client,
+     type AS contentType,
+     IFNULL(ThirdPartyTable.category,
+       IF(DomainsOver50Table.requestDomain IS NULL, 'first-party', 'other')
+ ) AS thirdPartyCategory
+  FROM
+     `httparchive.almanac.summary_requests`
+  LEFT JOIN
+     `lighthouse-infrastructure.third_party_web.2019_07_01` AS ThirdPartyTable
+  ON NET.HOST(url) = ThirdPartyTable.domain
+  LEFT JOIN
+     `lighthouse-infrastructure.third_party_web.2019_07_01_all_observed_domains` AS DomainsOver50Table
+  ON NET.HOST(url) = DomainsOver50Table.requestDomain
+  WHERE
+     date = '2019-07-01'
 )
 GROUP BY
   client,

--- a/sql/2019/third-parties/05_04.sql
+++ b/sql/2019/third-parties/05_04.sql
@@ -8,22 +8,22 @@ SELECT
   ROUND(SUM(requestBytes) * 100 / SUM(SUM(requestBytes)) OVER (PARTITION BY 0), 4) AS percentBytes
 FROM (
   SELECT
-      client,
-      type AS contentType,
-      respBodySize AS requestBytes,
-      IFNULL(ThirdPartyTable.category,
-        IF(DomainsOver50Table.requestDomain IS NULL, 'first-party', 'other')
-      ) AS thirdPartyCategory
-    FROM
-      `httparchive.almanac.summary_requests`
-    LEFT JOIN
-      `lighthouse-infrastructure.third_party_web.2019_07_01` AS ThirdPartyTable
-    ON NET.HOST(url) = ThirdPartyTable.domain
-    LEFT JOIN
-      `lighthouse-infrastructure.third_party_web.2019_07_01_all_observed_domains` AS DomainsOver50Table
-    ON NET.HOST(url) = DomainsOver50Table.requestDomain
-    WHERE
-      date = '2019-07-01'
+     client,
+     type AS contentType,
+     respBodySize AS requestBytes,
+     IFNULL(ThirdPartyTable.category,
+       IF(DomainsOver50Table.requestDomain IS NULL, 'first-party', 'other')
+ ) AS thirdPartyCategory
+  FROM
+     `httparchive.almanac.summary_requests`
+  LEFT JOIN
+     `lighthouse-infrastructure.third_party_web.2019_07_01` AS ThirdPartyTable
+  ON NET.HOST(url) = ThirdPartyTable.domain
+  LEFT JOIN
+     `lighthouse-infrastructure.third_party_web.2019_07_01_all_observed_domains` AS DomainsOver50Table
+  ON NET.HOST(url) = DomainsOver50Table.requestDomain
+  WHERE
+     date = '2019-07-01'
 )
 GROUP BY
   client,

--- a/sql/2019/third-parties/05_06.sql
+++ b/sql/2019/third-parties/05_06.sql
@@ -7,16 +7,16 @@ SELECT
   SUM(requestBytes) AS totalBytes
 FROM (
   SELECT
-      respSize AS requestBytes,
-      NET.HOST(url) AS requestDomain,
-      DomainsOver50Table.requestDomain AS thirdPartyDomain
-    FROM
-      `httparchive.almanac.summary_requests`
-    LEFT JOIN
-      `lighthouse-infrastructure.third_party_web.2019_07_01_all_observed_domains` AS DomainsOver50Table
-    ON NET.HOST(url) = DomainsOver50Table.requestDomain
-    WHERE
-      date = '2019-07-01'
+     respSize AS requestBytes,
+     NET.HOST(url) AS requestDomain,
+     DomainsOver50Table.requestDomain AS thirdPartyDomain
+  FROM
+     `httparchive.almanac.summary_requests`
+  LEFT JOIN
+     `lighthouse-infrastructure.third_party_web.2019_07_01_all_observed_domains` AS DomainsOver50Table
+  ON NET.HOST(url) = DomainsOver50Table.requestDomain
+  WHERE
+     date = '2019-07-01'
 ),
 (
   SELECT COUNT(0) AS totalRequestCount FROM `httparchive.almanac.summary_requests` WHERE date = '2019-07-01'

--- a/sql/2019/third-parties/05_07.sql
+++ b/sql/2019/third-parties/05_07.sql
@@ -7,16 +7,16 @@ SELECT
   ROUND(SUM(requestBytes) * 100 / MAX(totalRequestBytes), 2) AS percentBytes
 FROM (
   SELECT
-      respSize AS requestBytes,
-      NET.HOST(url) AS requestDomain,
-      DomainsOver50Table.requestDomain AS thirdPartyDomain
-    FROM
-      `httparchive.almanac.summary_requests`
-    LEFT JOIN
-      `lighthouse-infrastructure.third_party_web.2019_07_01_all_observed_domains` AS DomainsOver50Table
-    ON NET.HOST(url) = DomainsOver50Table.requestDomain
-    WHERE
-      date = '2019-07-01'
+     respSize AS requestBytes,
+     NET.HOST(url) AS requestDomain,
+     DomainsOver50Table.requestDomain AS thirdPartyDomain
+  FROM
+     `httparchive.almanac.summary_requests`
+  LEFT JOIN
+     `lighthouse-infrastructure.third_party_web.2019_07_01_all_observed_domains` AS DomainsOver50Table
+  ON NET.HOST(url) = DomainsOver50Table.requestDomain
+  WHERE
+     date = '2019-07-01'
 ),
 (
   SELECT SUM(respSize) AS totalRequestBytes FROM `httparchive.almanac.summary_requests` WHERE date = '2019-07-01'

--- a/sql/2019/third-parties/05_08.sql
+++ b/sql/2019/third-parties/05_08.sql
@@ -32,16 +32,15 @@ FROM (
   ON
     NET.HOST(item.url) = DomainsOver50Table.requestDomain ) t1,
   (
-  SELECT
-    SUM(item.execution_time) AS totalExecutionTime
-  FROM
-    `httparchive.lighthouse.2019_07_01_mobile`,
-    UNNEST(getExecutionTimes(report)) AS item ) t2
+    SELECT
+      SUM(item.execution_time) AS totalExecutionTime
+    FROM
+      `httparchive.lighthouse.2019_07_01_mobile`,
+      UNNEST(getExecutionTimes(report)) AS item ) t2
 WHERE
   thirdPartyDomain IS NOT NULL
 GROUP BY
   thirdPartyDomain
 ORDER BY
   totalExecutionTime DESC
-LIMIT
-  100
+LIMIT 100

--- a/sql/2019/third-parties/05_09.sql
+++ b/sql/2019/third-parties/05_09.sql
@@ -7,12 +7,12 @@ SELECT
   ROUND(COUNT(0) * 100 / MAX(t2.totalRequestCount), 2) AS percentRequestCount
 FROM (
   SELECT
-      url AS requestUrl,
-      respBodySize AS requestBytes
-    FROM
-      `httparchive.almanac.summary_requests`
-    WHERE
-      date = '2019-07-01'
+     url AS requestUrl,
+     respBodySize AS requestBytes
+  FROM
+     `httparchive.almanac.summary_requests`
+  WHERE
+     date = '2019-07-01'
 ),
 (
   SELECT COUNT(0) AS totalRequestCount FROM `httparchive.almanac.summary_requests` WHERE date = '2019-07-01'

--- a/sql/2019/third-parties/05_10.sql
+++ b/sql/2019/third-parties/05_10.sql
@@ -27,15 +27,14 @@ FROM (
     `httparchive.lighthouse.2019_07_01_mobile`,
     UNNEST(getExecutionTimes(report)) AS item) t1,
   (
-  SELECT
-    SUM(item.execution_time) AS totalExecutionTime
-  FROM
-    `httparchive.lighthouse.2019_07_01_mobile`,
-    UNNEST(getExecutionTimes(report)) AS item ) t2
+    SELECT
+      SUM(item.execution_time) AS totalExecutionTime
+    FROM
+      `httparchive.lighthouse.2019_07_01_mobile`,
+      UNNEST(getExecutionTimes(report)) AS item ) t2
 WHERE requestUrl != 'Other'
 GROUP BY
   requestUrl
 ORDER BY
   totalExecutionTime DESC
-LIMIT
-  100
+LIMIT 100

--- a/sql/2020/accessibility/lighthouse_a11y_score.sql
+++ b/sql/2020/accessibility/lighthouse_a11y_score.sql
@@ -8,9 +8,9 @@ SELECT
   APPROX_QUANTILES(score, 1000)[OFFSET(percentile * 10)] AS score
 FROM (
   SELECT
-     CAST(JSON_EXTRACT(report, '$.categories.accessibility.score') AS NUMERIC) AS score
+    CAST(JSON_EXTRACT(report, '$.categories.accessibility.score') AS NUMERIC) AS score
   FROM
-     `httparchive.lighthouse.2019_07_01_mobile`),
+    `httparchive.lighthouse.2019_07_01_mobile`),
   UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   date,
@@ -22,9 +22,9 @@ SELECT
   APPROX_QUANTILES(score, 1000)[OFFSET(percentile * 10)] AS score
 FROM (
   SELECT
-     CAST(JSON_EXTRACT(report, '$.categories.accessibility.score') AS NUMERIC) AS score
+    CAST(JSON_EXTRACT(report, '$.categories.accessibility.score') AS NUMERIC) AS score
   FROM
-     `httparchive.lighthouse.2020_08_01_mobile`),
+    `httparchive.lighthouse.2020_08_01_mobile`),
   UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   date,

--- a/sql/2020/caching/content_age_older_than_ttl_by_party.sql
+++ b/sql/2020/caching/content_age_older_than_ttl_by_party.sql
@@ -17,30 +17,30 @@ SELECT
   COUNTIF(diff < 0) AS req_too_short_cache,
   COUNTIF(diff < 0) / COUNT(0) AS perc_req_too_short_cache
 FROM
-   (
-     SELECT
-       "desktop" AS client,
-       IF(NET.HOST(url) IN (
-         SELECT domain FROM `httparchive.almanac.third_parties` WHERE date = '2020-08-01' AND category != 'hosting'
-       ), 'third party', 'first party') AS party,
-       requests.expAge - (requests.startedDateTime - toTimestamp(requests.resp_last_modified)) AS diff
-     FROM
-       `httparchive.summary_requests.2020_08_01_desktop` requests
-     WHERE
-       TRIM(requests.resp_last_modified) <> "" AND
-       expAge > 0
-     UNION ALL
-     SELECT
-       "mobile" AS client,
-       IF(NET.HOST(url) IN (
-         SELECT domain FROM `httparchive.almanac.third_parties` WHERE date = '2020-08-01' AND category != 'hosting'
-       ), 'third party', 'first party') AS party,
-       requests.expAge - (requests.startedDateTime - toTimestamp(requests.resp_last_modified)) AS diff
-     FROM
-       `httparchive.summary_requests.2020_08_01_mobile` requests
-     WHERE
-       TRIM(requests.resp_last_modified) <> "" AND
-       expAge > 0
+  (
+    SELECT
+      "desktop" AS client,
+      IF(NET.HOST(url) IN (
+        SELECT domain FROM `httparchive.almanac.third_parties` WHERE date = '2020-08-01' AND category != 'hosting'
+      ), 'third party', 'first party') AS party,
+      requests.expAge - (requests.startedDateTime - toTimestamp(requests.resp_last_modified)) AS diff
+    FROM
+      `httparchive.summary_requests.2020_08_01_desktop` requests
+    WHERE
+      TRIM(requests.resp_last_modified) <> "" AND
+      expAge > 0
+    UNION ALL
+    SELECT
+      "mobile" AS client,
+      IF(NET.HOST(url) IN (
+        SELECT domain FROM `httparchive.almanac.third_parties` WHERE date = '2020-08-01' AND category != 'hosting'
+      ), 'third party', 'first party') AS party,
+      requests.expAge - (requests.startedDateTime - toTimestamp(requests.resp_last_modified)) AS diff
+    FROM
+      `httparchive.summary_requests.2020_08_01_mobile` requests
+    WHERE
+      TRIM(requests.resp_last_modified) <> "" AND
+      expAge > 0
   )
 GROUP BY
   client,

--- a/sql/2020/caching/invalid_cache_control_directives.sql
+++ b/sql/2020/caching/invalid_cache_control_directives.sql
@@ -9,59 +9,59 @@ SELECT
   pct_of_cache_control,
   pct_of_total_requests
 FROM
-(
   (
-    SELECT
-      "desktop" AS client,
-      total_requests,
-      total_using_cache_control,
-      directive_name,
-      COUNT(0) AS directive_occurrences,
-      COUNT(0) / total_using_cache_control AS pct_of_cache_control,
-      COUNT(0) / total_requests AS pct_of_total_requests
-    FROM
-      `httparchive.summary_requests.2020_08_01_desktop`,
-      UNNEST(REGEXP_EXTRACT_ALL(LOWER(resp_cache_control), r'([a-z][^,\s="\']*)')) AS directive_name
-    CROSS JOIN (
+    (
       SELECT
-        COUNT(0) AS total_requests,
-        COUNTIF(TRIM(resp_cache_control) != "") AS total_using_cache_control
+        "desktop" AS client,
+        total_requests,
+        total_using_cache_control,
+        directive_name,
+        COUNT(0) AS directive_occurrences,
+        COUNT(0) / total_using_cache_control AS pct_of_cache_control,
+        COUNT(0) / total_requests AS pct_of_total_requests
       FROM
-        `httparchive.summary_requests.2020_08_01_desktop`
+        `httparchive.summary_requests.2020_08_01_desktop`,
+        UNNEST(REGEXP_EXTRACT_ALL(LOWER(resp_cache_control), r'([a-z][^,\s="\']*)')) AS directive_name
+      CROSS JOIN (
+        SELECT
+          COUNT(0) AS total_requests,
+          COUNTIF(TRIM(resp_cache_control) != "") AS total_using_cache_control
+        FROM
+          `httparchive.summary_requests.2020_08_01_desktop`
+      )
+      GROUP BY
+        client,
+        total_requests,
+        total_using_cache_control,
+        directive_name
     )
-    GROUP BY
-      client,
-      total_requests,
-      total_using_cache_control,
-      directive_name
-  )
-  UNION ALL
-  (
-    SELECT
-      "mobile" AS client,
-      total_requests,
-      total_using_cache_control,
-      directive_name,
-      COUNT(0) AS directive_occurrences,
-      COUNT(0) / total_using_cache_control AS pct_of_cache_control,
-      COUNT(0) / total_requests AS pct_of_total_requests
-    FROM
-      `httparchive.summary_requests.2020_08_01_mobile`,
-      UNNEST(REGEXP_EXTRACT_ALL(LOWER(resp_cache_control), r'([a-z][^,\s="\']*)')) AS directive_name
-    CROSS JOIN (
+    UNION ALL
+    (
       SELECT
-        COUNT(0) AS total_requests,
-        COUNTIF(TRIM(resp_cache_control) != "") AS total_using_cache_control
+        "mobile" AS client,
+        total_requests,
+        total_using_cache_control,
+        directive_name,
+        COUNT(0) AS directive_occurrences,
+        COUNT(0) / total_using_cache_control AS pct_of_cache_control,
+        COUNT(0) / total_requests AS pct_of_total_requests
       FROM
-        `httparchive.summary_requests.2020_08_01_mobile`
+        `httparchive.summary_requests.2020_08_01_mobile`,
+        UNNEST(REGEXP_EXTRACT_ALL(LOWER(resp_cache_control), r'([a-z][^,\s="\']*)')) AS directive_name
+      CROSS JOIN (
+        SELECT
+          COUNT(0) AS total_requests,
+          COUNTIF(TRIM(resp_cache_control) != "") AS total_using_cache_control
+        FROM
+          `httparchive.summary_requests.2020_08_01_mobile`
+      )
+      GROUP BY
+        client,
+        total_requests,
+        total_using_cache_control,
+        directive_name
     )
-    GROUP BY
-      client,
-      total_requests,
-      total_using_cache_control,
-      directive_name
   )
-)
 WHERE
   directive_name NOT IN ('max-age', 'public', 'no-cache', 'must-revalidate', 'no-store', 'private', 'proxy-revalidate', 's-maxage', 'no-transform', 'immutable', 'stale-while-revalidate', 'stale-if-error', 'pre-check', 'post-check')
 ORDER BY

--- a/sql/2020/caching/resource_age_party_and_type_wise_groups.sql
+++ b/sql/2020/caching/resource_age_party_and_type_wise_groups.sql
@@ -29,19 +29,19 @@ SELECT
   SAFE_DIVIDE(COUNTIF(age_weeks >= 53 AND age_weeks <= 104), COUNTIF(age_weeks IS NOT NULL)) AS age_gt_1y_pct,
   SAFE_DIVIDE(COUNTIF(age_weeks >= 105), COUNTIF(age_weeks IS NOT NULL)) AS age_gt_2y_pct
 FROM
-(
-  SELECT
-    _TABLE_SUFFIX AS client,
-    IF(NET.HOST(url) IN (
-      SELECT domain FROM `httparchive.almanac.third_parties` WHERE date = '2020-08-01' AND category != 'hosting'
-    ), 'third party', 'first party') AS party,
-    type AS resource_type,
-    ROUND((startedDateTime - toTimestamp(resp_last_modified)) / (60 * 60 * 24 * 7)) AS age_weeks
-  FROM
-    `httparchive.summary_requests.2020_08_01_*`
-  WHERE
-    TRIM(resp_last_modified) <> ""
-)
+  (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      IF(NET.HOST(url) IN (
+        SELECT domain FROM `httparchive.almanac.third_parties` WHERE date = '2020-08-01' AND category != 'hosting'
+      ), 'third party', 'first party') AS party,
+      type AS resource_type,
+      ROUND((startedDateTime - toTimestamp(resp_last_modified)) / (60 * 60 * 24 * 7)) AS age_weeks
+    FROM
+      `httparchive.summary_requests.2020_08_01_*`
+    WHERE
+      TRIM(resp_last_modified) <> ""
+  )
 GROUP BY
   client,
   party,

--- a/sql/2020/caching/ttl_by_resource.sql
+++ b/sql/2020/caching/ttl_by_resource.sql
@@ -6,7 +6,7 @@ SELECT
   percentile,
   APPROX_QUANTILES(expAge, 1000)[OFFSET(percentile * 10)] AS ttl
 FROM
- `httparchive.summary_requests.2020_08_01_*`,
+  `httparchive.summary_requests.2020_08_01_*`,
   UNNEST([10, 25, 50, 75, 90]) AS percentile
 WHERE
   NOT REGEXP_CONTAINS(resp_cache_control, r'(?i)no-store') AND

--- a/sql/2020/caching/vary_headers.sql
+++ b/sql/2020/caching/vary_headers.sql
@@ -11,64 +11,64 @@ SELECT
   total_using_both / total_using_vary AS pct_of_vary_with_cache_control,
   total_using_vary / total_requests AS pct_using_vary
 FROM
-(
   (
-     SELECT
-      "desktop" AS client,
-      total_requests,
-      total_using_vary,
-      total_using_both,
-      vary_header,
-      COUNT(0) AS occurrences,
-      COUNT(0) / total_using_vary AS pct_of_vary,
-      COUNT(0) / total_requests AS pct_of_total_requests
-    FROM
-      `httparchive.summary_requests.2020_08_01_desktop`,
-      UNNEST(REGEXP_EXTRACT_ALL(LOWER(resp_vary), r'([a-z][^,\s="\']*)')) AS vary_header
-    CROSS JOIN (
+    (
       SELECT
-        COUNT(0) AS total_requests,
-        COUNTIF(TRIM(resp_vary) != "") AS total_using_vary,
-        COUNTIF(TRIM(resp_vary) != "" AND TRIM(resp_cache_control) != "") AS total_using_both
+        "desktop" AS client,
+        total_requests,
+        total_using_vary,
+        total_using_both,
+        vary_header,
+        COUNT(0) AS occurrences,
+        COUNT(0) / total_using_vary AS pct_of_vary,
+        COUNT(0) / total_requests AS pct_of_total_requests
       FROM
-        `httparchive.summary_requests.2020_08_01_desktop`
+        `httparchive.summary_requests.2020_08_01_desktop`,
+        UNNEST(REGEXP_EXTRACT_ALL(LOWER(resp_vary), r'([a-z][^,\s="\']*)')) AS vary_header
+      CROSS JOIN (
+        SELECT
+          COUNT(0) AS total_requests,
+          COUNTIF(TRIM(resp_vary) != "") AS total_using_vary,
+          COUNTIF(TRIM(resp_vary) != "" AND TRIM(resp_cache_control) != "") AS total_using_both
+        FROM
+          `httparchive.summary_requests.2020_08_01_desktop`
+      )
+      GROUP BY
+        client,
+        total_requests,
+        total_using_vary,
+        total_using_both,
+        vary_header
     )
-    GROUP BY
-      client,
-      total_requests,
-      total_using_vary,
-      total_using_both,
-      vary_header
-  )
-  UNION ALL
-  (
-    SELECT
-      "mobile" AS client,
-      total_requests,
-      total_using_vary,
-      total_using_both,
-      vary_header,
-      COUNT(0) AS occurrences,
-      COUNT(0) / total_using_vary AS pct_of_vary,
-      COUNT(0) / total_requests AS pct_of_total_requests
-    FROM
-      `httparchive.summary_requests.2020_08_01_mobile`,
-      UNNEST(REGEXP_EXTRACT_ALL(LOWER(resp_vary), r'([a-z][^,\s="\']*)')) AS vary_header
-    CROSS JOIN (
+    UNION ALL
+    (
       SELECT
-        COUNT(0) AS total_requests,
-        COUNTIF(TRIM(resp_vary) != "") AS total_using_vary,
-        COUNTIF(TRIM(resp_vary) != "" AND TRIM(resp_cache_control) != "") AS total_using_both
+        "mobile" AS client,
+        total_requests,
+        total_using_vary,
+        total_using_both,
+        vary_header,
+        COUNT(0) AS occurrences,
+        COUNT(0) / total_using_vary AS pct_of_vary,
+        COUNT(0) / total_requests AS pct_of_total_requests
       FROM
-        `httparchive.summary_requests.2020_08_01_mobile`
+        `httparchive.summary_requests.2020_08_01_mobile`,
+        UNNEST(REGEXP_EXTRACT_ALL(LOWER(resp_vary), r'([a-z][^,\s="\']*)')) AS vary_header
+      CROSS JOIN (
+        SELECT
+          COUNT(0) AS total_requests,
+          COUNTIF(TRIM(resp_vary) != "") AS total_using_vary,
+          COUNTIF(TRIM(resp_vary) != "" AND TRIM(resp_cache_control) != "") AS total_using_both
+        FROM
+          `httparchive.summary_requests.2020_08_01_mobile`
+      )
+      GROUP BY
+        client,
+        total_requests,
+        total_using_vary,
+        total_using_both,
+        vary_header
     )
-    GROUP BY
-      client,
-      total_requests,
-      total_using_vary,
-      total_using_both,
-      vary_header
   )
-)
 ORDER BY
   client, occurrences DESC

--- a/sql/2020/cms/distribution_of_page_weight_requests_and_co2_grams_per_cms_web_page.sql
+++ b/sql/2020/cms/distribution_of_page_weight_requests_and_co2_grams_per_cms_web_page.sql
@@ -1,21 +1,15 @@
 #standardSQL
 # Distribution of page weight, requests, and co2 grams per CMS web page
 # https://gitlab.com/wholegrain/carbon-api-2-0/-/blob/b498ec3bb239536d3612c5f3d758f46e0d2431a6/includes/carbonapi.php
-CREATE TEMP FUNCTION
-  GREEN(url STRING) AS (FALSE); -- TODO: Investigate fetching from Green Web Foundation
-CREATE TEMP FUNCTION
-  adjustDataTransfer(val INT64) AS (val * 0.75 + 0.02 * val * 0.25);
-CREATE TEMP FUNCTION
-  energyConsumption(bytes FLOAT64) AS (bytes * 1.805 / 1073741824);
-CREATE TEMP FUNCTION
-  getCo2Grid(energy FLOAT64) AS (energy * 475);
-CREATE TEMP FUNCTION
-  getCo2Renewable(energy FLOAT64) AS (energy * 0.1008 * 33.4 + energy * 0.8992 * 475);
-CREATE TEMP FUNCTION
-  CO2(url STRING, bytes INT64) AS (
+CREATE TEMP FUNCTION GREEN(url STRING) AS (FALSE); -- TODO: Investigate fetching from Green Web Foundation
+CREATE TEMP FUNCTION adjustDataTransfer(val INT64) AS (val * 0.75 + 0.02 * val * 0.25);
+CREATE TEMP FUNCTION energyConsumption(bytes FLOAT64) AS (bytes * 1.805 / 1073741824);
+CREATE TEMP FUNCTION getCo2Grid(energy FLOAT64) AS (energy * 475);
+CREATE TEMP FUNCTION getCo2Renewable(energy FLOAT64) AS (energy * 0.1008 * 33.4 + energy * 0.8992 * 475);
+CREATE TEMP FUNCTION CO2(url STRING, bytes INT64) AS (
   IF(GREEN(url),
-      getCo2Renewable(energyConsumption(adjustDataTransfer(bytes))),
-      getCo2Grid(energyConsumption(adjustDataTransfer(bytes)))));
+    getCo2Renewable(energyConsumption(adjustDataTransfer(bytes))),
+    getCo2Grid(energyConsumption(adjustDataTransfer(bytes)))));
 
 SELECT
   percentile,

--- a/sql/2020/css/calc_constants.sql
+++ b/sql/2020/css/calc_constants.sql
@@ -88,5 +88,4 @@ GROUP BY
   const
 ORDER BY
   pct DESC
-LIMIT
-  200
+LIMIT 200

--- a/sql/2020/css/custom_property_names.sql
+++ b/sql/2020/css/custom_property_names.sql
@@ -40,5 +40,4 @@ GROUP BY
   total
 ORDER BY
   pct DESC
-LIMIT
-  1000
+LIMIT 1000

--- a/sql/2020/css/custom_property_values.sql
+++ b/sql/2020/css/custom_property_values.sql
@@ -40,5 +40,4 @@ GROUP BY
   total
 ORDER BY
   pct DESC
-LIMIT
-  1000
+LIMIT 1000

--- a/sql/2020/css/meta_important_adoption.sql
+++ b/sql/2020/css/meta_important_adoption.sql
@@ -47,7 +47,7 @@ FROM (
       FROM
         `httparchive.almanac.parsed_css`
       WHERE
-      date = '2020-08-01')
+        date = '2020-08-01')
   GROUP BY
     client,
     page),

--- a/sql/2020/css/meta_important_properties.sql
+++ b/sql/2020/css/meta_important_properties.sql
@@ -54,5 +54,4 @@ GROUP BY
   property
 ORDER BY
   pct DESC
-LIMIT
-  500
+LIMIT 500

--- a/sql/2020/css/meta_longhand_first_properties.sql
+++ b/sql/2020/css/meta_longhand_first_properties.sql
@@ -467,5 +467,4 @@ GROUP BY
   property
 ORDER BY
   pct DESC
-LIMIT
-  500
+LIMIT 500

--- a/sql/2020/css/meta_longhand_properties.sql
+++ b/sql/2020/css/meta_longhand_properties.sql
@@ -467,5 +467,4 @@ GROUP BY
   property
 ORDER BY
   pct DESC
-LIMIT
-  500
+LIMIT 500

--- a/sql/2020/css/meta_property_pairs.sql
+++ b/sql/2020/css/meta_property_pairs.sql
@@ -110,5 +110,4 @@ GROUP BY
   pair
 ORDER BY
   pct DESC
-LIMIT
-  500
+LIMIT 500

--- a/sql/2020/css/meta_shorthand_first_properties.sql
+++ b/sql/2020/css/meta_shorthand_first_properties.sql
@@ -468,5 +468,4 @@ GROUP BY
   property
 ORDER BY
   pct DESC
-LIMIT
-  500
+LIMIT 500

--- a/sql/2020/css/meta_shorthand_properties.sql
+++ b/sql/2020/css/meta_shorthand_properties.sql
@@ -467,5 +467,4 @@ GROUP BY
   property
 ORDER BY
   pct DESC
-LIMIT
-  500
+LIMIT 500

--- a/sql/2020/css/sass_combined_variable_names.sql
+++ b/sql/2020/css/sass_combined_variable_names.sql
@@ -28,5 +28,4 @@ GROUP BY
   name
 ORDER BY
   pct DESC
-LIMIT
-  100
+LIMIT 100

--- a/sql/2020/css/sass_custom_function_names.sql
+++ b/sql/2020/css/sass_custom_function_names.sql
@@ -43,5 +43,4 @@ GROUP BY
   total_sass
 ORDER BY
   pct DESC
-LIMIT
-  1000
+LIMIT 1000

--- a/sql/2020/css/sass_mixin_names.sql
+++ b/sql/2020/css/sass_mixin_names.sql
@@ -43,5 +43,4 @@ GROUP BY
   total_sass
 ORDER BY
   pct DESC
-LIMIT
-  1000
+LIMIT 1000

--- a/sql/2020/css/sass_variable_usage.sql
+++ b/sql/2020/css/sass_variable_usage.sql
@@ -37,5 +37,4 @@ GROUP BY
   variable
 ORDER BY
   pct DESC
-LIMIT
-  500
+LIMIT 500

--- a/sql/2020/css/stylesheet_kbytes.sql
+++ b/sql/2020/css/stylesheet_kbytes.sql
@@ -7,7 +7,7 @@ WITH summary_pages AS (
     bytesCSS
   FROM
     `httparchive.summary_pages.2019_07_01_*`
-UNION ALL
+  UNION ALL
   SELECT
     2020 AS year,
     _TABLE_SUFFIX AS client,

--- a/sql/2020/css/supports_criteria.sql
+++ b/sql/2020/css/supports_criteria.sql
@@ -63,5 +63,4 @@ GROUP BY
   supports
 ORDER BY
   pct DESC
-LIMIT
-  300
+LIMIT 300

--- a/sql/2020/css/vendor_prefix_functions.sql
+++ b/sql/2020/css/vendor_prefix_functions.sql
@@ -102,5 +102,4 @@ FROM (
     function)
 ORDER BY
   pct DESC
-LIMIT
-  500
+LIMIT 500

--- a/sql/2020/css/vendor_prefix_keywords.sql
+++ b/sql/2020/css/vendor_prefix_keywords.sql
@@ -104,5 +104,4 @@ FROM (
     keyword)
 ORDER BY
   pct DESC
-LIMIT
-  500
+LIMIT 500

--- a/sql/2020/css/vendor_prefix_media.sql
+++ b/sql/2020/css/vendor_prefix_media.sql
@@ -102,5 +102,4 @@ FROM (
     media)
 ORDER BY
   pct DESC
-LIMIT
-  500
+LIMIT 500

--- a/sql/2020/css/vendor_prefix_pseudo_classes.sql
+++ b/sql/2020/css/vendor_prefix_pseudo_classes.sql
@@ -102,5 +102,4 @@ FROM (
     pseudo_class)
 ORDER BY
   pct DESC
-LIMIT
-  500
+LIMIT 500

--- a/sql/2020/css/vendor_prefix_pseudo_elements.sql
+++ b/sql/2020/css/vendor_prefix_pseudo_elements.sql
@@ -102,5 +102,4 @@ FROM (
     pseudo_element)
 ORDER BY
   pct DESC
-LIMIT
-  500
+LIMIT 500

--- a/sql/2020/ecommerce/core_web_vitals_distribution_byvendor_bydevice.sql
+++ b/sql/2020/ecommerce/core_web_vitals_distribution_byvendor_bydevice.sql
@@ -29,9 +29,9 @@ JOIN (
   FROM
     `httparchive.technologies.2020_08_01_*`
   WHERE
-  category = 'Ecommerce' AND
-  (app != 'Cart Functionality' AND
-   app != 'Google Analytics Enhanced eCommerce'))
+    category = 'Ecommerce' AND
+    (app != 'Cart Functionality' AND
+      app != 'Google Analytics Enhanced eCommerce'))
 ON
   CONCAT(origin, '/') = url AND
   IF(device = 'desktop', 'desktop', 'mobile') = client

--- a/sql/2020/ecommerce/core_web_vitals_passingmetrics_byvendor_bydevice.sql
+++ b/sql/2020/ecommerce/core_web_vitals_passingmetrics_byvendor_bydevice.sql
@@ -50,7 +50,7 @@ JOIN (
   WHERE
     category = 'Ecommerce' AND
     (app != 'Cart Functionality' AND
-    app != 'Google Analytics Enhanced eCommerce'))
+      app != 'Google Analytics Enhanced eCommerce'))
 ON
   CONCAT(origin, '/') = url AND
   IF(device = 'desktop', 'desktop', 'mobile') = client

--- a/sql/2020/ecommerce/pagestats_image_bydevice.sql
+++ b/sql/2020/ecommerce/pagestats_image_bydevice.sql
@@ -14,7 +14,7 @@ JOIN (
   FROM `httparchive.technologies.2020_08_01_*`
   WHERE category = 'Ecommerce')
 USING (_TABLE_SUFFIX, url),
-UNNEST([10, 25, 50, 75, 90]) AS percentile
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   percentile,
   client

--- a/sql/2020/ecommerce/pagestats_image_dimensions_bydevice.sql
+++ b/sql/2020/ecommerce/pagestats_image_dimensions_bydevice.sql
@@ -24,8 +24,8 @@ FROM
 JOIN
   `httparchive.technologies.2020_08_01_*`
 USING (_TABLE_SUFFIX, url),
-UNNEST(getImageDimensions(payload)) AS image,
-UNNEST([10, 25, 50, 75, 90]) AS percentile
+  UNNEST(getImageDimensions(payload)) AS image,
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
 WHERE
   category = 'Ecommerce'
 GROUP BY

--- a/sql/2020/ecommerce/pagestats_percentile_bydevice_format.sql
+++ b/sql/2020/ecommerce/pagestats_percentile_bydevice_format.sql
@@ -28,7 +28,7 @@ FROM (
     client,
     type,
     page),
-UNNEST([10, 25, 50, 75, 90]) AS percentile
+  UNNEST([10, 25, 50, 75, 90])
 GROUP BY
   percentile,
   client,

--- a/sql/2020/ecommerce/pagestats_percentiles_bydevice.sql
+++ b/sql/2020/ecommerce/pagestats_percentiles_bydevice.sql
@@ -25,7 +25,7 @@ FROM (
   GROUP BY
     client,
     page),
-UNNEST([10, 25, 50, 75, 90]) AS percentile
+  UNNEST([10, 25, 50, 75, 90])
 GROUP BY
   percentile,
   client

--- a/sql/2020/ecommerce/pct_3pusage_bydevice.sql
+++ b/sql/2020/ecommerce/pct_3pusage_bydevice.sql
@@ -21,13 +21,13 @@ FROM (
   WHERE
     date = '2020-08-01' AND
     NET.HOST(url) IN
-      (SELECT domain
-        FROM `httparchive.almanac.third_parties`
-        WHERE category != 'hosting')
+    (SELECT domain
+            FROM `httparchive.almanac.third_parties`
+      WHERE category != 'hosting')
   GROUP BY
     client,
     page),
-UNNEST([10, 25, 50, 75, 90]) AS percentile
+  UNNEST([10, 25, 50, 75, 90])
 GROUP BY
   percentile,
   client

--- a/sql/2020/ecommerce/pct_3pusage_bydevice_vendor.sql
+++ b/sql/2020/ecommerce/pct_3pusage_bydevice_vendor.sql
@@ -24,15 +24,15 @@ FROM (
   WHERE
     date = '2020-08-01' AND
     NET.HOST(url) IN
-      (SELECT domain
-        FROM `httparchive.almanac.third_parties`
-        WHERE date = '2020-08-01' AND
-          category != 'hosting')
+    (SELECT domain
+            FROM `httparchive.almanac.third_parties`
+      WHERE date = '2020-08-01' AND
+        category != 'hosting')
   GROUP BY
     client,
     app,
     page),
-UNNEST([10, 25, 50, 75, 90]) AS percentile
+  UNNEST([10, 25, 50, 75, 90])
 GROUP BY
   client,
   app,

--- a/sql/2020/ecommerce/pct_3pusage_bydevice_vendor_category.sql
+++ b/sql/2020/ecommerce/pct_3pusage_bydevice_vendor_category.sql
@@ -27,14 +27,14 @@ FROM (
     `httparchive.almanac.third_parties`
   ON
     NET.HOST(url) = domain
-WHERE
-  `httparchive.almanac.requests`.date = '2020-08-01'
-GROUP BY
+  WHERE
+    `httparchive.almanac.requests`.date = '2020-08-01'
+  GROUP BY
     client,
     category,
     page),
 
-UNNEST([10, 25, 50, 75, 90]) AS percentile
+  UNNEST([10, 25, 50, 75, 90])
 GROUP BY
   percentile,
   client,

--- a/sql/2020/ecommerce/pct_ampusage_bydevice_vendor.sql
+++ b/sql/2020/ecommerce/pct_ampusage_bydevice_vendor.sql
@@ -14,8 +14,8 @@ JOIN (
   FROM
     `httparchive.technologies.2020_08_01_*`
   WHERE
-     category = 'Ecommerce'
-    )
+    category = 'Ecommerce'
+)
 USING
   (_TABLE_SUFFIX, url)
 JOIN (
@@ -25,10 +25,10 @@ JOIN (
   FROM
     `httparchive.technologies.2020_08_01_*`
   WHERE
-     category = 'Ecommerce'
+    category = 'Ecommerce'
   GROUP BY
     _TABLE_SUFFIX
-    )
+)
 USING
   (_TABLE_SUFFIX)
 WHERE

--- a/sql/2020/ecommerce/pct_ecommsites_bydevice_compare20192020.sql
+++ b/sql/2020/ecommerce/pct_ecommsites_bydevice_compare20192020.sql
@@ -4,7 +4,7 @@
 ## This query is built using 2019 query from https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2019/13_Ecommerce/13_02b.sql but this commit fixes a flaw in 2019 query. See - https://github.com/HTTPArchive/almanac.httparchive.org/issues/1810
 SELECT
   _TABLE_SUFFIX AS client,
-   2020 AS year,
+  2020 AS year,
   COUNT(DISTINCT url) AS freq,
   total,
   COUNT(DISTINCT url) / total AS pct
@@ -28,7 +28,7 @@ GROUP BY
 UNION ALL
 SELECT
   _TABLE_SUFFIX AS client,
-   2019 AS year,
+  2019 AS year,
   COUNT(DISTINCT url) AS freq,
   total,
   COUNT(DISTINCT url) / total AS pct

--- a/sql/2020/ecommerce/percent_of_ecommsites_using_a11y_solutions.sql
+++ b/sql/2020/ecommerce/percent_of_ecommsites_using_a11y_solutions.sql
@@ -14,8 +14,8 @@ JOIN (
   FROM
     `httparchive.technologies.2020_08_01_*`
   WHERE
-     category = 'Ecommerce'
-    )
+    category = 'Ecommerce'
+)
 USING
   (_TABLE_SUFFIX, url)
 JOIN (
@@ -25,10 +25,10 @@ JOIN (
   FROM
     `httparchive.technologies.2020_08_01_*`
   WHERE
-     category = 'Ecommerce'
+    category = 'Ecommerce'
   GROUP BY
     _TABLE_SUFFIX
-    )
+)
 USING
   (_TABLE_SUFFIX)
 WHERE

--- a/sql/2020/ecommerce/percent_of_ecommsites_using_cmp.sql
+++ b/sql/2020/ecommerce/percent_of_ecommsites_using_cmp.sql
@@ -14,8 +14,8 @@ JOIN (
   FROM
     `httparchive.technologies.2020_08_01_*`
   WHERE
-     category = 'Ecommerce'
-    )
+    category = 'Ecommerce'
+)
 USING
   (_TABLE_SUFFIX, url)
 JOIN (
@@ -25,10 +25,10 @@ JOIN (
   FROM
     `httparchive.technologies.2020_08_01_*`
   WHERE
-     category = 'Ecommerce'
+    category = 'Ecommerce'
   GROUP BY
     _TABLE_SUFFIX
-    )
+)
 USING
   (_TABLE_SUFFIX)
 WHERE

--- a/sql/2020/ecommerce/percent_of_ecommsites_using_each_a11y_solutions.sql
+++ b/sql/2020/ecommerce/percent_of_ecommsites_using_each_a11y_solutions.sql
@@ -15,8 +15,8 @@ JOIN (
   FROM
     `httparchive.technologies.2020_08_01_*`
   WHERE
-     category = 'Ecommerce'
-    )
+    category = 'Ecommerce'
+)
 USING
   (_TABLE_SUFFIX, url)
 JOIN (
@@ -26,10 +26,10 @@ JOIN (
   FROM
     `httparchive.technologies.2020_08_01_*`
   WHERE
-     category = 'Ecommerce'
+    category = 'Ecommerce'
   GROUP BY
     _TABLE_SUFFIX
-    )
+)
 USING
   (_TABLE_SUFFIX)
 WHERE

--- a/sql/2020/ecommerce/percent_of_ecommsites_using_each_cmp.sql
+++ b/sql/2020/ecommerce/percent_of_ecommsites_using_each_cmp.sql
@@ -15,8 +15,8 @@ JOIN (
   FROM
     `httparchive.technologies.2020_08_01_*`
   WHERE
-     category = 'Ecommerce'
-    )
+    category = 'Ecommerce'
+)
 USING
   (_TABLE_SUFFIX, url)
 JOIN (
@@ -26,10 +26,10 @@ JOIN (
   FROM
     `httparchive.technologies.2020_08_01_*`
   WHERE
-     category = 'Ecommerce'
+    category = 'Ecommerce'
   GROUP BY
     _TABLE_SUFFIX
-    )
+)
 USING
   (_TABLE_SUFFIX)
 WHERE

--- a/sql/2020/ecommerce/percent_of_ecommsites_using_each_payment_processors.sql
+++ b/sql/2020/ecommerce/percent_of_ecommsites_using_each_payment_processors.sql
@@ -15,8 +15,8 @@ JOIN (
   FROM
     `httparchive.technologies.2020_08_01_*`
   WHERE
-     category = 'Ecommerce'
-    )
+    category = 'Ecommerce'
+)
 USING
   (_TABLE_SUFFIX, url)
 JOIN (
@@ -26,10 +26,10 @@ JOIN (
   FROM
     `httparchive.technologies.2020_08_01_*`
   WHERE
-     category = 'Ecommerce'
+    category = 'Ecommerce'
   GROUP BY
     _TABLE_SUFFIX
-    )
+)
 USING
   (_TABLE_SUFFIX)
 WHERE

--- a/sql/2020/ecommerce/percent_of_ecommsites_using_each_tag_managers.sql
+++ b/sql/2020/ecommerce/percent_of_ecommsites_using_each_tag_managers.sql
@@ -15,8 +15,8 @@ JOIN (
   FROM
     `httparchive.technologies.2020_08_01_*`
   WHERE
-     category = 'Ecommerce'
-    )
+    category = 'Ecommerce'
+)
 USING
   (_TABLE_SUFFIX, url)
 JOIN (
@@ -26,10 +26,10 @@ JOIN (
   FROM
     `httparchive.technologies.2020_08_01_*`
   WHERE
-     category = 'Ecommerce'
+    category = 'Ecommerce'
   GROUP BY
     _TABLE_SUFFIX
-    )
+)
 USING
   (_TABLE_SUFFIX)
 WHERE

--- a/sql/2020/ecommerce/top_adplatform_bydevice_vendor_wapp.sql
+++ b/sql/2020/ecommerce/top_adplatform_bydevice_vendor_wapp.sql
@@ -7,25 +7,25 @@ SELECT
   COUNTIF(category = 'Advertising') AS AdPlatfromFreq,
   SUM(COUNT(0)) OVER (PARTITION BY vendor) AS total,
   ROUND(COUNTIF(category = 'Advertising') * 100 / SUM(COUNT(0)) OVER (PARTITION BY vendor), 2) AS pct
-  FROM
-    `httparchive.technologies.2020_08_01_*`
+FROM
+  `httparchive.technologies.2020_08_01_*`
 JOIN
-(
-  SELECT
-    _TABLE_SUFFIX AS client,
-    url,
-    app AS vendor
-  FROM
-    `httparchive.technologies.2020_08_01_*`
-  WHERE
-    category = 'Ecommerce'
- )
+  (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      url,
+      app AS vendor
+    FROM
+      `httparchive.technologies.2020_08_01_*`
+    WHERE
+      category = 'Ecommerce'
+  )
 USING
   (url)
 GROUP BY
   client, vendor, app
 HAVING
- AdPlatfromFreq > 0
+  AdPlatfromFreq > 0
 ORDER BY
   total DESC,
   Vendor,

--- a/sql/2020/ecommerce/top_analytics_bydevice_vendor.sql
+++ b/sql/2020/ecommerce/top_analytics_bydevice_vendor.sql
@@ -30,8 +30,8 @@ JOIN (
 USING
   (client)
 WHERE
-    `httparchive.almanac.summary_requests`.date = '2020-08-01' AND
-    LOWER(category) = 'analytics'
+  `httparchive.almanac.summary_requests`.date = '2020-08-01' AND
+  LOWER(category) = 'analytics'
 GROUP BY
   client,
   total,

--- a/sql/2020/ecommerce/top_analytics_providers_bydevice_wapp.sql
+++ b/sql/2020/ecommerce/top_analytics_providers_bydevice_wapp.sql
@@ -15,8 +15,8 @@ JOIN (
   FROM
     `httparchive.technologies.2020_08_01_*`
   WHERE
-     category = 'Ecommerce'
-    )
+    category = 'Ecommerce'
+)
 USING
   (_TABLE_SUFFIX, url)
 JOIN (
@@ -26,10 +26,10 @@ JOIN (
   FROM
     `httparchive.technologies.2020_08_01_*`
   WHERE
-     category = 'Ecommerce'
+    category = 'Ecommerce'
   GROUP BY
     _TABLE_SUFFIX
-    )
+)
 USING
   (_TABLE_SUFFIX)
 WHERE

--- a/sql/2020/ecommerce/top_cdn_bydevice.sql
+++ b/sql/2020/ecommerce/top_cdn_bydevice.sql
@@ -28,8 +28,8 @@ JOIN (
 USING
   (client)
 WHERE
-    `httparchive.almanac.summary_requests`.date = '2020-08-01' AND
-    LOWER(category) = 'cdn'
+  `httparchive.almanac.summary_requests`.date = '2020-08-01' AND
+  LOWER(category) = 'cdn'
 GROUP BY
   client,
   total,

--- a/sql/2020/ecommerce/top_cdn_bydevice_vendor_cdn.sql
+++ b/sql/2020/ecommerce/top_cdn_bydevice_vendor_cdn.sql
@@ -7,19 +7,19 @@ SELECT
   COUNTIF(category = 'CDN') AS Cdnfreq,
   SUM(COUNT(0)) OVER (PARTITION BY vendor) AS total,
   ROUND(COUNTIF(category = 'CDN') * 100 / SUM(COUNT(0)) OVER (PARTITION BY vendor), 2) AS pct
-  FROM
-    `httparchive.technologies.2020_08_01_*`
+FROM
+  `httparchive.technologies.2020_08_01_*`
 JOIN
-(
-  SELECT
-    _TABLE_SUFFIX AS client,
-    url,
-    app AS vendor
-  FROM
-    `httparchive.technologies.2020_08_01_*`
-  WHERE
-    category = 'Ecommerce'
- )
+  (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      url,
+      app AS vendor
+    FROM
+      `httparchive.technologies.2020_08_01_*`
+    WHERE
+      category = 'Ecommerce'
+  )
 USING
   (url)
 GROUP BY
@@ -27,7 +27,7 @@ GROUP BY
   vendor,
   app
 HAVING
- Cdnfreq > 0
+  Cdnfreq > 0
 ORDER BY
   total DESC,
   Vendor,

--- a/sql/2020/ecommerce/top_cdn_bydevice_vendor_wapp.sql
+++ b/sql/2020/ecommerce/top_cdn_bydevice_vendor_wapp.sql
@@ -7,19 +7,19 @@ SELECT
   COUNTIF(category = 'CDN') AS CDNPlatfromFreq,
   SUM(COUNT(0)) OVER (PARTITION BY vendor) AS total,
   ROUND(COUNTIF(category = 'CDN') * 100 / SUM(COUNT(0)) OVER (PARTITION BY vendor), 2) AS pct
-  FROM
-    `httparchive.technologies.2020_08_01_*`
+FROM
+  `httparchive.technologies.2020_08_01_*`
 JOIN
-(
-  SELECT
-    _TABLE_SUFFIX AS client,
-    url,
-    app AS vendor
-  FROM
-    `httparchive.technologies.2020_08_01_*`
-  WHERE
-    category = 'Ecommerce'
- )
+  (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      url,
+      app AS vendor
+    FROM
+      `httparchive.technologies.2020_08_01_*`
+    WHERE
+      category = 'Ecommerce'
+  )
 USING
   (url)
 GROUP BY
@@ -27,7 +27,7 @@ GROUP BY
   vendor,
   app
 HAVING
- CDNPlatfromFreq > 0
+  CDNPlatfromFreq > 0
 ORDER BY
   total DESC,
   Vendor,

--- a/sql/2020/ecommerce/webpush_adoption_by_ecommsites.sql
+++ b/sql/2020/ecommerce/webpush_adoption_by_ecommsites.sql
@@ -2,24 +2,24 @@
 # 13_16a: Web Push adoption stats by eCommerce origins by device
 
  SELECT
-    client,
-    COUNT(DISTINCT origin) AS totalECommOrigins,
-    COUNTIF(notification_permission_accept IS NOT NULL) AS eCommOriginsWithWebPush,
-    COUNTIF(notification_permission_accept IS NOT NULL) / COUNT(DISTINCT origin) AS pct
+  client,
+  COUNT(DISTINCT origin) AS totalECommOrigins,
+  COUNTIF(notification_permission_accept IS NOT NULL) AS eCommOriginsWithWebPush,
+  COUNTIF(notification_permission_accept IS NOT NULL) / COUNT(DISTINCT origin) AS pct
 
-  FROM
-    `chrome-ux-report.materialized.metrics_summary`
-  JOIN (
+ FROM
+  `chrome-ux-report.materialized.metrics_summary`
+ JOIN (
     SELECT DISTINCT
       _TABLE_SUFFIX AS client,
       RTRIM(url, "/") AS origin
     FROM
       `httparchive.technologies.2020_08_01_*`
     WHERE category = 'Ecommerce')
-  USING
-    (origin)
-  WHERE date IN ('2020-08-01')
-  GROUP BY
-    client
-  ORDER BY
-    client
+ USING
+  (origin)
+ WHERE date IN ('2020-08-01')
+ GROUP BY
+  client
+ ORDER BY
+  client

--- a/sql/2020/ecommerce/webpushstats_ecommsites.sql
+++ b/sql/2020/ecommerce/webpushstats_ecommsites.sql
@@ -2,54 +2,54 @@
 # 13_16b: Web Push Notification CRUX stats (10th / 25th / 50th / 75th / 90th / 100th percentile) for eCommerce origins
 
  SELECT
-    date,
-    client,
+  date,
+  client,
 
-    ROUND(APPROX_QUANTILES(notification_permission_accept, 1000 RESPECT NULLS)[OFFSET(100)], 3) AS notification_permission_accept_10th_percentile,
-    ROUND(APPROX_QUANTILES(notification_permission_accept, 1000 RESPECT NULLS)[OFFSET(250)], 3) AS notification_permission_accept_25th_percentile,
-    ROUND(APPROX_QUANTILES(notification_permission_accept, 1000 RESPECT NULLS)[OFFSET(500)], 3) AS notification_permission_accept_50th_percentile,
-    ROUND(APPROX_QUANTILES(notification_permission_accept, 1000 RESPECT NULLS)[OFFSET(750)], 3) AS notification_permission_accept_75th_percentile,
-    ROUND(APPROX_QUANTILES(notification_permission_accept, 1000 RESPECT NULLS)[OFFSET(900)], 3) AS notification_permission_accept_90th_percentile,
-    ROUND(APPROX_QUANTILES(notification_permission_accept, 1000 RESPECT NULLS)[OFFSET(1000)], 3) AS notification_permission_accept_100th_percentile,
+  ROUND(APPROX_QUANTILES(notification_permission_accept, 1000 RESPECT NULLS)[OFFSET(100)], 3) AS notification_permission_accept_10th_percentile,
+  ROUND(APPROX_QUANTILES(notification_permission_accept, 1000 RESPECT NULLS)[OFFSET(250)], 3) AS notification_permission_accept_25th_percentile,
+  ROUND(APPROX_QUANTILES(notification_permission_accept, 1000 RESPECT NULLS)[OFFSET(500)], 3) AS notification_permission_accept_50th_percentile,
+  ROUND(APPROX_QUANTILES(notification_permission_accept, 1000 RESPECT NULLS)[OFFSET(750)], 3) AS notification_permission_accept_75th_percentile,
+  ROUND(APPROX_QUANTILES(notification_permission_accept, 1000 RESPECT NULLS)[OFFSET(900)], 3) AS notification_permission_accept_90th_percentile,
+  ROUND(APPROX_QUANTILES(notification_permission_accept, 1000 RESPECT NULLS)[OFFSET(1000)], 3) AS notification_permission_accept_100th_percentile,
 
-    ROUND(APPROX_QUANTILES(notification_permission_deny, 1000 RESPECT NULLS)[OFFSET(100)], 3) AS notification_permission_deny_10th_percentile,
-    ROUND(APPROX_QUANTILES(notification_permission_deny, 1000 RESPECT NULLS)[OFFSET(250)], 3) AS notification_permission_deny_25th_percentile,
-    ROUND(APPROX_QUANTILES(notification_permission_deny, 1000 RESPECT NULLS)[OFFSET(500)], 3) AS notification_permission_deny_50th_percentile,
-    ROUND(APPROX_QUANTILES(notification_permission_deny, 1000 RESPECT NULLS)[OFFSET(750)], 3) AS notification_permission_deny_75th_percentile,
-    ROUND(APPROX_QUANTILES(notification_permission_deny, 1000 RESPECT NULLS)[OFFSET(900)], 3) AS notification_permission_deny_90th_percentile,
-    ROUND(APPROX_QUANTILES(notification_permission_deny, 1000 RESPECT NULLS)[OFFSET(1000)], 3) AS notification_permission_deny_100th_percentile,
+  ROUND(APPROX_QUANTILES(notification_permission_deny, 1000 RESPECT NULLS)[OFFSET(100)], 3) AS notification_permission_deny_10th_percentile,
+  ROUND(APPROX_QUANTILES(notification_permission_deny, 1000 RESPECT NULLS)[OFFSET(250)], 3) AS notification_permission_deny_25th_percentile,
+  ROUND(APPROX_QUANTILES(notification_permission_deny, 1000 RESPECT NULLS)[OFFSET(500)], 3) AS notification_permission_deny_50th_percentile,
+  ROUND(APPROX_QUANTILES(notification_permission_deny, 1000 RESPECT NULLS)[OFFSET(750)], 3) AS notification_permission_deny_75th_percentile,
+  ROUND(APPROX_QUANTILES(notification_permission_deny, 1000 RESPECT NULLS)[OFFSET(900)], 3) AS notification_permission_deny_90th_percentile,
+  ROUND(APPROX_QUANTILES(notification_permission_deny, 1000 RESPECT NULLS)[OFFSET(1000)], 3) AS notification_permission_deny_100th_percentile,
 
-    ROUND(APPROX_QUANTILES(notification_permission_ignore, 1000 RESPECT NULLS)[OFFSET(100)], 3) AS notification_permission_ignore_10th_percentile,
-    ROUND(APPROX_QUANTILES(notification_permission_ignore, 1000 RESPECT NULLS)[OFFSET(250)], 3) AS notification_permission_ignore_25th_percentile,
-    ROUND(APPROX_QUANTILES(notification_permission_ignore, 1000 RESPECT NULLS)[OFFSET(500)], 3) AS notification_permission_ignore_50th_percentile,
-    ROUND(APPROX_QUANTILES(notification_permission_ignore, 1000 RESPECT NULLS)[OFFSET(750)], 3) AS notification_permission_ignore_75th_percentile,
-    ROUND(APPROX_QUANTILES(notification_permission_ignore, 1000 RESPECT NULLS)[OFFSET(900)], 3) AS notification_permission_ignore_90th_percentile,
-    ROUND(APPROX_QUANTILES(notification_permission_ignore, 1000 RESPECT NULLS)[OFFSET(1000)], 3) AS notification_permission_ignore_100th_percentile,
+  ROUND(APPROX_QUANTILES(notification_permission_ignore, 1000 RESPECT NULLS)[OFFSET(100)], 3) AS notification_permission_ignore_10th_percentile,
+  ROUND(APPROX_QUANTILES(notification_permission_ignore, 1000 RESPECT NULLS)[OFFSET(250)], 3) AS notification_permission_ignore_25th_percentile,
+  ROUND(APPROX_QUANTILES(notification_permission_ignore, 1000 RESPECT NULLS)[OFFSET(500)], 3) AS notification_permission_ignore_50th_percentile,
+  ROUND(APPROX_QUANTILES(notification_permission_ignore, 1000 RESPECT NULLS)[OFFSET(750)], 3) AS notification_permission_ignore_75th_percentile,
+  ROUND(APPROX_QUANTILES(notification_permission_ignore, 1000 RESPECT NULLS)[OFFSET(900)], 3) AS notification_permission_ignore_90th_percentile,
+  ROUND(APPROX_QUANTILES(notification_permission_ignore, 1000 RESPECT NULLS)[OFFSET(1000)], 3) AS notification_permission_ignore_100th_percentile,
 
-    ROUND(APPROX_QUANTILES(notification_permission_dismiss, 1000 RESPECT NULLS)[OFFSET(100)], 3) AS notification_permission_dismiss_10th_percentile,
-    ROUND(APPROX_QUANTILES(notification_permission_dismiss, 1000 RESPECT NULLS)[OFFSET(250)], 3) AS notification_permission_dismiss_25th_percentile,
-    ROUND(APPROX_QUANTILES(notification_permission_dismiss, 1000 RESPECT NULLS)[OFFSET(500)], 3) AS notification_permission_dismiss_50th_percentile,
-    ROUND(APPROX_QUANTILES(notification_permission_dismiss, 1000 RESPECT NULLS)[OFFSET(750)], 3) AS notification_permission_dismiss_75th_percentile,
-    ROUND(APPROX_QUANTILES(notification_permission_dismiss, 1000 RESPECT NULLS)[OFFSET(900)], 3) AS notification_permission_dismiss_90th_percentile,
-    ROUND(APPROX_QUANTILES(notification_permission_dismiss, 1000 RESPECT NULLS)[OFFSET(1000)], 3) AS notification_permission_dismis_100th_percentiles
+  ROUND(APPROX_QUANTILES(notification_permission_dismiss, 1000 RESPECT NULLS)[OFFSET(100)], 3) AS notification_permission_dismiss_10th_percentile,
+  ROUND(APPROX_QUANTILES(notification_permission_dismiss, 1000 RESPECT NULLS)[OFFSET(250)], 3) AS notification_permission_dismiss_25th_percentile,
+  ROUND(APPROX_QUANTILES(notification_permission_dismiss, 1000 RESPECT NULLS)[OFFSET(500)], 3) AS notification_permission_dismiss_50th_percentile,
+  ROUND(APPROX_QUANTILES(notification_permission_dismiss, 1000 RESPECT NULLS)[OFFSET(750)], 3) AS notification_permission_dismiss_75th_percentile,
+  ROUND(APPROX_QUANTILES(notification_permission_dismiss, 1000 RESPECT NULLS)[OFFSET(900)], 3) AS notification_permission_dismiss_90th_percentile,
+  ROUND(APPROX_QUANTILES(notification_permission_dismiss, 1000 RESPECT NULLS)[OFFSET(1000)], 3) AS notification_permission_dismis_100th_percentiles
 
-FROM
+ FROM
   `chrome-ux-report.materialized.metrics_summary`
-JOIN (
+ JOIN (
     SELECT DISTINCT
       _TABLE_SUFFIX AS client,
       RTRIM(url, "/") AS origin
     FROM
       `httparchive.technologies.2020_08_01_*`
     WHERE category = 'Ecommerce')
-USING
+ USING
   (origin)
-WHERE date IN ('2020-08-01') AND
+ WHERE date IN ('2020-08-01') AND
   notification_permission_accept IS NOT NULL
-GROUP BY
+ GROUP BY
   date,
   client
-ORDER BY
+ ORDER BY
   date,
   client
 

--- a/sql/2020/fonts/04_03.popular_font_hosts_by_country.sql
+++ b/sql/2020/fonts/04_03.popular_font_hosts_by_country.sql
@@ -8,37 +8,37 @@ SELECT
   total,
   pct
 FROM
-(
-  SELECT
-    client,
-    country,
-    NET.HOST(url) AS host,
-    COUNT(DISTINCT page) AS pages,
-    SUM(COUNT(DISTINCT page)) OVER (PARTITION BY client) AS total,
-    COUNT(DISTINCT page) / SUM(COUNT(DISTINCT page)) OVER (PARTITION BY client) AS pct,
-    ROW_NUMBER() OVER (PARTITION BY client, country ORDER BY COUNT(DISTINCT page) DESC) AS sort_row
-  FROM
-    `httparchive.almanac.requests`
-  JOIN (
-    SELECT DISTINCT
-      origin, device,
-      `chrome-ux-report`.experimental.GET_COUNTRY(country_code) AS country
+  (
+    SELECT
+      client,
+      country,
+      NET.HOST(url) AS host,
+      COUNT(DISTINCT page) AS pages,
+      SUM(COUNT(DISTINCT page)) OVER (PARTITION BY client) AS total,
+      COUNT(DISTINCT page) / SUM(COUNT(DISTINCT page)) OVER (PARTITION BY client) AS pct,
+      ROW_NUMBER() OVER (PARTITION BY client, country ORDER BY COUNT(DISTINCT page) DESC) AS sort_row
     FROM
-      `chrome-ux-report.materialized.country_summary`
+      `httparchive.almanac.requests`
+    JOIN (
+      SELECT DISTINCT
+        origin, device,
+        `chrome-ux-report`.experimental.GET_COUNTRY(country_code) AS country
+      FROM
+        `chrome-ux-report.materialized.country_summary`
+      WHERE
+        yyyymm = 202008)
+    ON
+      CONCAT(origin, '/') = page AND
+      IF(device = 'desktop', 'desktop', 'mobile') = client
     WHERE
-      yyyymm = 202008)
-  ON
-    CONCAT(origin, '/') = page AND
-    IF(device = 'desktop', 'desktop', 'mobile') = client
-  WHERE
-    type = 'font' AND
-    NET.HOST(url) != NET.HOST(page) AND
-    date = '2020-08-01'
-  GROUP BY
-    client,
-    country,
-    host
-  ORDER BY
-    pct DESC
-)
+      type = 'font' AND
+      NET.HOST(url) != NET.HOST(page) AND
+      date = '2020-08-01'
+    GROUP BY
+      client,
+      country,
+      host
+    ORDER BY
+      pct DESC
+  )
 WHERE sort_row <= 1

--- a/sql/2020/fonts/04_05a.web_font_usage_breakdown_2019.sql
+++ b/sql/2020/fonts/04_05a.web_font_usage_breakdown_2019.sql
@@ -7,13 +7,13 @@ SELECT
   SUM(COUNT(DISTINCT page)) OVER (PARTITION BY client) AS total,
   COUNT(DISTINCT page) / SUM(COUNT(DISTINCT page)) OVER (PARTITION BY client) AS pct
 FROM
-    `httparchive.almanac.requests`
+  `httparchive.almanac.requests`
 WHERE
-    date = '2019-07-01' AND
-    type = 'font' AND
-    NET.HOST(page) != NET.HOST(url)
+  date = '2019-07-01' AND
+  type = 'font' AND
+  NET.HOST(page) != NET.HOST(url)
 GROUP BY
-    client, url, page
+  client, url, page
 HAVING
   pages >= 1000
 ORDER BY

--- a/sql/2020/fonts/04_07.font_resource_hints_with_fcp.sql
+++ b/sql/2020/fonts/04_07.font_resource_hints_with_fcp.sql
@@ -1,6 +1,6 @@
 CREATE TEMPORARY FUNCTION getResourceHints(payload STRING)
 RETURNS ARRAY < STRUCT < name STRING, href STRING >>
-    LANGUAGE js AS '''
+LANGUAGE js AS '''
 var hints = new Set(['preload', 'prefetch', 'preconnect', 'prerender', 'dns-prefetch']);
 try {
     var $ = JSON.parse(payload);

--- a/sql/2020/fonts/04_08.font_unicode_range_with_fcp.sql
+++ b/sql/2020/fonts/04_08.font_unicode_range_with_fcp.sql
@@ -30,7 +30,7 @@ SELECT
   client,
   CASE
     WHEN unicode != " " THEN "unicode_ranges"
-  ELSE "none"
+    ELSE "none"
   END AS use_unicode,
   COUNT(DISTINCT page) AS pages,
   SUM(COUNT(DISTINCT page)) OVER (PARTITION BY client) AS total,

--- a/sql/2020/fonts/04_10.font_formats.sql
+++ b/sql/2020/fonts/04_10.font_formats.sql
@@ -1,17 +1,17 @@
 #standardSQL
 #font_formats
 SELECT
- client,
- LOWER(IFNULL(REGEXP_EXTRACT(mimeType, '/(?:x-)?(?:font-)?(.*)'), ext)) AS mime_type,
- COUNT(0) AS freq,
- SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
- COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct
+  client,
+  LOWER(IFNULL(REGEXP_EXTRACT(mimeType, '/(?:x-)?(?:font-)?(.*)'), ext)) AS mime_type,
+  COUNT(0) AS freq,
+  SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct
 FROM
- `httparchive.almanac.requests`
+  `httparchive.almanac.requests`
 WHERE
- type = 'font' AND mimeType != '' AND date = '2020-08-01'
+  type = 'font' AND mimeType != '' AND date = '2020-08-01'
 GROUP BY
- client,
- mime_type
+  client,
+  mime_type
 ORDER BY
- client, pct DESC
+  client, pct DESC

--- a/sql/2020/fonts/04_12.font_weight_font_style.sql
+++ b/sql/2020/fonts/04_12.font_weight_font_style.sql
@@ -51,7 +51,7 @@ FROM (
     font.stretch AS stretch
   FROM
     `httparchive.almanac.parsed_css`
-     LEFT JOIN UNNEST(getFonts(css)) AS font
+  LEFT JOIN UNNEST(getFonts(css)) AS font
   WHERE
     date = '2020-08-01')
 JOIN (

--- a/sql/2020/fonts/04_17.VF_axis_value.sql
+++ b/sql/2020/fonts/04_17.VF_axis_value.sql
@@ -19,21 +19,21 @@ try {
 }
 ''';
 SELECT
- client,
- REGEXP_EXTRACT(LOWER(values), '[\'"]([\\w]{4})[\'"]') AS axis,
- CAST(REGEXP_EXTRACT(value, '\\d+') AS NUMERIC) AS num_axis,
- COUNT(DISTINCT page) AS pages,
- SUM(COUNT(DISTINCT page)) OVER (PARTITION BY client) AS total,
- COUNT(DISTINCT page) / SUM(COUNT(DISTINCT page)) OVER (PARTITION BY client) AS pct
+  client,
+  REGEXP_EXTRACT(LOWER(values), '[\'"]([\\w]{4})[\'"]') AS axis,
+  CAST(REGEXP_EXTRACT(value, '\\d+') AS NUMERIC) AS num_axis,
+  COUNT(DISTINCT page) AS pages,
+  SUM(COUNT(DISTINCT page)) OVER (PARTITION BY client) AS total,
+  COUNT(DISTINCT page) / SUM(COUNT(DISTINCT page)) OVER (PARTITION BY client) AS pct
 FROM
- `httparchive.almanac.parsed_css`,
- UNNEST(getFontVariationSettings(css)) AS value,
- UNNEST(SPLIT(value, ',')) AS values
+  `httparchive.almanac.parsed_css`,
+  UNNEST(getFontVariationSettings(css)) AS value,
+  UNNEST(SPLIT(value, ',')) AS values
 WHERE
- date = '2020-08-01'
+  date = '2020-08-01'
 GROUP BY
- client, axis, num_axis
+  client, axis, num_axis
 HAVING
- axis IS NOT NULL
+  axis IS NOT NULL
 ORDER BY
- pages DESC
+  pages DESC

--- a/sql/2020/fonts/04_18.VF_animation.sql
+++ b/sql/2020/fonts/04_18.VF_animation.sql
@@ -24,7 +24,7 @@ FROM (
     page,
     COUNTIF(animatesVariableFonts(css)) AS animates_variable_fonts
   FROM
-   `httparchive.almanac.parsed_css`
+    `httparchive.almanac.parsed_css`
   GROUP BY
     client,
     page)

--- a/sql/2020/fonts/04_19.color_fonts.sql
+++ b/sql/2020/fonts/04_19.color_fonts.sql
@@ -15,8 +15,8 @@ FROM (
   FROM
     `httparchive.almanac.requests`
   WHERE
-     date = '2020-09-01' AND
-     type = 'font')
+    date = '2020-09-01' AND
+    type = 'font')
 JOIN (
   SELECT
     _TABLE_SUFFIX AS client,

--- a/sql/2020/fonts/04_20.icon_fonts.sql
+++ b/sql/2020/fonts/04_20.icon_fonts.sql
@@ -17,19 +17,19 @@ try {
 ''';
 
 SELECT
- client,
- COUNT(DISTINCT page) AS pages,
- total_page,
- COUNT(DISTINCT page) / total_page AS pct_ficon
+  client,
+  COUNT(DISTINCT page) AS pages,
+  total_page,
+  COUNT(DISTINCT page) / total_page AS pct_ficon
 FROM
- `httparchive.almanac.parsed_css`
+  `httparchive.almanac.parsed_css`
 JOIN
- (SELECT _TABLE_SUFFIX AS client, COUNT(0) AS total_page FROM `httparchive.summary_pages.2020_08_01_*` GROUP BY _TABLE_SUFFIX)
+  (SELECT _TABLE_SUFFIX AS client, COUNT(0) AS total_page FROM `httparchive.summary_pages.2020_08_01_*` GROUP BY _TABLE_SUFFIX)
 USING
- (client)
+  (client)
 WHERE
- ARRAY_LENGTH(checksSupports(css)) > 0 AND date = '2020-08-01' OR url LIKE '%fontawesome%' OR url LIKE '%icomoon%' OR url LIKE '%fontello%' OR url LIKE '%iconic%'
+  ARRAY_LENGTH(checksSupports(css)) > 0 AND date = '2020-08-01' OR url LIKE '%fontawesome%' OR url LIKE '%icomoon%' OR url LIKE '%fontello%' OR url LIKE '%iconic%'
 GROUP BY
- client, url, total_page
+  client, url, total_page
 ORDER BY
- client, pages DESC
+  client, pages DESC

--- a/sql/2020/fonts/4_10a.font_formats_font_face.sql
+++ b/sql/2020/fonts/4_10a.font_formats_font_face.sql
@@ -29,18 +29,18 @@ try {
 }
 ''';
 SELECT
- client,
- format,
- COUNT(0) AS freq,
- SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
- COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct
+  client,
+  format,
+  COUNT(0) AS freq,
+  SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct
 FROM
- `httparchive.almanac.parsed_css`,
- UNNEST(getFontFormats(css)) AS format
+  `httparchive.almanac.parsed_css`,
+  UNNEST(getFontFormats(css)) AS format
 WHERE
- date = '2020-08-01'
+  date = '2020-08-01'
 GROUP BY
- client,
- format
+  client,
+  format
 ORDER BY
- client, pct DESC
+  client, pct DESC

--- a/sql/2020/http2/cdn_detail_by_cdn.sql
+++ b/sql/2020/http2/cdn_detail_by_cdn.sql
@@ -13,24 +13,24 @@ FROM (
     firstHTML,
     CDN,
     COUNTIF(http_version IN ('HTTP/2', 'QUIC', 'http/2+quic/46')) / COUNT(0) AS http2_pct
-FROM (
-  SELECT
-     client,
-     page,
-     firstHTML,
-     IFNULL(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), '') AS CDN,
-     url,
-     JSON_EXTRACT_SCALAR(payload, '$._protocol') AS http_version
-FROM
-  `httparchive.almanac.requests`
-WHERE
-  date = '2020-08-01')
-GROUP BY
-  client,
-  page,
-  firstHTML,
-  CDN),
-UNNEST([0, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 100]) AS percentile
+  FROM (
+    SELECT
+      client,
+      page,
+      firstHTML,
+      IFNULL(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), '') AS CDN,
+      url,
+      JSON_EXTRACT_SCALAR(payload, '$._protocol') AS http_version
+    FROM
+      `httparchive.almanac.requests`
+    WHERE
+      date = '2020-08-01')
+  GROUP BY
+    client,
+    page,
+    firstHTML,
+    CDN),
+  UNNEST([0, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 100])
 GROUP BY
   percentile,
   client,

--- a/sql/2020/http2/cdn_summary.sql
+++ b/sql/2020/http2/cdn_summary.sql
@@ -13,24 +13,24 @@ FROM (
     firstHTML,
     CDN,
     COUNTIF(http_version IN ('HTTP/2', 'QUIC', 'http/2+quic/46')) / COUNT(0) AS http2_pct
-FROM (
-  SELECT
+  FROM (
+    SELECT
+      client,
+      page,
+      firstHTML,
+      IF(IFNULL(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), '') = '', FALSE, TRUE) AS CDN,
+      url,
+      JSON_EXTRACT_SCALAR(payload, '$._protocol') AS http_version
+    FROM
+      `httparchive.almanac.requests`
+    WHERE
+      date = '2020-08-01')
+  GROUP BY
     client,
     page,
     firstHTML,
-    IF(IFNULL(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), '') = '', FALSE, TRUE) AS CDN,
-    url,
-    JSON_EXTRACT_SCALAR(payload, '$._protocol') AS http_version
-FROM
-  `httparchive.almanac.requests`
-WHERE
-  date = '2020-08-01')
-GROUP BY
-  client,
-  page,
-  firstHTML,
-  CDN),
-UNNEST(GENERATE_ARRAY(1, 100)) AS percentile
+    CDN),
+  UNNEST(GENERATE_ARRAY(1, 100))
 GROUP BY
   percentile,
   client,

--- a/sql/2020/http2/count_of_h2_and_h3_sites_grouped_by_server.sql
+++ b/sql/2020/http2/count_of_h2_and_h3_sites_grouped_by_server.sql
@@ -14,9 +14,9 @@ WHERE
   date = '2020-08-01' AND
   firstHtml AND
   (LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/2" OR
-   LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "%quic%" OR
-   LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "h3%" OR
-   LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/3%"
+                             LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "%quic%" OR
+    LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "h3%" OR
+    LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/3%"
   )
 GROUP BY
   client,

--- a/sql/2020/http2/count_of_h2_and_h3_sites_using_push.sql
+++ b/sql/2020/http2/count_of_h2_and_h3_sites_using_push.sql
@@ -17,10 +17,10 @@ FROM (
   WHERE
     date = '2020-08-01' AND
     (LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/2" OR
-     LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "%quic%" OR
-     LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "h3%" OR
-     LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/3%")
-    )
+                               LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "%quic%" OR
+      LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "h3%" OR
+      LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/3%")
+)
 GROUP BY
   client,
   http_version

--- a/sql/2020/http2/count_of_preload_http_headers_with_nopush_attribute_set.sql
+++ b/sql/2020/http2/count_of_preload_http_headers_with_nopush_attribute_set.sql
@@ -21,10 +21,10 @@ FROM (
     client,
     getLinkHeaders(payload) AS link_headers
   FROM
-   `httparchive.almanac.requests`
+    `httparchive.almanac.requests`
   WHERE
-   date = '2020-08-01' AND
-   firstHtml),
+    date = '2020-08-01' AND
+    firstHtml),
   UNNEST(link_headers) AS link_header
 WHERE
   link_header LIKE '%preload%'

--- a/sql/2020/http2/http2_1st_party_vs_3rd_party.sql
+++ b/sql/2020/http2/http2_1st_party_vs_3rd_party.sql
@@ -11,26 +11,26 @@ FROM (
     page,
     is_third_party,
     COUNTIF(http_version IN ('HTTP/2', 'QUIC', 'http/2+quic/46')) / COUNT(0) AS http2_pct
-FROM (
-  SELECT
+  FROM (
+    SELECT
+      client,
+      page,
+      url,
+      type,
+      respSize,
+      JSON_EXTRACT_SCALAR(payload, '$._protocol') AS http_version,
+      NET.HOST(url) IN (SELECT domain FROM `httparchive.almanac.third_parties` WHERE date = '2020-08-01') AS is_third_party
+    FROM
+      `httparchive.almanac.requests`
+    WHERE
+      date = '2020-08-01')
+  WHERE
+    type = 'script'
+  GROUP BY
     client,
     page,
-    url,
-    type,
-    respSize,
-    JSON_EXTRACT_SCALAR(payload, '$._protocol') AS http_version,
-    NET.HOST(url) IN (SELECT domain FROM `httparchive.almanac.third_parties` WHERE date = '2020-08-01') AS is_third_party
-FROM
-  `httparchive.almanac.requests`
-WHERE
-  date = '2020-08-01')
-WHERE
-  type = 'script'
-GROUP BY
-  client,
-  page,
-  is_third_party),
-UNNEST(GENERATE_ARRAY(1, 100)) AS percentile
+    is_third_party),
+  UNNEST(GENERATE_ARRAY(1, 100))
 GROUP BY
   percentile,
   client,

--- a/sql/2020/http2/http2_1st_party_vs_3rd_party_by_type.sql
+++ b/sql/2020/http2/http2_1st_party_vs_3rd_party_by_type.sql
@@ -13,25 +13,25 @@ FROM (
     is_third_party,
     type,
     COUNTIF(http_version IN ('HTTP/2', 'QUIC', 'http/2+quic/46')) / COUNT(0) AS http2_pct
-FROM (
-  SELECT
+  FROM (
+    SELECT
+      client,
+      page,
+      url,
+      type,
+      respSize,
+      JSON_EXTRACT_SCALAR(payload, '$._protocol') AS http_version,
+      NET.HOST(url) IN (SELECT domain FROM `httparchive.almanac.third_parties` WHERE date = '2020-08-01') AS is_third_party
+    FROM
+      `httparchive.almanac.requests`
+    WHERE
+      date = '2020-08-01')
+  GROUP BY
     client,
     page,
-    url,
-    type,
-    respSize,
-    JSON_EXTRACT_SCALAR(payload, '$._protocol') AS http_version,
-    NET.HOST(url) IN (SELECT domain FROM `httparchive.almanac.third_parties` WHERE date = '2020-08-01') AS is_third_party
-FROM
-  `httparchive.almanac.requests`
-WHERE
-  date = '2020-08-01')
-GROUP BY
-  client,
-  page,
-  is_third_party,
-  type),
-UNNEST([5, 10, 20, 30, 40, 50, 60, 70, 90, 95, 100]) AS percentile
+    is_third_party,
+    type),
+  UNNEST([5, 10, 20, 30, 40, 50, 60, 70, 90, 95, 100])
 GROUP BY
   percentile,
   client,

--- a/sql/2020/http2/http2_3rd_party_by_types.sql
+++ b/sql/2020/http2/http2_3rd_party_by_types.sql
@@ -11,25 +11,25 @@ FROM (
     page,
     category,
     COUNTIF(http_version IN ('HTTP/2', 'QUIC', 'http/2+quic/46')) / COUNT(0) AS http2_pct
-FROM (
-  SELECT
+  FROM (
+    SELECT
+      client,
+      page,
+      url,
+      category,
+      JSON_EXTRACT_SCALAR(payload, '$._protocol') AS http_version
+    FROM
+      `httparchive.almanac.requests` r,
+      `httparchive.almanac.third_parties` tp
+    WHERE
+      r.date = '2020-08-01' AND
+      tp.date = '2020-08-01' AND
+      NET.HOST(url) = domain)
+  GROUP BY
     client,
     page,
-    url,
-    category,
-    JSON_EXTRACT_SCALAR(payload, '$._protocol') AS http_version
-FROM
-  `httparchive.almanac.requests` r,
-  `httparchive.almanac.third_parties` tp
-WHERE
-  r.date = '2020-08-01' AND
-  tp.date = '2020-08-01' AND
-  NET.HOST(url) = domain)
-GROUP BY
-  client,
-  page,
-  category),
-UNNEST([5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 100]) AS percentile
+    category),
+  UNNEST([5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 100])
 GROUP BY
   percentile,
   client,

--- a/sql/2020/http2/measure_of_all_http_versions_for_main_page_of_all_sites.sql
+++ b/sql/2020/http2/measure_of_all_http_versions_for_main_page_of_all_sites.sql
@@ -9,10 +9,10 @@ SELECT
   COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct_pages,
   COUNTIF(url LIKE 'https://%') / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct_https
 FROM
-   `httparchive.almanac.requests`
+  `httparchive.almanac.requests`
 WHERE
-   date = '2020-08-01' AND
-   firstHtml
+  date = '2020-08-01' AND
+  firstHtml
 GROUP BY
   client,
   protocol

--- a/sql/2020/http2/number_of_h2_and_h3_pushed_resources_and_bytes_by_content_type.sql
+++ b/sql/2020/http2/number_of_h2_and_h3_pushed_resources_and_bytes_by_content_type.sql
@@ -22,9 +22,9 @@ FROM (
     date = '2020-08-01' AND
     JSON_EXTRACT_SCALAR(payload, "$._was_pushed") = "1" AND
     (LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/2" OR
-     LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "%quic%" OR
-     LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "h3%" OR
-     LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/3%")
+                               LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "%quic%" OR
+      LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "h3%" OR
+      LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/3%")
   GROUP BY
     client,
     http_version,

--- a/sql/2020/http2/number_of_h2_and_h3_pushed_resources_and_bytes_transferred.sql
+++ b/sql/2020/http2/number_of_h2_and_h3_pushed_resources_and_bytes_transferred.sql
@@ -8,25 +8,25 @@ SELECT
   APPROX_QUANTILES(num_requests, 1000)[OFFSET(percentile * 10)] AS pushed_requests,
   APPROX_QUANTILES(kb_transfered, 1000)[OFFSET(percentile * 10)] AS kb_transfered
 FROM (
- SELECT
-    client,
-    page,
-    JSON_EXTRACT_SCALAR(payload, '$._protocol') AS http_version,
-    SUM(CAST(JSON_EXTRACT_SCALAR(payload, '$._bytesIn') AS INT64) / 1024) AS kb_transfered,
-    COUNT(0) AS num_requests
-  FROM
-    `httparchive.almanac.requests`
-  WHERE
-    date = '2020-08-01' AND
-    JSON_EXTRACT_SCALAR(payload, '$._was_pushed') = '1' AND
-    (LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/2" OR
-     LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "%quic%" OR
-     LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "h3%" OR
-     LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/3%")
-  GROUP BY
-    client,
-    http_version,
-    page),
+    SELECT
+      client,
+      page,
+      JSON_EXTRACT_SCALAR(payload, '$._protocol') AS http_version,
+      SUM(CAST(JSON_EXTRACT_SCALAR(payload, '$._bytesIn') AS INT64) / 1024) AS kb_transfered,
+      COUNT(0) AS num_requests
+    FROM
+      `httparchive.almanac.requests`
+    WHERE
+      date = '2020-08-01' AND
+      JSON_EXTRACT_SCALAR(payload, '$._was_pushed') = '1' AND
+      (LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/2" OR
+                                 LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "%quic%" OR
+        LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "h3%" OR
+        LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/3%")
+    GROUP BY
+      client,
+      http_version,
+      page),
   UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   percentile,

--- a/sql/2020/http2/percentage_of_h2_and_h3_sites_affected_by_cdn_prioritization.sql
+++ b/sql/2020/http2/percentage_of_h2_and_h3_sites_affected_by_cdn_prioritization.sql
@@ -20,10 +20,10 @@ FROM (
       date = '2020-08-01' AND
       firstHtml AND
       (LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/2" OR
-       LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "%quic%" OR
-       LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "h3%" OR
-       LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/3%")
-    ) AS pages
+                                 LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "%quic%" OR
+        LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "h3%" OR
+        LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/3%")
+) AS pages
 LEFT JOIN
   `httparchive.almanac.h2_prioritization_cdns`
 USING (cdn, date)

--- a/sql/2020/jamstack/distribution_of_page_weight_requests_and_co2_grams_per_ssg_web_page.sql
+++ b/sql/2020/jamstack/distribution_of_page_weight_requests_and_co2_grams_per_ssg_web_page.sql
@@ -2,20 +2,20 @@
 # Distribution of page weight, requests, and co2 grams per SSG web page
 # https://gitlab.com/wholegrain/carbon-api-2-0/-/blob/b498ec3bb239536d3612c5f3d758f46e0d2431a6/includes/carbonapi.php
 CREATE TEMP FUNCTION
-  GREEN(url STRING) AS (FALSE); -- TODO: Investigate fetching from Green Web Foundation
+GREEN(url STRING) AS (FALSE); -- TODO: Investigate fetching from Green Web Foundation
 CREATE TEMP FUNCTION
-  adjustDataTransfer(val INT64) AS (val * 0.75 + 0.02 * val * 0.25);
+adjustDataTransfer(val INT64) AS (val * 0.75 + 0.02 * val * 0.25);
 CREATE TEMP FUNCTION
-  energyConsumption(bytes FLOAT64) AS (bytes * 1.805 / 1073741824);
+energyConsumption(bytes FLOAT64) AS (bytes * 1.805 / 1073741824);
 CREATE TEMP FUNCTION
-  getCo2Grid(energy FLOAT64) AS (energy * 475);
+getCo2Grid(energy FLOAT64) AS (energy * 475);
 CREATE TEMP FUNCTION
-  getCo2Renewable(energy FLOAT64) AS (energy * 0.1008 * 33.4 + energy * 0.8992 * 475);
+getCo2Renewable(energy FLOAT64) AS (energy * 0.1008 * 33.4 + energy * 0.8992 * 475);
 CREATE TEMP FUNCTION
-  CO2(url STRING, bytes INT64) AS (
+CO2(url STRING, bytes INT64) AS (
   IF(GREEN(url),
-      getCo2Renewable(energyConsumption(adjustDataTransfer(bytes))),
-      getCo2Grid(energyConsumption(adjustDataTransfer(bytes)))));
+           getCo2Renewable(energyConsumption(adjustDataTransfer(bytes))),
+    getCo2Grid(energyConsumption(adjustDataTransfer(bytes)))));
 
 SELECT
   percentile,

--- a/sql/2020/javascript/breakdown_of_scripts_using_async_defer_module_nomodule.sql
+++ b/sql/2020/javascript/breakdown_of_scripts_using_async_defer_module_nomodule.sql
@@ -2,11 +2,11 @@
 # Breakdown of scripts using Async, Defer, Module or NoModule attributes.  Also breakdown of inline vs external scripts
 SELECT
   client,
-  COUNT(*) AS total_scripts,
+  COUNT(0) AS total_scripts,
   SUM(IF(script NOT LIKE "%src%", 1, 0)) AS inline_script,
   SUM(IF(script LIKE "%src%", 1, 0)) AS external_script,
-  SUM(IF(script LIKE "%src%", 1, 0)) / COUNT(*) AS pct_external_script,
-  SUM(IF(script NOT LIKE "%src%", 1, 0)) / COUNT(*) AS pct_inline_script,
+  SUM(IF(script LIKE "%src%", 1, 0)) / COUNT(0) AS pct_external_script,
+  SUM(IF(script NOT LIKE "%src%", 1, 0)) / COUNT(0) AS pct_inline_script,
   SUM(IF(script LIKE "%async%", 1, 0)) AS async,
   SUM(IF(script LIKE "%defer%", 1, 0)) AS defer,
   SUM(IF(script LIKE "%module%", 1, 0)) AS module,
@@ -16,7 +16,7 @@ SELECT
   SUM(IF(script LIKE "%module%", 1, 0)) / SUM(IF(script LIKE "%src%", 1, 0)) AS pct_external_module,
   SUM(IF(script LIKE "%nomodule%", 1, 0)) / SUM(IF(script LIKE "%src%", 1, 0)) AS pct_external_nomodule
 FROM
-(
+  (
     SELECT
       client,
       page,
@@ -27,7 +27,7 @@ FROM
     WHERE
       date = '2020-08-01' AND
       firstHtml
-)
+  )
 CROSS JOIN
   UNNEST(scripts) AS script
 GROUP BY

--- a/sql/2020/javascript/dist_pct_per_page_scripts_using_async_defer_module_nomodule.sql
+++ b/sql/2020/javascript/dist_pct_per_page_scripts_using_async_defer_module_nomodule.sql
@@ -8,40 +8,40 @@ SELECT
   APPROX_QUANTILES(pct_external_module, 1000)[OFFSET(percentile * 10)] AS pct_external_module,
   APPROX_QUANTILES(pct_external_nomodule, 1000)[OFFSET(percentile * 10)] AS pct_external_nomodule
 FROM
-(
-  SELECT
-    client,
-    page,
-    COUNT(*) AS external_scripts,
-    SUM(IF(script LIKE "%async%", 1, 0)) AS async,
-    SUM(IF(script LIKE "%defer%", 1, 0)) AS defer,
-    SUM(IF(script LIKE "%module%", 1, 0)) AS module,
-    SUM(IF(script LIKE "%nomodule%", 1, 0)) AS nomodule,
-    SUM(IF(script LIKE "%async%", 1, 0)) / COUNT(*) AS pct_external_async,
-    SUM(IF(script LIKE "%defer%", 1, 0)) / COUNT(*) AS pct_external_defer,
-    SUM(IF(script LIKE "%module%", 1, 0)) / COUNT(*) AS pct_external_module,
-    SUM(IF(script LIKE "%nomodule%", 1, 0)) / COUNT(*) AS pct_external_nomodule
-  FROM
   (
     SELECT
       client,
       page,
-      url,
-      REGEXP_EXTRACT_ALL(LOWER(body), "(<script [^>]*)") AS scripts
+      COUNT(0) AS external_scripts,
+      SUM(IF(script LIKE "%async%", 1, 0)) AS async,
+      SUM(IF(script LIKE "%defer%", 1, 0)) AS defer,
+      SUM(IF(script LIKE "%module%", 1, 0)) AS module,
+      SUM(IF(script LIKE "%nomodule%", 1, 0)) AS nomodule,
+      SUM(IF(script LIKE "%async%", 1, 0)) / COUNT(0) AS pct_external_async,
+      SUM(IF(script LIKE "%defer%", 1, 0)) / COUNT(0) AS pct_external_defer,
+      SUM(IF(script LIKE "%module%", 1, 0)) / COUNT(0) AS pct_external_module,
+      SUM(IF(script LIKE "%nomodule%", 1, 0)) / COUNT(0) AS pct_external_nomodule
     FROM
-      `httparchive.almanac.summary_response_bodies`
+      (
+        SELECT
+          client,
+          page,
+          url,
+          REGEXP_EXTRACT_ALL(LOWER(body), "(<script [^>]*)") AS scripts
+        FROM
+          `httparchive.almanac.summary_response_bodies`
+        WHERE
+          date = '2020-08-01' AND
+          firstHtml
+      )
+    CROSS JOIN
+      UNNEST(scripts) AS script
     WHERE
-      date = '2020-08-01' AND
-      firstHtml
-  )
-  CROSS JOIN
-    UNNEST(scripts) AS script
-  WHERE
-    script LIKE "%src%"
-  GROUP BY
-    client,
-    page
-),
+      script LIKE "%src%"
+    GROUP BY
+      client,
+      page
+  ),
   UNNEST([10, 25, 50, 75, 90, 100]) AS percentile
 GROUP BY
   percentile,

--- a/sql/2020/javascript/lighthouse_vulnerable_libraries.sql
+++ b/sql/2020/javascript/lighthouse_vulnerable_libraries.sql
@@ -18,10 +18,10 @@ SELECT
 FROM
   `httparchive.lighthouse.2020_08_01_mobile`,
   UNNEST(getVulnerabilities(JSON_EXTRACT(report, "$.audits['no-vulnerable-libraries']"))) AS lib, (
-  SELECT
-    COUNT(DISTINCT url) AS total
-  FROM
-    `httparchive.lighthouse.2020_08_01_mobile`)
+    SELECT
+      COUNT(DISTINCT url) AS total
+    FROM
+      `httparchive.lighthouse.2020_08_01_mobile`)
 GROUP BY
   lib,
   total

--- a/sql/2020/markup/pages_almanac_by_device.sql
+++ b/sql/2020/markup/pages_almanac_by_device.sql
@@ -98,12 +98,12 @@ SELECT
   AS_PERCENT(COUNTIF(almanac_info.html_node_lang IS NULL OR LENGTH(almanac_info.html_node_lang) = 0), COUNT(0)) AS pct_no_html_lang_m404
 
 FROM
-    (
-      SELECT
-        _TABLE_SUFFIX AS client,
-        get_almanac_info(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS almanac_info
-      FROM
-        `httparchive.pages.2020_08_01_*`
-    )
+  (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      get_almanac_info(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS almanac_info
+    FROM
+      `httparchive.pages.2020_08_01_*`
+  )
 GROUP BY
   client

--- a/sql/2020/markup/pages_almanac_by_device_and_attribute_name_frequency.sql
+++ b/sql/2020/markup/pages_almanac_by_device_and_attribute_name_frequency.sql
@@ -36,5 +36,4 @@ GROUP BY
 ORDER BY
   freq DESC,
   client
-LIMIT
-  1000
+LIMIT 1000

--- a/sql/2020/markup/pages_almanac_by_device_and_attribute_name_present.sql
+++ b/sql/2020/markup/pages_almanac_by_device_and_attribute_name_present.sql
@@ -32,9 +32,9 @@ FROM
   `httparchive.pages.2020_08_01_*`
 JOIN
   (SELECT _TABLE_SUFFIX, COUNT(0) AS total
-  FROM
-  `httparchive.pages.2020_08_01_*`
-  GROUP BY _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
+    FROM
+      `httparchive.pages.2020_08_01_*`
+    GROUP BY _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
 USING (_TABLE_SUFFIX),
   UNNEST(get_almanac_attribute_names(JSON_EXTRACT_SCALAR(payload, '$._almanac'))) AS attribute_name
 GROUP BY
@@ -44,5 +44,4 @@ GROUP BY
 ORDER BY
   pages / total DESC,
   client
-LIMIT
-  1000
+LIMIT 1000

--- a/sql/2020/markup/pages_almanac_by_device_and_data_attribute_name_frequency.sql
+++ b/sql/2020/markup/pages_almanac_by_device_and_data_attribute_name_frequency.sql
@@ -36,5 +36,4 @@ GROUP BY
 ORDER BY
   freq DESC,
   client
-LIMIT
-  1000
+LIMIT 1000

--- a/sql/2020/markup/pages_almanac_by_device_and_favicon_image_type.sql
+++ b/sql/2020/markup/pages_almanac_by_device_and_favicon_image_type.sql
@@ -59,18 +59,17 @@ SELECT
 
   AS_PERCENT(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY client)) AS pct
 
-  FROM
-    (
-      SELECT
-        _TABLE_SUFFIX AS client,
-        get_almanac_info(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS almanac_info
-      FROM
-        `httparchive.pages.2020_08_01_*`
-    )
+FROM
+  (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      get_almanac_info(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS almanac_info
+    FROM
+      `httparchive.pages.2020_08_01_*`
+  )
 GROUP BY
   client,
   image_type_extension
 ORDER BY
   freq DESC
-LIMIT
-  1000
+LIMIT 1000

--- a/sql/2020/markup/pages_almanac_by_device_and_html_lang.sql
+++ b/sql/2020/markup/pages_almanac_by_device_and_html_lang.sql
@@ -29,14 +29,14 @@ SELECT
 
   AS_PERCENT(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY client)) AS pct_m405
 
-  FROM
-    (
-      SELECT
-        _TABLE_SUFFIX AS client,
-        get_almanac_html_lang(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS almanac_html_lang
-      FROM
-        `httparchive.pages.2020_08_01_*`
-    )
+FROM
+  (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      get_almanac_html_lang(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS almanac_html_lang
+    FROM
+      `httparchive.pages.2020_08_01_*`
+  )
 GROUP BY
   client,
   html_lang

--- a/sql/2020/markup/pages_almanac_by_device_and_percentile.sql
+++ b/sql/2020/markup/pages_almanac_by_device_and_percentile.sql
@@ -52,8 +52,8 @@ FROM (
     url,
     get_almanac_info(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS almanac_info
   FROM
-  `httparchive.pages.2020_08_01_*`,
-  UNNEST([10, 25, 50, 75, 90]) AS percentile
+    `httparchive.pages.2020_08_01_*`,
+    UNNEST([10, 25, 50, 75, 90])
 )
 GROUP BY
   percentile,

--- a/sql/2020/markup/pages_element_count_by_device.sql
+++ b/sql/2020/markup/pages_element_count_by_device.sql
@@ -50,12 +50,12 @@ SELECT
   AS_PERCENT(COUNTIF(element_count_info.contains_details_element AND element_count_info.contains_summary_element), COUNT(0)) AS pct_contains_details_and_summary_element_m214
 
 FROM
-    (
-      SELECT
-        _TABLE_SUFFIX AS client,
-        get_element_count_info(JSON_EXTRACT_SCALAR(payload, '$._element_count')) AS element_count_info
-      FROM
-        `httparchive.pages.2020_08_01_*`
-    )
+  (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      get_element_count_info(JSON_EXTRACT_SCALAR(payload, '$._element_count')) AS element_count_info
+    FROM
+      `httparchive.pages.2020_08_01_*`
+  )
 GROUP BY
   client

--- a/sql/2020/markup/pages_element_count_by_device_and_custom_dash_elements.sql
+++ b/sql/2020/markup/pages_element_count_by_device_and_custom_dash_elements.sql
@@ -40,8 +40,8 @@ FROM
 
 JOIN
   (SELECT _TABLE_SUFFIX, COUNT(0) AS total FROM
-  `httparchive.pages.2020_08_01_*`
-  GROUP BY _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
+    `httparchive.pages.2020_08_01_*`
+    GROUP BY _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
 USING (_TABLE_SUFFIX),
   UNNEST(get_element_types_with_a_dash(JSON_EXTRACT_SCALAR(payload, '$._element_count'))) AS element_type_with_a_dash # so we end up with pages + element_type_with_a_dash rows
 GROUP BY

--- a/sql/2020/markup/pages_element_count_by_device_and_element_type_frequency.sql
+++ b/sql/2020/markup/pages_element_count_by_device_and_element_type_frequency.sql
@@ -36,5 +36,4 @@ GROUP BY
 ORDER BY
   freq_m201 DESC,
   client
-LIMIT
-  1000
+LIMIT 1000

--- a/sql/2020/markup/pages_element_count_by_device_and_element_type_present.sql
+++ b/sql/2020/markup/pages_element_count_by_device_and_element_type_present.sql
@@ -22,7 +22,7 @@ try {
 }
 ''';
 
- SELECT
+SELECT
   _TABLE_SUFFIX AS client,
   element_type,
   COUNT(DISTINCT url) AS pages,
@@ -32,9 +32,9 @@ FROM
   `httparchive.pages.2020_08_01_*`
 JOIN
   (SELECT _TABLE_SUFFIX, COUNT(0) AS total
-  FROM
-  `httparchive.pages.2020_08_01_*`
-  GROUP BY _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
+    FROM
+      `httparchive.pages.2020_08_01_*`
+    GROUP BY _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
 USING (_TABLE_SUFFIX),
   UNNEST(get_element_types(JSON_EXTRACT_SCALAR(payload, '$._element_count'))) AS element_type
 GROUP BY

--- a/sql/2020/markup/pages_element_count_by_device_and_obsolete_elements.sql
+++ b/sql/2020/markup/pages_element_count_by_device_and_obsolete_elements.sql
@@ -34,11 +34,11 @@ SELECT
   AS_PERCENT(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX)) AS ratio_compared_to_all_obsolete_elements
 FROM
   `httparchive.pages.2020_08_01_*`
-    JOIN
-    (SELECT _TABLE_SUFFIX, COUNT(0) AS total FROM
-  `httparchive.pages.2020_08_01_*`
+JOIN
+  (SELECT _TABLE_SUFFIX, COUNT(0) AS total FROM
+    `httparchive.pages.2020_08_01_*`
     GROUP BY _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
-  USING (_TABLE_SUFFIX),
+USING (_TABLE_SUFFIX),
   UNNEST(get_element_types(JSON_EXTRACT_SCALAR(payload, '$._element_count'))) AS element_type
 WHERE
   is_obsolete(element_type)

--- a/sql/2020/markup/pages_element_count_by_device_and_percentile.sql
+++ b/sql/2020/markup/pages_element_count_by_device_and_percentile.sql
@@ -31,7 +31,7 @@ SELECT
   # total number of elements on a page
   APPROX_QUANTILES(element_count_info.elements_count, 1000)[OFFSET(percentile * 10)] AS elements_count,
 
-    # number of types of elements on a page
+  # number of types of elements on a page
   APPROX_QUANTILES(element_count_info.types_count, 1000)[OFFSET(percentile * 10)] AS types_count
 
 FROM (
@@ -41,8 +41,8 @@ FROM (
     url,
     get_element_count_info(JSON_EXTRACT_SCALAR(payload, '$._element_count')) AS element_count_info
   FROM
-  `httparchive.pages.2020_08_01_*`,
-  UNNEST([10, 25, 50, 75, 90]) AS percentile
+    `httparchive.pages.2020_08_01_*`,
+    UNNEST([10, 25, 50, 75, 90])
 )
 GROUP BY
   percentile,

--- a/sql/2020/markup/pages_markup_by_device.sql
+++ b/sql/2020/markup/pages_markup_by_device.sql
@@ -169,12 +169,12 @@ SELECT
   AS_PERCENT(COUNTIF(markup_info.dirs_body_nodes_dir_total > 0), COUNT(0)) AS pct_body_nodes_dir_set_m414
 
 FROM
-    (
-      SELECT
-        _TABLE_SUFFIX AS client,
-        get_markup_info(JSON_EXTRACT_SCALAR(payload, '$._markup')) AS markup_info
-      FROM
-        `httparchive.pages.2020_08_01_*`
-    )
+  (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      get_markup_info(JSON_EXTRACT_SCALAR(payload, '$._markup')) AS markup_info
+    FROM
+      `httparchive.pages.2020_08_01_*`
+  )
 GROUP BY
   client

--- a/sql/2020/markup/pages_markup_by_device_and_button_types.sql
+++ b/sql/2020/markup/pages_markup_by_device_and_button_types.sql
@@ -9,9 +9,9 @@ CREATE TEMP FUNCTION AS_PERCENT (freq FLOAT64, total FLOAT64) RETURNS FLOAT64 AS
 # returns all the data we need from _markup
 CREATE TEMPORARY FUNCTION get_markup_buttons_info(markup_string STRING)
 RETURNS ARRAY<STRUCT<
-name STRING,
-freq INT64
->> LANGUAGE js AS '''
+  name STRING,
+  freq INT64
+  >> LANGUAGE js AS '''
 var result = [];
 try {
     var markup = JSON.parse(markup_string);
@@ -40,13 +40,13 @@ SELECT
   SUM(button_type_info.freq) AS freq_button,
   AS_PERCENT(SUM(button_type_info.freq), SUM(SUM(button_type_info.freq)) OVER (PARTITION BY _TABLE_SUFFIX)) AS pct_button
 FROM
-    `httparchive.pages.2020_08_01_*`
-    JOIN
-      (SELECT _TABLE_SUFFIX, COUNT(0) AS total FROM
+  `httparchive.pages.2020_08_01_*`
+JOIN
+  (SELECT _TABLE_SUFFIX, COUNT(0) AS total FROM
       `httparchive.pages.2020_08_01_*`
-      GROUP BY _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
-    USING (_TABLE_SUFFIX),
-    UNNEST(get_markup_buttons_info(JSON_EXTRACT_SCALAR(payload, '$._markup'))) AS button_type_info
+    GROUP BY _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
+USING (_TABLE_SUFFIX),
+  UNNEST(get_markup_buttons_info(JSON_EXTRACT_SCALAR(payload, '$._markup'))) AS button_type_info
 GROUP BY
   client,
   button_type,

--- a/sql/2020/markup/pages_markup_by_device_and_input_types.sql
+++ b/sql/2020/markup/pages_markup_by_device_and_input_types.sql
@@ -9,9 +9,9 @@ CREATE TEMP FUNCTION AS_PERCENT (freq FLOAT64, total FLOAT64) RETURNS FLOAT64 AS
 # returns all the data we need from _markup
 CREATE TEMPORARY FUNCTION get_markup_inputs_info(markup_string STRING)
 RETURNS ARRAY<STRUCT<
-name STRING,
-freq INT64
->> LANGUAGE js AS '''
+  name STRING,
+  freq INT64
+  >> LANGUAGE js AS '''
 var result = [];
 try {
     var markup = JSON.parse(markup_string);
@@ -40,13 +40,13 @@ SELECT
   SUM(markup_input_info.freq) AS freq_input,
   AS_PERCENT(SUM(markup_input_info.freq), SUM(SUM(markup_input_info.freq)) OVER (PARTITION BY _TABLE_SUFFIX)) AS pct_input
 FROM
-    `httparchive.pages.2020_08_01_*`
-    JOIN
-      (SELECT _TABLE_SUFFIX, COUNT(0) AS total FROM
+  `httparchive.pages.2020_08_01_*`
+JOIN
+  (SELECT _TABLE_SUFFIX, COUNT(0) AS total FROM
       `httparchive.pages.2020_08_01_*`
-      GROUP BY _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
-    USING (_TABLE_SUFFIX),
-    UNNEST(get_markup_inputs_info(JSON_EXTRACT_SCALAR(payload, '$._markup'))) AS markup_input_info
+    GROUP BY _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
+USING (_TABLE_SUFFIX),
+  UNNEST(get_markup_inputs_info(JSON_EXTRACT_SCALAR(payload, '$._markup'))) AS markup_input_info
 GROUP BY
   client,
   input_type,

--- a/sql/2020/markup/pages_markup_by_device_and_percentile.sql
+++ b/sql/2020/markup/pages_markup_by_device_and_percentile.sql
@@ -131,8 +131,8 @@ FROM (
     url,
     get_markup_info(JSON_EXTRACT_SCALAR(payload, '$._markup')) AS markup_info
   FROM
-  `httparchive.pages.2020_08_01_*`,
-  UNNEST([10, 25, 50, 75, 90, 95, 96, 97, 98, 99]) AS percentile
+    `httparchive.pages.2020_08_01_*`,
+    UNNEST([10, 25, 50, 75, 90, 95, 96, 97, 98, 99])
 )
 GROUP BY
   percentile,

--- a/sql/2020/markup/pages_wpt_bodies_by_device.sql
+++ b/sql/2020/markup/pages_wpt_bodies_by_device.sql
@@ -162,12 +162,12 @@ SELECT
   SUM(wpt_bodies_info.n_h8) AS freq_h8
 
 FROM
-    (
-      SELECT
-        _TABLE_SUFFIX AS client,
-        get_wpt_bodies_info(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
-      FROM
-       `httparchive.pages.2020_08_01_*`
-    )
+  (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      get_wpt_bodies_info(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
+    FROM
+      `httparchive.pages.2020_08_01_*`
+  )
 GROUP BY
   client

--- a/sql/2020/markup/pages_wpt_bodies_by_device_and_percentile.sql
+++ b/sql/2020/markup/pages_wpt_bodies_by_device_and_percentile.sql
@@ -52,8 +52,8 @@ FROM (
     url,
     get_wpt_bodies_info(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
   FROM
-  `httparchive.pages.2020_08_01_*`,
-  UNNEST([10, 25, 50, 75, 90]) AS percentile
+    `httparchive.pages.2020_08_01_*`,
+    UNNEST([10, 25, 50, 75, 90])
 )
 GROUP BY
   percentile,

--- a/sql/2020/markup/pages_wpt_bodies_by_device_and_percentile_and_heading_level.sql
+++ b/sql/2020/markup/pages_wpt_bodies_by_device_and_percentile_and_heading_level.sql
@@ -4,9 +4,9 @@
 # returns all the data we need from _wpt_bodies
 CREATE TEMPORARY FUNCTION get_heading_info(wpt_bodies_string STRING)
 RETURNS ARRAY<STRUCT<
-heading STRING,
-total INT64
->> LANGUAGE js AS '''
+  heading STRING,
+  total INT64
+  >> LANGUAGE js AS '''
 var result = [];
 try {
     var wpt_bodies = JSON.parse(wpt_bodies_string);
@@ -38,9 +38,9 @@ FROM (
     heading_info.total AS total,
     url
   FROM
-  `httparchive.pages.2020_08_01_*`,
-  UNNEST([10, 25, 50, 75, 90]) AS percentile,
-  UNNEST(get_heading_info(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies'))) AS heading_info
+    `httparchive.pages.2020_08_01_*`,
+    UNNEST([10, 25, 50, 75, 90]),
+    UNNEST(get_heading_info(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies'))) AS heading_info
 )
 GROUP BY
   heading,

--- a/sql/2020/markup/pages_wpt_bodies_by_device_and_protocol.sql
+++ b/sql/2020/markup/pages_wpt_bodies_by_device_and_protocol.sql
@@ -33,13 +33,13 @@ SELECT
   AS_PERCENT(COUNT(DISTINCT url), total) AS pct
 
 FROM
-    `httparchive.pages.2020_08_01_*`
-    JOIN
-      (SELECT _TABLE_SUFFIX, COUNT(0) AS total FROM
+  `httparchive.pages.2020_08_01_*`
+JOIN
+  (SELECT _TABLE_SUFFIX, COUNT(0) AS total FROM
       `httparchive.pages.2020_08_01_*`
-      GROUP BY _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
-    USING (_TABLE_SUFFIX),
-    UNNEST(get_wpt_bodies_protocols(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies'))) AS protocol
+    GROUP BY _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
+USING (_TABLE_SUFFIX),
+  UNNEST(get_wpt_bodies_protocols(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')))
 GROUP BY
   client,
   total,

--- a/sql/2020/markup/summary_pages_by_device_and_doctype.sql
+++ b/sql/2020/markup/summary_pages_by_device_and_doctype.sql
@@ -18,5 +18,4 @@ GROUP BY
 ORDER BY
   freq DESC,
   client
-LIMIT
-  100
+LIMIT 100

--- a/sql/2020/markup/summary_pages_by_device_and_viewport.sql
+++ b/sql/2020/markup/summary_pages_by_device_and_viewport.sql
@@ -33,5 +33,4 @@ GROUP BY
 ORDER BY
   freq DESC,
   client
-LIMIT
-  100
+LIMIT 100

--- a/sql/2020/media/pixel_volume.sql
+++ b/sql/2020/media/pixel_volume.sql
@@ -43,21 +43,21 @@ SELECT
   Round(APPROX_QUANTILES(naturalPixels, 1000)[OFFSET(750)] / (any_value(viewportHeight) * any_value(viewportWidth)), 2) AS pct_p75,
   Round(APPROX_QUANTILES(naturalPixels, 1000)[OFFSET(900)] / (any_value(viewportHeight) * any_value(viewportWidth)), 2) AS pct_p90
 FROM
-(
-  SELECT
-    _TABLE_SUFFIX AS client,
-    url AS page,
-    getCssPixels(JSON_EXTRACT_SCALAR(payload, '$._Images')) AS cssPixels,
-    getNaturalPixels(JSON_EXTRACT_SCALAR(payload, '$._Images')) AS naturalPixels,
-    CAST(JSON_EXTRACT_SCALAR(payload, '$._smallImageCount') AS Int64) AS smallImageCount,
-    CAST(JSON_EXTRACT_SCALAR(payload, '$._bigImageCount') AS Int64) AS bigImageCount,
-    CAST(JSON_EXTRACT_SCALAR(payload, '$._image_total') AS Int64) AS imageBytes,
-    CAST(JSON_EXTRACT_SCALAR(json_extract_scalar(payload, '$._Dpi'), '$.dppx') AS Float64) AS dpr,
-    CAST(JSON_EXTRACT_SCALAR(json_extract_scalar(payload, '$._Resolution'), '$.absolute.height') AS Float64) AS viewportHeight,
-    CAST(JSON_EXTRACT_SCALAR(json_extract_scalar(payload, '$._Resolution'), '$.absolute.width') AS Float64) AS viewportWidth
-  FROM
-    `httparchive.pages.2020_08_01_*`
-)
+  (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      url AS page,
+      getCssPixels(JSON_EXTRACT_SCALAR(payload, '$._Images')) AS cssPixels,
+      getNaturalPixels(JSON_EXTRACT_SCALAR(payload, '$._Images')) AS naturalPixels,
+      CAST(JSON_EXTRACT_SCALAR(payload, '$._smallImageCount') AS Int64) AS smallImageCount,
+      CAST(JSON_EXTRACT_SCALAR(payload, '$._bigImageCount') AS Int64) AS bigImageCount,
+      CAST(JSON_EXTRACT_SCALAR(payload, '$._image_total') AS Int64) AS imageBytes,
+      CAST(JSON_EXTRACT_SCALAR(json_extract_scalar(payload, '$._Dpi'), '$.dppx') AS Float64) AS dpr,
+      CAST(JSON_EXTRACT_SCALAR(json_extract_scalar(payload, '$._Resolution'), '$.absolute.height') AS Float64) AS viewportHeight,
+      CAST(JSON_EXTRACT_SCALAR(json_extract_scalar(payload, '$._Resolution'), '$.absolute.width') AS Float64) AS viewportWidth
+    FROM
+      `httparchive.pages.2020_08_01_*`
+  )
 WHERE
   # it appears the _Images array is populated only from <img> tag requests and not CSS or favicon
   # likewise the bigImageCount and smallImageCount only track images > 100,000 and < 10,000 respectively.

--- a/sql/2020/performance/lh6_vs_lh5_performance_score_01.sql
+++ b/sql/2020/performance/lh6_vs_lh5_performance_score_01.sql
@@ -8,13 +8,13 @@ FROM (
   SELECT
     perf_score_lh6 - perf_score_lh5 AS perf_score_delta
   FROM
-  (
-    SELECT
-      CAST(JSON_EXTRACT(lh6.report, '$.categories.performance.score') AS NUMERIC) AS perf_score_lh6,
-      CAST(JSON_EXTRACT(lh5.report, '$.categories.performance.score') AS NUMERIC) AS perf_score_lh5
-    FROM `httparchive.lighthouse.2020_09_01_mobile` lh6
-    JOIN `httparchive.lighthouse.2019_07_01_mobile` lh5 ON lh5.url = lh6.url
-  )
+    (
+      SELECT
+        CAST(JSON_EXTRACT(lh6.report, '$.categories.performance.score') AS NUMERIC) AS perf_score_lh6,
+        CAST(JSON_EXTRACT(lh5.report, '$.categories.performance.score') AS NUMERIC) AS perf_score_lh5
+      FROM `httparchive.lighthouse.2020_09_01_mobile` lh6
+      JOIN `httparchive.lighthouse.2019_07_01_mobile` lh5 ON lh5.url = lh6.url
+    )
 ),
 UNNEST([0, 10, 25, 50, 75, 90, 100]) AS percentile
 GROUP BY percentile

--- a/sql/2020/performance/web_vitals_by_country.sql
+++ b/sql/2020/performance/web_vitals_by_country.sql
@@ -19,7 +19,7 @@ CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor 
 );
 
 WITH
-  base AS (
+base AS (
   SELECT
     origin,
     country_code,
@@ -59,94 +59,94 @@ SELECT
   COUNT(DISTINCT origin) AS total_origins,
 
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_GOOD(fast_fid, avg_fid, slow_fid) AND
-          IS_GOOD(fast_lcp, avg_lcp, slow_lcp) AND
-          IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fid, avg_fid, slow_fid) AND
-          IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp) AND
-          IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cwv_good,
+    COUNT(DISTINCT IF(
+        IS_GOOD(fast_fid, avg_fid, slow_fid) AND
+        IS_GOOD(fast_lcp, avg_lcp, slow_lcp) AND
+        IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_fid, avg_fid, slow_fid) AND
+        IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp) AND
+        IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cwv_good,
 
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_GOOD(fast_lcp, avg_lcp, slow_lcp), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) AS pct_lcp_good,
+    COUNT(DISTINCT IF(
+        IS_GOOD(fast_lcp, avg_lcp, slow_lcp), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) AS pct_lcp_good,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_NI(fast_lcp, avg_lcp, slow_lcp), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) AS pct_lcp_ni,
+    COUNT(DISTINCT IF(
+        IS_NI(fast_lcp, avg_lcp, slow_lcp), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) AS pct_lcp_ni,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_POOR(fast_lcp, avg_lcp, slow_lcp), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) AS pct_lcp_poor,
+    COUNT(DISTINCT IF(
+        IS_POOR(fast_lcp, avg_lcp, slow_lcp), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) AS pct_lcp_poor,
 
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_GOOD(fast_fid, avg_fid, slow_fid), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) AS pct_fid_good,
+    COUNT(DISTINCT IF(
+        IS_GOOD(fast_fid, avg_fid, slow_fid), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) AS pct_fid_good,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_NI(fast_fid, avg_fid, slow_fid), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) AS pct_fid_ni,
+    COUNT(DISTINCT IF(
+        IS_NI(fast_fid, avg_fid, slow_fid), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) AS pct_fid_ni,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_POOR(fast_fid, avg_fid, slow_fid), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) AS pct_fid_poor,
+    COUNT(DISTINCT IF(
+        IS_POOR(fast_fid, avg_fid, slow_fid), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) AS pct_fid_poor,
 
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cls_good,
+    COUNT(DISTINCT IF(
+        IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cls_good,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_NI(small_cls, medium_cls, large_cls), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cls_ni,
+    COUNT(DISTINCT IF(
+        IS_NI(small_cls, medium_cls, large_cls), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cls_ni,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_POOR(small_cls, medium_cls, large_cls), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cls_poor,
+    COUNT(DISTINCT IF(
+        IS_POOR(small_cls, medium_cls, large_cls), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cls_poor,
 
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_GOOD(fast_fcp, avg_fcp, slow_fcp), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) AS pct_fcp_good,
+    COUNT(DISTINCT IF(
+        IS_GOOD(fast_fcp, avg_fcp, slow_fcp), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) AS pct_fcp_good,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_NI(fast_fcp, avg_fcp, slow_fcp), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) AS pct_fcp_ni,
+    COUNT(DISTINCT IF(
+        IS_NI(fast_fcp, avg_fcp, slow_fcp), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) AS pct_fcp_ni,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_POOR(fast_fcp, avg_fcp, slow_fcp), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) AS pct_fcp_poor,
+    COUNT(DISTINCT IF(
+        IS_POOR(fast_fcp, avg_fcp, slow_fcp), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) AS pct_fcp_poor,
 
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_GOOD(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL))) AS pct_ttfb_good,
+    COUNT(DISTINCT IF(
+        IS_GOOD(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL))) AS pct_ttfb_good,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_NI(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL))) AS pct_ttfb_ni,
+    COUNT(DISTINCT IF(
+        IS_NI(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL))) AS pct_ttfb_ni,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_POOR(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL))) AS pct_ttfb_poor
+    COUNT(DISTINCT IF(
+        IS_POOR(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL))) AS pct_ttfb_poor
 
 FROM
   base

--- a/sql/2020/performance/web_vitals_by_device.sql
+++ b/sql/2020/performance/web_vitals_by_device.sql
@@ -19,7 +19,7 @@ CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor 
 );
 
 WITH
-  base AS (
+base AS (
   SELECT
     date,
     origin,
@@ -59,94 +59,94 @@ SELECT
   COUNT(DISTINCT origin) AS total_origins,
 
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_GOOD(fast_fid, avg_fid, slow_fid) AND
-          IS_GOOD(fast_lcp, avg_lcp, slow_lcp) AND
-          IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fid, avg_fid, slow_fid) AND
-          IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp) AND
-          IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cwv_good,
+    COUNT(DISTINCT IF(
+        IS_GOOD(fast_fid, avg_fid, slow_fid) AND
+        IS_GOOD(fast_lcp, avg_lcp, slow_lcp) AND
+        IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_fid, avg_fid, slow_fid) AND
+        IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp) AND
+        IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cwv_good,
 
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_GOOD(fast_lcp, avg_lcp, slow_lcp), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) AS pct_lcp_good,
+    COUNT(DISTINCT IF(
+        IS_GOOD(fast_lcp, avg_lcp, slow_lcp), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) AS pct_lcp_good,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_NI(fast_lcp, avg_lcp, slow_lcp), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) AS pct_lcp_ni,
+    COUNT(DISTINCT IF(
+        IS_NI(fast_lcp, avg_lcp, slow_lcp), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) AS pct_lcp_ni,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_POOR(fast_lcp, avg_lcp, slow_lcp), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) AS pct_lcp_poor,
+    COUNT(DISTINCT IF(
+        IS_POOR(fast_lcp, avg_lcp, slow_lcp), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) AS pct_lcp_poor,
 
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_GOOD(fast_fid, avg_fid, slow_fid), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) AS pct_fid_good,
+    COUNT(DISTINCT IF(
+        IS_GOOD(fast_fid, avg_fid, slow_fid), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) AS pct_fid_good,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_NI(fast_fid, avg_fid, slow_fid), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) AS pct_fid_ni,
+    COUNT(DISTINCT IF(
+        IS_NI(fast_fid, avg_fid, slow_fid), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) AS pct_fid_ni,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_POOR(fast_fid, avg_fid, slow_fid), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) AS pct_fid_poor,
+    COUNT(DISTINCT IF(
+        IS_POOR(fast_fid, avg_fid, slow_fid), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) AS pct_fid_poor,
 
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cls_good,
+    COUNT(DISTINCT IF(
+        IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cls_good,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_NI(small_cls, medium_cls, large_cls), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cls_ni,
+    COUNT(DISTINCT IF(
+        IS_NI(small_cls, medium_cls, large_cls), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cls_ni,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_POOR(small_cls, medium_cls, large_cls), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cls_poor,
+    COUNT(DISTINCT IF(
+        IS_POOR(small_cls, medium_cls, large_cls), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cls_poor,
 
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_GOOD(fast_fcp, avg_fcp, slow_fcp), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) AS pct_fcp_good,
+    COUNT(DISTINCT IF(
+        IS_GOOD(fast_fcp, avg_fcp, slow_fcp), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) AS pct_fcp_good,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_NI(fast_fcp, avg_fcp, slow_fcp), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) AS pct_fcp_ni,
+    COUNT(DISTINCT IF(
+        IS_NI(fast_fcp, avg_fcp, slow_fcp), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) AS pct_fcp_ni,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_POOR(fast_fcp, avg_fcp, slow_fcp), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) AS pct_fcp_poor,
+    COUNT(DISTINCT IF(
+        IS_POOR(fast_fcp, avg_fcp, slow_fcp), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) AS pct_fcp_poor,
 
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_GOOD(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL))) AS pct_ttfb_good,
+    COUNT(DISTINCT IF(
+        IS_GOOD(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL))) AS pct_ttfb_good,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_NI(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL))) AS pct_ttfb_ni,
+    COUNT(DISTINCT IF(
+        IS_NI(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL))) AS pct_ttfb_ni,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_POOR(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL))) AS pct_ttfb_poor
+    COUNT(DISTINCT IF(
+        IS_POOR(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL))) AS pct_ttfb_poor
 
 FROM
   base

--- a/sql/2020/performance/web_vitals_by_ect.sql
+++ b/sql/2020/performance/web_vitals_by_ect.sql
@@ -109,7 +109,7 @@ ttfb AS (
     SUM(IF(bin.start >= 1500, bin.density, 0)) AS slow,
     `chrome-ux-report`.experimental.PERCENTILE(ARRAY_AGG(bin), 75) AS p75
   FROM
-      base
+    base
   LEFT JOIN
     UNNEST(time_to_first_byte.histogram.bin) AS bin
   GROUP BY
@@ -171,94 +171,94 @@ SELECT
   COUNT(DISTINCT origin) AS total_origins,
 
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_GOOD(fast_fid, avg_fid, slow_fid) AND
-          IS_GOOD(fast_lcp, avg_lcp, slow_lcp) AND
-          IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fid, avg_fid, slow_fid) AND
-          IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp) AND
-          IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cwv_good,
+    COUNT(DISTINCT IF(
+        IS_GOOD(fast_fid, avg_fid, slow_fid) AND
+        IS_GOOD(fast_lcp, avg_lcp, slow_lcp) AND
+        IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_fid, avg_fid, slow_fid) AND
+        IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp) AND
+        IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cwv_good,
 
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_GOOD(fast_lcp, avg_lcp, slow_lcp), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) AS pct_lcp_good,
+    COUNT(DISTINCT IF(
+        IS_GOOD(fast_lcp, avg_lcp, slow_lcp), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) AS pct_lcp_good,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_NI(fast_lcp, avg_lcp, slow_lcp), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) AS pct_lcp_ni,
+    COUNT(DISTINCT IF(
+        IS_NI(fast_lcp, avg_lcp, slow_lcp), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) AS pct_lcp_ni,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_POOR(fast_lcp, avg_lcp, slow_lcp), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) AS pct_lcp_poor,
+    COUNT(DISTINCT IF(
+        IS_POOR(fast_lcp, avg_lcp, slow_lcp), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) AS pct_lcp_poor,
 
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_GOOD(fast_fid, avg_fid, slow_fid), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) AS pct_fid_good,
+    COUNT(DISTINCT IF(
+        IS_GOOD(fast_fid, avg_fid, slow_fid), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) AS pct_fid_good,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_NI(fast_fid, avg_fid, slow_fid), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) AS pct_fid_ni,
+    COUNT(DISTINCT IF(
+        IS_NI(fast_fid, avg_fid, slow_fid), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) AS pct_fid_ni,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_POOR(fast_fid, avg_fid, slow_fid), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) AS pct_fid_poor,
+    COUNT(DISTINCT IF(
+        IS_POOR(fast_fid, avg_fid, slow_fid), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) AS pct_fid_poor,
 
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cls_good,
+    COUNT(DISTINCT IF(
+        IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cls_good,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_NI(small_cls, medium_cls, large_cls), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cls_ni,
+    COUNT(DISTINCT IF(
+        IS_NI(small_cls, medium_cls, large_cls), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cls_ni,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_POOR(small_cls, medium_cls, large_cls), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cls_poor,
+    COUNT(DISTINCT IF(
+        IS_POOR(small_cls, medium_cls, large_cls), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_cls_poor,
 
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_GOOD(fast_fcp, avg_fcp, slow_fcp), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) AS pct_fcp_good,
+    COUNT(DISTINCT IF(
+        IS_GOOD(fast_fcp, avg_fcp, slow_fcp), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) AS pct_fcp_good,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_NI(fast_fcp, avg_fcp, slow_fcp), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) AS pct_fcp_ni,
+    COUNT(DISTINCT IF(
+        IS_NI(fast_fcp, avg_fcp, slow_fcp), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) AS pct_fcp_ni,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_POOR(fast_fcp, avg_fcp, slow_fcp), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) AS pct_fcp_poor,
+    COUNT(DISTINCT IF(
+        IS_POOR(fast_fcp, avg_fcp, slow_fcp), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) AS pct_fcp_poor,
 
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_GOOD(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL))) AS pct_ttfb_good,
+    COUNT(DISTINCT IF(
+        IS_GOOD(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL))) AS pct_ttfb_good,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_NI(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL))) AS pct_ttfb_ni,
+    COUNT(DISTINCT IF(
+        IS_NI(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL))) AS pct_ttfb_ni,
   SAFE_DIVIDE(
-      COUNT(DISTINCT IF(
-          IS_POOR(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL))) AS pct_ttfb_poor
+    COUNT(DISTINCT IF(
+        IS_POOR(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL)),
+    COUNT(DISTINCT IF(
+        IS_NON_ZERO(fast_ttfb, avg_ttfb, slow_ttfb), origin, NULL))) AS pct_ttfb_poor
 
 FROM
   granular_metrics

--- a/sql/2020/performance/web_vitals_distribution_by_device.sql
+++ b/sql/2020/performance/web_vitals_distribution_by_device.sql
@@ -2,7 +2,7 @@
 # WebVitals distribution by device
 
 WITH
-  base AS (
+base AS (
   SELECT
     device,
 

--- a/sql/2020/pwa/lighthouse_pwa_score.sql
+++ b/sql/2020/pwa/lighthouse_pwa_score.sql
@@ -8,9 +8,9 @@ SELECT
   APPROX_QUANTILES(score, 1000)[OFFSET(percentile * 10)] AS score
 FROM (
   SELECT
-     CAST(JSON_EXTRACT(report, '$.categories.pwa.score') AS NUMERIC) AS score
+    CAST(JSON_EXTRACT(report, '$.categories.pwa.score') AS NUMERIC) AS score
   FROM
-     `httparchive.lighthouse.2019_07_01_mobile`),
+    `httparchive.lighthouse.2019_07_01_mobile`),
   UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   date,
@@ -22,9 +22,9 @@ SELECT
   APPROX_QUANTILES(score, 1000)[OFFSET(percentile * 10)] AS score
 FROM (
   SELECT
-     CAST(JSON_EXTRACT(report, '$.categories.pwa.score') AS NUMERIC) AS score
+    CAST(JSON_EXTRACT(report, '$.categories.pwa.score') AS NUMERIC) AS score
   FROM
-     `httparchive.lighthouse.2020_08_01_mobile`),
+    `httparchive.lighthouse.2020_08_01_mobile`),
   UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   date,

--- a/sql/2020/pwa/manifests_and_service_workers.sql
+++ b/sql/2020/pwa/manifests_and_service_workers.sql
@@ -10,36 +10,36 @@ SELECT
   both / total AS both_pct,
   total
 FROM
-    (SELECT
-        date,
-        client,
-        COUNT(DISTINCT m.page) AS manifests,
-        COUNT(DISTINCT sw.page) AS serviceworkers,
-        COUNT(DISTINCT IFNULL(m.page, sw.page)) AS either,
-        COUNT(DISTINCT m.page || sw.page) AS both
+  (SELECT
+      date,
+      client,
+      COUNT(DISTINCT m.page) AS manifests,
+      COUNT(DISTINCT sw.page) AS serviceworkers,
+      COUNT(DISTINCT IFNULL(m.page, sw.page)) AS either,
+      COUNT(DISTINCT m.page || sw.page) AS both
     FROM
-        `httparchive.almanac.manifests` m
+      `httparchive.almanac.manifests` m
     FULL OUTER JOIN
-        `httparchive.almanac.service_workers` sw
+      `httparchive.almanac.service_workers` sw
     USING
-        (date, client, page)
+      (date, client, page)
     GROUP BY
-        date,
-        client
-    )
+      date,
+      client
+  )
 JOIN
-    (SELECT
-        date,
-        client,
-        COUNT(DISTINCT page) AS total
+  (SELECT
+      date,
+      client,
+      COUNT(DISTINCT page) AS total
     FROM
-        `httparchive.almanac.summary_requests`
+      `httparchive.almanac.summary_requests`
     GROUP BY
-        date,
-        client
-    )
+      date,
+      client
+  )
 USING
-    (date, client)
+  (date, client)
 ORDER BY
   date,
   client

--- a/sql/2020/pwa/manifests_not_json_parsable.sql
+++ b/sql/2020/pwa/manifests_not_json_parsable.sql
@@ -21,10 +21,10 @@ FROM
     client,
     page,
     body
-  FROM
-    `httparchive.almanac.manifests`
-  WHERE
-    date = '2020-08-01')
+    FROM
+      `httparchive.almanac.manifests`
+    WHERE
+      date = '2020-08-01')
 GROUP BY
   client,
   can_parse

--- a/sql/2020/pwa/manifests_not_json_parsable_sw.sql
+++ b/sql/2020/pwa/manifests_not_json_parsable_sw.sql
@@ -21,14 +21,14 @@ FROM
     client,
     page,
     body
-  FROM
-    `httparchive.almanac.manifests`
-  JOIN
-    `httparchive.almanac.service_workers`
-  USING
-    (date, client, page)
-  WHERE
-    date = '2020-08-01')
+    FROM
+      `httparchive.almanac.manifests`
+    JOIN
+      `httparchive.almanac.service_workers`
+    USING
+      (date, client, page)
+    WHERE
+      date = '2020-08-01')
 GROUP BY
   client,
   can_parse

--- a/sql/2020/pwa/manifests_preferring_native_apps.sql
+++ b/sql/2020/pwa/manifests_preferring_native_apps.sql
@@ -21,10 +21,10 @@ FROM
     client,
     page,
     body
-  FROM
-    `httparchive.almanac.manifests`
-  WHERE
-    date = '2020-08-01')
+    FROM
+      `httparchive.almanac.manifests`
+    WHERE
+      date = '2020-08-01')
 GROUP BY
   client,
   prefers_native

--- a/sql/2020/pwa/manifests_preferring_native_apps_sw.sql
+++ b/sql/2020/pwa/manifests_preferring_native_apps_sw.sql
@@ -21,14 +21,14 @@ FROM
     client,
     page,
     body
-  FROM
-    `httparchive.almanac.manifests`
-  JOIN
-    `httparchive.almanac.service_workers`
-  USING
-    (date, client, page)
-  WHERE
-    date = '2020-08-01')
+    FROM
+      `httparchive.almanac.manifests`
+    JOIN
+      `httparchive.almanac.service_workers`
+    USING
+      (date, client, page)
+    WHERE
+      date = '2020-08-01')
 GROUP BY
   client,
   prefers_native

--- a/sql/2020/resource-hints/as_attribute_by_year.sql
+++ b/sql/2020/resource-hints/as_attribute_by_year.sql
@@ -37,7 +37,7 @@ WITH pages AS (
     payload
   FROM
     `httparchive.pages.2020_08_01_*`
-UNION ALL
+  UNION ALL
   SELECT
     _TABLE_SUFFIX,
     2019 AS year,

--- a/sql/2020/security/cryptominer_share.sql
+++ b/sql/2020/security/cryptominer_share.sql
@@ -15,5 +15,5 @@ GROUP BY
   client,
   app
 ORDER BY
-   client,
-   pct DESC
+  client,
+  pct DESC

--- a/sql/2020/security/feature_adoption_by_other_features.sql
+++ b/sql/2020/security/feature_adoption_by_other_features.sql
@@ -23,7 +23,7 @@ SELECT
   SAFE_DIVIDE(COUNTIF(REGEXP_CONTAINS(respOtherHeaders, CONCAT('(?i)', headername, ' ')) AND REGEXP_CONTAINS(respOtherHeaders, '(?i)X-XSS-Protection ')), COUNTIF(REGEXP_CONTAINS(respOtherHeaders, CONCAT('(?i)', headername, ' ')))) AS pct_header_and_xss
 FROM
   `httparchive.summary_requests.2020_08_01_*`,
-UNNEST(['Content-Security-Policy', 'Content-Security-Policy-Report-Only', 'Cross-Origin-Embedder-Policy', 'Cross-Origin-Opener-Policy', 'Cross-Origin-Resource-Policy', 'Expect-CT', 'Feature-Policy', 'Permissions-Policy', 'Referrer-Policy', 'Report-To', 'Strict-Transport-Security', 'X-Content-Type-Options', 'X-Frame-Options', 'X-XSS-Protection']) AS headername
+  UNNEST(['Content-Security-Policy', 'Content-Security-Policy-Report-Only', 'Cross-Origin-Embedder-Policy', 'Cross-Origin-Opener-Policy', 'Cross-Origin-Resource-Policy', 'Expect-CT', 'Feature-Policy', 'Permissions-Policy', 'Referrer-Policy', 'Report-To', 'Strict-Transport-Security', 'X-Content-Type-Options', 'X-Frame-Options', 'X-XSS-Protection'])
 WHERE
   firstHtml
 GROUP BY

--- a/sql/2020/security/feature_adoption_by_topN_technologies.sql
+++ b/sql/2020/security/feature_adoption_by_topN_technologies.sql
@@ -28,7 +28,7 @@ WITH app_headers AS (
   ON
     r._TABLE_SUFFIX = t._TABLE_SUFFIX AND
     r.urlShort = t.url,
-  UNNEST(['Content-Security-Policy', 'Content-Security-Policy-Report-Only', 'Cross-Origin-Embedder-Policy', 'Cross-Origin-Opener-Policy', 'Cross-Origin-Resource-Policy', 'Expect-CT', 'Feature-Policy', 'Permissions-Policy', 'Referrer-Policy', 'Report-To', 'Strict-Transport-Security', 'X-Content-Type-Options', 'X-Frame-Options', 'X-XSS-Protection']) AS headername
+    UNNEST(['Content-Security-Policy', 'Content-Security-Policy-Report-Only', 'Cross-Origin-Embedder-Policy', 'Cross-Origin-Opener-Policy', 'Cross-Origin-Resource-Policy', 'Expect-CT', 'Feature-Policy', 'Permissions-Policy', 'Referrer-Policy', 'Report-To', 'Strict-Transport-Security', 'X-Content-Type-Options', 'X-Frame-Options', 'X-XSS-Protection']) AS headername
   WHERE
     firstHtml AND
     category IN UNNEST(['Blogs', 'CDN', 'Web frameworks', 'Programming languages', 'CMS', 'Ecommerce', 'PaaS', 'Security'])
@@ -42,7 +42,7 @@ SELECT
   COUNT(DISTINCT IF(REGEXP_CONTAINS(respOtherHeaders, CONCAT('(?i)', headername, ' ')) AND CONCAT(category, '_', app) IN UNNEST(array_slice(top_apps, 0, topN - 1)), url, NULL)) AS freq_in_topN,
   SAFE_DIVIDE(COUNT(DISTINCT IF(REGEXP_CONTAINS(respOtherHeaders, CONCAT('(?i)', headername, ' ')) AND CONCAT(category, '_', app) IN UNNEST(array_slice(top_apps, 0, topN - 1)), url, NULL)), global_freq) AS pct_overall
 FROM
-    app_headers
+  app_headers
 INNER JOIN (
   SELECT
     headername,
@@ -84,7 +84,7 @@ INNER JOIN (
     headername)
 USING
   (client, headername),
-UNNEST(GENERATE_ARRAY(1, 10)) AS topN
+  UNNEST(GENERATE_ARRAY(1, 10))
 GROUP BY
   client,
   topN,

--- a/sql/2020/security/feature_adoption_by_topN_technologies.sql
+++ b/sql/2020/security/feature_adoption_by_topN_technologies.sql
@@ -6,8 +6,7 @@ RETURNS ARRAY<STRING> AS (
   ARRAY(
     SELECT part
     FROM UNNEST(arr) part
-    -- SQL Linter can't handle WITH OFFSET syntax so escape it
-    WITH OFFSET index  -- noqa: PRS
+    WITH OFFSET AS index
     WHERE index BETWEEN start AND finish
     ORDER BY index
   )

--- a/sql/2020/security/iframe_attributes_usage.sql
+++ b/sql/2020/security/iframe_attributes_usage.sql
@@ -27,7 +27,7 @@ FROM (
       JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.iframe-allow-sandbox") AS iframeAttrs
     FROM
       `httparchive.pages.2020_08_01_*`)
-    LEFT JOIN UNNEST(iframeAttrs) AS iframeAttr
+  LEFT JOIN UNNEST(iframeAttrs) AS iframeAttr
   )
 GROUP BY
   client

--- a/sql/2020/seo/lighthouse.sql
+++ b/sql/2020/seo/lighthouse.sql
@@ -11,10 +11,10 @@ CREATE TEMP FUNCTION AS_PERCENT (freq FLOAT64, total FLOAT64) RETURNS FLOAT64 AS
 CREATE TEMPORARY FUNCTION isCrawlableDetails(report STRING) -- noqa: PRS
 -- SQL Linter cannot handle DETERMINISTIC keyword so needs noqa ignore command on previous line
 RETURNS STRUCT<
-disallow BOOL,
-noindex BOOL,
-both BOOL,
-neither BOOL
+  disallow BOOL,
+  noindex BOOL,
+  both BOOL,
+  neither BOOL
 >
 DETERMINISTIC
 LANGUAGE js
@@ -31,49 +31,49 @@ return result;
 ''';
 
 SELECT
-    COUNT(0) AS total,
+  COUNT(0) AS total,
 
-    COUNTIF(is_canonical) AS is_canonical,
-    AS_PERCENT(COUNTIF(is_canonical), COUNT(0)) AS pct_is_canonical,
+  COUNTIF(is_canonical) AS is_canonical,
+  AS_PERCENT(COUNTIF(is_canonical), COUNT(0)) AS pct_is_canonical,
 
-    COUNTIF(has_title) AS has_title,
-    AS_PERCENT(COUNTIF(has_title), COUNT(0)) AS pct_has_title,
+  COUNTIF(has_title) AS has_title,
+  AS_PERCENT(COUNTIF(has_title), COUNT(0)) AS pct_has_title,
 
-    COUNTIF(has_meta_description) AS has_meta_description,
-    AS_PERCENT(COUNTIF(has_meta_description), COUNT(0)) AS pct_has_meta_description,
+  COUNTIF(has_meta_description) AS has_meta_description,
+  AS_PERCENT(COUNTIF(has_meta_description), COUNT(0)) AS pct_has_meta_description,
 
-    COUNTIF(has_title AND has_meta_description) AS has_title_and_meta_description,
-    AS_PERCENT(COUNTIF(has_title AND has_meta_description), COUNT(0)) AS pct_has_title_and_meta_description,
+  COUNTIF(has_title AND has_meta_description) AS has_title_and_meta_description,
+  AS_PERCENT(COUNTIF(has_title AND has_meta_description), COUNT(0)) AS pct_has_title_and_meta_description,
 
-    COUNTIF(img_alt_on_all) AS img_alt_on_all,
-    AS_PERCENT(COUNTIF(img_alt_on_all), COUNT(0)) AS pct_img_alt_on_all,
+  COUNTIF(img_alt_on_all) AS img_alt_on_all,
+  AS_PERCENT(COUNTIF(img_alt_on_all), COUNT(0)) AS pct_img_alt_on_all,
 
-    COUNTIF(link_text_descriptive) AS link_text_descriptive,
-    AS_PERCENT(COUNTIF(link_text_descriptive), COUNT(0)) AS pct_link_text_descriptive,
+  COUNTIF(link_text_descriptive) AS link_text_descriptive,
+  AS_PERCENT(COUNTIF(link_text_descriptive), COUNT(0)) AS pct_link_text_descriptive,
 
-    COUNTIF(robots_txt_valid) AS robots_txt_valid,
-    AS_PERCENT(COUNTIF(robots_txt_valid), COUNT(0)) AS pct_robots_txt_valid,
+  COUNTIF(robots_txt_valid) AS robots_txt_valid,
+  AS_PERCENT(COUNTIF(robots_txt_valid), COUNT(0)) AS pct_robots_txt_valid,
 
-    COUNTIF(is_crawlable) AS is_crawlable,
-    AS_PERCENT(COUNTIF(is_crawlable), COUNT(0)) AS pct_is_crawlable,
+  COUNTIF(is_crawlable) AS is_crawlable,
+  AS_PERCENT(COUNTIF(is_crawlable), COUNT(0)) AS pct_is_crawlable,
 
-    COUNTIF(is_crawlable_details.noindex) AS noindex,
-    AS_PERCENT(COUNTIF(is_crawlable_details.noindex), COUNT(0)) AS pct_noindex,
+  COUNTIF(is_crawlable_details.noindex) AS noindex,
+  AS_PERCENT(COUNTIF(is_crawlable_details.noindex), COUNT(0)) AS pct_noindex,
 
-    COUNTIF(is_crawlable_details.disallow) AS disallow,
-    AS_PERCENT(COUNTIF(is_crawlable_details.disallow), COUNT(0)) AS pct_disallow,
+  COUNTIF(is_crawlable_details.disallow) AS disallow,
+  AS_PERCENT(COUNTIF(is_crawlable_details.disallow), COUNT(0)) AS pct_disallow,
 
-    COUNTIF(is_crawlable_details.disallow AND is_crawlable_details.noindex) AS disallow_noindex,
-    AS_PERCENT(COUNTIF(is_crawlable_details.disallow AND is_crawlable_details.noindex), COUNT(0)) AS pct_disallow_noindex,
+  COUNTIF(is_crawlable_details.disallow AND is_crawlable_details.noindex) AS disallow_noindex,
+  AS_PERCENT(COUNTIF(is_crawlable_details.disallow AND is_crawlable_details.noindex), COUNT(0)) AS pct_disallow_noindex,
 
-    COUNTIF(NOT(is_crawlable_details.disallow) AND NOT(is_crawlable_details.noindex)) AS allow_index,
-    AS_PERCENT(COUNTIF(NOT(is_crawlable_details.disallow) AND NOT(is_crawlable_details.noindex)), COUNT(0)) AS pct_allow_index,
+  COUNTIF(NOT(is_crawlable_details.disallow) AND NOT(is_crawlable_details.noindex)) AS allow_index,
+  AS_PERCENT(COUNTIF(NOT(is_crawlable_details.disallow) AND NOT(is_crawlable_details.noindex)), COUNT(0)) AS pct_allow_index,
 
-    COUNTIF(is_crawlable_details.disallow AND NOT(is_crawlable_details.noindex)) AS disallow_index,
-    AS_PERCENT(COUNTIF(is_crawlable_details.disallow AND NOT(is_crawlable_details.noindex)), COUNT(0)) AS pct_disallow_index,
+  COUNTIF(is_crawlable_details.disallow AND NOT(is_crawlable_details.noindex)) AS disallow_index,
+  AS_PERCENT(COUNTIF(is_crawlable_details.disallow AND NOT(is_crawlable_details.noindex)), COUNT(0)) AS pct_disallow_index,
 
-    COUNTIF(NOT(is_crawlable_details.disallow) AND is_crawlable_details.noindex) AS allow_noindex,
-    AS_PERCENT(COUNTIF(NOT(is_crawlable_details.disallow) AND is_crawlable_details.noindex), COUNT(0)) AS pct_allow_noindex
+  COUNTIF(NOT(is_crawlable_details.disallow) AND is_crawlable_details.noindex) AS allow_noindex,
+  AS_PERCENT(COUNTIF(NOT(is_crawlable_details.disallow) AND is_crawlable_details.noindex), COUNT(0)) AS pct_allow_noindex
 FROM (
   SELECT
     JSON_EXTRACT_SCALAR(report, '$.audits.is-crawlable.score') = '1' AS is_crawlable,

--- a/sql/2020/seo/pages_almanac_by_device_and_alternate_media.sql
+++ b/sql/2020/seo/pages_almanac_by_device_and_alternate_media.sql
@@ -7,8 +7,7 @@ CREATE TEMP FUNCTION AS_PERCENT (freq FLOAT64, total FLOAT64) RETURNS FLOAT64 AS
 
 # returns all the data we need from _almanac
 CREATE TEMPORARY FUNCTION get_almanac_info(almanac_string STRING)
-RETURNS
- ARRAY<STRING>
+RETURNS ARRAY<STRING>
 LANGUAGE js AS '''
 var result = [];
 try {
@@ -34,24 +33,24 @@ SELECT
   COUNT(0) AS count,
   AS_PERCENT(COUNT(0), total) AS pct
 FROM
-(
-  SELECT
-    _TABLE_SUFFIX AS client,
-    total,
-    get_almanac_info(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS almanac_info
-  FROM
-    `httparchive.pages.2020_08_01_*`
-  JOIN
   (
-    # to get an accurate total of pages per device. also seems fast
-    SELECT _TABLE_SUFFIX, COUNT(0) AS total
+    SELECT
+      _TABLE_SUFFIX AS client,
+      total,
+      get_almanac_info(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS almanac_info
     FROM
-    `httparchive.pages.2020_08_01_*`
-    GROUP BY _TABLE_SUFFIX
-  )
-  USING (_TABLE_SUFFIX)
-),
-UNNEST(almanac_info) AS media
+      `httparchive.pages.2020_08_01_*`
+    JOIN
+      (
+        # to get an accurate total of pages per device. also seems fast
+        SELECT _TABLE_SUFFIX, COUNT(0) AS total
+        FROM
+          `httparchive.pages.2020_08_01_*`
+        GROUP BY _TABLE_SUFFIX
+      )
+    USING (_TABLE_SUFFIX)
+  ),
+  UNNEST(almanac_info) AS media
 GROUP BY total, media, client
 ORDER BY count DESC
 LIMIT 1000

--- a/sql/2020/seo/pages_almanac_by_device_and_content_language.sql
+++ b/sql/2020/seo/pages_almanac_by_device_and_content_language.sql
@@ -7,8 +7,7 @@ CREATE TEMP FUNCTION AS_PERCENT (freq FLOAT64, total FLOAT64) RETURNS FLOAT64 AS
 
 # returns all the data we need from _almanac
 CREATE TEMPORARY FUNCTION get_almanac_info(almanac_string STRING)
-RETURNS
- ARRAY<STRING>
+RETURNS ARRAY<STRING>
 LANGUAGE js AS '''
 var result = [];
 try {
@@ -34,25 +33,24 @@ SELECT
   COUNT(0) AS count,
   AS_PERCENT(COUNT(0), total) AS pct
 FROM
-(
-  SELECT
-    _TABLE_SUFFIX AS client,
-    total,
-    get_almanac_info(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS almanac_info
-  FROM
-    `httparchive.pages.2020_08_01_*`
-  JOIN
   (
-    # to get an accurate total of pages per device. also seems fast
-    SELECT _TABLE_SUFFIX, COUNT(0) AS total
+    SELECT
+      _TABLE_SUFFIX AS client,
+      total,
+      get_almanac_info(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS almanac_info
     FROM
-    `httparchive.pages.2020_08_01_*`
+      `httparchive.pages.2020_08_01_*`
+    JOIN
+      (
+        # to get an accurate total of pages per device. also seems fast
+        SELECT _TABLE_SUFFIX, COUNT(0) AS total
+        FROM
+          `httparchive.pages.2020_08_01_*`
 
-    GROUP BY _TABLE_SUFFIX
+        GROUP BY _TABLE_SUFFIX
+      )
+    USING (_TABLE_SUFFIX)
   )
-  USING (_TABLE_SUFFIX)
-),
-UNNEST(almanac_info) AS content_language
 GROUP BY total, content_language, client
 ORDER BY count DESC
 LIMIT 1000

--- a/sql/2020/seo/pages_almanac_by_device_and_meta_tag_name.sql
+++ b/sql/2020/seo/pages_almanac_by_device_and_meta_tag_name.sql
@@ -7,8 +7,7 @@ CREATE TEMP FUNCTION AS_PERCENT (freq FLOAT64, total FLOAT64) RETURNS FLOAT64 AS
 
 # returns all the data we need from _almanac
 CREATE TEMPORARY FUNCTION get_almanac_info(almanac_string STRING)
-RETURNS
- ARRAY<STRING>
+RETURNS ARRAY<STRING>
 LANGUAGE js AS '''
 var result = [];
 try {
@@ -34,24 +33,24 @@ SELECT
   COUNT(0) AS count,
   AS_PERCENT(COUNT(0), total) AS pct
 FROM
-(
-  SELECT
-    _TABLE_SUFFIX AS client,
-    total,
-    get_almanac_info(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS almanac_info
-  FROM
-    `httparchive.pages.2020_08_01_*`
-  JOIN
   (
-    # to get an accurate total of pages per device. also seems fast
-    SELECT _TABLE_SUFFIX, COUNT(0) AS total
+    SELECT
+      _TABLE_SUFFIX AS client,
+      total,
+      get_almanac_info(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS almanac_info
     FROM
-    `httparchive.pages.2020_08_01_*`
-    GROUP BY _TABLE_SUFFIX
-  )
-  USING (_TABLE_SUFFIX)
-),
-UNNEST(almanac_info) AS meta_tag_name
+      `httparchive.pages.2020_08_01_*`
+    JOIN
+      (
+        # to get an accurate total of pages per device. also seems fast
+        SELECT _TABLE_SUFFIX, COUNT(0) AS total
+        FROM
+          `httparchive.pages.2020_08_01_*`
+        GROUP BY _TABLE_SUFFIX
+      )
+    USING (_TABLE_SUFFIX)
+  ),
+  UNNEST(almanac_info)
 GROUP BY
   total,
   meta_tag_name,

--- a/sql/2020/seo/pages_almanac_by_device_and_meta_tag_property.sql
+++ b/sql/2020/seo/pages_almanac_by_device_and_meta_tag_property.sql
@@ -7,8 +7,7 @@ CREATE TEMP FUNCTION AS_PERCENT (freq FLOAT64, total FLOAT64) RETURNS FLOAT64 AS
 
 # returns all the data we need from _almanac
 CREATE TEMPORARY FUNCTION get_almanac_info(almanac_string STRING)
-RETURNS
- ARRAY<STRING>
+RETURNS ARRAY<STRING>
 LANGUAGE js AS '''
 var result = [];
 try {
@@ -34,24 +33,24 @@ SELECT
   COUNT(0) AS count,
   AS_PERCENT(COUNT(0), total) AS pct
 FROM
-(
-  SELECT
-    _TABLE_SUFFIX AS client,
-    total,
-    get_almanac_info(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS almanac_info
-  FROM
-    `httparchive.pages.2020_08_01_*`
-  JOIN
   (
-    # to get an accurate total of pages per device. also seems fast
-    SELECT _TABLE_SUFFIX, COUNT(0) AS total
+    SELECT
+      _TABLE_SUFFIX AS client,
+      total,
+      get_almanac_info(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS almanac_info
     FROM
-    `httparchive.pages.2020_08_01_*`
-    GROUP BY _TABLE_SUFFIX
-  )
-  USING (_TABLE_SUFFIX)
-),
-UNNEST(almanac_info) AS meta_tag_property
+      `httparchive.pages.2020_08_01_*`
+    JOIN
+      (
+        # to get an accurate total of pages per device. also seems fast
+        SELECT _TABLE_SUFFIX, COUNT(0) AS total
+        FROM
+          `httparchive.pages.2020_08_01_*`
+        GROUP BY _TABLE_SUFFIX
+      )
+    USING (_TABLE_SUFFIX)
+  ),
+  UNNEST(almanac_info)
 GROUP BY
   total,
   meta_tag_property,

--- a/sql/2020/seo/pages_almanac_video_by_device.sql
+++ b/sql/2020/seo/pages_almanac_video_by_device.sql
@@ -9,7 +9,7 @@ CREATE TEMP FUNCTION AS_PERCENT (freq FLOAT64, total FLOAT64) RETURNS FLOAT64 AS
 # returns all the data we need from _almanac
 CREATE TEMPORARY FUNCTION get_almanac_info(almanac_string STRING)
 RETURNS STRUCT<
-    videos_total INT64
+  videos_total INT64
 > LANGUAGE js AS '''
 var result = {
   videos_total: 0
@@ -35,12 +35,12 @@ SELECT
   AS_PERCENT(COUNTIF(almanac_info.videos_total > 0), COUNT(0)) AS pct_has_videos
 
 FROM
-    (
-      SELECT
-        _TABLE_SUFFIX AS client,
-        get_almanac_info(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS almanac_info
-      FROM
-        `httparchive.pages.2020_08_01_*`
-    )
+  (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      get_almanac_info(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS almanac_info
+    FROM
+      `httparchive.pages.2020_08_01_*`
+  )
 GROUP BY
   client

--- a/sql/2020/seo/pages_almanac_video_by_device_and_percentile.sql
+++ b/sql/2020/seo/pages_almanac_video_by_device_and_percentile.sql
@@ -4,7 +4,7 @@
 # returns all the data we need from _almanac
 CREATE TEMPORARY FUNCTION get_almanac_info(almanac_string STRING)
 RETURNS STRUCT<
-    videos_total INT64
+  videos_total INT64
 > LANGUAGE js AS '''
 var result = {
   videos_total: 0
@@ -36,8 +36,8 @@ FROM (
     url,
     get_almanac_info(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS almanac_info
   FROM
-  `httparchive.pages.2020_08_01_*`,
-  UNNEST([10, 25, 50, 75, 90]) AS percentile
+    `httparchive.pages.2020_08_01_*`,
+    UNNEST([10, 25, 50, 75, 90])
 )
 WHERE almanac_info.videos_total > 0
 GROUP BY

--- a/sql/2020/seo/pages_markup_by_device.sql
+++ b/sql/2020/seo/pages_markup_by_device.sql
@@ -82,13 +82,13 @@ SELECT
   # Pages with rel=amphtml
   AS_PERCENT(COUNTIF(markup_info.has_rel_amphtml_tag), COUNT(0)) AS pct_has_rel_amphtml_tag
 
-  FROM
-    (
-      SELECT
-        _TABLE_SUFFIX AS client,
-        get_markup_info(JSON_EXTRACT_SCALAR(payload, '$._markup')) AS markup_info
-      FROM
-        `httparchive.pages.2020_08_01_*`
-    )
+FROM
+  (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      get_markup_info(JSON_EXTRACT_SCALAR(payload, '$._markup')) AS markup_info
+    FROM
+      `httparchive.pages.2020_08_01_*`
+  )
 GROUP BY
   client

--- a/sql/2020/seo/pages_markup_by_device_and_iframe_loading.sql
+++ b/sql/2020/seo/pages_markup_by_device_and_iframe_loading.sql
@@ -46,23 +46,23 @@ SELECT
   SUM(COUNT(0)) OVER (PARTITION BY client) AS device_count,
   AS_PERCENT(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY client)) AS pct
 FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    total,
+    get_markup_info(JSON_EXTRACT_SCALAR(payload, '$._markup')) AS markup_info
+  FROM
+    `httparchive.pages.2020_08_01_*`
+  JOIN (
       SELECT
-        _TABLE_SUFFIX AS client,
-        total,
-        get_markup_info(JSON_EXTRACT_SCALAR(payload, '$._markup')) AS markup_info
+        _TABLE_SUFFIX,
+        COUNT(0) AS total
       FROM
         `httparchive.pages.2020_08_01_*`
-      JOIN (
-        SELECT
-          _TABLE_SUFFIX,
-          COUNT(0) AS total
-        FROM
-          `httparchive.pages.2020_08_01_*`
-        GROUP BY
-           _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
-      USING
-        (_TABLE_SUFFIX)
-    ),
-UNNEST(markup_info.loading) AS loading
+      GROUP BY
+        _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
+  USING
+    (_TABLE_SUFFIX)
+),
+UNNEST(markup_info.loading)
 GROUP BY
   total, loading, client

--- a/sql/2020/seo/pages_markup_by_device_and_img_loading.sql
+++ b/sql/2020/seo/pages_markup_by_device_and_img_loading.sql
@@ -39,11 +39,11 @@ return result;
 ''';
 
 SELECT
-client,
-loading,
-total,
-COUNT(0) AS count,
-AS_PERCENT(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY client)) AS pct
+  client,
+  loading,
+  total,
+  COUNT(0) AS count,
+  AS_PERCENT(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY client)) AS pct
 FROM
   (
     SELECT
@@ -53,12 +53,12 @@ FROM
     FROM
       `httparchive.pages.2020_08_01_*`
     JOIN
-    (
-      SELECT _TABLE_SUFFIX, COUNT(0) AS total
-      FROM
-      `httparchive.pages.2020_08_01_*`
-      GROUP BY _TABLE_SUFFIX
-    ) # to get an accurate total of pages per device. also seems fast
+      (
+        SELECT _TABLE_SUFFIX, COUNT(0) AS total
+        FROM
+          `httparchive.pages.2020_08_01_*`
+        GROUP BY _TABLE_SUFFIX
+      ) # to get an accurate total of pages per device. also seems fast
     USING (_TABLE_SUFFIX)
   ),
   UNNEST(markup_info.loading) AS loading

--- a/sql/2020/seo/pages_markup_by_device_and_percentile.sql
+++ b/sql/2020/seo/pages_markup_by_device_and_percentile.sql
@@ -70,8 +70,8 @@ FROM (
     url,
     get_markup_info(JSON_EXTRACT_SCALAR(payload, '$._markup')) AS markup_info
   FROM
-  `httparchive.pages.2020_08_01_*`,
-  UNNEST([10, 25, 50, 75, 90]) AS percentile
+    `httparchive.pages.2020_08_01_*`,
+    UNNEST([10, 25, 50, 75, 90])
 )
 GROUP BY
   percentile,

--- a/sql/2020/seo/pages_robots_txt_by_device_and_status.sql
+++ b/sql/2020/seo/pages_robots_txt_by_device_and_status.sql
@@ -33,14 +33,14 @@ SELECT
 
   AS_PERCENT(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY client)) AS pct
 
-  FROM
-    (
-      SELECT
-        _TABLE_SUFFIX AS client,
-        get_robots_txt_info(JSON_EXTRACT_SCALAR(payload, '$._robots_txt')) AS robots_txt_info
-      FROM
-        `httparchive.pages.2020_08_01_*`
-    )
+FROM
+  (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      get_robots_txt_info(JSON_EXTRACT_SCALAR(payload, '$._robots_txt')) AS robots_txt_info
+    FROM
+      `httparchive.pages.2020_08_01_*`
+  )
 GROUP BY
   client,
   status_code

--- a/sql/2020/seo/pages_robots_txt_by_device_and_useragent.sql
+++ b/sql/2020/seo/pages_robots_txt_by_device_and_useragent.sql
@@ -36,24 +36,24 @@ SELECT
   COUNT(0) AS count,
   AS_PERCENT(COUNT(0), total) AS pct
 FROM
-(
-  SELECT
-    _TABLE_SUFFIX AS client,
-    total,
-    get_robots_txt_info(JSON_EXTRACT_SCALAR(payload, '$._robots_txt')) AS robots_txt_info
-  FROM
-    `httparchive.pages.2020_08_01_*`
-  JOIN
   (
-    # to get an accurate total of pages per device. also seems fast
-    SELECT _TABLE_SUFFIX, COUNT(0) AS total
+    SELECT
+      _TABLE_SUFFIX AS client,
+      total,
+      get_robots_txt_info(JSON_EXTRACT_SCALAR(payload, '$._robots_txt')) AS robots_txt_info
     FROM
-    `httparchive.pages.2020_08_01_*`
-    GROUP BY _TABLE_SUFFIX
-  )
-  USING (_TABLE_SUFFIX)
-),
-UNNEST(robots_txt_info.user_agents) AS user_agent
+      `httparchive.pages.2020_08_01_*`
+    JOIN
+      (
+        # to get an accurate total of pages per device. also seems fast
+        SELECT _TABLE_SUFFIX, COUNT(0) AS total
+        FROM
+          `httparchive.pages.2020_08_01_*`
+        GROUP BY _TABLE_SUFFIX
+      )
+    USING (_TABLE_SUFFIX)
+  ),
+  UNNEST(robots_txt_info.user_agents)
 GROUP BY total, user_agent, client
 HAVING count >= 100
 ORDER BY count DESC

--- a/sql/2020/seo/pages_wpt_bodies_by_device.sql
+++ b/sql/2020/seo/pages_wpt_bodies_by_device.sql
@@ -478,12 +478,12 @@ SELECT
   AS_PERCENT(COUNTIF(wpt_bodies_info.rendered_googlebot_news_nocache), COUNT(0)) AS pct_rendered_googlebot_news_nocache
 
 FROM (
-      SELECT
-        _TABLE_SUFFIX AS client,
-        SPLIT(url, ":")[OFFSET(0)] AS protocol,
-        get_wpt_bodies_info(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
-      FROM
-        `httparchive.pages.2020_08_01_*`
-    )
+  SELECT
+    _TABLE_SUFFIX AS client,
+    SPLIT(url, ":")[OFFSET(0)] AS protocol,
+    get_wpt_bodies_info(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
+  FROM
+    `httparchive.pages.2020_08_01_*`
+)
 GROUP BY
   client

--- a/sql/2020/seo/pages_wpt_bodies_by_device_and_number_rel_attribute.sql
+++ b/sql/2020/seo/pages_wpt_bodies_by_device_and_number_rel_attribute.sql
@@ -10,7 +10,7 @@ CREATE TEMP FUNCTION AS_PERCENT (freq FLOAT64, total FLOAT64) RETURNS FLOAT64 AS
 # returns all the data we need from _wpt_bodies
 CREATE TEMPORARY FUNCTION get_wpt_bodies_info(wpt_bodies_string STRING)
 RETURNS STRUCT<
-    rel ARRAY<STRING>
+  rel ARRAY<STRING>
 > LANGUAGE js AS '''
 var result = {};
 
@@ -40,29 +40,29 @@ return result;
 ''';
 
 SELECT
-client,
-rel,
-total,
-COUNT(0) AS count,
-AS_PERCENT(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY client)) AS pct
+  client,
+  rel,
+  total,
+  COUNT(0) AS count,
+  AS_PERCENT(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY client)) AS pct
 FROM
-(
+  (
     SELECT
-        _TABLE_SUFFIX AS client,
-        total,
-        get_wpt_bodies_info(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
+      _TABLE_SUFFIX AS client,
+      total,
+      get_wpt_bodies_info(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
     FROM
-        `httparchive.pages.2020_08_01_*`
+      `httparchive.pages.2020_08_01_*`
     JOIN
-    (
+      (
         # to get an accurate total of pages per device. also seems fast
         SELECT _TABLE_SUFFIX, COUNT(0) AS total
         FROM
-        `httparchive.pages.2020_08_01_*`
+          `httparchive.pages.2020_08_01_*`
         GROUP BY _TABLE_SUFFIX
-    )
+      )
     USING (_TABLE_SUFFIX)
-),
-UNNEST(wpt_bodies_info.rel) AS rel
+  ),
+  UNNEST(wpt_bodies_info.rel)
 GROUP BY total, rel, client
 ORDER BY count DESC

--- a/sql/2020/seo/pages_wpt_bodies_by_device_and_percentile.sql
+++ b/sql/2020/seo/pages_wpt_bodies_by_device_and_percentile.sql
@@ -111,8 +111,8 @@ FROM (
     url,
     get_wpt_bodies_info(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
   FROM
-  `httparchive.pages.2020_08_01_*`,
-  UNNEST([10, 25, 50, 75, 90]) AS percentile
+    `httparchive.pages.2020_08_01_*`,
+    UNNEST([10, 25, 50, 75, 90])
 )
 GROUP BY
   percentile,

--- a/sql/2020/seo/pages_wpt_bodies_by_device_and_same_site_link_count.sql
+++ b/sql/2020/seo/pages_wpt_bodies_by_device_and_same_site_link_count.sql
@@ -10,10 +10,10 @@ CREATE TEMP FUNCTION AS_PERCENT (freq FLOAT64, total FLOAT64) RETURNS FLOAT64 AS
 # returns all the data we need from _wpt_bodies
 CREATE TEMPORARY FUNCTION get_wpt_bodies_info(wpt_bodies_string STRING)
 RETURNS STRUCT<
-links_same_site INT64,
-links_window_location INT64,
-links_window_open INT64,
-links_href_javascript INT64
+  links_same_site INT64,
+  links_window_location INT64,
+  links_window_open INT64,
+  links_href_javascript INT64
 
 > LANGUAGE js AS '''
 var result = {};

--- a/sql/2020/seo/pages_wpt_bodies_hreflang_by_device_and_http_header_value.sql
+++ b/sql/2020/seo/pages_wpt_bodies_hreflang_by_device_and_http_header_value.sql
@@ -9,7 +9,7 @@ CREATE TEMP FUNCTION AS_PERCENT (freq FLOAT64, total FLOAT64) RETURNS FLOAT64 AS
 # returns all the data we need from _wpt_bodies
 CREATE TEMPORARY FUNCTION get_wpt_bodies_info(wpt_bodies_string STRING)
 RETURNS STRUCT<
-    hreflangs ARRAY<STRING>
+  hreflangs ARRAY<STRING>
 > LANGUAGE js AS '''
 var result = {
   hreflangs: []
@@ -29,32 +29,32 @@ return result;
 ''';
 
 SELECT
-client,
-NORMALIZE_AND_CASEFOLD(hreflang) AS hreflang,
-total,
-COUNT(0) AS count,
-AS_PERCENT(COUNT(0), total) AS pct
+  client,
+  NORMALIZE_AND_CASEFOLD(hreflang) AS hreflang,
+  total,
+  COUNT(0) AS count,
+  AS_PERCENT(COUNT(0), total) AS pct
 
 FROM
-    (
-      SELECT
-        _TABLE_SUFFIX AS client,
-        total,
-        get_wpt_bodies_info(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
-      FROM
-  `httparchive.pages.2020_08_01_*`
-        JOIN
-  (SELECT _TABLE_SUFFIX, COUNT(0) AS total
-  FROM
+  (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      total,
+      get_wpt_bodies_info(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
+    FROM
+      `httparchive.pages.2020_08_01_*`
+    JOIN
+      (SELECT _TABLE_SUFFIX, COUNT(0) AS total
+                                   FROM
 
-  `httparchive.pages.2020_08_01_*`
-  GROUP BY _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
-USING (_TABLE_SUFFIX)
-    ), UNNEST(wpt_bodies_info.hreflangs) AS hreflang
+        `httparchive.pages.2020_08_01_*`
+        GROUP BY _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
+    USING (_TABLE_SUFFIX)
+  ), UNNEST(wpt_bodies_info.hreflangs) AS hreflang
 GROUP BY
-total,
-hreflang,
-client
+  total,
+  hreflang,
+  client
 ORDER BY
-count DESC,
-client DESC
+  count DESC,
+  client DESC

--- a/sql/2020/seo/pages_wpt_bodies_hreflang_by_device_and_link_tag_value.sql
+++ b/sql/2020/seo/pages_wpt_bodies_hreflang_by_device_and_link_tag_value.sql
@@ -9,7 +9,7 @@ CREATE TEMP FUNCTION AS_PERCENT (freq FLOAT64, total FLOAT64) RETURNS FLOAT64 AS
 # returns all the data we need from _wpt_bodies
 CREATE TEMPORARY FUNCTION get_wpt_bodies_info(wpt_bodies_string STRING)
 RETURNS STRUCT<
-    hreflangs ARRAY<STRING>
+  hreflangs ARRAY<STRING>
 > LANGUAGE js AS '''
 var result = {
 hreflangs: []
@@ -29,31 +29,31 @@ return result;
 ''';
 
 SELECT
-client,
-NORMALIZE_AND_CASEFOLD(hreflang) AS hreflang,
-total,
-COUNT(0) AS count,
-AS_PERCENT(COUNT(0), total) AS pct
+  client,
+  NORMALIZE_AND_CASEFOLD(hreflang) AS hreflang,
+  total,
+  COUNT(0) AS count,
+  AS_PERCENT(COUNT(0), total) AS pct
 
 FROM
-    (
-      SELECT
-        _TABLE_SUFFIX AS client,
-        total,
-        get_wpt_bodies_info(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
-      FROM
+  (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      total,
+      get_wpt_bodies_info(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
+    FROM
+      `httparchive.pages.2020_08_01_*`
+    JOIN
+      (SELECT _TABLE_SUFFIX, COUNT(0) AS total
+                                   FROM
         `httparchive.pages.2020_08_01_*`
-        JOIN
-  (SELECT _TABLE_SUFFIX, COUNT(0) AS total
-  FROM
-  `httparchive.pages.2020_08_01_*`
-  GROUP BY _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
-USING (_TABLE_SUFFIX)
-    ), UNNEST(wpt_bodies_info.hreflangs) AS hreflang
+        GROUP BY _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
+    USING (_TABLE_SUFFIX)
+  ), UNNEST(wpt_bodies_info.hreflangs) AS hreflang
 GROUP BY
-total,
-hreflang,
-client
+  total,
+  hreflang,
+  client
 ORDER BY
-count DESC,
-client DESC
+  count DESC,
+  client DESC

--- a/sql/2020/seo/pages_wpt_bodies_structured_data_by_device_and_format.sql
+++ b/sql/2020/seo/pages_wpt_bodies_structured_data_by_device_and_format.sql
@@ -9,7 +9,7 @@ CREATE TEMP FUNCTION AS_PERCENT (freq FLOAT64, total FLOAT64) RETURNS FLOAT64 AS
 # returns all the data we need from _wpt_bodies
 CREATE TEMPORARY FUNCTION get_wpt_bodies_info(wpt_bodies_string STRING)
 RETURNS STRUCT<
-    items_by_format ARRAY<STRING>
+  items_by_format ARRAY<STRING>
 > LANGUAGE js AS '''
 var result = {
 items_by_format: []
@@ -41,30 +41,30 @@ return result;
 ''';
 
 SELECT
-client,
-format,
-total,
-COUNT(0) AS count,
-AS_PERCENT(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY client)) AS pct
+  client,
+  format,
+  total,
+  COUNT(0) AS count,
+  AS_PERCENT(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY client)) AS pct
 
 FROM
-    (
-      SELECT
-        _TABLE_SUFFIX AS client,
-        total,
-        get_wpt_bodies_info(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
-      FROM
+  (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      total,
+      get_wpt_bodies_info(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
+    FROM
+      `httparchive.pages.2020_08_01_*`
+    JOIN
+      (SELECT _TABLE_SUFFIX, COUNT(0) AS total
+                                   FROM
         `httparchive.pages.2020_08_01_*`
-        JOIN
-  (SELECT _TABLE_SUFFIX, COUNT(0) AS total
-  FROM
-  `httparchive.pages.2020_08_01_*`
-  GROUP BY _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
-USING (_TABLE_SUFFIX)
-    ), UNNEST(wpt_bodies_info.items_by_format) AS format
+        GROUP BY _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
+    USING (_TABLE_SUFFIX)
+  ), UNNEST(wpt_bodies_info.items_by_format) AS format
 GROUP BY
-total,
-format,
-client
+  total,
+  format,
+  client
 ORDER BY
-count DESC
+  count DESC

--- a/sql/2020/seo/pages_wpt_bodies_structured_data_by_device_and_type.sql
+++ b/sql/2020/seo/pages_wpt_bodies_structured_data_by_device_and_type.sql
@@ -9,7 +9,7 @@ CREATE TEMP FUNCTION AS_PERCENT (freq FLOAT64, total FLOAT64) RETURNS FLOAT64 AS
 # returns all the data we need from _wpt_bodies
 CREATE TEMPORARY FUNCTION get_wpt_bodies_info(wpt_bodies_string STRING)
 RETURNS STRUCT<
-    jsonld_and_microdata_types ARRAY<STRING>
+  jsonld_and_microdata_types ARRAY<STRING>
 > LANGUAGE js AS '''
 var result = {};
 
@@ -29,32 +29,32 @@ return result;
 ''';
 
 SELECT
-client,
-type,
-total,
-COUNT(0) AS count,
-AS_PERCENT(COUNT(0), total) AS pct
+  client,
+  type,
+  total,
+  COUNT(0) AS count,
+  AS_PERCENT(COUNT(0), total) AS pct
 
 FROM
-    (
-      SELECT
-        _TABLE_SUFFIX AS client,
-        total,
-        get_wpt_bodies_info(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
-      FROM
+  (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      total,
+      get_wpt_bodies_info(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
+    FROM
+      `httparchive.pages.2020_08_01_*`
+    JOIN
+      (SELECT _TABLE_SUFFIX, COUNT(0) AS total
+                                   FROM
         `httparchive.pages.2020_08_01_*`
-        JOIN
-  (SELECT _TABLE_SUFFIX, COUNT(0) AS total
-  FROM
-  `httparchive.pages.2020_08_01_*`
-  GROUP BY _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
-USING (_TABLE_SUFFIX)
-    ), UNNEST(wpt_bodies_info.jsonld_and_microdata_types) AS type
+        GROUP BY _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
+    USING (_TABLE_SUFFIX)
+  ), UNNEST(wpt_bodies_info.jsonld_and_microdata_types) AS type
 GROUP BY
-total,
-type,
-client
+  total,
+  type,
+  client
 HAVING
-count > 100
+  count > 100
 ORDER BY
-count DESC
+  count DESC

--- a/sql/2020/seo/summary_requests_by_device_and_http_content_language.sql
+++ b/sql/2020/seo/summary_requests_by_device_and_http_content_language.sql
@@ -11,9 +11,9 @@ SELECT
   COUNT(0) AS freq,
   AS_PERCENT(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX)) AS pct
 FROM
-   `httparchive.summary_requests.2020_08_01_*`
+  `httparchive.summary_requests.2020_08_01_*`
 WHERE
-   firstHtml
+  firstHtml
 GROUP BY
   client,
   resp_content_language

--- a/sql/2020/seo/summary_requests_by_device_and_http_vary.sql
+++ b/sql/2020/seo/summary_requests_by_device_and_http_vary.sql
@@ -11,9 +11,9 @@ SELECT
   COUNT(0) AS freq,
   AS_PERCENT(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX)) AS pct
 FROM
-   `httparchive.summary_requests.2020_08_01_*`
+  `httparchive.summary_requests.2020_08_01_*`
 WHERE
-   firstHtml
+  firstHtml
 GROUP BY
   client,
   resp_vary_user_agent

--- a/sql/2020/third-parties/percent_of_third_party_cache.sql
+++ b/sql/2020/third-parties/percent_of_third_party_cache.sql
@@ -29,16 +29,16 @@ base AS (
     client,
     type,
     IF(
-    (
-      status IN (301, 302, 307, 308, 410) AND
-      NOT REGEXP_CONTAINS(resp_cache_control, r'(?i)private|no-store') AND
-      NOT REGEXP_CONTAINS(reqOtherHeaders, r'Authorization')
-    )
-    OR (
-      status IN (301, 302, 307, 308, 410)
-      OR REGEXP_CONTAINS(resp_cache_control, r'public|max-age|s-maxage')
-      OR REGEXP_CONTAINS(respOtherHeaders, r'Expires')
-    ), 1, 0) AS cached
+      (
+        status IN (301, 302, 307, 308, 410) AND
+        NOT REGEXP_CONTAINS(resp_cache_control, r'(?i)private|no-store') AND
+        NOT REGEXP_CONTAINS(reqOtherHeaders, r'Authorization')
+      )
+      OR (
+        status IN (301, 302, 307, 308, 410)
+        OR REGEXP_CONTAINS(resp_cache_control, r'public|max-age|s-maxage')
+        OR REGEXP_CONTAINS(respOtherHeaders, r'Expires')
+      ), 1, 0) AS cached
   FROM
     requests
   LEFT JOIN

--- a/sql/2020/third-parties/percent_of_third_party_with_security_headers.sql
+++ b/sql/2020/third-parties/percent_of_third_party_with_security_headers.sql
@@ -30,24 +30,24 @@ headers AS (
 ),
 
 base AS (
-    SELECT
-      req_origin,
-      req_category,
-      IF(STRPOS(respOtherHeaders, "strict-transport-security") > 0, 1, 0) AS hsts_header,
-      IF(STRPOS(respOtherHeaders, "x-content-type-options") > 0, 1, 0) AS x_content_type_options_header,
-      IF(STRPOS(respOtherHeaders, "x-frame-options") > 0, 1, 0) AS x_frame_options_header,
-      IF(STRPOS(respOtherHeaders, "x-xss-protection") > 0, 1, 0) AS x_xss_protection_header
-    FROM headers
+  SELECT
+    req_origin,
+    req_category,
+    IF(STRPOS(respOtherHeaders, "strict-transport-security") > 0, 1, 0) AS hsts_header,
+    IF(STRPOS(respOtherHeaders, "x-content-type-options") > 0, 1, 0) AS x_content_type_options_header,
+    IF(STRPOS(respOtherHeaders, "x-frame-options") > 0, 1, 0) AS x_frame_options_header,
+    IF(STRPOS(respOtherHeaders, "x-xss-protection") > 0, 1, 0) AS x_xss_protection_header
+  FROM headers
 )
 
 SELECT
-    req_category,
-    COUNT(0) AS total_requests,
-    SUM(hsts_header) / COUNT(0) AS pct_hsts_header_requests,
-    SUM(x_content_type_options_header) / COUNT(0) AS pct_x_content_type_options_header_requests,
-    SUM(x_frame_options_header) / COUNT(0) AS pct_x_frame_options_header_requests,
-    SUM(x_xss_protection_header) / COUNT(0) AS pct_x_xss_protection_header_requests
+  req_category,
+  COUNT(0) AS total_requests,
+  SUM(hsts_header) / COUNT(0) AS pct_hsts_header_requests,
+  SUM(x_content_type_options_header) / COUNT(0) AS pct_x_content_type_options_header_requests,
+  SUM(x_frame_options_header) / COUNT(0) AS pct_x_frame_options_header_requests,
+  SUM(x_xss_protection_header) / COUNT(0) AS pct_x_xss_protection_header_requests
 FROM
-    base
+  base
 GROUP BY
-    req_category
+  req_category

--- a/sql/2020/third-parties/percent_of_websites_with_third_party.sql
+++ b/sql/2020/third-parties/percent_of_websites_with_third_party.sql
@@ -25,7 +25,7 @@ SELECT
   COUNT(DISTINCT IF(domain IS NOT NULL, page, NULL)) / COUNT(DISTINCT page) AS pct_pages_with_third_party
 FROM
   requests
-  LEFT JOIN third_party
-  ON NET.HOST(requests.host) = NET.HOST(third_party.domain)
+LEFT JOIN third_party
+ON NET.HOST(requests.host) = NET.HOST(third_party.domain)
 GROUP BY
   client

--- a/sql/2020/third-parties/tao_by_third_party.sql
+++ b/sql/2020/third-parties/tao_by_third_party.sql
@@ -58,25 +58,25 @@ headers AS (
 ),
 
 base AS (
-    SELECT
-      client,
-      req_origin,
-      page_origin,
-      timing_allow_origin,
-      req_category,
-      IF(
-          page_origin = req_origin
-          OR timing_allow_origin = "*, "
-          OR STRPOS(timing_allow_origin, CONCAT(page_origin, ", ")) > 0,
+  SELECT
+    client,
+    req_origin,
+    page_origin,
+    timing_allow_origin,
+    req_category,
+    IF(
+      page_origin = req_origin
+      OR timing_allow_origin = "*, "
+      OR STRPOS(timing_allow_origin, CONCAT(page_origin, ", ")) > 0,
       1, 0) AS timing_allowed
-    FROM headers
+  FROM headers
 )
 
 SELECT
-    client,
-    COUNT(0) AS total_requests,
-    SUM(timing_allowed) / COUNT(0) AS pct_timing_allowed_requests
+  client,
+  COUNT(0) AS total_requests,
+  SUM(timing_allowed) / COUNT(0) AS pct_timing_allowed_requests
 FROM
-    base
+  base
 GROUP BY
   client

--- a/sql/util/pwa_candidates.sql
+++ b/sql/util/pwa_candidates.sql
@@ -17,7 +17,13 @@ FROM
   `httparchive.almanac.summary_response_bodies`
 WHERE
   date = '2020-08-01' AND
-  (REGEXP_EXTRACT(body, "navigator\\.serviceWorker\\.register\\s*\\(\\s*[\"']([^\\),\\s\"']+)") IS NOT NULL
-    AND REGEXP_EXTRACT(body, "navigator\\.serviceWorker\\.register\\s*\\(\\s*[\"']([^\\),\\s\"']+)") != "/")
-  OR (REGEXP_EXTRACT(REGEXP_EXTRACT(body, "(<link[^>]+rel=[\"']?manifest[\"']?[^>]+>)"), "href=[\"']?([^\\s\"'>]+)[\"']?") IS NOT NULL
-    AND REGEXP_EXTRACT(REGEXP_EXTRACT(body, "(<link[^>]+rel=[\"']?manifest[\"']?[^>]+>)"), "href=[\"']?([^\\s\"'>]+)[\"']?") != "/")
+  (
+    (
+      REGEXP_EXTRACT(body, "navigator\\.serviceWorker\\.register\\s*\\(\\s*[\"']([^\\),\\s\"']+)") IS NOT NULL AND
+      REGEXP_EXTRACT(body, "navigator\\.serviceWorker\\.register\\s*\\(\\s*[\"']([^\\),\\s\"']+)") != "/"
+    ) OR
+    (
+      REGEXP_EXTRACT(REGEXP_EXTRACT(body, "(<link[^>]+rel=[\"']?manifest[\"']?[^>]+>)"), "href=[\"']?([^\\s\"'>]+)[\"']?") IS NOT NULL AND
+      REGEXP_EXTRACT(REGEXP_EXTRACT(body, "(<link[^>]+rel=[\"']?manifest[\"']?[^>]+>)"), "href=[\"']?([^\\s\"'>]+)[\"']?") != "/"
+    )
+  )

--- a/sql/util/third_parties.sql
+++ b/sql/util/third_parties.sql
@@ -3,4 +3,4 @@ SELECT -- noqa: L044
   DATE('2020-08-01') AS date,
   *
 FROM
- `lighthouse-infrastructure.third_party_web.2020_08_01`
+  `lighthouse-infrastructure.third_party_web.2020_08_01`


### PR DESCRIPTION
The next version of the SQL Linter includes some fixes for us enabling us to turn on some additional rules to enforce indent consistency and forcing AND's to be at ends of the line...etc.

I've applied the changes to our SQL now in preparation but left those rules off until we get that version.