### PR TITLE
Better foreword handling

### DIFF
--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -179,7 +179,9 @@
     {% else %}
       <option value="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</option>
     {% endif %}
+    {% if self.foreword() | trim | length > 0 %}
     <option value="{{ url_for('table_of_contents', year=year, lang=lang, _anchor='foreword') }}">{{ self.foreword_title() }}</option>
+    {% endif %}
     {% for part_config in config.outline %}
     {% for chapter_config in part_config.chapters %}
       {% set title = localizedChapterTitles[chapter_config.slug] if localizedChapterTitles[chapter_config.slug]|length else chapter_config.title %}
@@ -279,9 +281,11 @@
       <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}">{{ self.table_of_contents_title() }}</a>
     </li>
     {% endif %}
+    {% if self.foreword() | trim | length > 0 %}
     <li class="nav-dropdown-list-chapter foreword">
       <a href="{{ url_for('table_of_contents', year=year, lang=lang, _anchor='foreword') }}">{{ self.foreword_title() }}</a>
     </li>
+    {% endif %}
 
     {% for part_config in config.outline %}
     <li class="nav-dropdown-list-part">

--- a/src/templates/base/base_ebook.html
+++ b/src/templates/base/base_ebook.html
@@ -271,6 +271,7 @@
   <section id="toc" class="contents-wrapper">
     <h1>{{ self.table_of_contents_title() }}</h1>
     <div class="parts">
+      {% if self.foreword() | trim | length > 0 %}
       <div class="part">
         <h2 class="part-name">{{ self.introduction() }}</h2>
         <div class="toc-chapters">
@@ -279,6 +280,7 @@
           </div>
         </div>
       </div>
+      {% endif %}
       {% for part_config in config.outline %}
       <div class="part">
         <h2 class="part-name">{{ self.part() }} {{ localizedPartTitles[part_config.part] if localizedPartTitles[part_config.part]|length else chapter_config.title }}</h2>
@@ -317,10 +319,12 @@
     </div>
   </section>
 
+  {% if self.foreword() | trim | length > 0 %}
   <section id="foreword">
     <h1>{{ self.foreword_title() }}</h1>
     {{ self.foreword() | replace('/%s/%s/contributors#' % (lang, year), '#contributors-') }}
   </section>
+  {% endif %}
 
   {{ self.chapters() }}
 

--- a/src/templates/base/table_of_contents.html
+++ b/src/templates/base/table_of_contents.html
@@ -98,10 +98,12 @@
 <main id="maincontent" class="main">
   <h1 class="title title-lg">{{ self.table_of_contents_title() }}</h1>
 
+  {% if self.foreword() | trim | length > 0 %}
   <section>
     <h2 id="foreword"><a href="#foreword" class="anchor-link">{{ self.foreword_title() }}</a></h2>
     {{ self.foreword() }}
   </section>
+  {% endif %}
 
   <div class="contents-wrapper">
     <div class="parts">

--- a/src/templates/es/2020/base.html
+++ b/src/templates/es/2020/base.html
@@ -7,7 +7,7 @@
 
 {% block foreword %}
 {# TODO - Translate this! #}
-{{ self.coming_soon() }}
+
 
 
 

--- a/src/templates/hi/2020/base.html
+++ b/src/templates/hi/2020/base.html
@@ -7,7 +7,7 @@
 
 {% block foreword %}
 {# TODO - Translate this! #}
-{{ self.coming_soon() }}
+
 
 
 

--- a/src/templates/ru/2020/base.html
+++ b/src/templates/ru/2020/base.html
@@ -7,7 +7,7 @@
 
 {% block foreword %}
 {# TODO - Translate this! #}
-{{ self.coming_soon() }}
+
 
 
 

--- a/src/templates/zh-TW/2020/base.html
+++ b/src/templates/zh-TW/2020/base.html
@@ -7,7 +7,7 @@
 
 {% block foreword %}
 {# TODO - Translate this! #}
-{{ self.coming_soon() }}
+
 
 
 


### PR DESCRIPTION
Hides the foreword from ToC page and menus, if it is empty (e.g. for pre-launch, or if a translation where the foreword has not yet been translated).

Makes progress on #2508 