### PR TITLE
Switch all GitHub avatars to same domain

### DIFF
--- a/src/config/2019.json
+++ b/src/config/2019.json
@@ -184,7 +184,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/44442451?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/44442451?v=4&s=200",
       "github": "AbbyTsai"
     },
     "kleinab": {
@@ -192,7 +192,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/1319324?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1319324?v=4&s=200",
       "github": "kleinab"
     },
     "argyleink": {
@@ -201,7 +201,7 @@
         "brainstormers",
         "authors"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/1134620?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1134620?v=4&s=200",
       "website": "https://nerdy.dev",
       "github": "argyleink",
       "twitter": "argyleink"
@@ -211,7 +211,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/110953?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/110953?v=4&s=200",
       "website": "https://www.addyosmani.com",
       "github": "addyosmani",
       "twitter": "addyosmani"
@@ -223,7 +223,7 @@
         "reviewers",
         "developers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/960133?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/960133?v=4&s=200",
       "website": "https://ahmadawais.com/",
       "github": "ahmadawais",
       "twitter": "MrAhmadAwais"
@@ -234,7 +234,7 @@
         "brainstormers",
         "authors"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/5702163?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/5702163?v=4&s=200",
       "website": "https://alankent.me",
       "github": "alankent",
       "twitter": "akent99"
@@ -245,7 +245,7 @@
         "brainstormers",
         "authors"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/506089?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/506089?v=4&s=200",
       "github": "amedina",
       "twitter": "iAlbMedina"
     },
@@ -255,7 +255,7 @@
         "brainstormers",
         "reviewers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/117643?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/117643?v=4&s=200",
       "website": "https://ghedini.me/",
       "github": "ghedo"
     },
@@ -264,7 +264,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/97331?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/97331?v=4&s=200",
       "website": "http://infrequently.org",
       "github": "slightlyoff",
       "twitter": "slightlylate"
@@ -274,7 +274,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/4408379?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/4408379?v=4&s=200",
       "website": "https://lex111.ru/",
       "github": "lex111"
     },
@@ -283,7 +283,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/22891577?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/22891577?v=4&s=200",
       "github": "ndrnmnn"
     },
     "dotjs": {
@@ -292,7 +292,7 @@
         "analysts",
         "reviewers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/2914966?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2914966?v=4&s=200",
       "github": "dotjs",
       "twitter": "dot_js"
     },
@@ -301,7 +301,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/38131750?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/38131750?v=4&s=200",
       "website": "https://artefact.com/gb-en/",
       "github": "andylimn",
       "twitter": "Artefact_Andy"
@@ -311,7 +311,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/7674171?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/7674171?v=4&s=200",
       "github": "anoblet"
     },
     "andydavies": {
@@ -320,7 +320,7 @@
         "authors",
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/427052?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/427052?v=4&s=200",
       "website": "http://andydavies.me/",
       "github": "andydavies",
       "twitter": "AndyDavies"
@@ -330,7 +330,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/50932885?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/50932885?v=4&s=200",
       "github": "arigaud-ca",
       "twitter": "arigaud_ca"
     },
@@ -340,7 +340,7 @@
         "authors",
         "brainstormers"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/665379?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/665379?v=4&s=200",
       "github": "arturjanc",
       "twitter": "arturjanc"
     },
@@ -350,7 +350,7 @@
         "reviewers",
         "developers"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/5750656?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/5750656?v=4&s=200",
       "website": "http://www.aymen-loukil.com/en/",
       "github": "AymenLoukil",
       "twitter": "LoukilAymen"
@@ -364,7 +364,7 @@
         "editors",
         "developers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/10931297?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/10931297?v=4&s=200",
       "website": "https://www.tunetheweb.com",
       "github": "tunetheweb",
       "linkedin": "tunetheweb",
@@ -376,7 +376,7 @@
         "developers",
         "translators"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/284742?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/284742?v=4&s=200",
       "website": "https://boris.schapira.dev",
       "github": "borisschapira",
       "twitter": "boostmarks"
@@ -388,7 +388,7 @@
         "authors",
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/870501?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/870501?v=4&s=200",
       "website": "https://bkardell.com",
       "github": "bkardell",
       "twitter": "briankardell"
@@ -398,7 +398,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/409841?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/409841?v=4&s=200",
       "website": "http://publishing-project.rivendellweb.net/",
       "github": "caraya",
       "twitter": "elrond25"
@@ -409,7 +409,7 @@
         "developers",
         "translators"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/6588246?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/6588246?v=4&s=200",
       "github": "c-torres",
       "twitter": "carlos_catb"
     },
@@ -419,7 +419,7 @@
         "reviewers",
         "developers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/1867900?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1867900?v=4&s=200",
       "website": "https://catalin.red/",
       "github": "catalinred",
       "twitter": "catalinred"
@@ -429,7 +429,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/1461498?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1461498?v=4&s=200",
       "website": "https://www.chenhuijing.com",
       "github": "huijing",
       "twitter": "hj_chen"
@@ -440,7 +440,7 @@
         "authors",
         "brainstormers"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/1622597?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1622597?v=4&s=200",
       "github": "colinbendell",
       "twitter": "colinbendell"
     },
