### PR TITLE
Fix Safari print view for chapters

### DIFF
--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -852,3 +852,7 @@ pre {
 .code-block code {
   width: 100%;
 }
+
+/* Needed for Safari to hide the index properly */
+@media print {
+

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -855,4 +855,7 @@ pre {
 
 /* Needed for Safari to hide the index properly */
 @media print {
-
+  .main {
+    grid-template-columns: 0px auto;
+  }
+}


### PR DESCRIPTION
Noticed this is how the chapters print in Safari:

![image](https://user-images.githubusercontent.com/10931297/141211850-0b50de67-3538-48cd-a1a7-a843d178a279.png)

Fixing this.