### PR TITLE
Upgrade SQLFluff and enable extra rules

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -28,8 +28,8 @@ jobs:
         run: |
           echo "VALIDATE_ALL_CODEBASE=false" >> $GITHUB_ENV
       - name: Lint Code Base
-        uses: github/super-linter@v4.6.1
-        #uses: docker://github/super-linter:v4.6.1
+        uses: github/super-linter@v4.6.2
+        #uses: docker://github/super-linter:v4.6.2
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_website.yml
+++ b/.github/workflows/test_website.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Use more complete checks for generated HTML linting
       run: cp -f .github/linters/.htmlhintrc_morechecks .github/linters/.htmlhintrc
     - name: Lint Generated HTML
-      uses: github/super-linter@v4.6.0
+      uses: github/super-linter@v4.6.2
       env:
         DEFAULT_BRANCH: main
         FILTER_REGEX_INCLUDE: src/static/html/.*

--- a/sql/.sqlfluff
+++ b/sql/.sqlfluff
@@ -4,27 +4,24 @@ nocolor = False
 dialect = bigquery
 templater = jinja
 rules = None
-exclude_rules = L003,L007,L011,L014,L016,L020,L026,L027,L028,L029,L030,L031,L032,L034,L035,L036,L037,L042,L043,L048
-# L003 - We don't agree wiht their UNION alignment. Revisit on next release thanks to https://github.com/sqlfluff/sqlfluff/pull/1257
-# L007 - We like our ANDs at the end. Revisit on next release if https://github.com/sqlfluff/sqlfluff/issues/1261 is resolved
+exclude_rules = L011,L014,L016,L020,L026,L027,L028,L029,L030,L031,L032,L034,L035,L036,L037,L042,L043
 # L011 - We don't always alias tables with AS ("FROM table1 AS tb1" instead of "FROM table1 tb1"). Do for columns but not for tables.
 # L014 - Unquoted identifiers (e.g. column names) will be mixed case so don't enforce case
 # L016 - We allow longer lines as some of our queries are complex. Maybe should limit in future?
 # L020 - Asks for unique table aliases meaning it complains if selecting from two 2021_07_01 tables as implicit alias is table name (not fully qualified) so same.
-# L026 - BigQuery uses arrays and functions which looks like incorrect references
+# L026 - BigQuery uses STRUCTS which can look like incorrect table references
 # L027 - Asks for qualified columns for ambiguous ones. Really should enable this but a lot to clean up. TODO
 # L028 - Insists on references in column names even if not ambiguous. Bit OTT.
 # L029 - Avoids keywords as identifiers but we use this a lot (e.g. AS count, AS max...etc.)
 # L030 - Function names will be mixed case so don't enforce case
 # L031 - Avoid aliases in from and join - why?
 # L032 - Uses joins instead of USING - why?
-# L034 - Inisits on wildcards (*) in certain SELECT order - why?
-# L035 - Do not use ELSE NULL as redudant. But it's clearer!?
+# L034 - Insists on wildcards (*) in certain SELECT order - why?
+# L035 - Do not use ELSE NULL as redundant. But it's clearer!?
 # L036 - Select targets should be on new lines but sub clauses don't always obey this. Maybe revisit in future?
 # L037 - if using DESC in one ORDER BY column, then insist on ASC/DESC for all.
 # L042 - Use CTEs instead of subqueries. We don't use this consistently and big rewrite to do that.
 # L043 - Use coalesce instead of case if you can. But it's clearer!?
-# L048 - Doesn't work with "AS '''" that we use in our LANGUAGE declarations
 recurse = 0
 output_line_length = 80
 runaway_limit = 10

--- a/sql/.sqlfluff
+++ b/sql/.sqlfluff
@@ -10,7 +10,7 @@ exclude_rules = L011,L014,L016,L020,L026,L027,L028,L029,L030,L031,L032,L034,L035
 # L016 - We allow longer lines as some of our queries are complex. Maybe should limit in future?
 # L020 - Asks for unique table aliases meaning it complains if selecting from two 2021_07_01 tables as implicit alias is table name (not fully qualified) so same.
 # L026 - BigQuery uses STRUCTS which can look like incorrect table references
-# L027 - Asks for qualified columns for ambiguous ones. Really should enable this but a lot to clean up. TODO
+# L027 - Asks for qualified columns for ambiguous ones, but we not qualify our columns, and they are not really ambiguous (or BigQuery would complain)
 # L028 - Insists on references in column names even if not ambiguous. Bit OTT.
 # L029 - Avoids keywords as identifiers but we use this a lot (e.g. AS count, AS max...etc.)
 # L030 - Function names will be mixed case so don't enforce case

--- a/sql/2019/accessibility/09_20.sql
+++ b/sql/2019/accessibility/09_20.sql
@@ -3,8 +3,8 @@
 SELECT
   is_valid,
   COUNT(0) AS pages,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total,
-  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (PARTITION BY 0), 2) AS pct
+  SUM(COUNT(0)) OVER () AS total,
+  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (), 2) AS pct
 FROM (
   SELECT
     JSON_EXTRACT_SCALAR(report, "$.audits['aria-valid-attr-value'].score") = '1' AS is_valid

--- a/sql/2019/cms/14_18.sql
+++ b/sql/2019/cms/14_18.sql
@@ -3,8 +3,8 @@
 SELECT
   JSON_EXTRACT_SCALAR(report, "$.audits.is-crawlable.score") AS crawlable,
   COUNT(0) AS freq,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total,
-  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (PARTITION BY 0), 2) AS pct
+  SUM(COUNT(0)) OVER () AS total,
+  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (), 2) AS pct
 FROM
   `httparchive.technologies.2019_07_01_mobile`,
   (SELECT COUNT(0) AS total FROM `httparchive.summary_pages.2019_07_01_mobile`)

--- a/sql/2019/cms/14_19.sql
+++ b/sql/2019/cms/14_19.sql
@@ -3,8 +3,8 @@
 SELECT
   JSON_EXTRACT_SCALAR(report, "$.categories.pwa.score") AS pwa_score,
   COUNT(0) AS freq,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total,
-  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (PARTITION BY 0), 2) AS pct
+  SUM(COUNT(0)) OVER () AS total,
+  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (), 2) AS pct
 FROM
   `httparchive.lighthouse.2019_07_01_mobile`
 LEFT JOIN

--- a/sql/2019/cms/14_20.sql
+++ b/sql/2019/cms/14_20.sql
@@ -3,8 +3,8 @@
 SELECT
   JSON_EXTRACT_SCALAR(report, "$.categories.accessibility.score") AS a11y_score,
   COUNT(0) AS freq,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total,
-  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (PARTITION BY 0), 2) AS pct
+  SUM(COUNT(0)) OVER () AS total,
+  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (), 2) AS pct
 FROM
   `httparchive.lighthouse.2019_07_01_mobile`
 LEFT JOIN

--- a/sql/2019/css/02_43.sql
+++ b/sql/2019/css/02_43.sql
@@ -1,7 +1,6 @@
 #standardSQL
 # 02_43: % of sites that use [id="foo"] selectors