@@ -449,7 +449,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/30398527?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/30398527?v=4&s=200",
       "github": "chengxicn"
     },
     "bagder": {
@@ -457,7 +457,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/177011?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/177011?v=4&s=200",
       "website": "https://daniel.haxx.se/",
       "github": "bagder",
       "twitter": "bagder"
@@ -467,7 +467,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/261579?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/261579?v=4&s=200",
       "website": "http://fonts.google.com",
       "github": "davelab6",
       "twitter": "davelab6"
@@ -481,7 +481,7 @@
         "analysts",
         "editors"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/684747?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/684747?v=4&s=200",
       "website": "https://www.lookzook.com",
       "github": "obto",
       "twitter": "theobto"
@@ -493,7 +493,7 @@
         "authors",
         "analysts"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/1514288?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1514288?v=4&s=200",
       "website": "https://dougsillars.com",
       "github": "dougsillars",
       "twitter": "dougsillars"
@@ -503,7 +503,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/17773211?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/17773211?v=4&s=200",
       "website": "https://eduqg.github.io/",
       "github": "eduqg"
     },
@@ -512,7 +512,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/24370436?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/24370436?v=4&s=200",
       "github": "elaynelemos",
       "linkedin": "elaynelemos"
     },
@@ -522,7 +522,7 @@
         "reviewers",
         "editors"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/939727?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/939727?v=4&s=200",
       "website": "https://meyerweb.com",
       "github": "meyerweb",
       "twitter": "meyerweb"
@@ -532,7 +532,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/3441390?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3441390?v=4&s=200",
       "website": "https://ericportis.com",
       "github": "eeeps",
       "twitter": "etportis"
@@ -543,7 +543,7 @@
         "brainstormers",
         "reviewers"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/6840678?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/6840678?v=4&s=200",
       "website": "https://erik.nygren.org/",
       "github": "enygren",
       "twitter": "akanygren"
@@ -570,7 +570,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/34923063?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/34923063?v=4&s=200",
       "website": "https://giacomo.online",
       "github": "GiacomoPignoni",
       "twitter": "Pigna__"
@@ -580,7 +580,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/25320782?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/25320782?v=4&s=200",
       "website": "https://tanhengyeow.github.io",
       "github": "tanhengyeow",
       "twitter": "tanhengyeow"
@@ -590,7 +590,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/50970808?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/50970808?v=4&s=200",
       "github": "henrihelvetica",
       "twitter": "HenriHelvetica"
     },
@@ -600,7 +600,7 @@
         "brainstormers",
         "authors"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/12476932?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/12476932?v=4&s=200",
       "website": "https://houssein.me",
       "github": "housseindjirdeh",
       "twitter": "hdjirdeh"
@@ -610,7 +610,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/16384750?s=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/16384750?s=4&s=200",
       "github": "SilentJMA",
       "twitter": "SilentJMA"
     },
@@ -619,7 +619,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/658496?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/658496?v=4&s=200",
       "website": "https://jaredwhite.com",
       "github": "jaredcwhite",
       "twitter": "jaredcwhite"
@@ -629,7 +629,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/7421844?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/7421844?v=4&s=200",
       "github": "jrharalson"
     },
     "jeffposnick": {
@@ -638,7 +638,7 @@
         "brainstormers",
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/1749548?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1749548?v=4&s=200",
       "website": "https://jeffy.info",
       "github": "jeffposnick",
       "twitter": "jeffposnick"
@@ -648,7 +648,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/13718746?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/13718746?v=4&s=200",
       "linkedin": "johnfox",
       "github": "clarkeclark"
     },
@@ -659,7 +659,7 @@
         "reviewers",
         "developers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/25212653?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/25212653?v=4&s=200",
       "website": "https://gemservers.com",
       "github": "logicalphase",
       "twitter": "jtteag"
@@ -669,7 +669,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/104149?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/104149?v=4&s=200",
       "website": "https://jonathanwold.com",
       "github": "sirjonathan",
       "twitter": "sirjonathan"
@@ -681,7 +681,7 @@
         "reviewers",
         "translators"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/416456?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/416456?v=4&s=200",
       "website": "https://jmperezperez.com",
       "github": "JMPerez",
       "twitter": "jmperezperez"
@@ -691,7 +691,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/33403964?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/33403964?v=4&s=200",
       "website": "https://segbedji.com/",
       "github": "JustinyAhin",
       "twitter": "justinahinon1"
@@ -701,7 +701,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/3008677?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3008677?v=4&s=200",
       "github": "welenofsky"
     },
     "KJLarson": {
@@ -709,7 +709,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/42503401?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/42503401?v=4&s=200",
       "website": "https://www.kjlarson.com",
       "github": "KJLarson",
       "twitter": "KaJLa47"
@@ -719,7 +719,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/25080897?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/25080897?v=4&s=200",
       "github": "tymosh",
       "linkedin": "tymosh"
     },
@@ -730,7 +730,7 @@
         "authors",
         "analysts"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/6076184?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/6076184?v=4&s=200",
       "github": "khempenius",
       "twitter": "katiehempenius"
     },
