### PR TITLE
Incorrect linting unnest

### DIFF
--- a/sql/2019/cms/14_13.sql
+++ b/sql/2019/cms/14_13.sql
@@ -10,7 +10,7 @@ FROM
 JOIN
   `httparchive.technologies.2019_07_01_*`
 USING (_TABLE_SUFFIX, url),
-  UNNEST([10, 25, 50, 75, 90])
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
 WHERE
   category = 'CMS'
 GROUP BY

--- a/sql/2019/cms/14_13c.sql
+++ b/sql/2019/cms/14_13c.sql
@@ -22,7 +22,7 @@ JOIN
   `httparchive.technologies.2019_07_01_*`
 USING (_TABLE_SUFFIX, url),
   UNNEST(getImageDimensions(payload)) AS image,
-  UNNEST([10, 25, 50, 75, 90])
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
 WHERE
   category = 'CMS'
 GROUP BY

--- a/sql/2019/cms/14_13d.sql
+++ b/sql/2019/cms/14_13d.sql
@@ -12,7 +12,7 @@ FROM
 JOIN
   `httparchive.technologies.2019_07_01_*`
 USING (_TABLE_SUFFIX, url),
-  UNNEST([10, 25, 50, 75, 90])
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
 WHERE
   category = 'CMS'
 GROUP BY

--- a/sql/2019/cms/14_15.sql
+++ b/sql/2019/cms/14_15.sql
@@ -24,7 +24,7 @@ FROM (
   GROUP BY
     client,
     page),
-  UNNEST([10, 25, 50, 75, 90])
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   percentile,
   client

--- a/sql/2019/cms/14_15b.sql
+++ b/sql/2019/cms/14_15b.sql
@@ -28,7 +28,7 @@ FROM (
     client,
     app,
     page),
-  UNNEST([10, 25, 50, 75, 90])
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   client,
   app,

--- a/sql/2019/cms/14_15c.sql
+++ b/sql/2019/cms/14_15c.sql
@@ -31,7 +31,7 @@ FROM (
     client,
     category,
     page),
-  UNNEST([10, 25, 50, 75, 90])
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   percentile,
   client,

--- a/sql/2019/cms/14_15d.sql
+++ b/sql/2019/cms/14_15d.sql
@@ -23,7 +23,7 @@ FROM (
   GROUP BY
     client,
     page),
-  UNNEST([10, 25, 50, 75, 90])
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   percentile,
   client

--- a/sql/2019/cms/14_15e.sql
+++ b/sql/2019/cms/14_15e.sql
@@ -26,7 +26,7 @@ FROM (
     client,
     type,
     page),
-  UNNEST([10, 25, 50, 75, 90])
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   percentile,
   client,

--- a/sql/2019/ecommerce/13_06.sql
+++ b/sql/2019/ecommerce/13_06.sql
@@ -10,7 +10,7 @@ FROM
 JOIN
   `httparchive.technologies.2019_07_01_*`
 USING (_TABLE_SUFFIX, url),
-  UNNEST([10, 25, 50, 75, 90])
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
 WHERE
   category = 'Ecommerce'
 GROUP BY

--- a/sql/2019/ecommerce/13_06c.sql
+++ b/sql/2019/ecommerce/13_06c.sql
@@ -22,7 +22,7 @@ JOIN
   `httparchive.technologies.2019_07_01_*`
 USING (_TABLE_SUFFIX, url),
   UNNEST(getImageDimensions(payload)) AS image,
-  UNNEST([10, 25, 50, 75, 90])
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
 WHERE
   category = 'Ecommerce'
 GROUP BY

--- a/sql/2019/ecommerce/13_09.sql
+++ b/sql/2019/ecommerce/13_09.sql
@@ -24,7 +24,7 @@ FROM (
   GROUP BY
     client,
     page),
-  UNNEST([10, 25, 50, 75, 90])
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   percentile,
   client

--- a/sql/2019/ecommerce/13_09b.sql
+++ b/sql/2019/ecommerce/13_09b.sql
@@ -28,7 +28,7 @@ FROM (
     client,
     app,
     page),
-  UNNEST([10, 25, 50, 75, 90])
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   client,
   app,

