### PR TITLE
Fix link and logicalphase's username

### DIFF
--- a/src/content/en/2021/cms.md
+++ b/src/content/en/2021/cms.md
@@ -3,7 +3,7 @@
 title: CMS
 description: CMS chapter of the 2021 Web Almanac covering CMS adoption, user experience of websites running on CMS platforms, and CMS resource weights.
 authors: [alonko]
-reviewers: [alankent, andreylipattsev, chrissater, hyperpress]
+reviewers: [alankent, andreylipattsev, chrissater, logicalphase]
 analysts: [rviscomi, tosinarasi]
 editors: []
 translators: []

--- a/src/static/css/almanac.css
+++ b/src/static/css/almanac.css
@@ -726,6 +726,7 @@ blockquote::before {
   font-size: 20rem;
   font-family: 'Courier New', 'Courier', monospace;
   line-height: 1;
+  pointer-events: none;
 }
 
 blockquote em {


### PR DESCRIPTION
The block quote obscure's links so link doesn't work as reported by @shantsis in Slack:

![image](https://user-images.githubusercontent.com/10931297/142033597-9ba9c419-abe9-44d3-bcf1-3ffcb775f417.png)
  ![image](https://user-images.githubusercontent.com/10931297/142033514-9dff3434-a26f-42fd-8a28-dd1efad3c45d.png)