@@ -739,7 +739,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/3392338?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3392338?v=4&s=200",
       "github": "ljme"
     },
     "chefleo": {
@@ -747,7 +747,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/26022943?s=460&u=64b286deddd79f94a2dc8dee0e7610e0dd2a7b34&v=4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/26022943?s=460&u=64b286deddd79f94a2dc8dee0e7610e0dd2a7b34&v=4",
       "website": "https://chefleo.dev/",
       "github": "chefleo",
       "twitter": "simdigiorgio"
@@ -758,7 +758,7 @@
         "developers",
         "translators"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/2183053?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2183053?v=4&s=200",
       "website": "https://twitter.com/msakamaki2",
       "github": "MSakamaki",
       "twitter": "msakamaki2"
@@ -768,7 +768,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/7148510?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/7148510?v=4&s=200",
       "github": "soulcorrosion",
       "linkedin": "manuel-garcia-12b6928",
       "twitter": "corrosion_pt"
@@ -778,7 +778,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/74384?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/74384?v=4&s=200",
       "website": "https://www.mnot.net/",
       "github": "mnot",
       "twitter": "mnot"
@@ -789,7 +789,7 @@
         "brainstormers",
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/204268?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/204268?v=4&s=200",
       "website": "https://speedcurve.com",
       "github": "zeman",
       "twitter": "MarkZeman"
@@ -800,7 +800,7 @@
         "authors",
         "brainstormers"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/370246?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/370246?v=4&s=200",
       "website": "http://geekonaut.de",
       "github": "AVGP",
       "twitter": "g33konaut"
@@ -811,7 +811,7 @@
         "brainstormers",
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/81942?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/81942?v=4&s=200",
       "website": "https://mathiasbynens.be/",
       "github": "mathiasbynens",
       "twitter": "mathias"
@@ -828,7 +828,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/361671?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/361671?v=4&s=200",
       "github": "matthewp"
     },
     "mikegeyser": {
@@ -836,7 +836,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/105242?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/105242?v=4&s=200",
       "website": "https://mikerambl.es",
       "github": "mikegeyser",
       "twitter": "mikegeyser"
@@ -846,7 +846,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/1132200?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1132200?v=4&s=200",
       "website": "http://mor10.com/",
       "github": "mor10",
       "twitter": "mor10"
@@ -862,7 +862,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/2578321?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2578321?v=4&s=200",
       "website": "https://www.nicolas-hoffmann.net/",
       "github": "nico3333fr",
       "twitter": "Nico3333fr"
@@ -872,7 +872,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/561590?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/561590?v=4&s=200",
       "website": "https://www.noahblon.com",
       "github": "noahblon",
       "twitter": "noahblon"
@@ -882,7 +882,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/46689362?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/46689362?v=4&s=200",
       "github": "noah-vdv",
       "twitter": "noah_aaron_vdv"
     },
@@ -893,7 +893,7 @@
         "authors",
         "analysts"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/2301202?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2301202?v=4&s=200",
       "website": "http://patrickhulce.com",
       "github": "patrickhulce",
       "twitter": "patrickhulce"
@@ -904,7 +904,7 @@
         "brainstormers",
         "reviewers"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/444165?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/444165?v=4&s=200",
       "website": "https://www.webpagetest.org/",
       "github": "pmeenan",
       "twitter": "patmeenan"
@@ -918,7 +918,7 @@
         "reviewers",
         "developers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/7459458?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/7459458?v=4&s=200",
       "github": "paulcalvano",
       "twitter": "paulcalvano",
       "website": "https://paulcalvano.com"
@@ -928,7 +928,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/6407114?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/6407114?v=4&s=200",
       "github": "Pavel-Evdokimov",
       "twitter": "Pavel_Evdokimov"
     },
@@ -937,7 +937,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/34737190?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/34737190?v=4&s=200",
       "website": "https://praveenpal4232.github.io",
       "github": "PraveenPal4232",
       "twitter": "PraveenPal4232"
@@ -949,7 +949,7 @@
         "authors",
         "editors"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/49983543?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/49983543?v=4&s=200",
       "github": "rachellcostello",
       "twitter": "rachellcostello"
     },
@@ -958,7 +958,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/24447527?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/24447527?v=4&s=200",
       "github": "raghuramakrishnan71"
     },
     "raghav": {
@@ -966,7 +966,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/9475742?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/9475742?v=4&s=200",
       "github": "arsenicraghav",
       "twitter": "mail_raghvendra"
     },
@@ -975,7 +975,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/8108643?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/8108643?v=4&s=200",
       "website": "https://reneesvirtualoffice.com",
       "github": "ernee",
       "twitter": "reneesoffice"
@@ -990,7 +990,7 @@
         "developers",
         "editors"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/1120896?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1120896?v=4&s=200",
       "github": "rviscomi",
       "twitter": "rick_viscomi"
     },
@@ -999,7 +999,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/2240689?s=460&v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2240689?s=460&v=4&s=200",
       "github": "rmarx",
       "twitter": "programmingart"
     },
@@ -1014,7 +1014,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/1982567?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1982567?v=4&s=200",
       "website": "https://www.ksakae1216.com/archive",
       "github": "ksakae1216",
       "twitter": "beltway7"
@@ -1025,7 +1025,7 @@
         "brainstormers",
         "authors"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/205226?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/205226?v=4&s=200",
       "website": "https://simpl.info",
       "github": "samdutton",
       "twitter": "sw12"
@@ -1036,7 +1036,7 @@
         "brainstormers",
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/5352840?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/5352840?v=4&s=200",
       "website": "https://scotthelme.co.uk",
       "github": "ScottHelme",
       "twitter": "Scott_Helme"
@@ -1046,7 +1046,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/3684740?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3684740?v=4&s=200",
       "website": "https://sebastienallemand.fr/",
       "github": "allemas",
       "twitter": "allema_s"
@@ -1056,7 +1056,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/38076?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/38076?v=4&s=200",
       "website": "http://sergeychernyshev.com/",
       "github": "sergeychernyshev",
       "twitter": "sergeyche"
@@ -1067,7 +1067,7 @@
         "brainstormers",
         "reviewers"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/244772?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/244772?v=4&s=200",
       "github": "zcorpan",
       "twitter": "zcorpan"
     },
@@ -1084,7 +1084,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/15661032?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/15661032?v=4&s=200",
       "website": "https://speedcurve.com/",
       "github": "tammyeverts",
       "twitter": "tameverts"