-CREATE TEMPORARY FUNCTION getAttributeSelectorType(css STRING) -- noqa: PRS
--- SQL Linter expects STRUCT field names to beging with a-z or A-Z so needs noqa ignore command on previous line
+CREATE TEMPORARY FUNCTION getAttributeSelectorType(css STRING)
 RETURNS STRUCT<`=` BOOLEAN, `*=` BOOLEAN, `^=` BOOLEAN, `$=` BOOLEAN, `~=` BOOLEAN>
 LANGUAGE js
 AS '''

--- a/sql/2019/css/02_44.sql
+++ b/sql/2019/css/02_44.sql
@@ -1,7 +1,6 @@
 #standardSQL
 # 02_44: % of sites that use different class attr selectors
-CREATE TEMPORARY FUNCTION getAttributeSelectorType(css STRING) -- noqa: PRS
--- SQL Linter expects STRUCT field names to beging with a-z or A-Z so needs noqa ignore command on previous line
+CREATE TEMPORARY FUNCTION getAttributeSelectorType(css STRING)
 RETURNS STRUCT<`=` BOOLEAN, `*=` BOOLEAN, `^=` BOOLEAN, `$=` BOOLEAN, `~=` BOOLEAN> LANGUAGE js AS '''
 try {
   var reduceValues = (values, rule) => {

--- a/sql/2019/ecommerce/13_12.sql
+++ b/sql/2019/ecommerce/13_12.sql
@@ -3,8 +3,8 @@
 SELECT
   JSON_EXTRACT_SCALAR(report, "$.audits.is-crawlable.score") AS crawlable,
   COUNT(0) AS freq,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total,
-  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (PARTITION BY 0), 2) AS pct
+  SUM(COUNT(0)) OVER () AS total,
+  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (), 2) AS pct
 FROM
   `httparchive.technologies.2019_07_01_mobile`,
   (SELECT COUNT(0) AS total FROM `httparchive.summary_pages.2019_07_01_mobile`)

--- a/sql/2019/ecommerce/13_13.sql
+++ b/sql/2019/ecommerce/13_13.sql
@@ -3,8 +3,8 @@
 SELECT
   JSON_EXTRACT_SCALAR(report, "$.categories.pwa.score") AS pwa_score,
   COUNT(0) AS freq,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total,
-  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (PARTITION BY 0), 2) AS pct
+  SUM(COUNT(0)) OVER () AS total,
+  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (), 2) AS pct
 FROM
   `httparchive.lighthouse.2019_07_01_mobile`
 LEFT JOIN

--- a/sql/2019/fonts/06_04.sql
+++ b/sql/2019/fonts/06_04.sql
@@ -3,8 +3,8 @@
 SELECT
   score,
   COUNT(0) AS freq,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total,
