### PR TITLE
Allow optional `feat` query param for home page to force Featured Chapter

### DIFF
--- a/src/templates/base/featured_chapters.ejs.html
+++ b/src/templates/base/featured_chapters.ejs.html
@@ -3,7 +3,7 @@
 <% } else { -%>
 {%- set featured_chapter = ("<%- Object.keys(featured_quotes).join('","') %>") | random %}
 <% } -%>
-{%- if request.args.get('feat') != None %}
+{%- if request.args.get('feat') != None and request.args.get('feat') in [ "<%-Object.keys(featured_quotes).join('","') %>"] %}
 {%- set featured_chapter = request.args.get('feat') %}
 {%- endif %}
 

--- a/src/templates/base/featured_chapters.ejs.html
+++ b/src/templates/base/featured_chapters.ejs.html
@@ -3,6 +3,9 @@
 <% } else { -%>
 {%- set featured_chapter = ("<%- Object.keys(featured_quotes).join('","') %>") | random %}
 <% } -%>
+{%- if request.args.get('feat') != None %}
+{%- set featured_chapter = request.args.get('feat') %}
+{%- endif %}
 
 <% let loop = 0 -%>
 <% for (chapter in featured_quotes) { -%>


### PR DESCRIPTION
With this PR you can now use this, for example:

http://127.0.0.1:8080/en/2021/?feat=third-parties

To force the Third Parties chapter to be the featured quote on the home page. Useful for when reviewing a chapter and want to see what the featured quote will look like.

Will also be available on staged versions (once this is merged obviously) and production (once it goes live). Could add tests to test all chapters of home page if we wanted to in a future PR.

Note this still requires a full `npm run generate` as the lighter, `npm run watch` does not generate featured quotes as currently required processing all chapters (though maybe should change that too!).