@@ -1094,7 +1094,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/2645718?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2645718?v=4&s=200",
       "github": "tjmonsi"
     },
     "tomayac": {
@@ -1103,7 +1103,7 @@
         "brainstormers",
         "authors"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/145676?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/145676?v=4&s=200",
       "website": "https://blog.tomayac.com/",
       "github": "tomayac",
       "twitter": "tomayac"
@@ -1113,7 +1113,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/955601?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/955601?v=4&s=200",
       "website": "http://codepen.io/tomhodgins",
       "github": "tomhodgins"
     },
@@ -1123,7 +1123,7 @@
         "brainstormers",
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/1693164?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1693164?v=4&s=200",
       "website": "http://una.im",
       "github": "una",
       "twitter": "una"
@@ -1133,7 +1133,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/2366341?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2366341?v=4&s=200",
       "website": "https://vamseejasti.com",
       "github": "jasti",
       "twitter": "vamseejasti"
@@ -1144,7 +1144,7 @@
         "brainstormers",
         "reviewers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/2698956?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2698956?v=4&s=200",
       "website": "https://data-seo.com",
       "github": "voltek62"
     },
@@ -1153,7 +1153,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/33907565?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/33907565?v=4&s=200",
       "website": "https://hakacode.github.io",
       "github": "HakaCode",
       "twitter": "hakacode"
@@ -1164,7 +1164,7 @@
         "brainstormers",
         "reviewers"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/786187?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/786187?v=4&s=200",
       "website": "https://blog.yoav.ws",
       "github": "yoavweiss",
       "twitter": "yoavweiss"
@@ -1174,7 +1174,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/106703?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/106703?v=4&s=200",
       "website": "http://tyohan.me",
       "github": "tyohan",
       "twitter": "tyohan"
@@ -1184,7 +1184,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/134745?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/134745?v=4&s=200",
       "website": "https://weston.ruter.net/",
       "github": "westonruter",
       "twitter": "westonruter"
@@ -1197,7 +1197,7 @@
         "analysts",
         "developers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/91795?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/91795?v=4&s=200",
       "website": "https://build.amsterdam/",
       "github": "ymschaap",
       "twitter": "yvoschaap"
@@ -1208,7 +1208,7 @@
         "brainstormers",
         "authors"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/39355?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/39355?v=4&s=200",
       "website": "https://zachleat.com/",
       "github": "zachleat",
       "twitter": "zachleat"

--- a/src/config/2020.json
+++ b/src/config/2020.json
@@ -201,7 +201,7 @@
         "translators",
         "developers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/44442451?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/44442451?v=4&s=200",
       "github": "AbbyTsai"
     },
     "adityapandey1998": {
@@ -209,7 +209,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/31750960?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/31750960?v=4&s=200",
       "github": "adityapandey1998",
       "twitter": "adityapandey98",
       "linkedin": "adityapandey98"
@@ -219,7 +219,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/1376607?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1376607?v=4&s=200",
       "website": "https://adrianroselli.com/",
       "github": "aardrian",
       "twitter": "aardrian"
@@ -229,7 +229,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/960133?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/960133?v=4&s=200",
       "website": "https://AhmadAwais.com",
       "github": "ahmadawais",
       "twitter": "MrAhmadAwais"
@@ -248,7 +248,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/5702163?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/5702163?v=4&s=200",
       "website": "https://alankent.me",
       "github": "alankent",
       "twitter": "akent99"
@@ -258,7 +258,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/506089?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/506089?v=4&s=200",
       "github": "amedina",
       "twitter": "iAlbMedina"
     },
@@ -267,7 +267,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/3109255?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3109255?v=4&s=200",
       "website": "https://getellipsis.com",
       "github": "alexdenning",
       "twitter": "AlexDenning"
@@ -277,7 +277,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/24625637?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/24625637?v=4&s=200",
       "website": "https://togethertech.ca/",
       "github": "alextait1",
       "twitter": "at_fresh_dev"
@@ -289,7 +289,7 @@
         "editors",
         "developers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/4408379?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/4408379?v=4&s=200",
       "website": "https://lex111.ru/",
       "github": "lex111"
     },
@@ -298,7 +298,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/469304?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/469304?v=4&s=200",
       "website": "https://www.aleydasolis.com/en/",
       "github": "aleyda",
       "twitter": "aleyda"
@@ -308,7 +308,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/2914966?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2914966?v=4&s=200",
       "github": "dotjs",
       "twitter": "dot_js"
     },
@@ -317,7 +317,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/8672583?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/8672583?v=4&s=200",
       "website": "https://hankchizljaw.com/",
       "github": "hankchizljaw",
       "twitter": "hankchizljaw"
@@ -327,7 +327,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/5269414?s=460",
+      "avatar_url": "https://avatars.githubusercontent.com/u/5269414?s=460",
       "github": "andy0130tw"
     },
     "antoineeripret": {
@@ -335,7 +335,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/9512616?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/9512616?v=4&s=200",
       "github": "antoineeripret"
     },
     "denar90": {
@@ -344,7 +344,7 @@
         "reviewers",
         "analysts"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/6231516?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/6231516?v=4&s=200",
       "github": "denar90",
       "twitter": "denar90_"
     },
@@ -358,7 +358,7 @@
         "leads",
         "reviewers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/10931297?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/10931297?v=4&s=200",
       "website": "https://www.tunetheweb.com",
       "github": "tunetheweb",
       "linkedin": "tunetheweb",
@@ -369,7 +369,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/6849494?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/6849494?v=4&s=200",
       "website": "https://benseymour.com",
       "github": "bseymour",
       "twitter": "bseymour",
@@ -380,7 +380,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/43988371?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/43988371?v=4&s=200",
       "website": "https://iambharat.me",
       "github": "bharatagsrwal"
     },