--- a/sql/2019/ecommerce/13_09c.sql
+++ b/sql/2019/ecommerce/13_09c.sql
@@ -31,7 +31,7 @@ FROM (
     client,
     category,
     page),
-  UNNEST([10, 25, 50, 75, 90])
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   percentile,
   client,

--- a/sql/2019/ecommerce/13_09d.sql
+++ b/sql/2019/ecommerce/13_09d.sql
@@ -23,7 +23,7 @@ FROM (
   GROUP BY
     client,
     page),
-  UNNEST([10, 25, 50, 75, 90])
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   percentile,
   client

--- a/sql/2019/ecommerce/13_09e.sql
+++ b/sql/2019/ecommerce/13_09e.sql
@@ -26,7 +26,7 @@ FROM (
     client,
     type,
     page),
-  UNNEST([10, 25, 50, 75, 90])
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   percentile,
   client,

--- a/sql/2019/mobile-web/12_12.sql
+++ b/sql/2019/mobile-web/12_12.sql
@@ -23,6 +23,6 @@ SELECT
 FROM
   `httparchive.pages.2019_07_01_mobile`,
   (SELECT COUNT(0) AS total FROM `httparchive.summary_pages.2019_07_01_mobile`),
-  UNNEST(getInputTypes(payload))
+  UNNEST(getInputTypes(payload)) AS input_type
 GROUP BY input_type, total
 ORDER BY occurence DESC

--- a/sql/2019/mobile-web/12_14.sql
+++ b/sql/2019/mobile-web/12_14.sql
@@ -46,7 +46,7 @@ SELECT
   ROUND(COUNT(DISTINCT url) * 100 / total_pages_with_inputs, 2) AS perc_of_pages_using
 FROM
   `httparchive.pages.2019_07_01_mobile`,
-  UNNEST(getInputAttributes(payload)),
+  UNNEST(getInputAttributes(payload)) AS input_attributes,
   (SELECT COUNTIF(hasInputs(payload)) AS total_pages_with_inputs FROM `httparchive.pages.2019_07_01_mobile`)
 GROUP BY input_attributes, total_pages_with_inputs
 ORDER BY perc_of_pages_using DESC

--- a/sql/2020/ecommerce/pagestats_percentile_bydevice_format.sql
+++ b/sql/2020/ecommerce/pagestats_percentile_bydevice_format.sql
@@ -28,7 +28,7 @@ FROM (
     client,
     type,
     page),
-  UNNEST([10, 25, 50, 75, 90])
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   percentile,
   client,

--- a/sql/2020/ecommerce/pagestats_percentiles_bydevice.sql
+++ b/sql/2020/ecommerce/pagestats_percentiles_bydevice.sql
@@ -25,7 +25,7 @@ FROM (
   GROUP BY
     client,
     page),
-  UNNEST([10, 25, 50, 75, 90])
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   percentile,
   client

--- a/sql/2020/ecommerce/pct_3pusage_bydevice.sql
+++ b/sql/2020/ecommerce/pct_3pusage_bydevice.sql
@@ -27,7 +27,7 @@ FROM (
   GROUP BY
     client,
     page),
-  UNNEST([10, 25, 50, 75, 90])
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   percentile,
   client

--- a/sql/2020/ecommerce/pct_3pusage_bydevice_vendor.sql
+++ b/sql/2020/ecommerce/pct_3pusage_bydevice_vendor.sql
@@ -32,7 +32,7 @@ FROM (
     client,
     app,
     page),
-  UNNEST([10, 25, 50, 75, 90])
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   client,
   app,

--- a/sql/2020/ecommerce/pct_3pusage_bydevice_vendor_category.sql
+++ b/sql/2020/ecommerce/pct_3pusage_bydevice_vendor_category.sql
@@ -34,7 +34,7 @@ FROM (
     category,
     page),
 
-  UNNEST([10, 25, 50, 75, 90])
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   percentile,
   client,

--- a/sql/2020/http2/cdn_detail_by_cdn.sql
+++ b/sql/2020/http2/cdn_detail_by_cdn.sql
@@ -30,7 +30,7 @@ FROM (
     page,
     firstHTML,
     CDN),
