### PR TITLE
Update "join the team" link on Contributors page

### DIFF
--- a/src/templates/base/contributors.html
+++ b/src/templates/base/contributors.html
@@ -296,7 +296,7 @@
 
     <ul class="contributor-grid">
       <li class="contributor-join">
-        <a href="https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/README.md" aria-labelledby="jointheteam">
+        <a href="https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/CONTRIBUTING.md" aria-labelledby="jointheteam">
           <svg xmlns="http://www.w3.org/2000/svg" role="img" width="174" height="100" viewBox="0 0 173 96">
             <title id="jointheteam">{{ self.join_the_team_title() }}</title>
             <path d="M0,0l8.4,75.1l88.7,0.8L93.3,96l24.9-19.1l50.6-1.8l3.7-67.5L0,0z"/>


### PR DESCRIPTION
Point to CONTRIBUTING.md rather than the base README, which just links to the other file anyway. (I've also updated CONTRIBUTING with 2022 info and committed it directly to main)