-  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (PARTITION BY 0), 2) AS pct
+  SUM(COUNT(0)) OVER () AS total,
+  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (), 2) AS pct
 FROM (
   SELECT
     JSON_EXTRACT(report, '$.audits.font-display.score') AS score

--- a/sql/2019/javascript/01_01c.sql
+++ b/sql/2019/javascript/01_01c.sql
@@ -8,7 +8,7 @@ SELECT
 FROM (
   SELECT
     *,
-    volume / SUM(volume) OVER (PARTITION BY 0) AS pdf
+    volume / SUM(volume) OVER () AS pdf
   FROM (
     SELECT
       COUNT(0) AS volume,

--- a/sql/2019/media/04_06b.sql
+++ b/sql/2019/media/04_06b.sql
@@ -4,8 +4,8 @@ SELECT
   client,
   sizes,
   COUNT(0) AS freq,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total,
-  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (PARTITION BY 0), 2) AS pct
+  SUM(COUNT(0)) OVER () AS total,
+  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (), 2) AS pct
 FROM
   `httparchive.almanac.summary_response_bodies`,
   UNNEST(REGEXP_EXTRACT_ALL(body, r'(?im)<(?:source|img)[^>]*sizes=[\'"]?([^\'"]*)')) AS sizes

--- a/sql/2019/mobile-web/12_12.sql
+++ b/sql/2019/mobile-web/12_12.sql
@@ -16,7 +16,7 @@ RETURNS ARRAY<STRING> LANGUAGE js AS '''
 SELECT
   input_type,
   COUNT(input_type) AS occurence,
-  ROUND(COUNT(input_type) * 100 / SUM(COUNT(0)) OVER (PARTITION BY 0), 2) AS occurence_perc,
+  ROUND(COUNT(input_type) * 100 / SUM(COUNT(0)) OVER (), 2) AS occurence_perc,
   COUNT(DISTINCT url) AS pages,
   total AS total_pages,
   ROUND(COUNT(DISTINCT url) * 100 / total, 2) AS pages_perc

--- a/sql/2019/mobile-web/12_14.sql
+++ b/sql/2019/mobile-web/12_14.sql
@@ -37,12 +37,12 @@ RETURNS BOOLEAN LANGUAGE js AS '''
 
 SELECT
   total_pages_with_inputs,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total_inputs,
+  SUM(COUNT(0)) OVER () AS total_inputs,
   input_attributes,
 
   COUNT(input_attributes) AS occurence,
   COUNT(DISTINCT url) AS total_pages_using,
-  ROUND(COUNT(input_attributes) * 100 / SUM(COUNT(0)) OVER (PARTITION BY 0), 2) AS occurence_perc,
+  ROUND(COUNT(input_attributes) * 100 / SUM(COUNT(0)) OVER (), 2) AS occurence_perc,
   ROUND(COUNT(DISTINCT url) * 100 / total_pages_with_inputs, 2) AS perc_of_pages_using
 FROM
   `httparchive.pages.2019_07_01_mobile`,

--- a/sql/2019/mobile-web/12_17.sql
+++ b/sql/2019/mobile-web/12_17.sql
@@ -8,7 +8,7 @@ SELECT
 FROM (
   SELECT
     *,
-    volume / SUM(volume) OVER (PARTITION BY 0) AS pdf
+    volume / SUM(volume) OVER () AS pdf
   FROM (
     SELECT
       COUNT(0) AS volume,

--- a/sql/2019/mobile-web/12_20.sql
+++ b/sql/2019/mobile-web/12_20.sql
@@ -4,7 +4,7 @@ SELECT
   * EXCEPT (row)
 FROM (
   SELECT
-    ROW_NUMBER() OVER (PARTITION BY 0) AS row,
+    ROW_NUMBER() OVER () AS row,
     ROUND(SAFE_DIVIDE(small_cls, small_cls + medium_cls + large_cls) * 100, 2) AS small_cls,
     ROUND(SAFE_DIVIDE(medium_cls, small_cls + medium_cls + large_cls) * 100, 2) AS medium_cls,
     ROUND(SAFE_DIVIDE(large_cls, small_cls + medium_cls + large_cls) * 100, 2) AS large_cls

--- a/sql/2019/performance/07_01.sql
+++ b/sql/2019/performance/07_01.sql
@@ -10,7 +10,7 @@ FROM (
     ROUND(avg_fcp * 100, 2) AS avg,
     ROUND(slow_fcp * 100, 2) AS slow,
     ROW_NUMBER() OVER (ORDER BY fast_fcp DESC) AS row,
-    COUNT(0) OVER (PARTITION BY 0) AS n
+    COUNT(0) OVER () AS n
   FROM
     `chrome-ux-report.materialized.metrics_summary`
   WHERE

--- a/sql/2019/performance/07_01b.sql
+++ b/sql/2019/performance/07_01b.sql
@@ -11,7 +11,7 @@ FROM (
     ROUND(SAFE_DIVIDE(avg_fcp, fast_fcp + avg_fcp + slow_fcp) * 100, 2) AS avg,
     ROUND(SAFE_DIVIDE(slow_fcp, fast_fcp + avg_fcp + slow_fcp) * 100, 2) AS slow,
     ROW_NUMBER() OVER (ORDER BY fast_fcp DESC) AS row,
-    COUNT(0) OVER (PARTITION BY 0) AS n
+    COUNT(0) OVER () AS n
   FROM
     `chrome-ux-report.materialized.device_summary`
   WHERE

--- a/sql/2019/performance/07_01c.sql
+++ b/sql/2019/performance/07_01c.sql
@@ -11,7 +11,7 @@ FROM (
     ROUND(SAFE_DIVIDE(avg_fcp, fast_fcp + avg_fcp + slow_fcp) * 100, 2) AS avg,
     ROUND(SAFE_DIVIDE(slow_fcp, fast_fcp + avg_fcp + slow_fcp) * 100, 2) AS slow,
     ROW_NUMBER() OVER (ORDER BY fast_fcp DESC) AS row,
-    COUNT(0) OVER (PARTITION BY 0) AS n
+    COUNT(0) OVER () AS n
   FROM
     `chrome-ux-report.materialized.device_summary`
   WHERE

--- a/sql/2019/performance/07_02.sql
+++ b/sql/2019/performance/07_02.sql
@@ -10,7 +10,7 @@ FROM (
     ROUND(avg_fid * 100, 2) AS avg,
     ROUND(slow_fid * 100, 2) AS slow,
     ROW_NUMBER() OVER (ORDER BY fast_fid DESC) AS row,
-    COUNT(0) OVER (PARTITION BY 0) AS n
+    COUNT(0) OVER () AS n
   FROM
     `chrome-ux-report.materialized.metrics_summary`
   WHERE

--- a/sql/2019/performance/07_02b.sql
+++ b/sql/2019/performance/07_02b.sql
@@ -11,7 +11,7 @@ FROM (
     ROUND(SAFE_DIVIDE(avg_fid, fast_fid + avg_fid + slow_fid) * 100, 2) AS avg,
     ROUND(SAFE_DIVIDE(slow_fid, fast_fid + avg_fid + slow_fid) * 100, 2) AS slow,
     ROW_NUMBER() OVER (ORDER BY fast_fid DESC) AS row,
-    COUNT(0) OVER (PARTITION BY 0) AS n
+    COUNT(0) OVER () AS n
   FROM
     `chrome-ux-report.materialized.device_summary`
   WHERE

--- a/sql/2019/performance/07_02c.sql
+++ b/sql/2019/performance/07_02c.sql
@@ -11,7 +11,7 @@ FROM (
     ROUND(SAFE_DIVIDE(avg_fid, fast_fid + avg_fid + slow_fid) * 100, 2) AS avg,
     ROUND(SAFE_DIVIDE(slow_fid, fast_fid + avg_fid + slow_fid) * 100, 2) AS slow,
     ROW_NUMBER() OVER (ORDER BY fast_fid DESC) AS row,
-    COUNT(0) OVER (PARTITION BY 0) AS n
+    COUNT(0) OVER () AS n
   FROM
     `chrome-ux-report.materialized.device_summary`
   WHERE

--- a/sql/2019/performance/07_07.sql
+++ b/sql/2019/performance/07_07.sql
@@ -10,7 +10,7 @@ FROM (
     ROUND(avg_ttfb * 100, 2) AS avg,
     ROUND(slow_ttfb * 100, 2) AS slow,
     ROW_NUMBER() OVER (ORDER BY fast_ttfb DESC) AS row,
-    COUNT(0) OVER (PARTITION BY 0) AS n
+    COUNT(0) OVER () AS n
   FROM
     `chrome-ux-report.materialized.metrics_summary`
   WHERE

--- a/sql/2019/performance/07_07b.sql
+++ b/sql/2019/performance/07_07b.sql
@@ -11,7 +11,7 @@ FROM (
     ROUND(SAFE_DIVIDE(avg_ttfb, fast_ttfb + avg_ttfb + slow_ttfb) * 100, 2) AS avg,
     ROUND(SAFE_DIVIDE(slow_ttfb, fast_ttfb + avg_ttfb + slow_ttfb) * 100, 2) AS slow,
     ROW_NUMBER() OVER (ORDER BY fast_ttfb DESC) AS row,
-    COUNT(0) OVER (PARTITION BY 0) AS n
+    COUNT(0) OVER () AS n
   FROM
     `chrome-ux-report.materialized.device_summary`
   WHERE

--- a/sql/2019/performance/07_07c.sql
+++ b/sql/2019/performance/07_07c.sql
@@ -11,7 +11,7 @@ FROM (
     ROUND(SAFE_DIVIDE(avg_ttfb, fast_ttfb + avg_ttfb + slow_ttfb) * 100, 2) AS avg,
     ROUND(SAFE_DIVIDE(slow_ttfb, fast_ttfb + avg_ttfb + slow_ttfb) * 100, 2) AS slow,
     ROW_NUMBER() OVER (ORDER BY fast_ttfb DESC) AS row,
-    COUNT(0) OVER (PARTITION BY 0) AS n
+    COUNT(0) OVER () AS n
   FROM
     `chrome-ux-report.materialized.device_summary`
   WHERE

--- a/sql/2019/resource-hints/19_01.sql
+++ b/sql/2019/resource-hints/19_01.sql
@@ -1,7 +1,6 @@
 #standardSQL
 # 19_01: % of sites that use each type of hint.
-CREATE TEMPORARY FUNCTION getResourceHints(payload STRING) -- noqa: PRS
--- SQL Linter expects STRUCT field names to beging with a-z or A-Z so needs noqa ignore command on previous line
+CREATE TEMPORARY FUNCTION getResourceHints(payload STRING)
 RETURNS STRUCT<preload BOOLEAN, prefetch BOOLEAN, preconnect BOOLEAN, prerender BOOLEAN, `dns-prefetch` BOOLEAN>
 LANGUAGE js AS '''
 var hints = ['preload', 'prefetch', 'preconnect', 'prerender', 'dns-prefetch'];

--- a/sql/2019/resource-hints/19_02.sql
+++ b/sql/2019/resource-hints/19_02.sql
@@ -1,7 +1,6 @@
 #standardSQL
 # 19_02: Distribution of number of times each hint is used per site.
-CREATE TEMPORARY FUNCTION getResourceHints(payload STRING) -- noqa: PRS
--- SQL Linter expects STRUCT field names to beging with a-z or A-Z so needs noqa ignore command on previous line
+CREATE TEMPORARY FUNCTION getResourceHints(payload STRING)
 RETURNS STRUCT<preload INT64, prefetch INT64, preconnect INT64, prerender INT64, `dns-prefetch` INT64>
 LANGUAGE js AS '''
 var hints = ['preload', 'prefetch', 'preconnect', 'prerender', 'dns-prefetch'];

--- a/sql/2019/security/08_40.sql
+++ b/sql/2019/security/08_40.sql
@@ -5,8 +5,8 @@
 SELECT
   JSON_EXTRACT_SCALAR(report, '$.audits.no-vulnerable-libraries.score') AS score,
   COUNT(0) AS freq,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total,
-  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (PARTITION BY 0), 2) AS pct
+  SUM(COUNT(0)) OVER () AS total,
+  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (), 2) AS pct
 FROM
   `httparchive.lighthouse.2019_07_01_mobile`
 GROUP BY

--- a/sql/2019/security/08_40b.sql
+++ b/sql/2019/security/08_40b.sql
@@ -13,8 +13,8 @@ try {
 SELECT
   lib,
   COUNT(0) AS freq,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total,
-  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (PARTITION BY 0), 2) AS pct
+  SUM(COUNT(0)) OVER () AS total,
+  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (), 2) AS pct
 FROM
   `httparchive.lighthouse.2019_07_01_mobile`,
   UNNEST(getVulnerabilities(report)) AS lib

--- a/sql/2019/seo/10_01.sql
+++ b/sql/2019/seo/10_01.sql
@@ -23,7 +23,7 @@ SELECT
   client,
   COUNTIF(has_eligible_type) AS freq,
   COUNT(0) AS total,
-  ROUND(COUNTIF(has_eligible_type) * 100 / SUM(COUNT(0)) OVER (PARTITION BY 0), 2) AS pct
+  ROUND(COUNTIF(has_eligible_type) * 100 / SUM(COUNT(0)) OVER (), 2) AS pct
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,

--- a/sql/2019/seo/10_12.sql
+++ b/sql/2019/seo/10_12.sql
@@ -3,8 +3,8 @@
 SELECT
   JSON_EXTRACT_SCALAR(report, '$.audits.robots-txt.score') AS score,
   COUNT(0) AS freq,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total,
-  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (PARTITION BY 0), 2) AS pct
+  SUM(COUNT(0)) OVER () AS total,
+  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (), 2) AS pct
 FROM
   `httparchive.lighthouse.2019_07_01_mobile`
 GROUP BY

--- a/sql/2019/third-parties/05_03.sql
+++ b/sql/2019/third-parties/05_03.sql
@@ -5,7 +5,7 @@ SELECT
   thirdPartyCategory,
   contentType,
   COUNT(0) AS totalRequests,
-  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (PARTITION BY 0), 4) AS percentRequests
+  ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (), 4) AS percentRequests
 FROM (
   SELECT
     client,

--- a/sql/2019/third-parties/05_04.sql
+++ b/sql/2019/third-parties/05_04.sql
@@ -5,7 +5,7 @@ SELECT
   thirdPartyCategory,
   contentType,
   SUM(requestBytes) AS totalBytes,
-  ROUND(SUM(requestBytes) * 100 / SUM(SUM(requestBytes)) OVER (PARTITION BY 0), 4) AS percentBytes
+  ROUND(SUM(requestBytes) * 100 / SUM(SUM(requestBytes)) OVER (), 4) AS percentBytes
 FROM (
   SELECT
     client,

--- a/sql/2019/third-parties/05_05.sql
+++ b/sql/2019/third-parties/05_05.sql
@@ -18,7 +18,7 @@ SELECT
     IF(DomainsOver50Table.requestDomain IS NULL, 'first-party', 'other')
   ) AS third_party_category,
   SUM(item.execution_time) AS total_execution_time,
-  ROUND(SUM(item.execution_time) * 100 / SUM(SUM(item.execution_time)) OVER (PARTITION BY 0), 4) AS pct_execution_time
+  ROUND(SUM(item.execution_time) * 100 / SUM(SUM(item.execution_time)) OVER (), 4) AS pct_execution_time
 FROM
   `httparchive.lighthouse.2019_07_01_mobile`,
   UNNEST(getExecutionTimes(report)) AS item

--- a/sql/2020/caching/appcache_and_serviceworkers.sql
+++ b/sql/2020/caching/appcache_and_serviceworkers.sql
@@ -5,8 +5,8 @@ SELECT
   JSON_EXTRACT_SCALAR(report, "$.audits.appcache-manifest.score") AS using_appcache,
   JSON_EXTRACT_SCALAR(report, "$.audits.service-worker.score") AS using_serviceworkers,
   COUNT(0) AS occurrences,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total,
-  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY 0) AS pct
+  SUM(COUNT(0)) OVER () AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER () AS pct
 FROM
   `httparchive.lighthouse.2020_08_01_mobile`
 GROUP BY

--- a/sql/2020/caching/appcache_and_serviceworkers_2019.sql
+++ b/sql/2020/caching/appcache_and_serviceworkers_2019.sql
@@ -5,8 +5,8 @@ SELECT
   JSON_EXTRACT_SCALAR(report, "$.audits.appcache-manifest.score") AS using_appcache,
   JSON_EXTRACT_SCALAR(report, "$.audits.service-worker.score") AS using_serviceworkers,
   COUNT(0) AS occurrences,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total,
-  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY 0) AS pct
+  SUM(COUNT(0)) OVER () AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER () AS pct
 FROM
   `httparchive.lighthouse.2019_07_01_mobile`
 GROUP BY

--- a/sql/2020/caching/top_domains_using_immutable.sql
+++ b/sql/2020/caching/top_domains_using_immutable.sql
@@ -5,8 +5,8 @@ SELECT
   NET.HOST(url) AS domain,
   COUNT(DISTINCT pageid) AS pages,
   COUNT(0) AS requests,
-  SUM(COUNT(DISTINCT pageid)) OVER (PARTITION BY 0) AS total_pages,
-  SUM(COUNT(0)) OVER(PARTITION BY 0) AS total_requests
+  SUM(COUNT(DISTINCT pageid)) OVER () AS total_pages,
+  SUM(COUNT(0)) OVER () AS total_requests
 FROM
   `httparchive.summary_requests.2020_08_01_*`
 WHERE

--- a/sql/2020/css/css_in_js_frameworks_only.sql
+++ b/sql/2020/css/css_in_js_frameworks_only.sql
@@ -15,8 +15,8 @@ RETURNS ARRAY<STRING> LANGUAGE js AS '''
 SELECT
   cssInJs,
   COUNT(0) AS freq,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total,
-  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY 0) AS pct
+  SUM(COUNT(0)) OVER () AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER () AS pct
 FROM (
   SELECT
     url,

--- a/sql/2020/css/top_selector_attributes.sql
+++ b/sql/2020/css/top_selector_attributes.sql
@@ -76,8 +76,7 @@ FROM (
       FROM
         `httparchive.almanac.parsed_css`
       LEFT JOIN
-        -- SQL Linter can't handle STRUCTs fields so noqa next line
-        UNNEST(getSelectorParts(css).attribute) AS attribute -- noqa: PRS
+        UNNEST(getSelectorParts(css).attribute) AS attribute
       WHERE
         date = '2020-08-01' AND
         # Limit the size of the CSS to avoid OOM crashes.

--- a/sql/2020/css/top_selector_class_prefixes.sql
+++ b/sql/2020/css/top_selector_class_prefixes.sql
@@ -76,8 +76,7 @@ FROM (
       FROM
         `httparchive.almanac.parsed_css`
       LEFT JOIN
-        -- SQL Linter can't handle STRUCTs fields so noqa next line
-        UNNEST(getSelectorParts(css).class) AS class -- noqa: PRS
+        UNNEST(getSelectorParts(css).class) AS class
       WHERE
         date = '2020-08-01' AND
         # Limit the size of the CSS to avoid OOM crashes.

--- a/sql/2020/css/top_selector_classes.sql
+++ b/sql/2020/css/top_selector_classes.sql
@@ -76,8 +76,7 @@ FROM (
       FROM
         `httparchive.almanac.parsed_css`
       LEFT JOIN
-        -- SQL Linter can't handle STRUCTs fields so noqa next line
-        UNNEST(getSelectorParts(css).class) AS class -- noqa: PRS
+        UNNEST(getSelectorParts(css).class) AS class
       WHERE
         date = '2020-08-01' AND
         # Limit the size of the CSS to avoid OOM crashes.

--- a/sql/2020/css/top_selector_classes_wp_fa_prefixes.sql
+++ b/sql/2020/css/top_selector_classes_wp_fa_prefixes.sql
@@ -76,8 +76,7 @@ FROM (
       FROM
         `httparchive.almanac.parsed_css`
       LEFT JOIN
-        -- SQL Linter can't handle STRUCTs fields so noqa next line
-        UNNEST(getSelectorParts(css).class) AS class -- noqa: PRS
+        UNNEST(getSelectorParts(css).class) AS class
       WHERE
         date = '2020-08-01' AND
         # Limit the size of the CSS to avoid OOM crashes.

--- a/sql/2020/css/top_selector_ids.sql
+++ b/sql/2020/css/top_selector_ids.sql
@@ -76,8 +76,7 @@ FROM (
       FROM
         `httparchive.almanac.parsed_css`
       LEFT JOIN
-        -- SQL Linter can't handle STRUCTs fields so noqa next line
-        UNNEST(getSelectorParts(css).id) AS id -- noqa: PRS
+        UNNEST(getSelectorParts(css).id) AS id
       WHERE
         date = '2020-08-01' AND
         # Limit the size of the CSS to avoid OOM crashes.

--- a/sql/2020/css/top_selector_pseudo_classes.sql
+++ b/sql/2020/css/top_selector_pseudo_classes.sql
@@ -76,8 +76,7 @@ FROM (
       FROM
         `httparchive.almanac.parsed_css`
       LEFT JOIN
-        -- SQL Linter can't handle STRUCTs fields so noqa next line
-        UNNEST(getSelectorParts(css).pseudo_class) AS pseudo_class -- noqa: PRS
+        UNNEST(getSelectorParts(css).pseudo_class) AS pseudo_class
       WHERE
         date = '2020-08-01' AND
         # Limit the size of the CSS to avoid OOM crashes.

--- a/sql/2020/css/top_selector_pseudo_elements.sql
+++ b/sql/2020/css/top_selector_pseudo_elements.sql
@@ -76,8 +76,7 @@ FROM (
       FROM
         `httparchive.almanac.parsed_css`
       LEFT JOIN
-        -- SQL Linter can't handle STRUCTs fields so noqa next line
-        UNNEST(getSelectorParts(css).pseudo_element) AS pseudo_element -- noqa: PRS
+        UNNEST(getSelectorParts(css).pseudo_element) AS pseudo_element
       WHERE
         date = '2020-08-01' AND
         # Limit the size of the CSS to avoid OOM crashes.

--- a/sql/2020/javascript/compression_method.sql
+++ b/sql/2020/javascript/compression_method.sql
@@ -1,6 +1,5 @@
 #standardSQL
-CREATE TEMPORARY FUNCTION getHeader(headers STRING, headername STRING) -- noqa: PRS
--- SQL Linter cannot handle DETERMINISTIC keyword so needs noqa ignore command on previous line
+CREATE TEMPORARY FUNCTION getHeader(headers STRING, headername STRING)
 RETURNS STRING
 DETERMINISTIC
 LANGUAGE js AS '''

--- a/sql/2020/javascript/compression_method_by_3p.sql
+++ b/sql/2020/javascript/compression_method_by_3p.sql
@@ -1,6 +1,5 @@
 #standardSQL
-CREATE TEMPORARY FUNCTION getHeader(headers STRING, headername STRING) -- noqa: PRS
--- SQL Linter cannot handle DETERMINISTIC keyword so needs noqa ignore command on previous line
+CREATE TEMPORARY FUNCTION getHeader(headers STRING, headername STRING)
 RETURNS STRING
 DETERMINISTIC
 LANGUAGE js AS '''

--- a/sql/2020/javascript/compression_none_by_bytes.sql
+++ b/sql/2020/javascript/compression_none_by_bytes.sql
@@ -1,6 +1,5 @@
 #standardSQL
-CREATE TEMPORARY FUNCTION getHeader(headers STRING, headername STRING) -- noqa: PRS
--- SQL Linter cannot handle DETERMINISTIC keyword so needs noqa ignore command on previous line
+CREATE TEMPORARY FUNCTION getHeader(headers STRING, headername STRING)
 RETURNS STRING
 DETERMINISTIC
 LANGUAGE js AS '''

--- a/sql/2020/javascript/js_bytes_histogram.sql
+++ b/sql/2020/javascript/js_bytes_histogram.sql
@@ -8,7 +8,7 @@ SELECT
 FROM (
   SELECT
     *,
-    volume / SUM(volume) OVER (PARTITION BY 0) AS pdf
+    volume / SUM(volume) OVER () AS pdf
   FROM (
     SELECT
       COUNT(0) AS volume,

--- a/sql/2020/javascript/lighthouse_unminified_js.sql
+++ b/sql/2020/javascript/lighthouse_unminified_js.sql
@@ -3,8 +3,8 @@
 SELECT
   score,
   COUNT(0) AS pages,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total,
-  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY 0) AS pct
+  SUM(COUNT(0)) OVER () AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER () AS pct
 FROM (
   SELECT
     JSON_EXTRACT_SCALAR(report, "$.audits['unminified-javascript'].score") AS score

--- a/sql/2020/javascript/lighthouse_unminified_js_bytes.sql
+++ b/sql/2020/javascript/lighthouse_unminified_js_bytes.sql
@@ -13,8 +13,8 @@ try {
 SELECT
   IF(unminified_js_kbytes <= 200, CEIL(unminified_js_kbytes / 10) * 10, 200) AS unminified_js_kbytes,
   COUNT(0) AS pages,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total,
-  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY 0) AS pct
+  SUM(COUNT(0)) OVER () AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER () AS pct
 FROM (
   SELECT
     test.url AS page,

--- a/sql/2020/javascript/lighthouse_unminified_js_requests.sql
+++ b/sql/2020/javascript/lighthouse_unminified_js_requests.sql
@@ -13,8 +13,8 @@ try {
 SELECT
   IF(unminified_js_kbytes <= 200, CEIL(unminified_js_kbytes / 10) * 10, 200) AS unminified_js_kbytes,
   COUNT(0) AS pages,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total,
-  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY 0) AS pct
+  SUM(COUNT(0)) OVER () AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER () AS pct
 FROM (
   SELECT
     test.url AS page,

--- a/sql/2020/javascript/lighthouse_vulnerabilities.sql
+++ b/sql/2020/javascript/lighthouse_vulnerabilities.sql
@@ -3,8 +3,8 @@
 SELECT
   score,
   COUNT(0) AS pages,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total,
-  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY 0) AS pct
+  SUM(COUNT(0)) OVER () AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER () AS pct
 FROM (
   SELECT
     JSON_EXTRACT_SCALAR(report, "$.audits['no-vulnerable-libraries'].score") AS score

--- a/sql/2020/javascript/sourcemap_header.sql
+++ b/sql/2020/javascript/sourcemap_header.sql
@@ -1,6 +1,5 @@
 #standardSQL
-CREATE TEMPORARY FUNCTION getHeader(headers STRING, headername STRING) -- noqa: PRS
--- SQL Linter cannot handle DETERMINISTIC keyword so needs noqa ignore command on previous line
+CREATE TEMPORARY FUNCTION getHeader(headers STRING, headername STRING)
 RETURNS STRING
 DETERMINISTIC
 LANGUAGE js AS '''

--- a/sql/2020/javascript/sourcemap_header_by_3p.sql
+++ b/sql/2020/javascript/sourcemap_header_by_3p.sql
@@ -1,6 +1,5 @@
 #standardSQL
-CREATE TEMPORARY FUNCTION getHeader(headers STRING, headername STRING) -- noqa: PRS
--- SQL Linter cannot handle DETERMINISTIC keyword so needs noqa ignore command on previous line
+CREATE TEMPORARY FUNCTION getHeader(headers STRING, headername STRING)
 RETURNS STRING
 DETERMINISTIC
 LANGUAGE js AS '''

--- a/sql/2020/mobile-web/popular_mobile_input_types.sql
+++ b/sql/2020/mobile-web/popular_mobile_input_types.sql
@@ -14,13 +14,13 @@ RETURNS ARRAY<STRING> LANGUAGE js AS '''
 
 SELECT
   total_pages_with_inputs,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total_inputs,
+  SUM(COUNT(0)) OVER () AS total_inputs,
 
   input_type,
   COUNT(input_type) AS occurences,
   COUNT(DISTINCT url) AS total_pages_used_in,
 
-  COUNT(input_type) / SUM(COUNT(0)) OVER (PARTITION BY 0) AS perc_of_all_inputs,
+  COUNT(input_type) / SUM(COUNT(0)) OVER () AS perc_of_all_inputs,
   COUNT(DISTINCT url) / total_pages_with_inputs AS perc_used_in_pages
 FROM
   `httparchive.pages.2020_08_01_mobile`,

--- a/sql/2020/performance/lh5_performance_score_distribution.sql
+++ b/sql/2020/performance/lh5_performance_score_distribution.sql
@@ -4,8 +4,8 @@
 SELECT
   JSON_EXTRACT_SCALAR(report, '$.categories.performance.score') AS score,
   COUNT(0) AS freq,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total,
-  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY 0) AS pct
+  SUM(COUNT(0)) OVER () AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER () AS pct
 FROM
   `httparchive.lighthouse.2019_07_01_mobile`
 GROUP BY

--- a/sql/2020/performance/lh6_performance_score_distribution.sql
+++ b/sql/2020/performance/lh6_performance_score_distribution.sql
@@ -4,8 +4,8 @@
 SELECT
   JSON_EXTRACT_SCALAR(report, '$.categories.performance.score') AS score,
   COUNT(0) AS freq,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total,
-  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY 0) AS pct
+  SUM(COUNT(0)) OVER () AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER () AS pct
 FROM
   `httparchive.lighthouse.2020_09_01_mobile`
 GROUP BY

--- a/sql/2020/performance/lh6_vs_lh5_performance_score_02.sql
+++ b/sql/2020/performance/lh6_vs_lh5_performance_score_02.sql
@@ -4,8 +4,8 @@ SELECT
   direction,
   magnitude,
   pages AS freq,
-  SUM(pages) OVER (PARTITION BY 0) AS total,
-  pages / SUM(pages) OVER (PARTITION BY 0) AS pct
+  SUM(pages) OVER () AS total,
+  pages / SUM(pages) OVER () AS pct
 FROM (
   SELECT
     CASE

--- a/sql/2020/performance/lh6_vs_lh5_performance_score_distribution.sql
+++ b/sql/2020/performance/lh6_vs_lh5_performance_score_distribution.sql
@@ -6,7 +6,7 @@ FROM (
   SELECT
     perf_score_lh6 - perf_score_lh5 AS perf_score_delta,
     ROW_NUMBER() OVER (ORDER BY (perf_score_lh6 - perf_score_lh5)) AS row_number,
-    COUNT(0) OVER (PARTITION BY 0) AS n
+    COUNT(0) OVER () AS n
   FROM (
     SELECT
       CAST(JSON_EXTRACT(lh6.report, '$.categories.performance.score') AS NUMERIC) AS perf_score_lh6,

--- a/sql/2020/privacy/percent_of_websites_using_each_cmp.sql
+++ b/sql/2020/privacy/percent_of_websites_using_each_cmp.sql
@@ -19,7 +19,7 @@ base AS (
     url,
     cmp_app,
     COUNT(DISTINCT url) OVER (PARTITION BY client) AS total_pages,
-    COUNT(DISTINCT url) / COUNT(DISTINCT url) OVER (PARTITION BY 0) AS pct_pages_with_cmp
+    COUNT(DISTINCT url) / COUNT(DISTINCT url) OVER () AS pct_pages_with_cmp
   FROM
     apps
   GROUP BY

--- a/sql/2020/privacy/top100_cookies_set_from_header.sql
+++ b/sql/2020/privacy/top100_cookies_set_from_header.sql
@@ -1,8 +1,7 @@
 #standardSQL
 # Top100 popular cookies and their origins
 
-CREATE TEMPORARY FUNCTION cookieNames(headers STRING) -- noqa: PRS
--- SQL Linter cannot handle DETERMINISTIC keyword so needs noqa ignore command on previous line
+CREATE TEMPORARY FUNCTION cookieNames(headers STRING)
 RETURNS ARRAY<STRING>
 DETERMINISTIC
 LANGUAGE js AS '''

--- a/sql/2020/resource-hints/adoption.sql
+++ b/sql/2020/resource-hints/adoption.sql
@@ -1,7 +1,6 @@
 #standardSQL
 # 21_01: % of sites that use each type of hint.
-CREATE TEMPORARY FUNCTION getResourceHints(payload STRING) -- noqa: PRS
--- SQL Linter expects STRUCT field names to beging with a-z or A-Z so needs noqa ignore command on previous line
+CREATE TEMPORARY FUNCTION getResourceHints(payload STRING)
 RETURNS STRUCT<preload BOOLEAN, prefetch BOOLEAN, preconnect BOOLEAN, prerender BOOLEAN, `dns-prefetch` BOOLEAN>
 LANGUAGE js AS '''
 var hints = ['preload', 'prefetch', 'preconnect', 'prerender', 'dns-prefetch'];

--- a/sql/2020/resource-hints/adoption_service_workers.sql
+++ b/sql/2020/resource-hints/adoption_service_workers.sql
@@ -1,7 +1,6 @@
 #standardSQL
 # 21_16: Usage of resource hints by service-worker controlled pages
-CREATE TEMPORARY FUNCTION getResourceHints(payload STRING) -- noqa: PRS
--- SQL Linter expects STRUCT field names to beging with a-z or A-Z so needs noqa ignore command on previous line
+CREATE TEMPORARY FUNCTION getResourceHints(payload STRING)
 RETURNS STRUCT<preload BOOLEAN, prefetch BOOLEAN, preconnect BOOLEAN, prerender BOOLEAN, `dns-prefetch` BOOLEAN>
 LANGUAGE js AS '''
 var hints = ['preload', 'prefetch', 'preconnect', 'prerender', 'dns-prefetch'];

--- a/sql/2020/resource-hints/hints_per_page.sql
+++ b/sql/2020/resource-hints/hints_per_page.sql
@@ -1,7 +1,6 @@
 #standardSQL
 # 21_02: Distribution of number of times each hint is used per site.
-CREATE TEMPORARY FUNCTION getResourceHints(payload STRING) -- noqa: PRS
--- SQL Linter expects STRUCT field names to beging with a-z or A-Z so needs noqa ignore command on previous line
+CREATE TEMPORARY FUNCTION getResourceHints(payload STRING)
 RETURNS STRUCT<preload INT64, prefetch INT64, preconnect INT64, prerender INT64, `dns-prefetch` INT64>
 LANGUAGE js AS '''
 var hints = ['preload', 'prefetch', 'preconnect', 'prerender', 'dns-prefetch'];

--- a/sql/2020/resource-hints/lighthouse_offscreen_images.sql
+++ b/sql/2020/resource-hints/lighthouse_offscreen_images.sql
@@ -3,8 +3,8 @@
 SELECT
   JSON_EXTRACT_SCALAR(report, "$.audits.offscreen-images.score") AS score,
   COUNT(0) AS freq,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total,
-  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY 0) AS pct
+  SUM(COUNT(0)) OVER () AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER () AS pct
 FROM
   `httparchive.lighthouse.2020_08_01_mobile`
 GROUP BY

--- a/sql/2020/resource-hints/lighthouse_preconnect.sql
+++ b/sql/2020/resource-hints/lighthouse_preconnect.sql
@@ -3,8 +3,8 @@
 SELECT
   JSON_EXTRACT_SCALAR(report, "$.audits.uses-rel-preconnect.score") AS score,
   COUNT(0) AS freq,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total,
-  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY 0) AS pct
+  SUM(COUNT(0)) OVER () AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER () AS pct
 FROM
   `httparchive.lighthouse.2020_08_01_mobile`
 GROUP BY

--- a/sql/2020/resource-hints/lighthouse_preload.sql
+++ b/sql/2020/resource-hints/lighthouse_preload.sql
@@ -3,8 +3,8 @@
 SELECT
   JSON_EXTRACT_SCALAR(report, "$.audits.uses-rel-preload.score") AS score,
   COUNT(0) AS freq,
-  SUM(COUNT(0)) OVER (PARTITION BY 0) AS total,
-  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY 0) AS pct
+  SUM(COUNT(0)) OVER () AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER () AS pct
 FROM
   `httparchive.lighthouse.2020_08_01_mobile`
 GROUP BY

--- a/sql/2020/security/cookie_attributes.sql
+++ b/sql/2020/security/cookie_attributes.sql
@@ -1,7 +1,6 @@
 #standardSQL
 # Cookie attributes (HttpOnly, Secure, SameSite, __Secure- and __Host- prefixes) for cookies set on first-party and third-party requests
-CREATE TEMPORARY FUNCTION getSetCookieHeaders(headers STRING) -- noqa: PRS
--- SQL Linter cannot handle DETERMINISTIC keyword so needs noqa ignore command on previous line
+CREATE TEMPORARY FUNCTION getSetCookieHeaders(headers STRING)
 RETURNS ARRAY<STRING>
 DETERMINISTIC
 LANGUAGE js AS '''

--- a/sql/2020/security/csp_allowed_host_frequency.sql
+++ b/sql/2020/security/csp_allowed_host_frequency.sql
@@ -1,7 +1,6 @@
 #standardSQL
 # CSP on home pages: most prevalent allowed hosts
-CREATE TEMPORARY FUNCTION getHeader(headers STRING, headername STRING) -- noqa: PRS
--- SQL Linter cannot handle DETERMINISTIC keyword so needs noqa ignore command on previous line
+CREATE TEMPORARY FUNCTION getHeader(headers STRING, headername STRING)
 RETURNS STRING
 DETERMINISTIC
 LANGUAGE js AS '''

--- a/sql/2020/security/csp_directives_usage.sql
+++ b/sql/2020/security/csp_directives_usage.sql
@@ -1,7 +1,6 @@
 #standardSQL
 # CSP on home pages: popularity of different directives
-CREATE TEMPORARY FUNCTION getHeader(headers STRING, headername STRING) -- noqa: PRS
--- SQL Linter cannot handle DETERMINISTIC keyword so needs noqa ignore command on previous line
+CREATE TEMPORARY FUNCTION getHeader(headers STRING, headername STRING)
 RETURNS STRING
 DETERMINISTIC
 LANGUAGE js AS '''

--- a/sql/2020/security/csp_most_common_header.sql
+++ b/sql/2020/security/csp_most_common_header.sql
@@ -1,7 +1,6 @@
 #standardSQL
 # CSP on home pages: most commonly used header values
-CREATE TEMPORARY FUNCTION getHeader(headers STRING, headername STRING) -- noqa: PRS
--- SQL Linter cannot handle DETERMINISTIC keyword so needs noqa ignore command on previous line
+CREATE TEMPORARY FUNCTION getHeader(headers STRING, headername STRING)
 RETURNS STRING
 DETERMINISTIC
 LANGUAGE js AS '''

--- a/sql/2020/security/csp_number_of_allowed_hosts.sql
+++ b/sql/2020/security/csp_number_of_allowed_hosts.sql
@@ -1,7 +1,6 @@
 #standardSQL
 # CSP on home pages: number of unique headers, header length and number of allowed hosts in all directives
-CREATE TEMPORARY FUNCTION getHeader(headers STRING, headername STRING) -- noqa: PRS
--- SQL Linter cannot handle DETERMINISTIC keyword so needs noqa ignore command on previous line
+CREATE TEMPORARY FUNCTION getHeader(headers STRING, headername STRING)
 RETURNS STRING
 DETERMINISTIC
 LANGUAGE js AS '''

--- a/sql/2020/security/csp_script_source_list_keywords.sql
+++ b/sql/2020/security/csp_script_source_list_keywords.sql
@@ -1,7 +1,6 @@
 #standardSQL
 # CSP: usage of default/script-src, and within the directive usage of strict-dynamic, nonce values, unsafe-inline and unsafe-eval
-CREATE TEMPORARY FUNCTION getHeader(headers STRING, headername STRING) -- noqa: PRS
--- SQL Linter cannot handle DETERMINISTIC keyword so needs noqa ignore command on previous line
+CREATE TEMPORARY FUNCTION getHeader(headers STRING, headername STRING)
 RETURNS STRING
 DETERMINISTIC
 LANGUAGE js AS '''

--- a/sql/2020/security/iframe_attribute_popular_hosts.sql
+++ b/sql/2020/security/iframe_attribute_popular_hosts.sql
@@ -1,7 +1,6 @@
 #standardSQL
 # most common hostnames of iframes that have the allow or sandbox attribute
-CREATE TEMP FUNCTION hasPolicy(attr STRING, policy_type STRING) -- noqa: PRS
--- SQL Linter cannot handle DETERMINISTIC keyword so needs noqa ignore command on previous line
+CREATE TEMP FUNCTION hasPolicy(attr STRING, policy_type STRING)
 RETURNS BOOL
 DETERMINISTIC
 LANGUAGE js

--- a/sql/2020/security/security_headers_prevalence.sql
+++ b/sql/2020/security/security_headers_prevalence.sql
@@ -1,7 +1,6 @@
 #standardSQL
 # Prevalence of security headers set in a first-party context; count by number of hosts.
-CREATE TEMPORARY FUNCTION hasHeader(headers STRING, headername STRING) -- noqa: PRS
--- SQL Linter cannot handle DETERMINISTIC keyword so needs noqa ignore command on previous line
+CREATE TEMPORARY FUNCTION hasHeader(headers STRING, headername STRING)
 RETURNS BOOL
 DETERMINISTIC
 LANGUAGE js

--- a/sql/2020/seo/lighthouse.sql
+++ b/sql/2020/seo/lighthouse.sql
@@ -8,8 +8,7 @@ CREATE TEMP FUNCTION AS_PERCENT (freq FLOAT64, total FLOAT64) RETURNS FLOAT64 AS
   ROUND(SAFE_DIVIDE(freq, total), 4)
 );
 
-CREATE TEMPORARY FUNCTION isCrawlableDetails(report STRING) -- noqa: PRS
--- SQL Linter cannot handle DETERMINISTIC keyword so needs noqa ignore command on previous line
+CREATE TEMPORARY FUNCTION isCrawlableDetails(report STRING)
 RETURNS STRUCT<
   disallow BOOL,
   noindex BOOL,

--- a/sql/2020/third-parties/top100_third_parties_by_median_body_size_and_time.sql
+++ b/sql/2020/third-parties/top100_third_parties_by_median_body_size_and_time.sql
@@ -55,7 +55,7 @@ FROM (
     category,
     canonicalDomain,
     median_body_size_kb AS metric,
-    DENSE_RANK() OVER(PARTITION BY client ORDER BY median_body_size_kb DESC) AS rank
+    DENSE_RANK() OVER (PARTITION BY client ORDER BY median_body_size_kb DESC) AS rank
   FROM base
   UNION ALL (
     SELECT
@@ -64,7 +64,7 @@ FROM (
       category,
       canonicalDomain,
       median_time_s AS metric,
-      DENSE_RANK() OVER(PARTITION BY client ORDER BY median_time_s DESC) AS rank
+      DENSE_RANK() OVER (PARTITION BY client ORDER BY median_time_s DESC) AS rank
     FROM base
   )
 )

--- a/sql/2020/third-parties/top100_third_parties_by_number_of_websites.sql
+++ b/sql/2020/third-parties/top100_third_parties_by_number_of_websites.sql
@@ -23,7 +23,7 @@ base AS (
   SELECT
     canonicalDomain,
     COUNT(DISTINCT page) AS total_pages,
-    COUNT(DISTINCT page) / COUNT(DISTINCT page) OVER (PARTITION BY 0) AS pct_pages
+    COUNT(DISTINCT page) / COUNT(DISTINCT page) OVER () AS pct_pages
   FROM
     requests
   LEFT JOIN
@@ -46,7 +46,7 @@ FROM (
     canonicalDomain,
     total_pages,
     pct_pages,
-    DENSE_RANK() OVER(PARTITION BY client ORDER BY total_pages DESC) AS rank
+    DENSE_RANK() OVER (PARTITION BY client ORDER BY total_pages DESC) AS rank
   FROM
     base
 )

--- a/sql/util/requests.sql
+++ b/sql/util/requests.sql
@@ -1,5 +1,4 @@
-CREATE TEMPORARY FUNCTION getSummary(payload STRING) -- noqa: PRS
--- SQL Linter expects STRUCT field names to beging with a-z or A-Z so needs noqa ignore command on previous line
+CREATE TEMPORARY FUNCTION getSummary(payload STRING)
 RETURNS STRUCT<requestId STRING, startedDateTime INT64, time INT64, method STRING, urlShort STRING, redirectUrl STRING, firstReq BOOLEAN, firstHtml BOOLEAN, reqHttpVersion STRING, reqHeadersSize INT64,
   reqBodySize INT64, reqCookieLen INT64, reqOtherHeaders STRING, status INT64, respHttpVersion STRING, respHeadersSize INT64, respBodySize INT64, respSize INT64, respCookieLen INT64, expAge NUMERIC, mimeType STRING, respOtherHeaders STRING,
   req_accept STRING, req_accept_charset STRING, req_accept_encoding STRING, req_accept_language STRING, req_connection STRING, req_host STRING, req_if_modified_since STRING, req_if_none_match STRING, req_referer STRING, req_user_agent STRING,
@@ -198,7 +197,7 @@ SELECT
   page,
   rank,
   url,
-  getSummary(payload).*, -- noqa: PRS, L013
+  getSummary(payload).*, -- noqa: L013
   JSON_EXTRACT(payload, "$.request.headers") AS request_headers,
   JSON_EXTRACT(payload, "$.response.headers") AS response_headers,
   payload


### PR DESCRIPTION
Upgrades to latest version of SQL Fluff and enables the new rules it allows us to turn on thanks to some enhancements in there. Namely:

- Fix and remove all `noqa: PRS` overrides for parsing errors as all parsing errors are now fixed.
- Enable L003 - We can check for consistent spacing now they allow us to configure `UNION` to be spaced at same level as `FROM` as we use a lot.
- Enable L007 - We now force operators (e.g. `AND`) at end of line instead of beginning of previous line (though gotta say I personally prefer beginning of line as easier to comment out!)
- L048 you need space around quoted literals (e.g. not `SELECT 'foo'AS bar`). Previously this caused a problem with triple quotes used at beginning and end of UDFs
- Enforce `COUNT(0)` over `COUNT(1)` or `COUNT(*)` now that rule L047 allows this to be configured.
- Fix unnecessary use of `PARTITION BY 0` in `OVER` clauses as empty `OVER ()` is now supported.