### PR TITLE
Support emphasis within italic sections

### DIFF
--- a/src/static/css/almanac.css
+++ b/src/static/css/almanac.css
@@ -727,6 +727,10 @@ blockquote::before {
   line-height: 1;
 }
 
+blockquote em {
+  font-style: normal;
+}
+
 /* Footer */
 footer .container {
   display: grid;

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -408,6 +408,12 @@ aside,
   font-style: italic;
 }
 
+aside em,
+.note em {
+  font-style: normal;
+}
+
+
 table,
 figure {
   max-width: 100%;

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -413,7 +413,6 @@ aside em,
   font-style: normal;
 }
 
-
 table,
 figure {
   max-width: 100%;


### PR DESCRIPTION
Notes and Blockquotes are shown in italics which is the default for `<em>` (or `_example_` in markdown).

We should reverse this to allow emphasis to still be used within these blocks.