### PR TITLE
Add Search button to Contributors page

### DIFF
--- a/src/templates/base/contributors.html
+++ b/src/templates/base/contributors.html
@@ -98,7 +98,7 @@
   align-items: center;
   border-radius: 15px;
   box-shadow: 0 0 16px 0 rgba(78, 85, 100, 0.2);
-  padding: 24px 34px;
+  padding: 24px 24px;
   width: 230px;
   margin: 10px;
 }
@@ -141,7 +141,6 @@
   color: #757575;
   font-size: 14px;
   font-size: 0.875rem;
-  flex-grow: 1;
 }
 
 .contributor-team {
@@ -149,27 +148,6 @@
   font-size: 0.875rem;
   white-space: nowrap;
 }
-
-.contributor-search-btn {
-  margin-top: 20px;
-  padding: 5px 20px;
-  display: inline-block;
-  align-items: center;
-  border-radius: 29px;
-  text-decoration: none;
-  background-color: transparent;
-  border: 1px solid #757575;
-  cursor: pointer;
-  font-size: 13.6px;
-  font-size: 0.8em;
-}
-
-.contributor-search-btn:hover,
-.contributor-search-btn:focus {
-  background-color: #f7f779;
-  text-decoration: none;
-}
-
 
 {% for id in config.teams.keys() %}
 .contributors.{{ id }} .contributor.{{ id }} {
@@ -217,7 +195,7 @@
     grid-column-start: 1;
     grid-column-end: 1;
     grid-row-start: 1;
-    grid-row-end: 5;
+    grid-row-end: 4;
     width: 80px;
     height: auto;
     margin: 0;
@@ -363,6 +341,11 @@
             </svg>
           </a>
           {% endif %}
+          <a href="/{{ lang }}/search?q={{ contributor.name | urlencode }}" aria-label="{{ self.search_title() }} {{ contributor.name }}">
+            <svg width="22" height="22" role="img">
+              <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#search"></use>
+            </svg>
+          </a>
         </div>
 
         <div class="contributor-teams">
@@ -370,10 +353,6 @@
           <span class="contributor-team team-{{ id }}">{{ localizedTeamNames[id] if localizedTeamNames[id]|length else team.name }}</span>{% if loop.length > 2 %}{{ self.comma() if loop.index < loop.length - 1 }}{{ self.oxford_comma() if loop.index == loop.length - 1 }}{% endif %}
           {% if loop.index == loop.length - 1 %}{{ self.and() }}{% endif %}
           {% endfor %}
-        </div>
-
-        <div class="contributor-search">
-          <a href="/{{ lang }}/search?q={{ contributor.name | urlencode }}" class="contributor-search-btn">{{ self.search_title() }}<span class="visually-hidden"> {{ contributor.name }}</span></a>
         </div>
       </li>
     {% endfor %}

--- a/src/templates/base/contributors.html
+++ b/src/templates/base/contributors.html
@@ -373,7 +373,7 @@
         </div>
 
         <div class="contributor-search">
-          <a href="/{{ lang }}/search?q={{ contributor.name | urlencode }}" class="contributor-search-btn">{{ self.search_title() }}</a>
+          <a href="/{{ lang }}/search?q={{ contributor.name | urlencode }}" class="contributor-search-btn">{{ self.search_title() }}<span class="visually-hidden"> {{ contributor.name }}</span></a>
         </div>
       </li>
     {% endfor %}

--- a/src/templates/base/contributors.html
+++ b/src/templates/base/contributors.html
@@ -153,7 +153,7 @@
 .contributor-search-btn {
   margin-top: 20px;
   padding: 5px 20px;
-  display: flex;
+  display: inline-block;
   align-items: center;
   border-radius: 29px;
   text-decoration: none;
@@ -217,7 +217,7 @@
     grid-column-start: 1;
     grid-column-end: 1;
     grid-row-start: 1;
-    grid-row-end: 4;
+    grid-row-end: 5;
     width: 80px;
     height: auto;
     margin: 0;

--- a/src/templates/base/contributors.html
+++ b/src/templates/base/contributors.html
@@ -141,6 +141,7 @@
   color: #757575;
   font-size: 14px;
   font-size: 0.875rem;
+  flex-grow: 1;
 }
 
 .contributor-team {
@@ -148,6 +149,27 @@
   font-size: 0.875rem;
   white-space: nowrap;
 }
+
+.contributor-search-btn {
+  margin-top: 20px;
+  padding: 5px 20px;
+  display: flex;
+  align-items: center;
+  border-radius: 29px;
+  text-decoration: none;
+  background-color: transparent;
+  border: 1px solid #757575;
+  cursor: pointer;
+  font-size: 13.6px;
+  font-size: 0.8em;
+}
+
+.contributor-search-btn:hover,
+.contributor-search-btn:focus {
+  background-color: #f7f779;
+  text-decoration: none;
+}
+
 
 {% for id in config.teams.keys() %}
 .contributors.{{ id }} .contributor.{{ id }} {
@@ -348,6 +370,10 @@
           <span class="contributor-team team-{{ id }}">{{ localizedTeamNames[id] if localizedTeamNames[id]|length else team.name }}</span>{% if loop.length > 2 %}{{ self.comma() if loop.index < loop.length - 1 }}{{ self.oxford_comma() if loop.index == loop.length - 1 }}{% endif %}
           {% if loop.index == loop.length - 1 %}{{ self.and() }}{% endif %}
           {% endfor %}
+        </div>
+
+        <div class="contributor-search">
+          <a href="/{{ lang }}/search?q={{ contributor.name | urlencode }}" class="contributor-search-btn">{{ self.search_title() }}</a>
         </div>
       </li>
     {% endfor %}


### PR DESCRIPTION
With the addition of Site Search in #2273 I thought it would be nice to use this to allow users to search for what chapters contributors contributed too, by adding a search to the social media section (note this was updated from when the original PR was opened):

![Desktop view](https://user-images.githubusercontent.com/10931297/129532772-f615774d-2165-4cfc-9f6b-3a9187ca8e38.png)

Clicking on this shows all the chapters they'd contributed too:

![Tony McCreath search results](https://user-images.githubusercontent.com/10931297/129340892-50f43d02-45d6-4be6-a82d-d6127a360d7f.png)

I've staged a version here for you to play with: https://20210816t091305-dot-webalmanac.uk.r.appspot.com/en/2020/contributors

@rviscomi it's not to the scale of what you wanted in #1195 but think it's a nice feature along the way.

@HTTPArchive/designers appreciate any design tips or suggestions!