### PR TITLE
Translate generated by message to Japanese

### DIFF
--- a/src/templates/ja/base.html
+++ b/src/templates/ja/base.html
@@ -132,8 +132,8 @@ Web Almanacは、ウェブ・コミュニティの努力によって実現して
 {% block appendices %}付属資料{% endblock %}
 
 {% block ebook_title %}電子ブック{% endblock %}
-{% block ebook_download_short %}電子ブックPDF ({{ ebook_size_in_mb }}MB){% endblock %}
-{% block ebook_download %} {{ year }} Web AlmanacのPDFファイルをダウンロードする ({{ ebook_size_in_mb }}MB){% endblock %}
+{% block ebook_download_short %}電子ブックPDF（{{ ebook_size_in_mb }}MB）{% endblock %}
+{% block ebook_download %} {{ year }} Web AlmanacのPDFファイルをダウンロードする（{{ ebook_size_in_mb }}MB）{% endblock %}
 {% block ebook_download_note %}（<a href="https://www.princexml.com/">www.princexml.com</a>で生成）{% endblock %}
 
 {%


### PR DESCRIPTION
Noticed this in Japanese version:

![Screenshot](https://user-images.githubusercontent.com/10931297/138589607-c19532d5-d270-4d91-863a-d8b53f6675be.png)

This PR translates the missing text