### PR TITLE
Fix Lighthouse tests

### DIFF
--- a/src/tools/scripts/set_lighthouse_urls.sh
+++ b/src/tools/scripts/set_lighthouse_urls.sh
@@ -52,6 +52,9 @@ if [ "${production}" == "1" ]; then
     # Get the production URLs from the production sitemap (except PDFs and Stories)
     LIGHTHOUSE_URLS=$(curl -s https://almanac.httparchive.org/sitemap.xml | grep "<loc" | grep -v "/static/" | grep -v stories | sed 's/ *<loc>//g' | sed 's/<\/loc>//g')
 
+    # Temporarily remove Russian CSS file as failing in Lighthouse - TODO remove this
+    LIGHTHOUSE_URLS=$(echo "${LIGHTHOUSE_URLS}" | grep -v "/ru/2020/css")
+
     # Switch to the Production Config file
     LIGHTHOUSE_CONFIG_FILE="${LIGHTHOUSE_PROD_CONFIG_FILE}"
 
@@ -80,7 +83,6 @@ else
 
     # Temporarily remove Russian CSS file as failing in Lighthouse - TODO remove this
     LIGHTHOUSE_URLS=$(echo "${LIGHTHOUSE_URLS}" | grep -v "/ru/2020/css")
-
 fi
 
 echo "URLS to check:"

--- a/src/tools/scripts/set_lighthouse_urls.sh
+++ b/src/tools/scripts/set_lighthouse_urls.sh
@@ -43,6 +43,7 @@ http://127.0.0.1:8080/en/2019/
 http://127.0.0.1:8080/en/2019/javascript
 http://127.0.0.1:8080/en/2020/
 http://127.0.0.1:8080/en/2020/css
+http://127.0.0.1:8080/en/2021/
 END
 )
 
@@ -69,9 +70,6 @@ elif [ "${RUN_TYPE}" == "pull_request" ] && [ "${COMMIT_SHA}" != "" ]; then
     # Transform the files to http://127.0.0.1:8080 URLs
     LIGHTHOUSE_URLS=$(echo "${CHANGED_FILES}" | sed 's/src\/content/http:\/\/127.0.0.1:8080/g' | sed 's/\.md//g' | sed 's/\/base\//\/en\/2019\//g' | sed 's/src\/templates/http:\/\/127.0.0.1:8080/g' | sed 's/index\.html//g' | sed 's/\.html//g' | sed 's/_/-/g' | sed 's/\/2019\/accessibility-statement/\/accessibility-statement/g' | sed 's/\/2019\/search/\/search/g' )
 
-    # Temporarily remove 2021 until ready to test that - TODO remove this
-    LIGHTHOUSE_URLS=$(echo "${LIGHTHOUSE_URLS}" | grep -v 2021)
-
     # Add base URLs and strip out newlines
     LIGHTHOUSE_URLS=$(echo -e "${LIGHTHOUSE_URLS}\n${BASE_URLS}" | sort -u | sed '/^$/d')
 
@@ -79,6 +77,9 @@ else
 
     # Else test every URL (except PDFs and Stories) in the sitemap
     LIGHTHOUSE_URLS=$(grep loc templates/sitemap.xml | grep -v "/static/" | grep -v stories | sed 's/ *<loc>//g' | sed 's/<\/loc>//g' | sed 's/https:\/\/almanac.httparchive.org/http:\/\/127.0.0.1:8080/g')
+
+    # Temporarily remove Russian CSS file as failing in Lighthouse - TODO remove this
+    LIGHTHOUSE_URLS=$(echo "${LIGHTHOUSE_URLS}" | grep -v "/ru/css")
 
 fi
 

--- a/src/tools/scripts/set_lighthouse_urls.sh
+++ b/src/tools/scripts/set_lighthouse_urls.sh
@@ -79,7 +79,7 @@ else
     LIGHTHOUSE_URLS=$(grep loc templates/sitemap.xml | grep -v "/static/" | grep -v stories | sed 's/ *<loc>//g' | sed 's/<\/loc>//g' | sed 's/https:\/\/almanac.httparchive.org/http:\/\/127.0.0.1:8080/g')
 
     # Temporarily remove Russian CSS file as failing in Lighthouse - TODO remove this
-    LIGHTHOUSE_URLS=$(echo "${LIGHTHOUSE_URLS}" | grep -v "/ru/css")
+    LIGHTHOUSE_URLS=$(echo "${LIGHTHOUSE_URLS}" | grep -v "/ru/2020/css")
 
 fi
 


### PR DESCRIPTION
- Enables 2021 chapters
- Adds 2021 home page by default
- Removes Russian 2020 CSS page from production tests (failing due to a bug in Lighthouse)