### PR TITLE
Change predeloy to use booleans

### DIFF
--- a/.github/workflows/predeploy.yml
+++ b/.github/workflows/predeploy.yml
@@ -21,7 +21,7 @@ on:
       ebooks:
         type: boolean
         description: "Regenerate Ebooks?"
-        required: false
+        required: true
         default: true
 
 jobs:

--- a/.github/workflows/predeploy.yml
+++ b/.github/workflows/predeploy.yml
@@ -19,9 +19,10 @@ on:
   workflow_dispatch:
     inputs:
       ebooks:
-        description: "Regenerate Ebooks [Y/N]?"
+        type: boolean
+        description: "Regenerate Ebooks?"
         required: false
-        default: 'Y'
+        default: true
 
 jobs:
   build:
@@ -39,7 +40,7 @@ jobs:
       with:
         python-version: '3.8'
     - name: Install Asian Fonts
-      if: github.event.inputs.ebooks != 'N' && github.event.inputs.ebooks != 'n'
+      if: github.event.inputs.ebooks
       run: |
         # Install Japanese san-serif font
         sudo apt-get install -y fonts-ipafont-gothic


### PR DESCRIPTION
GitHub Actions [finally now allows more choices for Workflow inputs](https://github.blog/changelog/2021-11-10-github-actions-input-types-for-manual-workflows/).

This switches to `boolean` for the deploy action so you don't have to type Y or N