### PR TITLE
Jamstack 2021 queries

### DIFF
--- a/sql/2021/jamstack/adoption_of_image_formats_in_ssgs.sql
+++ b/sql/2021/jamstack/adoption_of_image_formats_in_ssgs.sql
@@ -21,7 +21,7 @@ JOIN (
     _TABLE_SUFFIX AS client,
     url AS page
   FROM
-    `httparchive.technologies.2021_08_01_*`
+    `httparchive.technologies.2021_07_01_*`
   WHERE
     LOWER(category) = "static site generator" OR
     app = "Next.js" OR

--- a/sql/2021/jamstack/adoption_of_image_formats_in_ssgs.sql
+++ b/sql/2021/jamstack/adoption_of_image_formats_in_ssgs.sql
@@ -1,0 +1,35 @@
+#standardSQL
+# Adoption of image formats in SSGs
+SELECT
+  client,
+  format,
+  COUNT(0) AS freq,
+  SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct
+FROM (
+  SELECT
+    client,
+    format,
+    page
+  FROM
+    `httparchive.almanac.requests`
+  WHERE
+    date = '2021-08-01' AND
+    type = 'image')
+JOIN (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    url AS page
+  FROM
+    `httparchive.technologies.2021_08_01_*`
+  WHERE
+    LOWER(category) = "static site generator" OR
+    app = "Next.js" OR
+    app = "Nuxt.js")
+USING
+  (client, page)
+GROUP BY
+  client,
+  format
+ORDER BY
+  pct DESC

--- a/sql/2021/jamstack/adoption_of_image_formats_in_ssgs.sql
+++ b/sql/2021/jamstack/adoption_of_image_formats_in_ssgs.sql
@@ -14,7 +14,7 @@ FROM (
   FROM
     `httparchive.almanac.requests`
   WHERE
-    date = '2021-08-01' AND
+    date = '2021-07-01' AND
     type = 'image')
 JOIN (
   SELECT

--- a/sql/2021/jamstack/core_web_vitals_distribution.sql
+++ b/sql/2021/jamstack/core_web_vitals_distribution.sql
@@ -27,7 +27,7 @@ FROM (
   FROM
     `chrome-ux-report.materialized.device_summary`
   WHERE
-    date = '2021-08-01')
+    date = '2021-07-01')
 JOIN (
   SELECT
     CASE
@@ -50,7 +50,7 @@ JOIN (
   FROM
     `httparchive.almanac.requests`
   WHERE
-    date = '2021-08-01' AND
+    date = '2021-07-01' AND
     firstHtml)
 USING
   (client, url)
@@ -60,7 +60,7 @@ JOIN (
     app,
     url
   FROM
-    `httparchive.technologies.2021_08_01_*`
+    `httparchive.technologies.2021_07_01_*`
   WHERE
     LOWER(category) = "static site generator" OR
     app = "Next.js" OR

--- a/sql/2021/jamstack/core_web_vitals_distribution.sql
+++ b/sql/2021/jamstack/core_web_vitals_distribution.sql
@@ -1,0 +1,77 @@
+#standardSQL
+# Core Web Vitals distribution by SSG
+#
+# Note that this is an unweighted average of all sites per SSG.
+# Performance of sites with millions of visitors as weighted the same as small sites.
+SELECT
+  app,
+  CDN,
+  client,
+  COUNT(DISTINCT origin) AS origins,
+  SUM(fast_lcp) / (SUM(fast_lcp) + SUM(avg_lcp) + SUM(slow_lcp)) AS good_lcp,
+  SUM(avg_lcp) / (SUM(fast_lcp) + SUM(avg_lcp) + SUM(slow_lcp)) AS ni_lcp,
+  SUM(slow_lcp) / (SUM(fast_lcp) + SUM(avg_lcp) + SUM(slow_lcp)) AS poor_lcp,
+
+  SUM(fast_fid) / (SUM(fast_fid) + SUM(avg_fid) + SUM(slow_fid)) AS good_fid,
+  SUM(avg_fid) / (SUM(fast_fid) + SUM(avg_fid) + SUM(slow_fid)) AS ni_fid,
+  SUM(slow_fid) / (SUM(fast_fid) + SUM(avg_fid) + SUM(slow_fid)) AS poor_fid,
+
+  SUM(small_cls) / (SUM(small_cls) + SUM(medium_cls) + SUM(large_cls)) AS good_cls,
+  SUM(medium_cls) / (SUM(small_cls) + SUM(medium_cls) + SUM(large_cls)) AS ni_cls,
+  SUM(large_cls) / (SUM(small_cls) + SUM(medium_cls) + SUM(large_cls)) AS poor_cls
+FROM (
+  SELECT
+    IF(device = 'desktop', 'desktop', 'mobile') AS client,
+    CONCAT(origin, '/') AS url,
+    *
+  FROM
+    `chrome-ux-report.materialized.device_summary`
+  WHERE
+    date = '2021-08-01')
+JOIN (
+  SELECT
+    CASE
+      WHEN REGEXP_EXTRACT(LOWER(CONCAT(respOtherHeaders, resp_x_powered_by, resp_via, resp_server)), '(x-github-request)') = 'x-github-request' THEN 'GitHub'
+      WHEN REGEXP_EXTRACT(LOWER(CONCAT(respOtherHeaders, resp_x_powered_by, resp_via, resp_server)), '(netlify)') = 'netlify' THEN 'Netlify'
+      WHEN REGEXP_EXTRACT(LOWER(CONCAT(respOtherHeaders, resp_x_powered_by, resp_via, resp_server)), '(x-nf-request-id)') IS NOT NULL THEN 'Netlify'
+      WHEN REGEXP_EXTRACT(LOWER(CONCAT(respOtherHeaders, resp_x_powered_by, resp_via, resp_server)), '(x-vercel-id)') IS NOT NULL THEN 'Vercel'
+      WHEN REGEXP_EXTRACT(LOWER(CONCAT(respOtherHeaders, resp_x_powered_by, resp_via, resp_server)), '(x-amz-cf-id)') IS NOT NULL THEN 'AWS'
+      WHEN REGEXP_EXTRACT(LOWER(CONCAT(respOtherHeaders, resp_x_powered_by, resp_via, resp_server)), '(x-azure-ref)') IS NOT NULL THEN 'Azure'
+      WHEN _cdn_provider = 'Microsoft Azure' THEN 'Azure'
+      WHEN _cdn_provider = 'DigitalOcean Spaces CDN' THEN 'DigitalOcean'
+      WHEN _cdn_provider = 'Vercel' THEN 'Vercel'
+      WHEN _cdn_provider = 'Amazon CloudFront' THEN 'AWS'
+      WHEN _cdn_provider = 'Akamai' THEN 'Akamai'
+      WHEN _cdn_provider = 'Cloudflare' THEN 'Cloudflare'
+      ELSE NULL
+    END AS CDN,
+    client,
+    page AS url
+  FROM
+    `httparchive.almanac.requests`
+  WHERE
+    date = '2021-08-01' AND
+    firstHtml)
+USING
+  (client, url)
+JOIN (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    app,
+    url
+  FROM
+    `httparchive.technologies.2021_08_01_*`
+  WHERE
+    LOWER(category) = "static site generator" OR
+    app = "Next.js" OR
+    app = "Nuxt.js"
+  )
+USING (client, url)
+WHERE
+  CDN IS NOT NULL
+GROUP BY
+  app,
+  CDN,
+  client
+ORDER BY
+  origins DESC

--- a/sql/2021/jamstack/core_web_vitals_passing.sql
+++ b/sql/2021/jamstack/core_web_vitals_passing.sql
@@ -1,0 +1,97 @@
+#standardSQL
+# Core Web Vitals performance by CMS
+CREATE TEMP FUNCTION IS_GOOD (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  good / (good + needs_improvement + poor) >= 0.75
+);
+
+CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  good + needs_improvement + poor > 0
+);
+
+
+SELECT
+  app,
+  CDN,
+  client,
+  COUNT(DISTINCT origin) AS origins,
+  # Origins with good LCP divided by origins with any LCP.
+  SAFE_DIVIDE(
+    COUNT(DISTINCT IF(IS_GOOD(fast_lcp, avg_lcp, slow_lcp), origin, NULL)),
+    COUNT(DISTINCT IF(IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) AS pct_good_lcp,
+
+  # Origins with good FID divided by origins with any FID.
+  SAFE_DIVIDE(
+    COUNT(DISTINCT IF(IS_GOOD(fast_fid, avg_fid, slow_fid), origin, NULL)),
+    COUNT(DISTINCT IF(IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) AS pct_good_fid,
+
+  # Origins with good CLS divided by origins with any CLS.
+  SAFE_DIVIDE(
+    COUNT(DISTINCT IF(IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)),
+    COUNT(DISTINCT IF(IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_good_cls,
+
+  # Origins with good LCP, FID, and CLS dividied by origins with any LCP, FID, and CLS.
+  SAFE_DIVIDE(
+    COUNT(DISTINCT IF(
+      IS_GOOD(fast_lcp, avg_lcp, slow_lcp) AND
+      IS_GOOD(fast_fid, avg_fid, slow_fid) AND
+      IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)),
+    COUNT(DISTINCT IF(
+      IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp) AND
+      IS_NON_ZERO(fast_fid, avg_fid, slow_fid) AND
+      IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_good_cwv
+FROM (
+  SELECT
+    IF(device = 'desktop', 'desktop', 'mobile') AS client,
+    CONCAT(origin, '/') AS url,
+    *
+  FROM
+    `chrome-ux-report.materialized.device_summary`
+  WHERE
+    date = '2021-08-01')
+JOIN (
+  SELECT
+    CASE
+      WHEN REGEXP_EXTRACT(LOWER(CONCAT(respOtherHeaders, resp_x_powered_by, resp_via, resp_server)), '(x-github-request)') = 'x-github-request' THEN 'GitHub'
+      WHEN REGEXP_EXTRACT(LOWER(CONCAT(respOtherHeaders, resp_x_powered_by, resp_via, resp_server)), '(netlify)') = 'netlify' THEN 'Netlify'
+      WHEN REGEXP_EXTRACT(LOWER(CONCAT(respOtherHeaders, resp_x_powered_by, resp_via, resp_server)), '(x-nf-request-id)') IS NOT NULL THEN 'Netlify'
+      WHEN REGEXP_EXTRACT(LOWER(CONCAT(respOtherHeaders, resp_x_powered_by, resp_via, resp_server)), '(x-vercel-id)') IS NOT NULL THEN 'Vercel'
+      WHEN REGEXP_EXTRACT(LOWER(CONCAT(respOtherHeaders, resp_x_powered_by, resp_via, resp_server)), '(x-amz-cf-id)') IS NOT NULL THEN 'AWS'
+      WHEN REGEXP_EXTRACT(LOWER(CONCAT(respOtherHeaders, resp_x_powered_by, resp_via, resp_server)), '(x-azure-ref)') IS NOT NULL THEN 'Azure'
+      WHEN _cdn_provider = 'Microsoft Azure' THEN 'Azure'
+      WHEN _cdn_provider = 'DigitalOcean Spaces CDN' THEN 'DigitalOcean'
+      WHEN _cdn_provider = 'Vercel' THEN 'Vercel'
+      WHEN _cdn_provider = 'Amazon CloudFront' THEN 'AWS'
+      WHEN _cdn_provider = 'Akamai' THEN 'Akamai'
+      WHEN _cdn_provider = 'Cloudflare' THEN 'Cloudflare'
+      ELSE NULL
+    END AS CDN,
+    client,
+    page AS url
+  FROM
+    `httparchive.almanac.requests`
+  WHERE
+    date = '2021-08-01' AND
+    firstHtml)
+USING
+  (client, url)
+JOIN (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    app,
+    url
+  FROM
+    `httparchive.technologies.2021_08_01_*`
+  WHERE
+    LOWER(category) = "static site generator" OR
+    app = "Next.js" OR
+    app = "Nuxt.js"
+  )
+USING (client, url)
+WHERE
+  CDN IS NOT NULL
+GROUP BY
+  app,
+  CDN,
+  client
+ORDER BY
+  origins DESC

--- a/sql/2021/jamstack/core_web_vitals_passing.sql
+++ b/sql/2021/jamstack/core_web_vitals_passing.sql
@@ -47,7 +47,7 @@ FROM (
   FROM
     `chrome-ux-report.materialized.device_summary`
   WHERE
-    date = '2021-08-01')
+    date = '2021-07-01')
 JOIN (
   SELECT
     CASE

--- a/sql/2021/jamstack/core_web_vitals_passing.sql
+++ b/sql/2021/jamstack/core_web_vitals_passing.sql
@@ -33,11 +33,10 @@ SELECT
   SAFE_DIVIDE(
     COUNT(DISTINCT IF(
       IS_GOOD(fast_lcp, avg_lcp, slow_lcp) AND
-      IS_GOOD(fast_fid, avg_fid, slow_fid) AND
+      (NOT IS_NON_ZERO(fast_fid, avg_fid, slow_fid) OR IS_GOOD(fast_fid, avg_fid, slow_fid)) AND
       IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)),
     COUNT(DISTINCT IF(
       IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp) AND
-      IS_NON_ZERO(fast_fid, avg_fid, slow_fid) AND
       IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS pct_good_cwv
 FROM (
   SELECT

--- a/sql/2021/jamstack/core_web_vitals_passing.sql
+++ b/sql/2021/jamstack/core_web_vitals_passing.sql
@@ -70,7 +70,7 @@ JOIN (
   FROM
     `httparchive.almanac.requests`
   WHERE
-    date = '2021-08-01' AND
+    date = '2021-07-01' AND
     firstHtml)
 USING
   (client, url)
@@ -80,7 +80,7 @@ JOIN (
     app,
     url
   FROM
-    `httparchive.technologies.2021_08_01_*`
+    `httparchive.technologies.2021_07_01_*`
   WHERE
     LOWER(category) = "static site generator" OR
     app = "Next.js" OR

--- a/sql/2021/jamstack/distribution_of_page_weight_requests_and_co2_grams_per_ssg_web_page.sql
+++ b/sql/2021/jamstack/distribution_of_page_weight_requests_and_co2_grams_per_ssg_web_page.sql
@@ -1,0 +1,53 @@
+#standardSQL
+# Distribution of page weight, requests, and co2 grams per SSG web page
+# https://gitlab.com/wholegrain/carbon-api-2-0/-/blob/b498ec3bb239536d3612c5f3d758f46e0d2431a6/includes/carbonapi.php
+CREATE TEMP FUNCTION
+GREEN(url STRING) AS (FALSE); -- TODO: Investigate fetching from Green Web Foundation
+CREATE TEMP FUNCTION
+adjustDataTransfer(val INT64) AS (val * 0.75 + 0.02 * val * 0.25);
+CREATE TEMP FUNCTION
+energyConsumption(bytes FLOAT64) AS (bytes * 1.805 / 1073741824);
+CREATE TEMP FUNCTION
+getCo2Grid(energy FLOAT64) AS (energy * 475);
+CREATE TEMP FUNCTION
+getCo2Renewable(energy FLOAT64) AS (energy * 0.1008 * 33.4 + energy * 0.8992 * 475);
+CREATE TEMP FUNCTION
+CO2(url STRING, bytes INT64) AS (
+  IF(GREEN(url),
+           getCo2Renewable(energyConsumption(adjustDataTransfer(bytes))),
+    getCo2Grid(energyConsumption(adjustDataTransfer(bytes)))));
+
+SELECT
+  percentile,
+  client,
+  APPROX_QUANTILES(requests, 1000)[OFFSET(percentile * 10)] AS requests,
+  ROUND(APPROX_QUANTILES(bytes, 1000)[OFFSET(percentile * 10)] / 1024 / 1024, 2) AS mbytes,
+  APPROX_QUANTILES(co2grams, 1000)[OFFSET(percentile * 10)] AS co2grams
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    reqTotal AS requests,
+    bytesTotal AS bytes,
+    CO2(url, bytesTotal) AS co2grams
+  FROM
+    `httparchive.summary_pages.2021_08_01_*`
+  JOIN (
+    SELECT
+      _TABLE_SUFFIX,
+      url
+    FROM
+      `httparchive.technologies.2021_08_01_*`
+    WHERE
+      LOWER(category) = "static site generator" OR
+      app = "Next.js" OR
+      app = "Nuxt.js"
+  )
+  USING
+    (_TABLE_SUFFIX, url)),
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
+GROUP BY
+  percentile,
+  client
+ORDER BY
+  percentile,
+  client

--- a/sql/2021/jamstack/distribution_of_page_weight_requests_and_co2_grams_per_ssg_web_page.sql
+++ b/sql/2021/jamstack/distribution_of_page_weight_requests_and_co2_grams_per_ssg_web_page.sql
@@ -30,13 +30,13 @@ FROM (
     bytesTotal AS bytes,
     CO2(url, bytesTotal) AS co2grams
   FROM
-    `httparchive.summary_pages.2021_08_01_*`
+    `httparchive.summary_pages.2021_07_01_*`
   JOIN (
     SELECT
       _TABLE_SUFFIX,
       url
     FROM
-      `httparchive.technologies.2021_08_01_*`
+      `httparchive.technologies.2021_07_01_*`
     WHERE
       LOWER(category) = "static site generator" OR
       app = "Next.js" OR

--- a/sql/2021/jamstack/median_lighthouse_score.sql
+++ b/sql/2021/jamstack/median_lighthouse_score.sql
@@ -8,9 +8,9 @@ SELECT
   APPROX_QUANTILES(CAST(JSON_EXTRACT_SCALAR(report, '$.categories.accessibility.score') AS NUMERIC), 1000)[OFFSET(500)] AS median_accessibility,
   APPROX_QUANTILES(CAST(JSON_EXTRACT_SCALAR(report, '$.categories.pwa.score') AS NUMERIC), 1000)[OFFSET(500)] AS median_pwa
 FROM
-  `httparchive.lighthouse.2021_09_01_*`
+  `httparchive.lighthouse.2021_07_01_*`
 JOIN
-  `httparchive.technologies.2021_09_01_*`
+  `httparchive.technologies.2021_07_01_*`
 USING
   (_TABLE_SUFFIX, url)
 WHERE

--- a/sql/2021/jamstack/median_lighthouse_score.sql
+++ b/sql/2021/jamstack/median_lighthouse_score.sql
@@ -1,0 +1,24 @@
+#standardSQL
+# Lighthouse category scores per SSG
+SELECT
+  _TABLE_SUFFIX AS client,
+  app AS ssg,
+  COUNT(DISTINCT url) AS freq,
+  APPROX_QUANTILES(CAST(JSON_EXTRACT_SCALAR(report, '$.categories.performance.score') AS NUMERIC), 1000)[OFFSET(500)] AS median_performance,
+  APPROX_QUANTILES(CAST(JSON_EXTRACT_SCALAR(report, '$.categories.accessibility.score') AS NUMERIC), 1000)[OFFSET(500)] AS median_accessibility,
+  APPROX_QUANTILES(CAST(JSON_EXTRACT_SCALAR(report, '$.categories.pwa.score') AS NUMERIC), 1000)[OFFSET(500)] AS median_pwa
+FROM
+  `httparchive.lighthouse.2021_09_01_*`
+JOIN
+  `httparchive.technologies.2021_09_01_*`
+USING
+  (_TABLE_SUFFIX, url)
+WHERE
+  LOWER(category) = "static site generator" OR
+  app = "Next.js" OR
+  app = "Nuxt.js"
+GROUP BY
+  ssg,
+  client
+ORDER BY
+  freq DESC

--- a/sql/2021/jamstack/ranking.sql
+++ b/sql/2021/jamstack/ranking.sql
@@ -1,0 +1,53 @@
+#standardSQL
+SELECT
+  client,
+  rank,
+  app,
+  COUNT(DISTINCT url) AS pages,
+  total_pages,
+  COUNT(DISTINCT url) / total_pages AS pct,
+  COUNT(DISTINCT url) / rank AS rank_pct
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    app,
+    url
+  FROM
+    `httparchive.technologies.2021_07_01_*`
+  WHERE
+    LOWER(category) = 'static site generator' OR
+    app = 'Next.js' OR
+    app = 'Nuxt.js')
+JOIN (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    COUNT(0) AS total_pages
+  FROM
+    `httparchive.summary_pages.2021_07_01_*`
+  GROUP BY
+    client)
+USING
+  (client)
+JOIN (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    url,
+    MAX(rank) AS rank
+  FROM
+    `httparchive.summary_pages.2021_07_01_*`,
+    UNNEST([1e3, 1e4, 1e5, 1e6, 1e7]) AS rank_magnitude
+  WHERE
+    rank <= rank_magnitude
+  GROUP BY
+    client,
+    url)
+USING
+  (client, url)
+GROUP BY
+  client,
+  rank,
+  app,
+  total_pages
+ORDER BY
+  rank,
+  pct DESC

--- a/sql/2021/jamstack/ssg_compared_to_2020.sql
+++ b/sql/2021/jamstack/ssg_compared_to_2020.sql
@@ -42,7 +42,7 @@ JOIN (
     _TABLE_SUFFIX,
     COUNT(0) AS total
   FROM
-    `httparchive.summary_pages.2020_07_01_*`
+    `httparchive.summary_pages.2020_08_01_*`
   GROUP BY
     _TABLE_SUFFIX)
 USING

--- a/sql/2021/jamstack/ssg_compared_to_2020.sql
+++ b/sql/2021/jamstack/ssg_compared_to_2020.sql
@@ -50,8 +50,7 @@ USING
 WHERE
   LOWER(category) = "static site generator" OR
   app = "Next.js" OR
-  app = "Nuxt.js" OR
-  app = "Docusaurus"
+  app = "Nuxt.js"
 GROUP BY
   client,
   total,

--- a/sql/2021/jamstack/ssg_compared_to_2020.sql
+++ b/sql/2021/jamstack/ssg_compared_to_2020.sql
@@ -1,0 +1,61 @@
+#standardSQL
+# SSG adoptions and top SSGs YoY
+SELECT
+  _TABLE_SUFFIX AS client,
+  2021 AS year,
+  app AS ssg,
+  COUNT(0) AS freq,
+  total,
+  COUNT(0) / total AS pct
+FROM
+  `httparchive.technologies.2021_08_01_*`
+JOIN (
+  SELECT
+    _TABLE_SUFFIX,
+    COUNT(0) AS total
+  FROM
+    `httparchive.summary_pages.2021_08_01_*`
+  GROUP BY
+    _TABLE_SUFFIX)
+USING
+  (_TABLE_SUFFIX)
+WHERE
+  LOWER(category) = "static site generator" OR
+  app = "Next.js" OR
+  app = "Nuxt.js"
+GROUP BY
+  client,
+  total,
+  ssg
+UNION ALL
+SELECT
+  _TABLE_SUFFIX AS client,
+  2020 AS year,
+  app AS ssg,
+  COUNT(0) AS freq,
+  total,
+  COUNT(0) / total AS pct
+FROM
+  `httparchive.technologies.2020_07_01_*`
+JOIN (
+  SELECT
+    _TABLE_SUFFIX,
+    COUNT(0) AS total
+  FROM
+    `httparchive.summary_pages.2020_07_01_*`
+  GROUP BY
+    _TABLE_SUFFIX)
+USING
+  (_TABLE_SUFFIX)
+WHERE
+  LOWER(category) = "static site generator" OR
+  app = "Next.js" OR
+  app = "Nuxt.js" OR
+  app = "Docusaurus"
+GROUP BY
+  client,
+  total,
+  ssg
+ORDER BY
+  year DESC,
+  pct DESC

--- a/sql/2021/jamstack/ssg_compared_to_2020.sql
+++ b/sql/2021/jamstack/ssg_compared_to_2020.sql
@@ -8,13 +8,13 @@ SELECT
   total,
   COUNT(0) / total AS pct
 FROM
-  `httparchive.technologies.2021_08_01_*`
+  `httparchive.technologies.2021_07_01_*`
 JOIN (
   SELECT
     _TABLE_SUFFIX,
     COUNT(0) AS total
   FROM
-    `httparchive.summary_pages.2021_08_01_*`
+    `httparchive.summary_pages.2021_07_01_*`
   GROUP BY
     _TABLE_SUFFIX)
 USING

--- a/sql/2021/jamstack/ssg_compared_to_2020.sql
+++ b/sql/2021/jamstack/ssg_compared_to_2020.sql
@@ -36,7 +36,7 @@ SELECT
   total,
   COUNT(0) / total AS pct
 FROM
-  `httparchive.technologies.2020_07_01_*`
+  `httparchive.technologies.2020_08_01_*`
 JOIN (
   SELECT
     _TABLE_SUFFIX,

--- a/sql/2021/jamstack/third_party_bytes_and_requests_on_ssgs.sql
+++ b/sql/2021/jamstack/third_party_bytes_and_requests_on_ssgs.sql
@@ -19,13 +19,13 @@ FROM (
     FROM
       `httparchive.almanac.requests`
     WHERE
-      date = '2020-07-01')
+      date = '2021-07-01')
   JOIN (
     SELECT
       _TABLE_SUFFIX AS client,
       url AS page
     FROM
-      `httparchive.technologies.2020_07_01_*`
+      `httparchive.technologies.2021_07_01_*`
     WHERE
       LOWER(category) = "static site generator" OR
       app = "Next.js" OR
@@ -39,7 +39,7 @@ FROM (
       FROM
         `httparchive.almanac.third_parties`
       WHERE
-        date = '2020-07-01' AND
+        date = '2021-07-01' AND
         category != 'hosting')
   GROUP BY
     client,

--- a/sql/2021/jamstack/third_party_bytes_and_requests_on_ssgs.sql
+++ b/sql/2021/jamstack/third_party_bytes_and_requests_on_ssgs.sql
@@ -1,0 +1,53 @@
+#standardSQL
+# Third party bytes and requests on SSGs
+SELECT
+  percentile,
+  client,
+  APPROX_QUANTILES(requests, 1000)[OFFSET(percentile * 10)] AS requests,
+  APPROX_QUANTILES(bytes, 1000)[OFFSET(percentile * 10)] / 1024 AS kbytes
+FROM (
+  SELECT
+    client,
+    COUNT(0) AS requests,
+    SUM(respSize) AS bytes
+  FROM (
+    SELECT
+      client,
+      page,
+      url,
+      respSize
+    FROM
+      `httparchive.almanac.requests`
+    WHERE
+      date = '2020-08-01')
+  JOIN (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      url AS page
+    FROM
+      `httparchive.technologies.2020_08_01_*`
+    WHERE
+      LOWER(category) = "static site generator" OR
+      app = "Next.js" OR
+      app = "Nuxt.js")
+  USING
+    (client, page)
+  WHERE
+    NET.HOST(url) IN (
+      SELECT
+        domain
+      FROM
+        `httparchive.almanac.third_parties`
+      WHERE
+        date = '2020-08-01' AND
+        category != 'hosting')
+  GROUP BY
+    client,
+    page),
+  UNNEST([10, 25, 50, 75, 90, 100]) AS percentile
+GROUP BY
+  percentile,
+  client
+ORDER BY
+  percentile,
+  client

--- a/sql/2021/jamstack/third_party_bytes_and_requests_on_ssgs.sql
+++ b/sql/2021/jamstack/third_party_bytes_and_requests_on_ssgs.sql
@@ -19,13 +19,13 @@ FROM (
     FROM
       `httparchive.almanac.requests`
     WHERE
-      date = '2020-08-01')
+      date = '2020-07-01')
   JOIN (
     SELECT
       _TABLE_SUFFIX AS client,
       url AS page
     FROM
-      `httparchive.technologies.2020_08_01_*`
+      `httparchive.technologies.2020_07_01_*`
     WHERE
       LOWER(category) = "static site generator" OR
       app = "Next.js" OR
@@ -39,7 +39,7 @@ FROM (
       FROM
         `httparchive.almanac.third_parties`
       WHERE
-        date = '2020-08-01' AND
+        date = '2020-07-01' AND
         category != 'hosting')
   GROUP BY
     client,


### PR DESCRIPTION
Queries for #2156 
These are most of queries from [2020](https://github.com/HTTPArchive/almanac.httparchive.org/pull/1228)
I have to run them again to see if we can add anything.

- [x] Adoption of image formats in SSGs
- [x] Core Web Vitals distribution by CDNs hosted top SSGs
- [x] Core Web Vitals of CDNs hosted SSGs
- [x] Distribution of page weight, requests, and co2 grams per SSG web page
- [x] Lighthouse category scores per SSG
- [x] SSG adoptions and top SSGs YoY
- [x] Core Web Vitals distribution by SSG
- [x] Core Web Vitals performance by SSG
- [x] Third party bytes and requests on SSGs
- [x] Jamstack rank magnitude (isn't tested)  