### PR TITLE
Hide discussion icons if no discuss metadata

### DIFF
--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -52,9 +52,11 @@
 {% endblock %}
 
 {% block scripts %}
+{% if metadata.get('discuss') %}
 <script nonce="{{ csp_nonce() }}">
 window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discuss') }}.json";
 </script>
+{% endif %}
 {{ super() }}
 {% endblock %}
 
@@ -65,6 +67,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
       {{ self.explore_the_results() }}
     </a>
   </h2>
+  {% if metadata.get('discuss') %}
   <a class="alt btn" hreflang="en" href="https://discuss.httparchive.org/t/{{ metadata.get('discuss') }}">
     <svg width="18" height="18" role="img" aria-labelledby="discuss-this-chapter">
       <title id="discuss-this-chapter">{{ self.discuss_this_chapter() }}:</title>
@@ -73,6 +76,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
     <span class="num_comments">{{ self.comments_fallback() }}</span> <span data-translation class="comment-singular">{{ self.comment() }}</span>
     <span data-translation class="comment-plural">{{ self.comments() }}</span>
   </a>
+  {% endif %}
   <a class="alt btn" hreflang="en" href="{{ metadata.get('results') }}">
     <svg width="18" height="18" role="img" aria-hidden="true">
       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#bar-chart"></use>
@@ -329,6 +333,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
         <section class="authors">
             {{ render_authors() }}
         </section>
+        {% if metadata.get('discuss') %}
         <div id="cta-container">
           <a class="alt btn chapter-cta comment-cta" hreflang="en" href="https://discuss.httparchive.org/t/{{ metadata.get('discuss') }}">
             <svg width="22" height="22" role="img" aria-labelledby="discuss-this-chapter-cta">
@@ -339,6 +344,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
             <span data-translation class="comment-plural visually-hidden-mobile">{{ self.comments() }}</span>
           </a>
         </div>
+        {% endif %}
         <nav aria-label="{{ self.prev_next_title() }}" id="chapter-navigation">
             {{ render_prevnext() }}
         </nav>


### PR DESCRIPTION
As per #2414 we'll not be having the HTTP Archive Discussion topics this year so we should hide the icon if not set in Metadata.