@@ -391,7 +391,7 @@
         "reviewers",
         "translators"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/284742?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/284742?v=4&s=200",
       "website": "https://boris.schapira.dev",
       "github": "borisschapira",
       "twitter": "boostmarks"
@@ -401,7 +401,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/870501?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/870501?v=4&s=200",
       "website": "https://bkardell.com",
       "github": "bkardell",
       "twitter": "briankardell"
@@ -411,7 +411,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/216712?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/216712?v=4&s=200",
       "website": "https://remotesynthesis.com/",
       "github": "remotesynth",
       "twitter": "remotesynth"
@@ -421,7 +421,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/1588185?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1588185?v=4&s=200",
       "github": "cqueern",
       "twitter": "httpsecheaders"
     },
@@ -442,7 +442,7 @@
         "developers",
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/1867900?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1867900?v=4&s=200",
       "website": "https://catalin.red/",
       "github": "catalinred",
       "twitter": "catalinred"
@@ -452,7 +452,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/30398527?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/30398527?v=4&s=200",
       "github": "chengxicn"
     },
     "svgeesus": {
@@ -461,7 +461,7 @@
         "authors",
         "reviewers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/2506926?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2506926?v=4&s=200",
       "website": "https://svgees.us/",
       "github": "svgeesus",
       "twitter": "svgeesus"
@@ -471,7 +471,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/6698344?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/6698344?v=4&s=200",
       "website": "https://christianliebel.com",
       "github": "christianliebel",
       "twitter": "christianliebel"
@@ -481,7 +481,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/1622597?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1622597?v=4&s=200",
       "github": "colinbendell",
       "twitter": "colinbendell"
     },
@@ -490,7 +490,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/6782666?s=460",
+      "avatar_url": "https://avatars.githubusercontent.com/u/6782666?s=460",
       "github": "CYBAI",
       "twitter": "_cybai"
     },
@@ -499,7 +499,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/261579?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/261579?v=4&s=200",
       "website": "https://fonts.google.com",
       "github": "davelab6",
       "twitter": "davelab6"
@@ -509,7 +509,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/11179452?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/11179452?v=4&s=200",
       "website": "https://tamethebots.com/",
       "github": "dwsmart",
       "twitter": "davewsmart"
@@ -519,7 +519,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/3630989?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3630989?v=4&s=200",
       "website": "https://opensourceseo.org/",
       "github": "dsottimano",
       "twitter": "dsottimano"
@@ -532,7 +532,7 @@
         "leads",
         "reviewers"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/684747?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/684747?v=4&s=200",
       "website": "https://www.lookzook.com",
       "github": "obto",
       "twitter": "theobto"
@@ -542,7 +542,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/1514288?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1514288?v=4&s=200",
       "website": "https://dougsillars.com",
       "github": "dougsillars",
       "twitter": "dougsillars"
@@ -552,7 +552,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/5795823?s=200&v=4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/5795823?s=200&v=4",
       "github": "dsadhanala",
       "twitter": "dsadhanala"
     },
@@ -561,7 +561,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/7061425?s=200&v=4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/7061425?s=200&v=4",
       "website": "https://dustinmontgomery.com/",
       "github": "en3r0",
       "twitter": "DustinMontSEO"
@@ -571,7 +571,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/68361682?s=200&v=4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/68361682?s=200&v=4",
       "website": "https://edmondwwchan.github.io/",
       "github": "edmondwwchan"
     },
@@ -580,7 +580,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/725717?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/725717?v=4&s=200",
       "website": "http://fantasai.inkedblade.net/",
       "github": "fantasai",
       "twitter": "fantasai"
@@ -590,7 +590,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/20342656?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/20342656?v=4&s=200",
       "website": "https://emanuelgsouza.dev/",
       "github": "emanuelgsouza",
       "twitter": "emanuelgsouza",
@@ -601,7 +601,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/634191?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/634191?v=4&s=200",
       "website": "https://ericwbailey.design/",
       "github": "ericwbailey",
       "twitter": "ericwbailey"
@@ -611,7 +611,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/3441390?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3441390?v=4&s=200",
       "website": "https://ericportis.com/",
       "github": "eeeps",
       "twitter": "etportis"
@@ -621,7 +621,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/69888?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/69888?v=4&s=200",
       "website": "http://standardista.com/",
       "github": "estelle",
       "twitter": "estellevw"
@@ -642,7 +642,7 @@
         "reviewers",
         "translators"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/1746646?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1746646?v=4&s=200",
       "github": "giopunt",
       "twitter": "giovannipuntil"
     },
@@ -651,7 +651,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/2944237?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2944237?v=4&s=200",
       "github": "gokulkrishh"
     },
     "GregBrimble": {
@@ -659,7 +659,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/8484333?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/8484333?v=4&s=200",
       "website": "https://gregbrimble.com/",
       "github": "GregBrimble",
       "twitter": "GregBrimble"
@@ -669,7 +669,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/8494683?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/8494683?v=4&s=200",
       "github": "gregorywolf"
     },
     "hemanth": {
@@ -677,7 +677,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/18315?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/18315?v=4&s=200",
       "website": "https://h3manth.com",
       "github": "hemanth",
       "twitter": "gnumanth"
@@ -687,7 +687,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/50970808?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/50970808?v=4&s=200",
       "github": "henrihelvetica",
       "twitter": "HenriHelvetica"
     },
