### PR TITLE
Extra PWA queries

### DIFF
--- a/sql/2021/pwa/pwa_notification_acceptance_rates_over_time.sql
+++ b/sql/2021/pwa/pwa_notification_acceptance_rates_over_time.sql
@@ -12,7 +12,6 @@ SELECT
 FROM
   `chrome-ux-report.materialized.device_summary`
 WHERE
-  date <= ('2021-07-01') AND
   (
     notification_permission_accept IS NOT NULL OR
     notification_permission_deny IS NOT NULL OR

--- a/sql/2021/pwa/pwa_notification_acceptance_rates_over_time.sql
+++ b/sql/2021/pwa/pwa_notification_acceptance_rates_over_time.sql
@@ -1,0 +1,28 @@
+#standardSQL
+# Total Noitification Acceptence Rates across all origins
+# Note: not weighted by domain popularity nor number of notifications shown
+
+SELECT
+  date,
+  IF(device = 'phone', 'mobile', device) AS client,
+  SUM(notification_permission_accept) / SUM(notification_permission_accept + notification_permission_deny + notification_permission_ignore + notification_permission_dismiss) AS accept,
+  SUM(notification_permission_deny) / SUM(notification_permission_accept + notification_permission_deny + notification_permission_ignore + notification_permission_dismiss) AS deny,
+  SUM(notification_permission_ignore) / SUM(notification_permission_accept + notification_permission_deny + notification_permission_ignore + notification_permission_dismiss) AS _ignore,
+  SUM(notification_permission_dismiss) / SUM(notification_permission_accept + notification_permission_deny + notification_permission_ignore + notification_permission_dismiss) AS dismiss
+FROM
+  `chrome-ux-report.materialized.device_summary`
+WHERE
+  date <= ('2021-07-01') AND
+  (
+    notification_permission_accept IS NOT NULL OR
+    notification_permission_deny IS NOT NULL OR
+    notification_permission_ignore IS NOT NULL OR
+    notification_permission_dismiss IS NOT NULL
+  ) AND
+  device IN ('desktop', 'phone')
+GROUP BY
+  date,
+  device
+ORDER BY
+  date DESC,
+  device

--- a/sql/2021/pwa/top_manifest_display_values.sql
+++ b/sql/2021/pwa/top_manifest_display_values.sql
@@ -27,7 +27,7 @@ WHERE
   JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true"
 GROUP BY
   client,
-  display -- noqa: PRS
+  display
 QUALIFY
   display IS NOT NULL AND
   freq > 100
@@ -45,7 +45,7 @@ WHERE
   JSON_EXTRACT(payload, '$._pwa.manifests') != "[]"
 GROUP BY
   client,
-  display -- noqa: PRS
+  display
 QUALIFY
   display IS NOT NULL AND
   freq > 100

--- a/sql/2021/pwa/workbox_methods.sql
+++ b/sql/2021/pwa/workbox_methods.sql
@@ -13,7 +13,9 @@ try {
       var workboxItems = workboxPackageMethods[i].toString().trim().split(',');
       for(var j = 0; j < workboxItems.length; j++) {
         if(workboxItems[j].indexOf(':') == -1) {
-          workboxMethods.push(workboxItems[j].trim());
+          if (workboxItems[j].trim().startsWith('workbox.')) {
+            workboxMethods.push(workboxItems[j].trim().substring(8));
+          }
         }
       }
   }
@@ -26,6 +28,8 @@ try {
 SELECT
   _TABLE_SUFFIX AS client,
   workbox_method,
+  REGEXP_EXTRACT(workbox_method, r'^([^.]+)') AS module_only,
+  REGEXP_EXTRACT(workbox_method, r'^[^.]+\.([^.]+)') AS method_only,
   COUNT(DISTINCT url) AS freq,
   total,
   COUNT(DISTINCT url) / total AS pct

--- a/sql/2021/pwa/workbox_packages.sql
+++ b/sql/2021/pwa/workbox_packages.sql
@@ -15,7 +15,7 @@ try {
         var workboxItem = workboxItems[j];
         var firstColonIndex = workboxItem.indexOf(':');
         if(firstColonIndex > -1) {
-          var workboxPackage = workboxItem.trim().substring(0, workboxItem.indexOf(':', firstColonIndex + 1));
+          var workboxPackage = workboxItem.trim().substring(firstColonIndex + 1, workboxItem.indexOf(':', firstColonIndex + 1));
           workboxPackages.push(workboxPackage);
         }
       }


### PR DESCRIPTION
Added some extra queries at author's request.

Informed author that the first would treat all origins as of equal weight and does not take into account how often these notifications show, but that's in keeping with the rest of our analysis anyway.

Allows graphs like this:

![Notification acceptance rates](https://user-images.githubusercontent.com/10931297/134799018-a6cf519c-8b6e-4661-8473-d623047bc039.png)

![Mobile notification acceptance rates over time](https://user-images.githubusercontent.com/10931297/134799030-19ffd1c0-ff85-4747-a99d-6e8c7414a291.png)

![Desktop notification acceptance rates over time](https://user-images.githubusercontent.com/10931297/134799036-3a5501d5-f177-49a8-8528-4443446a5398.png)
