### PR TITLE
Fix search button on iOS

### DIFF
--- a/src/static/css/almanac.css
+++ b/src/static/css/almanac.css
@@ -581,6 +581,7 @@ header .cta {
 
 .search-button svg {
   fill: #000;
+  color: #000
 }
 
 .table-of-contents-switcher:hover,

--- a/src/static/css/almanac.css
+++ b/src/static/css/almanac.css
@@ -581,7 +581,7 @@ header .cta {
 
 .search-button svg {
   fill: #000;
-  color: #000
+  color: #000;
 }
 
 .table-of-contents-switcher:hover,


### PR DESCRIPTION
Search icon is white on iOS:

![image](https://user-images.githubusercontent.com/10931297/141687493-4cd474a7-c9fa-4f1f-bec0-1f71611e2b2d.png)

Weirdly it's fine on Safari on desktop 🤷‍♂️