### PR TITLE
Add webmentions.io to website

### DIFF
--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -42,6 +42,7 @@
 
 <link rel="webmention" href="https://webmention.io/almanac.httparchive.org/webmention" />
 <link rel="pingback" href="https://webmention.io/almanac.httparchive.org/xmlrpc" />
+<link rel="me" href="mailto:team@httparchive.org" />
 
 {% block structured_data %}
 <script type="application/ld+json">


### PR DESCRIPTION
Makes progress on #2192 

This sets us up for webmentions.io so they can start tracking web mentions.

It does not include the UI to display them yet.