### PR TITLE
Stat updates for 2021

### DIFF
--- a/src/templates/en/2021/base.html
+++ b/src/templates/en/2021/base.html
@@ -1,8 +1,8 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}7.5M{% endblock %}
-{% block methodology_stat_2 %}30.4 TB{% endblock %}
-{% block total_websites %}over 7.5 million{% endblock %}
+{% block methodology_stat_1 %}8.2M{% endblock %}
+{% block methodology_stat_2 %}39.5 TB{% endblock %}
+{% block total_websites %}nearly 8.2 million{% endblock %}
 {% block dataset %}July 2021{% endblock %}
 
 {% block foreword %}

--- a/src/templates/es/2021/base.html
+++ b/src/templates/es/2021/base.html
@@ -1,8 +1,8 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}7,5M{% endblock %}
-{% block methodology_stat_2 %}30,4 TB{% endblock %}
-{% block total_websites %}más de 7.5 millones{% endblock %}
+{% block methodology_stat_1 %}8,2M{% endblock %}
+{% block methodology_stat_2 %}39,5 TB{% endblock %}
+{% block total_websites %}aproximadamente de 8.2 millones{% endblock %}
 {% block dataset %}Julio de 2021{% endblock %}
 
 {% block foreword %}

--- a/src/templates/fr/2021/base.html
+++ b/src/templates/fr/2021/base.html
@@ -1,8 +1,8 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}7,5&nbsp;M{% endblock %}
-{% block methodology_stat_2 %}30,4&nbsp;To{% endblock %}
-{% block total_websites %}plus de 7,5 millions{% endblock %}
+{% block methodology_stat_1 %}8,2&nbsp;M{% endblock %}
+{% block methodology_stat_2 %}39,5&nbsp;To{% endblock %}
+{% block total_websites %}près de 8,2 millions{% endblock %}
 {% block dataset %}juillet 2021{% endblock %}
 
 {% block foreword %}

--- a/src/templates/hi/2021/base.html
+++ b/src/templates/hi/2021/base.html
@@ -1,8 +1,8 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}7.5M{% endblock %}
-{% block methodology_stat_2 %}30.4 TB{% endblock %}
-{% block total_websites %}7.5 मिलियन से अधिक{% endblock %}
+{% block methodology_stat_1 %}8.2M{% endblock %}
+{% block methodology_stat_2 %}39.5 TB{% endblock %}
+{% block total_websites %}लगभग 8 मिलियन{% endblock %}
 {% block dataset %}जुलाई 2021{% endblock %}
 
 {% block foreword %}

--- a/src/templates/it/2021/base.html
+++ b/src/templates/it/2021/base.html
@@ -1,8 +1,8 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}7.5M{% endblock %}
-{% block methodology_stat_2 %}30.4 TB{% endblock %}
-{% block total_websites %}oltre 7,5 milioni{% endblock %}
+{% block methodology_stat_1 %}8.2M{% endblock %}
+{% block methodology_stat_2 %}39.5 TB{% endblock %}
+{% block total_websites %}quasi 8,2 milioni{% endblock %}
 {% block dataset %}luglio 2020{% endblock %}
 
 {% block foreword %}

--- a/src/templates/ja/2021/base.html
+++ b/src/templates/ja/2021/base.html
@@ -1,8 +1,8 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}7.5M{% endblock %}
-{% block methodology_stat_2 %}30.4 TB{% endblock %}
-{% block total_websites %}約750万の{% endblock %}
+{% block methodology_stat_1 %}8.2M{% endblock %}
+{% block methodology_stat_2 %}39.5 TB{% endblock %}
+{% block total_websites %}約820万の{% endblock %}
 {% block dataset %}2021年7{% endblock %}
 
 {% block foreword %}

--- a/src/templates/nl/2021/base.html
+++ b/src/templates/nl/2021/base.html
@@ -1,8 +1,8 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}7.5M{% endblock %}
-{% block methodology_stat_2 %}30.4 TB{% endblock %}
-{% block total_websites %}meer dan 7,5 miljoen{% endblock %}
+{% block methodology_stat_1 %}8.2M{% endblock %}
+{% block methodology_stat_2 %}39.5 TB{% endblock %}
+{% block total_websites %}bijna 8,2 miljoen{% endblock %}
 {% block dataset %}juli 2021{% endblock %}
 
 {% block foreword %}

--- a/src/templates/pt/2021/base.html
+++ b/src/templates/pt/2021/base.html
@@ -1,8 +1,8 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}7.5M{% endblock %}
-{% block methodology_stat_2 %}30.4 TB{% endblock %}
-{% block total_websites %}mais de 7.5 milhões{% endblock %}
+{% block methodology_stat_1 %}8.2M{% endblock %}
+{% block methodology_stat_2 %}39.5 TB{% endblock %}
+{% block total_websites %}cerca de 8.2 milhões{% endblock %}
 {% block dataset %}julho de 2021{% endblock %}
 
 {% block foreword %}