@@ -696,7 +696,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/286856?s=460",
+      "avatar_url": "https://avatars.githubusercontent.com/u/286856?s=460",
       "github": "ArvinH"
     },
     "aszx87410": {
@@ -704,7 +704,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/2755720?s=460",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2755720?s=460",
       "github": "aszx87410"
     },
     "iandevlin": {
@@ -712,7 +712,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/554326?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/554326?v=4&s=200",
       "website": "https://iandevlin.com",
       "github": "iandevlin",
       "twitter": "iandevlin"
@@ -722,7 +722,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/2265232?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2265232?v=4&s=200",
       "website": "https://learnjavascript.online/",
       "github": "jadjoubran",
       "twitter": "JoubranJad"
@@ -732,7 +732,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/52051775?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/52051775?v=4&s=200",
       "website": "https://not-a-robot.com/",
       "github": "fellowhuman1101",
       "twitter": "Jammer_Volts"
@@ -743,7 +743,7 @@
         "authors",
         "analysts"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/7421844?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/7421844?v=4&s=200",
       "github": "jrharalson"
     },
     "jpamental": {
@@ -751,7 +751,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/537413?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/537413?v=4&s=200",
       "website": "https://rwt.io",
       "github": "jpamental",
       "twitter": "jpamental"
@@ -762,7 +762,7 @@
         "authors",
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/1700772?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1700772?v=4&s=200",
       "website": "https://meiert.com/en/",
       "github": "j9t",
       "twitter": "j9t"
@@ -772,7 +772,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/59629525?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/59629525?v=4&s=200",
       "website": "https://www.jessicanicolet.com/",
       "github": "jessnicolet",
       "twitter": "jessica_nicolet"
@@ -782,7 +782,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/104149?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/104149?v=4&s=200",
       "website": "https://jonathanwold.com",
       "github": "sirjonathan",
       "twitter": "sirjonathan"
@@ -792,7 +792,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/2634031?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2634031?v=4&s=200",
       "github": "jzyang"
     },
     "jyrkialakuijala": {
@@ -800,7 +800,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/9086028?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/9086028?v=4&s=200",
       "github": "jyrkialakuijala"
     },
     "thefoxis": {
@@ -808,7 +808,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/375731?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/375731?v=4&s=200",
       "github": "thefoxis",
       "twitter": "fox"
     },
@@ -817,7 +817,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/25080897?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/25080897?v=4&s=200",
       "github": "tymosh",
       "linkedin": "tymosh"
     },
@@ -826,7 +826,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/6076184?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/6076184?v=4&s=200",
       "github": "khempenius",
       "twitter": "katiehempenius"
     },
@@ -835,7 +835,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/23695083?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/23695083?v=4&s=200",
       "website": "https://ldevernay.github.io/",
       "github": "ldevernay",
       "twitter": "ldevernay"
@@ -846,7 +846,7 @@
         "analysts",
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/175836?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/175836?v=4&s=200",
       "website": "https://lea.verou.me/",
       "github": "LeaVerou",
       "twitter": "leaverou"
@@ -856,7 +856,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/26022943?s=460&u=64b286deddd79f94a2dc8dee0e7610e0dd2a7b34&v=4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/26022943?s=460&u=64b286deddd79f94a2dc8dee0e7610e0dd2a7b34&v=4",
       "website": "https://chefleo.dev/",
       "github": "chefleo",
       "twitter": "simdigiorgio"
@@ -867,7 +867,7 @@
         "authors",
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/829214?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/829214?v=4&s=200",
       "website": "https://twitter.com/zizzamia",
       "github": "Zizzamia",
       "twitter": "Zizzamia"
@@ -877,7 +877,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/1896483?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1896483?v=4&s=200",
       "github": "veluca93"
     },
     "LPardue": {
@@ -885,7 +885,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/6571445?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/6571445?v=4&s=200",
       "website": "https://lucaspardue.com",
       "github": "LPardue",
       "twitter": "SimmerVigor"
@@ -895,7 +895,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/866229?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/866229?v=4&s=200",
       "github": "Super-Fly",
       "twitter": "angelovcode"
     },
@@ -904,7 +904,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/12712988?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/12712988?v=4&s=200",
       "website": "https://maedahbatool.com/",
       "github": "MaedahBatool",
       "twitter": "maedahbatool"
@@ -914,7 +914,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/11938879?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/11938879?v=4&s=200",
       "website": "https://mandymichael.com/",
       "github": "mandymichael",
       "twitter": "Mandy_Kerr"
@@ -924,7 +924,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/1496761?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1496761?v=4&s=200",
       "website": "https://www.matuzo.at/",
       "github": "matuzo",
       "twitter": "mmatuzo"
@@ -935,7 +935,7 @@
         "analysts",
         "developers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/1611259?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1611259?v=4&s=200",
       "website": "https://maxostapenko.com",
       "github": "max-ostapenko",
       "twitter": "themax_o"
@@ -945,7 +945,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/17748781?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/17748781?v=4&s=200",
       "github": "mdiblasio"
     },
     "ipullrank": {
@@ -953,7 +953,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/1043031?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1043031?v=4&s=200",
       "github": "ipullrank",
       "twitter": "IPullRank"
     },
@@ -968,7 +968,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/868584?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/868584?v=4&s=200",
       "linkedin": "miguelcarlosmartinezdiaz",
       "github": "mcmd",
       "twitter": "mcmd"
@@ -978,7 +978,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/4273797?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/4273797?v=4&s=200",
       "github": "MikeBishop"
     },
     "mgechev": {
@@ -986,7 +986,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/455023?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/455023?v=4&s=200",
       "website": "https://blog.mgechev.com/",
       "github": "mgechev",
       "twitter": "mgechev"
@@ -996,7 +996,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/104161?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/104161?v=4&s=200",
       "website": "https://miriamsuzanne.com/",
       "github": "mirisuzanne",
       "twitter": "MiriSuzanne"
@@ -1006,7 +1006,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/3491627?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3491627?v=4&s=200",
       "website": "https://mo271.github.io/",
       "github": "mo271"
     },
