### PR TITLE
Exclude Jinja templates from CodeQL scanning

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,4 @@
+# Ignore template files as CodeQL gets comfused with Jinja
+# and tries ot analysis it as though it's inline JavaScript
+paths-ignore:
+  - src/templates

--- a/.github/workflows/code-static-analysis.yml
+++ b/.github/workflows/code-static-analysis.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1
         with:
+          config-file: ./.github/codeql/codeql-config.yml
           queries: +security-and-quality
           setup-python-dependencies: false
           languages: '${{ matrix.language }}'

--- a/src/server/validate.py
+++ b/src/server/validate.py
@@ -12,6 +12,7 @@ TYPO_CHAPTERS = {
     'http-2': 'http',
     'http2': 'http',
     'http3': 'http',
+    'html': 'markup',
     'mobileweb': 'mobile-web',
     'pageweight': 'page-weight',
     'resourcehints': 'resource-hints',


### PR DESCRIPTION
It looks like the CodeQL security scanning tool has recently been enhanced to also scan HTML files when completing JavaScript scanning.

This causes us a problem as we use Jinja templates that look like JavaScript but it is not. So it raises 400+ alerts.

So let's exclude the `src/templates` directory from CodeQL to resolve.

NB: This PR also includes a small redirect change in our Python code, to force the scan to run.

First noticed by Privacy chapter in #2227