### PR TITLE
Update WebAssembly 2021 contributors

### DIFF
--- a/src/config/2021.json
+++ b/src/config/2021.json
@@ -252,6 +252,15 @@
       "github": "alankent",
       "twitter": "akent99"
     },
+    "kripken": {
+      "name": "Alon Zakai",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "https://avatars.githubusercontent.com/u/173661?v=4&s=200",
+      "github": "kripken",
+      "twitter": "kripken"
+    },
     "cyberandy": {
       "name": "Andrea Volpini",
       "teams": [
@@ -288,14 +297,6 @@
       ],
       "avatar_url": "https://avatars.githubusercontent.com/u/35119235?v=4&s=200",
       "github": "ashleyish"
-    },
-    "azakai": {
-      "name": "azakai",
-      "teams": [
-        "reviewers"
-      ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/451275?v=4&s=200",
-      "github": "azakai"
     },
     "tunetheweb": {
       "name": "Barry Pollard",

--- a/src/content/en/2021/webassembly.md
+++ b/src/content/en/2021/webassembly.md
@@ -3,7 +3,7 @@
 title: WebAssembly
 description: TODO
 authors: [RReverser]
-reviewers: [jsoverson, carlopi, azakai]
+reviewers: [jsoverson, carlopi, kripken]
 analysts: [RReverser]
 editors: []
 translators: []


### PR DESCRIPTION
I've used Alon's inactive handle there, which is why his name didn't show up correctly in the rendered article.