### PR TITLE
Only allow "done" chapters to be generated

### DIFF
--- a/src/tools/generate/generate_chapters.js
+++ b/src/tools/generate/generate_chapters.js
@@ -107,6 +107,8 @@ const generate_chapters = async (chapter_match) => {
           sitemap.push({ language, year, chapter });
         }
         ebook_chapters.push({ language, year, chapter, metadata, body, toc });
+
+        await write_template(language, year, chapter, metadata, body, toc);
       }
 
       const {authors, reviewers, analysts, editors} = metadata;
@@ -118,8 +120,6 @@ const generate_chapters = async (chapter_match) => {
         analysts.forEach(analyst=>contributors[year]["analysts"].add(analyst));
       if(editors && editors.length > 0)
         editors.forEach(editor=>contributors[year]["editors"].add(editor));
-
-      await write_template(language, year, chapter, metadata, body, toc);
     } catch (error) {
       console.error(error);
       console.error('  Failed to generate chapter, moving onto the next one. ');


### PR DESCRIPTION
Stop generating todo chapters (which I thought it already did to be honest!).

Note the deploy script also clears down chapters, so even if you have locally deployed chapters they will be reset:

https://github.com/HTTPArchive/almanac.httparchive.org/blob/685c512ea3902913611fb86094d44b2b7a979c14/src/tools/scripts/deploy.sh#L101-L104

FYI: @rviscomi @VictorLeP 