@@ -1015,7 +1015,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/67608345?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/67608345?v=4&s=200",
       "github": "natedame",
       "twitter": "seonate"
     },
@@ -1024,7 +1024,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/69532755?s=200&v=4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/69532755?s=200&v=4",
       "website": "http://www.nparthas.com/",
       "github": "Navaneeth-akam",
       "twitter": "Navanee55755217"
@@ -1034,7 +1034,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/2587348?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2587348?v=4&s=200",
       "website": "https://phacks.dev/",
       "github": "phacks",
       "twitter": "Phacks"
@@ -1044,7 +1044,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/78213?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/78213?v=4&s=200",
       "website": "https://nicolas-hoizey.com/",
       "github": "nhoizey",
       "twitter": "nhoizey"
@@ -1054,7 +1054,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/46689362?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/46689362?v=4&s=200",
       "github": "noah-vdv",
       "twitter": "noah_aaron_vdv"
     },
@@ -1063,7 +1063,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/88566?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/88566?v=4&s=200",
       "github": "noamr",
       "twitter": "nomsternom"
     },
@@ -1072,7 +1072,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/44582272?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/44582272?v=4&s=200",
       "github": "notwillk"
     },
     "nrllh": {
@@ -1081,7 +1081,7 @@
         "analysts",
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/13475745?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/13475745?v=4&s=200",
       "website": "https://internet-sicherheit.de",
       "github": "nrllh",
       "twitter": "nrllah"
@@ -1091,7 +1091,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/3077443?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3077443?v=4&s=200",
       "website": "https://olu.online/",
       "github": "oluoluoxenfree",
       "twitter": "oluoluoxenfree"
@@ -1101,7 +1101,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/841956?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/841956?v=4&s=200",
       "github": "swissspidy",
       "twitter": "swissspidy",
       "linkedin": "swissspidy"
@@ -1111,7 +1111,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/17054057?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/17054057?v=4&s=200",
       "github": "thepassle"
     },
     "pmeenan": {
@@ -1119,7 +1119,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/444165?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/444165?v=4&s=200",
       "website": "https://www.webpagetest.org/",
       "github": "pmeenan",
       "twitter": "patmeenan"
@@ -1132,7 +1132,7 @@
         "leads",
         "reviewers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/7459458?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/7459458?v=4&s=200",
       "github": "paulcalvano",
       "twitter": "paulcalvano",
       "website": "https://paulcalvano.com"
@@ -1142,7 +1142,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/1824908?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1824908?v=4&s=200",
       "github": "pearlbea",
       "twitter": "pblatteier"
     },
@@ -1151,7 +1151,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/124110?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/124110?v=4&s=200",
       "website": "https://pixboost.com",
       "github": "dooman87",
       "twitter": "otherpunk"
@@ -1161,7 +1161,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/34737190?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/34737190?v=4&s=200",
       "website": "https://praveenpal4232.github.io",
       "github": "PraveenPal4232",
       "twitter": "PraveenPal4232"
@@ -1171,7 +1171,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/2764898?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2764898?v=4&s=200",
       "website": "https://rachelandrew.co.uk/",
       "github": "rachelandrew",
       "twitter": "rachelandrew"
@@ -1182,7 +1182,7 @@
         "authors",
         "analysts"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/24447527?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/24447527?v=4&s=200",
       "github": "raghuramakrishnan71"
     },
     "raphlinus": {
@@ -1190,7 +1190,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/242367?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/242367?v=4&s=200",
       "github": "raphlinus",
       "twitter": "raphlinus",
       "website": "https://levien.com"
@@ -1200,7 +1200,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/8108643?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/8108643?v=4&s=200",
       "website": "https://reneesvirtualoffice.com",
       "github": "ernee",
       "twitter": "reneesoffice"
@@ -1214,7 +1214,7 @@
         "leads",
         "reviewers"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/1120896?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1120896?v=4&s=200",
       "github": "rviscomi",
       "twitter": "rick_viscomi"
     },
@@ -1223,7 +1223,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/2240689?s=460&v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2240689?s=460&v=4&s=200",
       "github": "rmarx",
       "twitter": "programmingart"
     },
@@ -1233,7 +1233,7 @@
         "authors",
         "analysts"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/1718757?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1718757?v=4&s=200",
       "github": "rockeynebhwani",
       "twitter": "rnebhwani",
       "linkedin": "rockeynebhwani"
@@ -1250,7 +1250,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/4570664?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/4570664?v=4&s=200",
       "website": "https://pixelambacht.nl/",
       "github": "RoelN",
       "twitter": "PixelAmbacht"
@@ -1260,7 +1260,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/11558891?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/11558891?v=4&s=200",
       "website": "https://romche.com/",
       "github": "roryhewitt",
       "twitter": "roryhewitt3",
@@ -1271,7 +1271,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/1982567?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1982567?v=4&s=200",
       "website": "https://www.ksakae1216.com/archive",
       "github": "ksakae1216",
       "twitter": "beltway7"
@@ -1281,7 +1281,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/16757512?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/16757512?v=4&s=200",
       "github": "sboukortt"
     },
     "saptaks": {
@@ -1289,7 +1289,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/9530293?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/9530293?v=4&s=200",
       "website": "https://saptaks.website/",
       "github": "saptaks",
       "twitter": "Saptak013"
@@ -1300,7 +1300,7 @@
         "developers",
         "reviewers"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/65147?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/65147?v=4&s=200",
       "website": "https://www.cs.odu.edu/~salam/",
       "github": "ibnesayeed",
       "twitter": "ibnesayeed"
@@ -1311,7 +1311,7 @@
         "editors",
         "reviewers"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/6392995?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/6392995?v=4&s=200",
       "github": "exterkamp",
       "twitter": "Shane_Exterkamp"
     },
