### PR TITLE
Allow markdown to be used in more places

### DIFF
--- a/src/tools/generate/generate_chapters.js
+++ b/src/tools/generate/generate_chapters.js
@@ -5,6 +5,7 @@ const prettier = require('prettier');
 
 const { convertSimpleMarkdown, find_markdown_files, get_yearly_configs, size_of, parse_array } = require('./shared');
 const { generate_table_of_contents } = require('./generate_table_of_contents');
+const { generate_extra_markdown_conversions } = require('./generate_extra_markdown_conversions');
 const { generate_header_links } = require('./generate_header_links');
 const { generate_figure_ids } = require('./generate_figure_ids');
 const { generate_typographic_punctuation_body, generate_typographic_punctuation_metadata } = require('./generate_typographic_punctuation');
@@ -144,6 +145,7 @@ const parse_file = async (markdown,chapter) => {
   let body = html;
 
   let m = converter.getMetadata();
+  body = generate_extra_markdown_conversions(body);
   body = generate_syntax_highlighting(body);
   body = generate_header_links(body);
   body = generate_figure_ids(body);

--- a/src/tools/generate/generate_extra_markdown_conversions.js
+++ b/src/tools/generate/generate_extra_markdown_conversions.js
@@ -1,0 +1,21 @@
+const { convertSimpleMarkdown } = require('./shared');
+
+// Allow markdown to be used within HTML tags by doing an extra conversion there
+const generate_extra_markdown_conversions = (body) => {
+  // Convert any markdown in table figure_links
+  body = body.replace(/(\{\{ figure_link\([^}]*caption=")(.*?[^\\])(")/g, function(a, b, c, d) { return b + convertSimpleMarkdown(c) + d});
+  body = body.replace(/(\{\{ figure_link\([^}]*caption=')(.*?[^\\])(')/g, function(a, b, c, d) { return b + convertSimpleMarkdown(c) + d});
+
+  // Convert any markdown in table cells
+  body = body.replace(/(<th[^>]*>)(.*?)(<\/th>)/g, function(a, b, c, d) { return b + convertSimpleMarkdown(c) + d});
+  body = body.replace(/(<td[^>]*>)(.*?)(<\/td>)/g, function(a, b, c, d) { return b + convertSimpleMarkdown(c) + d});
+
+  // Convert any markdown in <p class="note">
+  body = body.replace(/(<p class="note">)(.*?)(<\/p>)/g, function(a, b, c, d) { return b + convertSimpleMarkdown(c) + d});
+
+  return body;
+}
+
+module.exports = {
+  generate_extra_markdown_conversions
+};


### PR DESCRIPTION
Some authors expect markdown to work in more places than it does currently including:
- Table captions
- Table `<td>` and `<th>`'s
- Our asides (`<p class="note">`).

This last one can be worked around with `<p class="note" data-markdown="1">` but not many people know that, and for the others this doesn't seem to work.

This PR adds some additional functionality to allow markdown to be used in these elements.