### PR TITLE
Fix printing in Safari take 2

### DIFF
--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -856,6 +856,7 @@ pre {
 /* Needed for Safari to hide the index properly */
 @media print {
   .main {
-    grid-template-columns: 0px auto;
+    grid-template-areas: 'content';
+    grid-template-columns: auto;
   }
 }

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -859,4 +859,8 @@ pre {
     grid-template-areas: 'content';
     grid-template-columns: auto;
   }
+
+  .figure-dropdown {
+    display: none;
+  }
 }


### PR DESCRIPTION
#2465 fixed Safari, but broke Chrome and Firefox! So take 2.

Also hides the figure dropdown as spotted by @kevinfarrugia 