@@ -1320,7 +1320,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/4945616?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/4945616?v=4&s=200",
       "github": "spanicker",
       "twitter": "shubhie"
     },
@@ -1329,7 +1329,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/496189?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/496189?v=4&s=200",
       "website": "https://simonhearne.com",
       "github": "simonhearne",
       "twitter": "simonhearne"
@@ -1339,7 +1339,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/244772?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/244772?v=4&s=200",
       "github": "zcorpan",
       "twitter": "zcorpan"
     },
@@ -1348,7 +1348,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/17740806?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/17740806?v=4&s=200",
       "website": "https://www.advancedwebranking.com/",
       "github": "smatei",
       "twitter": "smatei"
@@ -1358,7 +1358,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/10291571?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/10291571?v=4&s=200",
       "github": "sudheendrachari",
       "twitter": "itsmesudheendra",
       "linkedin": "sudheendrachari"
@@ -1368,7 +1368,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/2042718?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2042718?v=4&s=200",
       "website": "https://tamas.io",
       "github": "tpiros",
       "twitter": "tpiros"
@@ -1379,7 +1379,7 @@
         "analysts",
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/145676?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/145676?v=4&s=200",
       "website": "https://blog.tomayac.com/",
       "github": "tomayac"
     },
@@ -1388,7 +1388,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/66536?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/66536?v=4&s=200",
       "github": "tkadlec",
       "website": "https://timkadlec.com/",
       "twitter": "tkadlec"
@@ -1399,7 +1399,7 @@
         "analysts",
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/4355579?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/4355579?v=4&s=200",
       "github": "tomvangoethem",
       "twitter": "tomvangoethem"
     },
@@ -1408,7 +1408,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/4947018?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/4947018?v=4&s=200",
       "website": "https://websiteadvantage.com.au/",
       "github": "Tiggerito",
       "twitter": "TonyMcCreath"
@@ -1418,7 +1418,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/33907565?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/33907565?v=4&s=200",
       "website": "https://hakacode.github.io",
       "github": "HakaCode",
       "twitter": "hakacode"
@@ -1429,7 +1429,7 @@
         "analysts",
         "authors"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/9135107?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/9135107?v=4&s=200",
       "github": "ydimova"
     },
     "Zuckjet": {
@@ -1437,7 +1437,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/17976139?v=4&s=460",
+      "avatar_url": "https://avatars.githubusercontent.com/u/17976139?v=4&s=460",
       "github": "Zuckjet",
       "twitter": "Zuckjet"
     },
@@ -1446,7 +1446,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/1439919?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1439919?v=4&s=200",
       "website": "https://mefody.dev/",
       "github": "MeFoDy"
     }

--- a/src/config/2021.json
+++ b/src/config/2021.json
@@ -241,7 +241,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/44442451?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/44442451?v=4&s=200",
       "github": "AbbyTsai"
     },
     "tropicadri": {
@@ -269,7 +269,7 @@
         "leads",
         "reviewers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/10931297?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/10931297?v=4&s=200",
       "website": "https://www.tunetheweb.com",
       "github": "tunetheweb",
       "linkedin": "tunetheweb",
@@ -280,7 +280,7 @@
       "teams": [
         "leads"
       ],
-      "avatar_url": "https://avatars2.githubusercontent.com/u/684747?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/684747?v=4&s=200",
       "website": "https://www.lookzook.com",
       "github": "obto",
       "twitter": "theobto"
@@ -300,7 +300,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/18315?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/18315?v=4&s=200",
       "website": "https://h3manth.com",
       "github": "hemanth",
       "twitter": "gnumanth"
@@ -310,7 +310,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars1.githubusercontent.com/u/1749548?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1749548?v=4&s=200",
       "website": "https://jeffy.info",
       "github": "jeffposnick",
       "twitter": "jeffposnick"
@@ -351,7 +351,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/17054057?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/17054057?v=4&s=200",
       "github": "thepassle"
     },
     "paulcalvano": {
@@ -359,7 +359,7 @@
       "teams": [
         "leads"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/7459458?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/7459458?v=4&s=200",
       "github": "paulcalvano",
       "twitter": "paulcalvano",
       "website": "https://paulcalvano.com"
@@ -370,7 +370,7 @@
         "editors",
         "leads"
       ],
-      "avatar_url": "https://avatars0.githubusercontent.com/u/1120896?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1120896?v=4&s=200",
       "github": "rviscomi",
       "twitter": "rick_viscomi"
     },
@@ -379,7 +379,7 @@
       "teams": [
         "designers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/22671477?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/22671477?v=4&s=200",
       "github": "shantsis"
     },
     "GeekBoySupreme": {
@@ -387,7 +387,7 @@
       "teams": [
         "designers"
       ],
-      "avatar_url": "https://avatars3.githubusercontent.com/u/15321738?v=4&s=200",
+      "avatar_url": "https://avatars.githubusercontent.com/u/15321738?v=4&s=200",
       "github": "GeekBoySupreme",
       "twitter": "shuvam360",
       "website": "https://shuvam.xyz"


### PR DESCRIPTION
Should be slightly better for performance as we only use one connection (GitHub also supports HTTP/2 and we use lazy-loading so not concerned about contention on that one connection).

Might cause a few merge conflicts on 2021.json file but think that's gonna be fun anyway as everyone adds to that.