-  UNNEST([0, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 100])
+  UNNEST([0, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 100]) AS percentile
 GROUP BY
   percentile,
   client,

--- a/sql/2020/http2/cdn_summary.sql
+++ b/sql/2020/http2/cdn_summary.sql
@@ -30,7 +30,7 @@ FROM (
     page,
     firstHTML,
     CDN),
-  UNNEST(GENERATE_ARRAY(1, 100))
+  UNNEST(GENERATE_ARRAY(1, 100)) AS percentile
 GROUP BY
   percentile,
   client,

--- a/sql/2020/http2/http2_1st_party_vs_3rd_party.sql
+++ b/sql/2020/http2/http2_1st_party_vs_3rd_party.sql
@@ -30,7 +30,7 @@ FROM (
     client,
     page,
     is_third_party),
-  UNNEST(GENERATE_ARRAY(1, 100))
+  UNNEST(GENERATE_ARRAY(1, 100)) AS percentile
 GROUP BY
   percentile,
   client,

--- a/sql/2020/http2/http2_1st_party_vs_3rd_party_by_type.sql
+++ b/sql/2020/http2/http2_1st_party_vs_3rd_party_by_type.sql
@@ -31,7 +31,7 @@ FROM (
     page,
     is_third_party,
     type),
-  UNNEST([5, 10, 20, 30, 40, 50, 60, 70, 90, 95, 100])
+  UNNEST([5, 10, 20, 30, 40, 50, 60, 70, 90, 95, 100]) AS percentile
 GROUP BY
   percentile,
   client,

--- a/sql/2020/http2/http2_3rd_party_by_types.sql
+++ b/sql/2020/http2/http2_3rd_party_by_types.sql
@@ -29,7 +29,7 @@ FROM (
     client,
     page,
     category),
-  UNNEST([5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 100])
+  UNNEST([5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 100]) AS percentile
 GROUP BY
   percentile,
   client,