--- a/src/templates/ru/2021/base.html
+++ b/src/templates/ru/2021/base.html
@@ -1,8 +1,8 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}7.5 млн{% endblock %}
-{% block methodology_stat_2 %}30.4 Тб{% endblock %}
-{% block total_websites %}около 7,5 миллионов{% endblock %}
+{% block methodology_stat_1 %}8.2 млн{% endblock %}
+{% block methodology_stat_2 %}39.5 Тб{% endblock %}
+{% block total_websites %}около 8,2 миллионов{% endblock %}
 {% block dataset %}июль 2021{% endblock %}
 
 {% block foreword %}

--- a/src/templates/tr/2021/base.html
+++ b/src/templates/tr/2021/base.html
@@ -1,8 +1,8 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}7.5M{% endblock %}
-{% block methodology_stat_2 %}30.4 TB{% endblock %}
-{% block total_websites %}7.5 milyonun üzerinde{% endblock %}
+{% block methodology_stat_1 %}8.2M{% endblock %}
+{% block methodology_stat_2 %}39.5 TB{% endblock %}
+{% block total_websites %}yaklaşık 8.2 milyon{% endblock %}
 {% block dataset %}Temmuz 2021{% endblock %}
 
 {% block foreword %}

--- a/src/templates/uk/2021/base.html
+++ b/src/templates/uk/2021/base.html
@@ -1,8 +1,8 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}7,5&nbsp;млн{% endblock %}
-{% block methodology_stat_2 %}30,4&nbsp;ТБ{% endblock %}
-{% block total_websites %}більш ніж 7,5 мільйонів{% endblock %}
+{% block methodology_stat_1 %}8,2&nbsp;млн{% endblock %}
+{% block methodology_stat_2 %}39,5&nbsp;ТБ{% endblock %}
+{% block total_websites %}майже 8 мільйонів{% endblock %}
 {% block dataset %}липня 2021{% endblock %}
 
 {% block foreword %}

--- a/src/templates/zh-CN/2021/base.html
+++ b/src/templates/zh-CN/2021/base.html
@@ -1,8 +1,8 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}7.5M{% endblock %}
-{% block methodology_stat_2 %}30.4 TB{% endblock %}
-{% block total_websites %}超过750万个{% endblock %}
+{% block methodology_stat_1 %}8.2M{% endblock %}
+{% block methodology_stat_2 %}39.5 TB{% endblock %}
+{% block total_websites %}大约820万个{% endblock %}
 {% block dataset %}2021年7{% endblock %}
 
 {% block foreword %}

--- a/src/templates/zh-TW/2021/base.html
+++ b/src/templates/zh-TW/2021/base.html
@@ -1,8 +1,8 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}7.5 M{% endblock %}
-{% block methodology_stat_2 %}30.4 TB{% endblock %}
-{% block total_websites %}超過7.5百萬{% endblock %}
+{% block methodology_stat_1 %}8.2 M{% endblock %}
+{% block methodology_stat_2 %}39.5 TB{% endblock %}
+{% block total_websites %}近8.2百萬{% endblock %}
 {% block dataset %}2021年7{% endblock %}
 
 {% block foreword %}


### PR DESCRIPTION
Updated based on this SQL:

```sql
# Number of sites analysed
SELECT "ALL", COUNT(DISTINCT url) FROM `httparchive.summary_pages.2021_07_01_*`
UNION ALL
SELECT _TABLE_SUFFIX as client, COUNT(DISTINCT url) FROM `httparchive.summary_pages.2021_07_01_*` group by _TABLE_SUFFIX;
```

And this (do NOT run this - just ote how much it will use):

```sql
 total TB used and one more TB for chrome country level data
SELECT *
FROM
  `httparchive.pages.2021_07_01_*`, # 389GB
  #`httparchive.summary_pages.2021_07_01_*`, # 78GB
  #`httparchive.requests.2021_07_01_*`, # 5.3TB
  `httparchive.summary_requests.2021_07_01_*`, # 850 GB
  `httparchive.response_bodies.2021_07_01_*`, # 17.1TB
  `httparchive.lighthouse.2021_07_01_*`, # 1.2 TB
  `chrome-ux-report.all.202008`, #0.5TB
  `chrome-ux-report.materialized.metrics_summary`, # 0.1 TB
  `chrome-ux-report.materialized.device_summary`, # 0.1 TB
  `httparchive.technologies.*`, # 150GB
  `httparchive.wappalyzer.*` # 27GB
```