### PR TITLE
Fix deploy script for ebooks

### DIFF
--- a/.github/workflows/predeploy.yml
+++ b/.github/workflows/predeploy.yml
@@ -22,7 +22,7 @@ on:
         type: boolean
         description: "Regenerate Ebooks?"
         required: true
-        default: true
+        default: "true"
 
 jobs:
   build:
@@ -40,7 +40,7 @@ jobs:
       with:
         python-version: '3.8'
     - name: Install Asian Fonts
-      if: github.event.inputs.ebooks
+      if: {{ github.event.inputs.ebooks == 'true' }}
       run: |
         # Install Japanese san-serif font
         sudo apt-get install -y fonts-ipafont-gothic
@@ -49,17 +49,17 @@ jobs:
         # Install Korean san-serif font
         sudo apt-get install -y fonts-unfonts-core
     - name: Install PrinceXML
-      if: github.event.inputs.ebooks != 'N' && github.event.inputs.ebooks != 'n'
+      if: {{ github.event.inputs.ebooks == 'true' }}
       run: |
         wget https://www.princexml.com/download/${{ env.PRINCE_PACKAGE }} --directory-prefix=/tmp
         DEBIAN_FRONTEND=noninteractive sudo apt install -y /tmp/${{ env.PRINCE_PACKAGE }}
     - name: Install pdftk
-      if: github.event.inputs.ebooks != 'N' && github.event.inputs.ebooks != 'n'
+      if: {{ github.event.inputs.ebooks == 'true' }}
       run: sudo apt install pdftk
     - name: Run the website
       run: ./src/tools/scripts/run_and_test_website.sh
     - name: Generating Ebooks
-      if: github.event.inputs.ebooks != 'N' && github.event.inputs.ebooks != 'n'
+      if: {{ github.event.inputs.ebooks == 'true' }}
       run: |
         cd src
         npm run ebooks


### PR DESCRIPTION
Noticed this was broken in last deploy. It ignores the ebook flag and always runs the ebooks, so when I did a second deploy for the accessibility statement typo, it regenerated the ebooks when it didn't need to.

Looks like I broke it in #2471 when I switched it to the new booleans (which it turns out GitHub have implemented as strings rather than booleans... sigh!)

Anyway this fixes it.