--- a/sql/2020/markup/pages_almanac_by_device_and_percentile.sql
+++ b/sql/2020/markup/pages_almanac_by_device_and_percentile.sql
@@ -53,7 +53,7 @@ FROM (
     get_almanac_info(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS almanac_info
   FROM
     `httparchive.pages.2020_08_01_*`,
-    UNNEST([10, 25, 50, 75, 90])
+    UNNEST([10, 25, 50, 75, 90]) AS percentile
 )
 GROUP BY
   percentile,

--- a/sql/2020/markup/pages_element_count_by_device_and_percentile.sql
+++ b/sql/2020/markup/pages_element_count_by_device_and_percentile.sql
@@ -42,7 +42,7 @@ FROM (
     get_element_count_info(JSON_EXTRACT_SCALAR(payload, '$._element_count')) AS element_count_info
   FROM
     `httparchive.pages.2020_08_01_*`,
-    UNNEST([10, 25, 50, 75, 90])
+    UNNEST([10, 25, 50, 75, 90]) AS percentile
 )
 GROUP BY
   percentile,

--- a/sql/2020/markup/pages_markup_by_device_and_percentile.sql
+++ b/sql/2020/markup/pages_markup_by_device_and_percentile.sql
@@ -132,7 +132,7 @@ FROM (
     get_markup_info(JSON_EXTRACT_SCALAR(payload, '$._markup')) AS markup_info
   FROM
     `httparchive.pages.2020_08_01_*`,
-    UNNEST([10, 25, 50, 75, 90, 95, 96, 97, 98, 99])
+    UNNEST([10, 25, 50, 75, 90, 95, 96, 97, 98, 99]) AS percentile
 )
 GROUP BY
   percentile,

--- a/sql/2020/markup/pages_wpt_bodies_by_device_and_percentile.sql
+++ b/sql/2020/markup/pages_wpt_bodies_by_device_and_percentile.sql
@@ -53,7 +53,7 @@ FROM (
     get_wpt_bodies_info(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
   FROM
     `httparchive.pages.2020_08_01_*`,
-    UNNEST([10, 25, 50, 75, 90])
+    UNNEST([10, 25, 50, 75, 90]) AS percentile
 )
 GROUP BY
   percentile,

--- a/sql/2020/markup/pages_wpt_bodies_by_device_and_percentile_and_heading_level.sql
+++ b/sql/2020/markup/pages_wpt_bodies_by_device_and_percentile_and_heading_level.sql
@@ -39,7 +39,7 @@ FROM (
     url
   FROM
     `httparchive.pages.2020_08_01_*`,
-    UNNEST([10, 25, 50, 75, 90]),
+    UNNEST([10, 25, 50, 75, 90]) AS percentile,
     UNNEST(get_heading_info(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies'))) AS heading_info
 )
 GROUP BY

--- a/sql/2020/markup/pages_wpt_bodies_by_device_and_protocol.sql
+++ b/sql/2020/markup/pages_wpt_bodies_by_device_and_protocol.sql
@@ -39,7 +39,7 @@ JOIN
       `httparchive.pages.2020_08_01_*`
     GROUP BY _TABLE_SUFFIX) # to get an accurate total of pages per device. also seems fast
 USING (_TABLE_SUFFIX),
-  UNNEST(get_wpt_bodies_protocols(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')))
+  UNNEST(get_wpt_bodies_protocols(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies'))) AS protocol
 GROUP BY
   client,
   total,

--- a/sql/2020/security/feature_adoption_by_other_features.sql
+++ b/sql/2020/security/feature_adoption_by_other_features.sql
@@ -23,7 +23,7 @@ SELECT
   SAFE_DIVIDE(COUNTIF(REGEXP_CONTAINS(respOtherHeaders, CONCAT('(?i)', headername, ' ')) AND REGEXP_CONTAINS(respOtherHeaders, '(?i)X-XSS-Protection ')), COUNTIF(REGEXP_CONTAINS(respOtherHeaders, CONCAT('(?i)', headername, ' ')))) AS pct_header_and_xss
 FROM
   `httparchive.summary_requests.2020_08_01_*`,
-  UNNEST(['Content-Security-Policy', 'Content-Security-Policy-Report-Only', 'Cross-Origin-Embedder-Policy', 'Cross-Origin-Opener-Policy', 'Cross-Origin-Resource-Policy', 'Expect-CT', 'Feature-Policy', 'Permissions-Policy', 'Referrer-Policy', 'Report-To', 'Strict-Transport-Security', 'X-Content-Type-Options', 'X-Frame-Options', 'X-XSS-Protection'])
+  UNNEST(['Content-Security-Policy', 'Content-Security-Policy-Report-Only', 'Cross-Origin-Embedder-Policy', 'Cross-Origin-Opener-Policy', 'Cross-Origin-Resource-Policy', 'Expect-CT', 'Feature-Policy', 'Permissions-Policy', 'Referrer-Policy', 'Report-To', 'Strict-Transport-Security', 'X-Content-Type-Options', 'X-Frame-Options', 'X-XSS-Protection']) AS headername
 WHERE
   firstHtml
 GROUP BY

--- a/sql/2020/security/feature_adoption_by_topN_technologies.sql
+++ b/sql/2020/security/feature_adoption_by_topN_technologies.sql
@@ -82,7 +82,7 @@ INNER JOIN (
     headername)
 USING
   (client, headername),
-  UNNEST(GENERATE_ARRAY(1, 10))
+  UNNEST(GENERATE_ARRAY(1, 10)) AS topN
 GROUP BY
   client,
   topN,

--- a/sql/2020/seo/pages_almanac_by_device_and_meta_tag_name.sql
+++ b/sql/2020/seo/pages_almanac_by_device_and_meta_tag_name.sql
@@ -50,7 +50,7 @@ FROM
       )
     USING (_TABLE_SUFFIX)
   ),
-  UNNEST(almanac_info)
+  UNNEST(almanac_info) AS meta_tag_name
 GROUP BY
   total,
   meta_tag_name,

--- a/sql/2020/seo/pages_almanac_by_device_and_meta_tag_property.sql
+++ b/sql/2020/seo/pages_almanac_by_device_and_meta_tag_property.sql
@@ -50,7 +50,7 @@ FROM
       )
     USING (_TABLE_SUFFIX)
   ),
-  UNNEST(almanac_info)
+  UNNEST(almanac_info) AS meta_tag_property
 GROUP BY
   total,
   meta_tag_property,

--- a/sql/2020/seo/pages_almanac_video_by_device_and_percentile.sql
+++ b/sql/2020/seo/pages_almanac_video_by_device_and_percentile.sql
@@ -37,7 +37,7 @@ FROM (
     get_almanac_info(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS almanac_info
   FROM
     `httparchive.pages.2020_08_01_*`,
-    UNNEST([10, 25, 50, 75, 90])
+    UNNEST([10, 25, 50, 75, 90]) AS percentile
 )
 WHERE almanac_info.videos_total > 0
 GROUP BY

--- a/sql/2020/seo/pages_markup_by_device_and_iframe_loading.sql
+++ b/sql/2020/seo/pages_markup_by_device_and_iframe_loading.sql
@@ -63,6 +63,6 @@ FROM (
   USING
     (_TABLE_SUFFIX)
 ),
-UNNEST(markup_info.loading)
+UNNEST(markup_info.loading) AS loading
 GROUP BY
   total, loading, client

--- a/sql/2020/seo/pages_markup_by_device_and_percentile.sql
+++ b/sql/2020/seo/pages_markup_by_device_and_percentile.sql
@@ -71,7 +71,7 @@ FROM (
     get_markup_info(JSON_EXTRACT_SCALAR(payload, '$._markup')) AS markup_info
   FROM
     `httparchive.pages.2020_08_01_*`,
-    UNNEST([10, 25, 50, 75, 90])
+    UNNEST([10, 25, 50, 75, 90]) AS percentile
 )
 GROUP BY
   percentile,

--- a/sql/2020/seo/pages_robots_txt_by_device_and_useragent.sql
+++ b/sql/2020/seo/pages_robots_txt_by_device_and_useragent.sql
@@ -53,7 +53,7 @@ FROM
       )
     USING (_TABLE_SUFFIX)
   ),
-  UNNEST(robots_txt_info.user_agents)
+  UNNEST(robots_txt_info.user_agents) AS user_agent
 GROUP BY total, user_agent, client
 HAVING count >= 100
 ORDER BY count DESC

--- a/sql/2020/seo/pages_wpt_bodies_by_device_and_number_rel_attribute.sql
+++ b/sql/2020/seo/pages_wpt_bodies_by_device_and_number_rel_attribute.sql
@@ -63,6 +63,6 @@ FROM
       )
     USING (_TABLE_SUFFIX)
   ),
