### PR TITLE
Add total blocking time query

### DIFF
--- a/sql/2021/performance/max_tbt.sql
+++ b/sql/2021/performance/max_tbt.sql
@@ -1,0 +1,7 @@
+#standardSQL
+# Max TBT
+
+SELECT
+  MAX(CAST(JSON_EXTRACT_SCALAR(report, "$.audits.total-blocking-time.numericValue") AS FLOAT64)) AS maxTbt
+FROM
+  `httparchive.lighthouse.2021_07_01_mobile`

--- a/sql/2021/performance/tbt.sql
+++ b/sql/2021/performance/tbt.sql
@@ -1,0 +1,39 @@
+#standardSQL
+# TBT data by threshold
+
+CREATE TEMP FUNCTION getTbtThreshold (lighthouseTbtScore FLOAT64) RETURNS STRING LANGUAGE js AS '''
+  if (lighthouseTbtScore >= 0.75) {
+      return 'GOOD'
+  } else if (lighthouseTbtScore >= 0.25) {
+      return 'NI'
+  } else if (lighthouseTbtScore >= 0) {
+      return 'POOR'
+  } else {
+      return 'NA'
+  }
+''';
+
+WITH
+tbt_stats AS (
+  SELECT
+    url,
+    report,
+    CAST(JSON_EXTRACT_SCALAR(report, "$.audits.total-blocking-time.numericValue") AS FLOAT64) AS lighthouseTbt,
+    CAST(JSON_EXTRACT_SCALAR(report, "$.audits.total-blocking-time.score") AS FLOAT64) AS lighthouseTbtScore,
+    getTbtThreshold(CAST(JSON_EXTRACT_SCALAR(report, "$.audits.total-blocking-time.score") AS FLOAT64)) AS threshold
+  FROM
+    --`httparchive.pages.2021_07_01_*`
+    `httparchive.sample_data.lighthouse_mobile_10k`
+)
+
+SELECT
+  threshold,
+  COUNT(DISTINCT url) AS pages,
+  --lighthouseTbt,
+  --lighthouseTbtScore,
+  --url,
+  --report,
+FROM
+  tbt_stats
+GROUP BY
+  threshold

--- a/sql/2021/performance/tbt.sql
+++ b/sql/2021/performance/tbt.sql
@@ -1,31 +1,27 @@
 #standardSQL
 # TBT data by threshold
 
-CREATE TEMP FUNCTION getTbtThreshold (lighthouseTbtScore FLOAT64) RETURNS STRING LANGUAGE js AS '''
-  if (lighthouseTbtScore >= 0.75) {
-      return 'GOOD'
-  } else if (lighthouseTbtScore >= 0.25) {
-      return 'NI'
-  } else if (lighthouseTbtScore >= 0) {
-      return 'POOR'
-  } else {
-      return 'NA'
-  }
-''';
-
-WITH
-tbt_stats AS (
+WITH tbt_stats AS (
   SELECT
     url,
-    getTbtThreshold(CAST(JSON_EXTRACT_SCALAR(report, "$.audits.total-blocking-time.score") AS FLOAT64)) AS threshold
+    CAST(JSON_EXTRACT_SCALAR(report, "$.audits.total-blocking-time.numericValue") AS FLOAT64) AS tbtValue,
+    CAST(JSON_EXTRACT_SCALAR(report, "$.audits.total-blocking-time.score") AS FLOAT64) AS tbtScore
   FROM
     `httparchive.lighthouse.2021_07_01_mobile`
 )
 
 SELECT
-  threshold,
-  COUNT(DISTINCT url) AS pages
+  CASE
+    WHEN tbtScore < 0.5 THEN 'POOR'
+    WHEN tbtScore < 0.9 THEN 'NI'
+    ELSE 'GOOD'
+  END AS tbt,
+  COUNT(0) AS pages,
+  SUM(COUNT(0)) OVER () AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER () AS pct
 FROM
   tbt_stats
 GROUP BY
-  threshold
+  tbt
+ORDER BY
+  tbt

--- a/sql/2021/performance/tbt.sql
+++ b/sql/2021/performance/tbt.sql
@@ -24,7 +24,7 @@ tbt_stats AS (
 
 SELECT
   threshold,
-  COUNT(DISTINCT url) AS pages,
+  COUNT(DISTINCT url) AS pages
 FROM
   tbt_stats
 GROUP BY

--- a/sql/2021/performance/tbt.sql
+++ b/sql/2021/performance/tbt.sql
@@ -17,22 +17,14 @@ WITH
 tbt_stats AS (
   SELECT
     url,
-    report,
-    CAST(JSON_EXTRACT_SCALAR(report, "$.audits.total-blocking-time.numericValue") AS FLOAT64) AS lighthouseTbt,
-    CAST(JSON_EXTRACT_SCALAR(report, "$.audits.total-blocking-time.score") AS FLOAT64) AS lighthouseTbtScore,
     getTbtThreshold(CAST(JSON_EXTRACT_SCALAR(report, "$.audits.total-blocking-time.score") AS FLOAT64)) AS threshold
   FROM
-    --`httparchive.pages.2021_07_01_*`
-    `httparchive.sample_data.lighthouse_mobile_10k`
+    `httparchive.lighthouse.2021_07_01_mobile`
 )
 
 SELECT
   threshold,
   COUNT(DISTINCT url) AS pages,
-  --lighthouseTbt,
-  --lighthouseTbtScore,
-  --url,
-  --report,
 FROM
   tbt_stats
 GROUP BY


### PR DESCRIPTION
Progress on #2148 

The FID data wasn't so interesting on its own so adding TBT for some better flavor. 

Here's a longer version of it if you want to test/debug some things:

```sql
#standardSQL
# TBT data by threshold

CREATE TEMP FUNCTION getTbtThreshold (lighthouseTbtScore FLOAT64) RETURNS STRING LANGUAGE js AS '''
  if (lighthouseTbtScore >= 0.75) {
      return 'GOOD'
  } else if (lighthouseTbtScore >= 0.25) {
      return 'NI'
  } else if (lighthouseTbtScore >= 0) {
      return 'POOR'
  } else {
      return 'NA'
  }
''';

WITH
tbt_stats AS (
  SELECT
    url,
    report,
    CAST(JSON_EXTRACT_SCALAR(report, "$.audits.total-blocking-time.numericValue") AS FLOAT64) AS lighthouseTbt,
    CAST(JSON_EXTRACT_SCALAR(report, "$.audits.total-blocking-time.score") AS FLOAT64) AS lighthouseTbtScore,
    getTbtThreshold(CAST(JSON_EXTRACT_SCALAR(report, "$.audits.total-blocking-time.score") AS FLOAT64)) AS threshold
  FROM
    --`httparchive.pages.2021_07_01_*`
    `httparchive.sample_data.lighthouse_mobile_10k`
)

SELECT
  threshold,
  COUNT(DISTINCT url) AS pages,
  --lighthouseTbt,
  --lighthouseTbtScore,
  --url,
  --report,
FROM
  tbt_stats
GROUP BY
  threshold
```