-  UNNEST(wpt_bodies_info.rel)
+  UNNEST(wpt_bodies_info.rel) AS rel
 GROUP BY total, rel, client
 ORDER BY count DESC

--- a/sql/2020/seo/pages_wpt_bodies_by_device_and_percentile.sql
+++ b/sql/2020/seo/pages_wpt_bodies_by_device_and_percentile.sql
@@ -112,7 +112,7 @@ FROM (
     get_wpt_bodies_info(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
   FROM
     `httparchive.pages.2020_08_01_*`,
-    UNNEST([10, 25, 50, 75, 90])
+    UNNEST([10, 25, 50, 75, 90]) AS percentile
 )
 GROUP BY
   percentile,


### PR DESCRIPTION
Found [a nasty bug in our SQL linter](https://github.com/sqlfluff/sqlfluff/issues/1302) where the `AS` part of `UNNEST` statements can be removed in error, therefore breaking the SQL:

It only happens when fixing indents at the same time and fix has been submitted](https://github.com/sqlfluff/sqlfluff/pull/1303).

So this:

```sql
SELECT
  client,
  percentile,
  APPROX_QUANTILES(body_size, 1000)[OFFSET(percentile * 10)] AS approx_redirect_body_size
FROM
  base,
UNNEST([10, 25, 50, 75, 90]) AS percentile
```

is "corrected" to this:

```sql
SELECT
  client,
  percentile,
  APPROX_QUANTILES(body_size, 1000)[OFFSET(percentile * 10)] AS approx_redirect_body_size
FROM
  base,
  UNNEST([10, 25, 50, 75, 90])
```

Which isn't valid SQL.

Have gone through and fixed the incorrectly auto-fixed SQL.