### PR TITLE
Implementation of UI for webmention reactions.

### DIFF
--- a/src/server/csp.py
+++ b/src/server/csp.py
@@ -15,6 +15,7 @@ csp = {
     ],
     'connect-src': [
         '\'self\'',
+        'webmention.io',
         'discuss.httparchive.org',
         'www.google-analytics.com',
         'www.googletagmanager.com'

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -250,7 +250,8 @@
 }
 
 .authors h2,
-.chapter-links h2 {
+.chapter-links h2,
+.webmentions h2 {
   padding: 16px 0;
   padding: 1rem 0;
 }
@@ -258,7 +259,9 @@
 .authors,
 .authors h2,
 .chapter-links,
-.chapter-links h2 {
+.chapter-links h2,
+.webmentions,
+.webmentions h2 {
   border-bottom: 1px solid #1a2b490a;
   font-size: 17px;
   font-size: 1.0625rem;
@@ -856,6 +859,47 @@ pre {
 
 .code-block code {
   width: 100%;
+}
+
+/* Webmention code */
+.reaction-tabs [role="tab"][aria-selected="true"] {
+  z-index: 3;
+  font-weight: bold;
+  border-bottom: 0.5rem solid #a8caba;
+}
+.reaction-tabs [role="tab"] {
+  position: relative;
+  z-index: 1;
+  background: white;
+  border: 0;
+  padding: 0rem 0.75rem 0.25rem;
+}
+
+.reactions [role="tabpanel"] {
+  margin-top: 1.5rem;
+}
+
+.webmention-likes,
+.webmention-reposts {
+  display: flex;
+}
+
+.webmentions .reactions ul {
+  padding: 0;
+}
+
+.webmentions .reactions ul > li {
+  margin-right: 1.5rem;
+}
+
+.webmentions .reactions ul > li::before {
+  display: none;
+}
+
+.webmention-author .webmention-author-avatar {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
 }
 
 /* Needed for Safari to hide the index properly */

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -867,6 +867,7 @@ pre {
   font-weight: bold;
   border-bottom: 0.5rem solid #a8caba;
 }
+
 .reaction-tabs [role="tab"] {
   position: relative;
   z-index: 1;

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -873,7 +873,7 @@ pre {
   z-index: 1;
   background: white;
   border: 0;
-  padding: 0rem 0.75rem 0.25rem;
+  padding: 0.6rem 0.75rem 0.6rem;
 }
 
 .reactions [role="tabpanel"] {

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -880,6 +880,10 @@ pre {
   margin-top: 1.5rem;
 }
 
+.reaction-tabs > button > span {
+  pointer-events: none;
+}
+
 .webmention-likes,
 .webmention-reposts {
   display: flex;
@@ -923,16 +927,16 @@ pre {
   color: #515660;
 }
 
-.webmention-reply-item,
-.webmention-mention-item {
+.webmention-replies-item,
+.webmention-mentions-item {
   display: flex;
   flex-direction: column;
   position: relative;
   padding: 1rem 0 1rem 60px;
 }
 
-.webmention-reply-item .webmention-author .webmention-author-avatar,
-.webmention-mention-item .webmention-author .webmention-author-avatar {
+.webmention-replies-item .webmention-author .webmention-author-avatar,
+.webmention-mentions-item .webmention-author .webmention-author-avatar {
   position: absolute;
   top: 1rem;
   left: 0;

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -882,6 +882,7 @@ pre {
 .webmention-likes,
 .webmention-reposts {
   display: flex;
+  flex-wrap: wrap;
 }
 
 .webmentions .reactions ul {
@@ -889,17 +890,51 @@ pre {
 }
 
 .webmentions .reactions ul > li {
-  margin-right: 1.5rem;
+  margin-right: 1rem;
 }
 
 .webmentions .reactions ul > li::before {
   display: none;
 }
 
+.webmentions a.webmention-author {
+  text-decoration: none;
+}
+
+.webmentions a.webmention-author:hover {
+  text-decoration: underline;
+}
+
 .webmention-author .webmention-author-avatar {
-  width: 60px;
-  height: 60px;
+  width: 48px;
+  height: 48px;
   border-radius: 50%;
+  object-fit: cover;
+  background: grey;
+}
+
+.webmention-meta {
+  font-size: 0.875rem;
+  color: #515660;
+}
+
+.webmention-meta a.webmention-source {
+  color: #515660;
+}
+
+.webmention-reply-item,
+.webmention-mention-item {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  padding: 1rem 0 1rem 60px;
+}
+
+.webmention-reply-item .webmention-author .webmention-author-avatar,
+.webmention-mention-item .webmention-author .webmention-author-avatar {
+  position: absolute;
+  top: 1rem;
+  left: 0;
 }
 
 /* Needed for Safari to hide the index properly */

--- a/src/static/js/webmentions.js
+++ b/src/static/js/webmentions.js
@@ -1,0 +1,170 @@
+// Code related to parsing and showing webmentions
+
+// Gets the webmentions json data from current URL
+async function getWebmentions(targetURL) {
+  const apiURL = `https://webmention.io/api/mentions.jf2?perPage=500&target=${targetURL}`;
+  let mentions = []
+  try {
+    const response = await window.fetch(apiURL);
+    if (response.status >= 200 && response.status < 300) {
+      json = await response.json();
+      mentions = json.children;
+    } else {
+      console.error("Could not parse response", response.statusText);
+    }
+  } catch(error) {
+    console.error("Request failed", error);
+  }
+  return mentions;
+}
+
+// Parse webmentions for individual category
+function parseMentions(webmentions, mentionType) {
+  let filteredMentions = []
+  webmentions.forEach(function(mention){
+    if (mention["wm-property"] == mentionType) {
+      filteredMentions.push(mention)
+    }
+  });
+  return filteredMentions;
+}
+
+// Renders webmention likes
+function renderLikes(likes) {
+  // Add the likes count to the likes-tab
+  document.querySelector('#likes-count').innerHTML = likes.length;
+  let likeHtmlElements = [];
+  likes.forEach(function(like) {
+    const likeHtml = `
+      <li class="webmention-likes-item">
+        <a class="webmention-author" href="${like["url"]}" aria-label="${like["author"]["name"]} liked this chapter">
+          <img class="webmention-author-avatar" src="${like["author"]["photo"]}" />
+        </a>
+      </li>
+    `;
+    likeHtmlElements.push(likeHtml);
+  })
+  document.querySelector("#likes-panel").innerHTML = `
+    <ul class="webmention-likes">
+      ${likeHtmlElements.join("\n")}
+    </ul>
+  `;
+}
+
+// Renders webmention reposts
+function renderReposts(reposts) {
+  // Add the reposts count to the reposts-tab
+  document.querySelector('#reposts-count').innerHTML = reposts.length;
+  let repostHtmlElements = [];
+  reposts.forEach(function(repost) {
+    const repostHtml = `
+      <li class="webmention-repost-item">
+        <a class="webmention-author" href="${repost["url"]}" aria-label="${repost["author"]["name"]} liked this chapter">
+          <img class="webmention-author-avatar" src="${repost["author"]["photo"]}" />
+        </a>
+      </li>
+    `;
+    repostHtmlElements.push(repostHtml);
+  })
+  document.querySelector("#reposts-panel").innerHTML = `
+    <ul class="webmention-reposts">
+      ${repostHtmlElements.join("\n")}
+    </ul>
+  `;
+}
+
+// Renders webmention replies
+function renderReplies(replies) {
+
+}
+
+// Parses and renders mentions into likes, reposts, replies and mentions
+async function renderWebmentions(targetURL) {
+  const webmentions = await getWebmentions(targetURL);
+  if (!webmentions.length) {
+    return;
+  }
+
+  const likes = parseMentions(webmentions, "like-of");
+  const reposts = parseMentions(webmentions, "repost-of");
+  const replies = parseMentions(webmentions, "in-reply-to");
+
+  if (likes.length) {
+    renderLikes(likes);
+  }
+
+  if (reposts.length) {
+    renderReposts(reposts);
+  }
+
+  if (replies.length) {
+    renderReplies(replies);
+  }
+}
+
+// Change tabs for webmentions UI
+function changeTabs(e) {
+  const target = e.target;
+  const parent = target.parentNode;
+  const grandparent = parent.parentNode;
+
+  // Remove all current selected tabs
+  parent
+    .querySelectorAll('[aria-selected="true"]')
+    .forEach(t => t.setAttribute("aria-selected", false));
+
+  // Set this tab as selected
+  target.setAttribute("aria-selected", true);
+
+  // Hide all tab panels
+  grandparent
+    .querySelectorAll('[role="tabpanel"]')
+    .forEach(p => p.setAttribute("hidden", true));
+
+  // Show the selected panel
+  grandparent.parentNode
+    .querySelector(`#${target.getAttribute("aria-controls")}`)
+    .removeAttribute("hidden");
+}
+
+function addTabListeners() {
+  const tabs = document.querySelectorAll('.reactions [role="tab"]');
+  const tabList = document.querySelector('.reactions [role="tablist"]');
+
+  // Add a click event handler to each tab
+  tabs.forEach(tab => {
+    tab.addEventListener("click", changeTabs);
+  });
+
+  // Enable arrow navigation between tabs in the tab list
+  let tabFocus = 0;
+
+  tabList.addEventListener("keydown", e => {
+    if (e.keyCode === 39 || e.keyCode === 37) {
+      tabs[tabFocus].setAttribute("tabindex", -1);
+      // Move right
+      if (e.keyCode === 39) {
+        tabFocus++;
+        // If we're at the end, go to the start
+        if (tabFocus >= tabs.length) {
+          tabFocus = 0;
+        }
+        // Move left
+      } else if (e.keyCode === 37) {
+        tabFocus--;
+        // If we're at the start, move to the end
+        if (tabFocus < 0) {
+          tabFocus = tabs.length - 1;
+        }
+      }
+
+      tabs[tabFocus].setAttribute("tabindex", 0);
+      tabs[tabFocus].focus();
+    }
+  });
+}
+
+window.addEventListener("DOMContentLoaded", () => {
+  addTabListeners();
+  renderWebmentions("https://almanac.httparchive.org/ru/2020/css");
+});

--- a/src/static/js/webmentions.js
+++ b/src/static/js/webmentions.js
@@ -2,8 +2,8 @@
 
 // Gets the webmentions json data from current URL
 async function getWebmentions(targetURL) {
-  const apiURL = `https://webmention.io/api/mentions.jf2?perPage=500&target=${targetURL}`;
-  let mentions = []
+  const apiURL = `https://webmention.io/api/mentions.jf2?perPage=500&target=${targetURL}&sort-dir=up`;
+  let mentions = [];
   try {
     const response = await window.fetch(apiURL);
     if (response.status >= 200 && response.status < 300) {
@@ -23,7 +23,7 @@ async function getWebmentions(targetURL) {
 // Format published date into human readable form
 function formatDate(dateString){
   const options = { year: "numeric", month: "long", day: "numeric" }
-  return new Date(dateString).toLocaleDateString(undefined, options)
+  return new Date(dateString).toLocaleTimeString(undefined, options)
 }
 
 // Parse webmentions for individual category
@@ -169,6 +169,9 @@ function addTabListeners() {
   const tabs = document.querySelectorAll('.reactions [role="tab"]');
   const tabList = document.querySelector('.reactions [role="tablist"]');
 
+  if (!tabs || !tabList) {
+    return;
+  }
   // Add a click event handler to each tab
   tabs.forEach(tab => {
     tab.addEventListener("click", function(e){changeTabs(e.target)});

--- a/src/static/js/webmentions.js
+++ b/src/static/js/webmentions.js
@@ -56,8 +56,8 @@ function renderReactions(webmentions, reactionType, wmProperty) {
   const webmentionReactionsList = document.createElement("ul");
   webmentionReactionsList.setAttribute("class", `webmention-${reactionType}`);
   reactions.forEach(function(reaction) {
-    const reactionLI = document.createElement("li");
-    reactionLI.setAttribute("class", `webmention-${reactionType}-item`);
+    const reactionLi = document.createElement("li");
+    reactionLi.setAttribute("class", `webmention-${reactionType}-item`);
 
     const reactionA = document.createElement("a");
     reactionA.setAttribute("class", "webmention-author");
@@ -76,45 +76,45 @@ function renderReactions(webmentions, reactionType, wmProperty) {
     reactionA.appendChild(reactionIMG);
 
     // Replies and mentions have some extra HTML
-    const reactionDIVContent = document.createElement("div");
-    const reactionDIVMeta = document.createElement("div");
+    const reactionDivContent = document.createElement("div");
+    const reactionDivMeta = document.createElement("div");
     if (reactionType === "replies" || reactionType === "mentions") {
       const reactionSTRONG = document.createElement("strong");
       reactionSTRONG.setAttribute("class", "webmention-author-name");
       reactionSTRONG.textContent = reaction["author"]["name"];
       reactionA.appendChild(reactionSTRONG);
 
-      reactionDIVContent.setAttribute("class", "webmention-content");
-      reactionDIVContent.textContent = reaction["content"]["text"];
+      reactionDivContent.setAttribute("class", "webmention-content");
+      reactionDivContent.textContent = reaction["content"]["text"];
 
-      reactionDIVMeta.setAttribute("class", "webmention-meta");
+      reactionDivMeta.setAttribute("class", "webmention-meta");
 
-      const reactionTIME = document.createElement("time");
-      reactionTIME.setAttribute("class", "webmention-pub-date");
-      reactionTIME.setAttribute("datetime", reaction["published"]);
-      reactionTIME.textContent = formatDate(reaction["published"]);
+      const reactionTime = document.createElement("time");
+      reactionTime.setAttribute("class", "webmention-pub-date");
+      reactionTime.setAttribute("datetime", reaction["published"]);
+      reactionTime.textContent = formatDate(reaction["published"]);
 
-      const reactionSPAN = document.createElement("span");
-      reactionSPAN.setAttribute("class", "webmention-divider");
-      reactionSPAN.setAttribute("aria-hidden", "true");
-      reactionSPAN.textContent = " ⋅ ";
+      const reactionSpan = document.createElement("span");
+      reactionSpan.setAttribute("class", "webmention-divider");
+      reactionSpan.setAttribute("aria-hidden", "true");
+      reactionSpan.textContent = " ⋅ ";
 
       const reactionASource = document.createElement("a");
       reactionASource.setAttribute("class", "webmention-source");
       reactionASource.setAttribute("href", reaction["url"]);
       reactionASource.textContent = document.querySelector(".reactions").getAttribute("data-source");
 
-      reactionDIVMeta.appendChild(reactionTIME);
-      reactionDIVMeta.appendChild(reactionSPAN);
-      reactionDIVMeta.appendChild(reactionASource);
+      reactionDivMeta.appendChild(reactionTime);
+      reactionDivMeta.appendChild(reactionSpan);
+      reactionDivMeta.appendChild(reactionASource);
     }
 
-    reactionLI.appendChild(reactionA);
+    reactionLi.appendChild(reactionA);
     if (reactionType === "replies" || reactionType === "mentions") {
-      reactionLI.appendChild(reactionDIVContent);
-      reactionLI.appendChild(reactionDIVMeta);
+      reactionLi.appendChild(reactionDivContent);
+      reactionLi.appendChild(reactionDivMeta);
     }
-    webmentionReactionsList.appendChild(reactionLI);
+    webmentionReactionsList.appendChild(reactionLi);
   });
   document.querySelector(`#${reactionType}-panel`).appendChild(webmentionReactionsList);
 }

--- a/src/static/js/webmentions.js
+++ b/src/static/js/webmentions.js
@@ -7,7 +7,7 @@ async function getWebmentions(targetURL) {
   try {
     const response = await window.fetch(apiURL);
     if (response.status >= 200 && response.status < 300) {
-      json = await response.json();
+      const json = await response.json();
       mentions = json.children;
     } else {
       console.error("Could not parse response", response.statusText);
@@ -38,8 +38,9 @@ function parseMentions(webmentions, mentionType) {
 // Renders webmention likes
 function renderLikes(likes) {
   // Add the likes count to the likes-tab
-  document.querySelector('#likes-count').innerHTML = likes.length;
-  let likeHtmlElements = [];
+  document.querySelector('#likes-count').textContent = likes.length;
+  const webmentionLikesList = document.createElement("ul");
+  webmentionLikesList.setAttribute("class", "webmention-likes");
   likes.forEach(function(like) {
     const likeHtml = `
       <li class="webmention-likes-item">
@@ -56,20 +57,19 @@ function renderLikes(likes) {
         </a>
       </li>
     `;
-    likeHtmlElements.push(likeHtml);
-  })
-  document.querySelector("#likes-panel").innerHTML = `
-    <ul class="webmention-likes">
-      ${likeHtmlElements.join("\n")}
-    </ul>
-  `;
+    const parser = new DOMParser();
+	  const likeHtmlObject = parser.parseFromString(likeHtml, 'text/html');
+    webmentionLikesList.appendChild(likeHtmlObject.body.childNodes[0]);
+  });
+  document.querySelector("#likes-panel").appendChild(webmentionLikesList);
 }
 
 // Renders webmention reposts
 function renderReposts(reposts) {
   // Add the reposts count to the reposts-tab
-  document.querySelector('#reposts-count').innerHTML = reposts.length;
-  let repostHtmlElements = [];
+  document.querySelector('#reposts-count').textContent = reposts.length;
+  const webmentionRepostsList = document.createElement("ul");
+  webmentionRepostsList.setAttribute("class", "webmention-reposts");
   reposts.forEach(function(repost) {
     const repostHtml = `
       <li class="webmention-repost-item">
@@ -86,20 +86,19 @@ function renderReposts(reposts) {
         </a>
       </li>
     `;
-    repostHtmlElements.push(repostHtml);
-  })
-  document.querySelector("#reposts-panel").innerHTML = `
-    <ul class="webmention-reposts">
-      ${repostHtmlElements.join("\n")}
-    </ul>
-  `;
+    const parser = new DOMParser();
+	  const repostHtmlObject = parser.parseFromString(repostHtml, 'text/html');
+    webmentionRepostsList.appendChild(repostHtmlObject.body.childNodes[0]);
+  });
+  document.querySelector("#reposts-panel").appendChild(webmentionRepostsList);
 }
 
 // Renders webmention replies
 function renderReplies(replies) {
   // Add the replies count to the replies-tab
-  document.querySelector('#replies-count').innerHTML = replies.length;
-  let repliesHtmlElements = [];
+  document.querySelector('#replies-count').textContent = replies.length;
+  const webmentionRepliesList = document.createElement("ul");
+  webmentionRepliesList.setAttribute("class", "webmention-replies");
   replies.forEach(function(reply) {
     const replyHtml = `
       <li class="webmention-reply-item">
@@ -129,20 +128,19 @@ function renderReplies(replies) {
         </div>
       </li>
     `;
-    repliesHtmlElements.push(replyHtml);
-  })
-  document.querySelector("#replies-panel").innerHTML = `
-    <ul class="webmention-replies">
-      ${repliesHtmlElements.join("\n")}
-    </ul>
-  `;
+    const parser = new DOMParser();
+	  const replyHtmlObject = parser.parseFromString(replyHtml, 'text/html');
+    webmentionRepliesList.appendChild(replyHtmlObject.body.childNodes[0]);
+  });
+  document.querySelector("#replies-panel").appendChild(webmentionRepliesList);
 }
 
 // Renders webmention mentions
 function renderMentions(mentions) {
-  // Add the replies count to the replies-tab
-  document.querySelector('#mentions-count').innerHTML = mentions.length;
-  let mentionsHtmlElements = [];
+  // Add the mentions count to the mentions-tab
+  document.querySelector('#mentions-count').textContent = mentions.length;
+  const webmentionMentionsList = document.createElement("ul");
+  webmentionMentionsList.setAttribute("class", "webmention-mentions");
   mentions.forEach(function(mention) {
     const mentionContent = mention["content"] ? mention["content"]["html"] : (
       `Source: <a href="${mention["wm-source"]}">${mention["wm-source"]}</a>`
@@ -175,13 +173,11 @@ function renderMentions(mentions) {
         </div>
       </li>
     `;
-    mentionsHtmlElements.push(mentionHtml);
-  })
-  document.querySelector("#mentions-panel").innerHTML = `
-    <ul class="webmention-mentions">
-      ${mentionsHtmlElements.join("\n")}
-    </ul>
-  `;
+    const parser = new DOMParser();
+	  const mentionHtmlObject = parser.parseFromString(mentionHtml, 'text/html');
+    webmentionMentionsList.appendChild(mentionHtmlObject.body.childNodes[0]);
+  });
+  document.querySelector("#mentions-panel").appendChild(webmentionMentionsList);
 }
 
 // Parses and renders mentions into likes, reposts, replies and mentions
@@ -257,17 +253,17 @@ function addTabListeners() {
   let tabFocus = 0;
 
   tabList.addEventListener("keydown", e => {
-    if (e.keyCode === 39 || e.keyCode === 37) {
+    if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
       tabs[tabFocus].setAttribute("tabindex", -1);
       // Move right
-      if (e.keyCode === 39) {
+      if (e.key === "ArrowRight") {
         tabFocus++;
         // If we're at the end, go to the start
         if (tabFocus >= tabs.length) {
           tabFocus = 0;
         }
         // Move left
-      } else if (e.keyCode === 37) {
+      } else if (e.key === "ArrowLeft") {
         tabFocus--;
         // If we're at the start, move to the end
         if (tabFocus < 0) {
@@ -281,8 +277,7 @@ function addTabListeners() {
   });
 }
 
-window.addEventListener("DOMContentLoaded", () => {
-  addTabListeners();
-  const BASE_URL = "https://almanac.httparchive.org"
-  processWebmentions(BASE_URL + window.location.pathname);
-});
+
+addTabListeners();
+const BASE_URL = "https://almanac.httparchive.org";
+processWebmentions(BASE_URL + window.location.pathname);

--- a/src/static/js/webmentions.js
+++ b/src/static/js/webmentions.js
@@ -36,7 +36,19 @@ function parseMentions(webmentions, mentionType) {
 }
 
 // Renders webmention into different sections, based on the type
-function renderReactions(reactions, reactionType) {
+function renderReactions(webmentions, reactionType) {
+  // Process webmentions
+  const reactionMap = {
+    likes: "like-of",
+    reposts: "repost-of",
+    replies: "in-reply-to",
+    mentions: "mention-of"
+  }
+  const reactions = parseMentions(webmentions, reactionMap[reactionType]);
+  if (!reactions.length) {
+    return;
+  }
+
   // Add the count to the reaction tab
   document.querySelector(`#${reactionType}-count`).textContent = reactions.length;
   const reactionLabel = document.querySelector(`#${reactionType}-label`);
@@ -117,26 +129,11 @@ function renderWebmentions(webmentions) {
     return;
   }
 
-  const likes = parseMentions(webmentions, "like-of");
-  const reposts = parseMentions(webmentions, "repost-of");
-  const replies = parseMentions(webmentions, "in-reply-to");
-  const mentions = parseMentions(webmentions, "mention-of");
+  renderReactions(webmentions, "likes");
+  renderReactions(webmentions, "reposts");
+  renderReactions(webmentions, "replies");
+  renderReactions(webmentions, "mentions");
 
-  if (likes.length) {
-    renderReactions(likes, "likes");
-  }
-
-  if (reposts.length) {
-    renderReactions(reposts, "reposts");
-  }
-
-  if (replies.length) {
-    renderReactions(replies, "replies");
-  }
-
-  if (mentions.length) {
-    renderReactions(mentions, "mentions");
-  }
 }
 
 // Process webmention promise

--- a/src/static/js/webmentions.js
+++ b/src/static/js/webmentions.js
@@ -147,8 +147,7 @@ function processWebmentions(targetURL) {
 }
 
 // Change tabs for webmentions UI
-function changeTabs(e) {
-  const target = e.target;
+function changeTabs(target) {
   const parent = target.parentNode;
   const grandparent = parent.parentNode;
 
@@ -177,7 +176,7 @@ function addTabListeners() {
 
   // Add a click event handler to each tab
   tabs.forEach(tab => {
-    tab.addEventListener("click", changeTabs);
+    tab.addEventListener("click", function(e){changeTabs(e.target)});
   });
 
   // Enable arrow navigation between tabs in the tab list
@@ -204,6 +203,7 @@ function addTabListeners() {
 
       tabs[tabFocus].setAttribute("tabindex", 0);
       tabs[tabFocus].focus();
+      changeTabs(tabs[tabFocus]);
     }
   });
 }

--- a/src/static/js/webmentions.js
+++ b/src/static/js/webmentions.js
@@ -39,6 +39,18 @@ function parseMentions(webmentions, mentionType) {
 function renderLikes(likes) {
   // Add the likes count to the likes-tab
   document.querySelector('#likes-count').textContent = likes.length;
+  if (likes.length === 1) {
+    document.querySelectorAll('.like-singular').forEach(el => {
+      el.removeAttribute('data-translation');
+    });
+  } else {
+    document.querySelectorAll('.like-plural').forEach(el => {
+      el.removeAttribute('data-translation');
+    });
+  }
+
+  const likePanel = document.querySelector("#likes-panel");
+  const likeAriaText = likePanel.getAttribute("data-like-text");
   const webmentionLikesList = document.createElement("ul");
   webmentionLikesList.setAttribute("class", "webmention-likes");
   likes.forEach(function(like) {
@@ -48,7 +60,7 @@ function renderLikes(likes) {
           class="webmention-author"
           href="${like["url"]}"
           title="${like["author"]["name"]}"
-          aria-label="${like["author"]["name"]} liked this chapter"
+          aria-label="${like["author"]["name"]} ${likeAriaText}"
         >
           <img
             class="webmention-author-avatar"
@@ -61,13 +73,25 @@ function renderLikes(likes) {
 	  const likeHtmlObject = parser.parseFromString(likeHtml, 'text/html');
     webmentionLikesList.appendChild(likeHtmlObject.body.childNodes[0]);
   });
-  document.querySelector("#likes-panel").appendChild(webmentionLikesList);
+  likePanel.appendChild(webmentionLikesList);
 }
 
 // Renders webmention reposts
 function renderReposts(reposts) {
   // Add the reposts count to the reposts-tab
   document.querySelector('#reposts-count').textContent = reposts.length;
+  if (reposts.length === 1) {
+    document.querySelectorAll('.repost-singular').forEach(el => {
+      el.removeAttribute('data-translation');
+    });
+  } else {
+    document.querySelectorAll('.repost-plural').forEach(el => {
+      el.removeAttribute('data-translation');
+    });
+  }
+
+  const repostPanel = document.querySelector("#reposts-panel");
+  const repostAriaText = repostPanel.getAttribute("data-repost-text");
   const webmentionRepostsList = document.createElement("ul");
   webmentionRepostsList.setAttribute("class", "webmention-reposts");
   reposts.forEach(function(repost) {
@@ -77,7 +101,7 @@ function renderReposts(reposts) {
           class="webmention-author"
           href="${repost["url"]}"
           title="${repost["author"]["name"]}"
-          aria-label="${repost["author"]["name"]} reposted this chapter"
+          aria-label="${repost["author"]["name"]} ${repostAriaText}"
         >
           <img
             class="webmention-author-avatar"
@@ -90,13 +114,25 @@ function renderReposts(reposts) {
 	  const repostHtmlObject = parser.parseFromString(repostHtml, 'text/html');
     webmentionRepostsList.appendChild(repostHtmlObject.body.childNodes[0]);
   });
-  document.querySelector("#reposts-panel").appendChild(webmentionRepostsList);
+  repostPanel.appendChild(webmentionRepostsList);
 }
 
 // Renders webmention replies
 function renderReplies(replies) {
   // Add the replies count to the replies-tab
   document.querySelector('#replies-count').textContent = replies.length;
+  if (replies.length === 1) {
+    document.querySelectorAll('.reply-singular').forEach(el => {
+      el.removeAttribute('data-translation');
+    });
+  } else {
+    document.querySelectorAll('.reply-plural').forEach(el => {
+      el.removeAttribute('data-translation');
+    });
+  }
+
+  const replyPanel = document.querySelector("#replies-panel");
+  const replyAriaText = replyPanel.getAttribute("data-reply-text");
   const webmentionRepliesList = document.createElement("ul");
   webmentionRepliesList.setAttribute("class", "webmention-replies");
   replies.forEach(function(reply) {
@@ -123,7 +159,7 @@ function renderReplies(replies) {
           <a
             class="webmention-source"
             href="${reply["url"]}"
-            aria-label="View source of reply by ${reply["author"]["name"]}"
+            aria-label="${replyAriaText} ${reply["author"]["name"]}"
           >View Source</a>
         </div>
       </li>
@@ -132,13 +168,25 @@ function renderReplies(replies) {
 	  const replyHtmlObject = parser.parseFromString(replyHtml, 'text/html');
     webmentionRepliesList.appendChild(replyHtmlObject.body.childNodes[0]);
   });
-  document.querySelector("#replies-panel").appendChild(webmentionRepliesList);
+  replyPanel.appendChild(webmentionRepliesList);
 }
 
 // Renders webmention mentions
 function renderMentions(mentions) {
   // Add the mentions count to the mentions-tab
   document.querySelector('#mentions-count').textContent = mentions.length;
+  if (mentions.length === 1) {
+    document.querySelectorAll('.mention-singular').forEach(el => {
+      el.removeAttribute('data-translation');
+    });
+  } else {
+    document.querySelectorAll('.mention-plural').forEach(el => {
+      el.removeAttribute('data-translation');
+    });
+  }
+
+  const mentionPanel = document.querySelector("#mentions-panel");
+  const mentionAriaText = mentionPanel.getAttribute("data-mention-text");
   const webmentionMentionsList = document.createElement("ul");
   webmentionMentionsList.setAttribute("class", "webmention-mentions");
   mentions.forEach(function(mention) {
@@ -168,7 +216,7 @@ function renderMentions(mentions) {
           <a
             class="webmention-source"
             href="${mention["url"]}"
-            aria-label="View source of mention by ${mention["author"]["name"]}"
+            aria-label="${mentionAriaText} ${mention["author"]["name"]}"
           >View Source</a>
         </div>
       </li>
@@ -177,7 +225,7 @@ function renderMentions(mentions) {
 	  const mentionHtmlObject = parser.parseFromString(mentionHtml, 'text/html');
     webmentionMentionsList.appendChild(mentionHtmlObject.body.childNodes[0]);
   });
-  document.querySelector("#mentions-panel").appendChild(webmentionMentionsList);
+  mentionPanel.appendChild(webmentionMentionsList);
 }
 
 // Parses and renders mentions into likes, reposts, replies and mentions

--- a/src/static/js/webmentions.js
+++ b/src/static/js/webmentions.js
@@ -216,7 +216,7 @@ function renderWebmentions(webmentions) {
 function processWebmentions(targetURL) {
   getWebmentions(targetURL)
     .then(webmentions => renderWebmentions(webmentions))
-    .catch(e => console.log(e))
+    .catch(e => console.error(e))
 }
 
 // Change tabs for webmentions UI
@@ -283,5 +283,6 @@ function addTabListeners() {
 
 window.addEventListener("DOMContentLoaded", () => {
   addTabListeners();
-  processWebmentions(window.location.href);
+  const BASE_URL = "https://almanac.httparchive.org"
+  processWebmentions(BASE_URL + window.location.pathname);
 });

--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -163,7 +163,8 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
         id="likes-tab"
         tabindex="0"
       >
-        <span id="likes-count">0</span> {{ self.likes() }}
+        <span id="likes-count">0</span> <span data-translation class="like-singular">{{ self.like() }}</span>
+        <span data-translation class="like-plural">{{ self.likes() }}</span>
       </button>
       <button
         role="tab"
@@ -172,7 +173,8 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
         id="reposts-tab"
         tabindex="-1"
       >
-        <span id="reposts-count">0</span> {{ self.reposts() }}
+        <span id="reposts-count">0</span> <span data-translation class="repost-singular">{{ self.repost() }}</span>
+        <span data-translation class="repost-plural">{{ self.reposts() }}</span>
       </button>
       <button
         role="tab"
@@ -181,7 +183,8 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
         id="replies-tab"
         tabindex="-1"
       >
-        <span id="replies-count">0</span> {{ self.replies() }}
+        <span id="replies-count">0</span> <span data-translation class="reply-singular">{{ self.reply() }}</span>
+        <span data-translation class="reply-plural">{{ self.replies() }}</span>
       </button>
       <button
         role="tab"
@@ -190,16 +193,17 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
         id="mentions-tab"
         tabindex="-1"
       >
-        <span id="mentions-count">0</span> {{ self.mentions() }}
+        <span id="mentions-count">0</span> <span data-translation class="mention-singular">{{ self.mention() }}</span>
+        <span data-translation class="mention-plural">{{ self.mentions() }}</span>
       </button>
     </div>
-    <div id="likes-panel" role="tabpanel" tabindex="0" aria-labelledby="likes-tab">
+    <div id="likes-panel" role="tabpanel" tabindex="0" aria-labelledby="likes-tab" data-like-text="{{ self.like_reaction_text() }}">
     </div>
-    <div id="reposts-panel" role="tabpanel" tabindex="0" aria-labelledby="reposts-tab" hidden>
+    <div id="reposts-panel" role="tabpanel" tabindex="0" aria-labelledby="reposts-tab" data-repost-text="{{ self.repost_reaction_text() }}" hidden>
     </div>
-    <div id="replies-panel" role="tabpanel" tabindex="0" aria-labelledby="replies-tab" hidden>
+    <div id="replies-panel" role="tabpanel" tabindex="0" aria-labelledby="replies-tab" data-reply-text="{{ self.reply_reaction_text() }}" hidden>
     </div>
-    <div id="mentions-panel" role="tabpanel" tabindex="0" aria-labelledby="mentions-tab" hidden>
+    <div id="mentions-panel" role="tabpanel" tabindex="0" aria-labelledby="mentions-tab" data-mention-text="{{ self.mention_reaction_text() }}" hidden>
     </div>
   </div>
 {% endmacro %}

--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -155,7 +155,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
     <a href="#reactions" class="anchor-link">{{ self.reactions() }}</a>
   </h2>
   <div class="reactions" data-source="{{ self.source() }}">
-    <div class="reaction-tabs" role="tablist" aria-label="Reaction Tabs">
+    <div class="reaction-tabs" role="tablist" aria-label="{{ self.reactions() }}">
       <button
         role="tab"
         aria-selected="true"
@@ -412,7 +412,6 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
         <div id="cta-container">
           <a class="alt btn chapter-cta comment-cta" href="#reactions">
             <svg width="22" height="22" role="img" aria-hidden="true">
-              <title id="discuss-this-chapter-cta">{{ self.discuss_this_chapter() }}:</title>
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#comment-logo"></use>
             </svg>
             {{ self.reactions() }}

--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -389,7 +389,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
         <div class="chapter-links">
           {{ render_actions() }}
         </div>
-        {% if year >= 2021 %}
+        {% if year | int >= 2021 %}
         <section class="webmentions js-enable hidden">
           {{ render_webmentions() }}
         </section>

--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -153,44 +153,55 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
 {% macro render_webmentions() %}
   <h2 id="reactions">
     <a href="#reactions" class="anchor-link">{{ self.reactions() }}</a>
-    <div class="reactions">
-      <div class="reaction-tabs" role="tablist" aria-label="Reaction Tabs">
-        <button
-          role="tab"
-          aria-selected="true"
-          aria-controls="likes-panel"
-          id="likes-tab"
-          tabindex="0"
-        >
-          <span id="likes-count">0</span> {{ self.likes() }}
-        </button>
-        <button
-          role="tab"
-          aria-selected="false"
-          aria-controls="reposts-panel"
-          id="reposts-tab"
-          tabindex="-1"
-        >
-          <span id="reposts-count">0</span> {{ self.reposts() }}
-        </button>
-        <button
-          role="tab"
-          aria-selected="false"
-          aria-controls="replies-panel"
-          id="replies-tab"
-          tabindex="-1"
-        >
-          <span id="replies-count">0</span> {{ self.replies() }}
-        </button>
-      </div>
-      <div id="likes-panel" role="tabpanel" tabindex="0" aria-labelledby="likes-tab">
-      </div>
-      <div id="reposts-panel" role="tabpanel" tabindex="0" aria-labelledby="reposts-tab" hidden>
-      </div>
-      <div id="replies-panel" role="tabpanel" tabindex="0" aria-labelledby="replies-tab" hidden>
-      </div>
-    </div>
   </h2>
+  <div class="reactions">
+    <div class="reaction-tabs" role="tablist" aria-label="Reaction Tabs">
+      <button
+        role="tab"
+        aria-selected="true"
+        aria-controls="likes-panel"
+        id="likes-tab"
+        tabindex="0"
+      >
+        <span id="likes-count">0</span> {{ self.likes() }}
+      </button>
+      <button
+        role="tab"
+        aria-selected="false"
+        aria-controls="reposts-panel"
+        id="reposts-tab"
+        tabindex="-1"
+      >
+        <span id="reposts-count">0</span> {{ self.reposts() }}
+      </button>
+      <button
+        role="tab"
+        aria-selected="false"
+        aria-controls="replies-panel"
+        id="replies-tab"
+        tabindex="-1"
+      >
+        <span id="replies-count">0</span> {{ self.replies() }}
+      </button>
+      <button
+        role="tab"
+        aria-selected="false"
+        aria-controls="mentions-panel"
+        id="mentions-tab"
+        tabindex="-1"
+      >
+        <span id="mentions-count">0</span> {{ self.mentions() }}
+      </button>
+    </div>
+    <div id="likes-panel" role="tabpanel" tabindex="0" aria-labelledby="likes-tab">
+    </div>
+    <div id="reposts-panel" role="tabpanel" tabindex="0" aria-labelledby="reposts-tab" hidden>
+    </div>
+    <div id="replies-panel" role="tabpanel" tabindex="0" aria-labelledby="replies-tab" hidden>
+    </div>
+    <div id="mentions-panel" role="tabpanel" tabindex="0" aria-labelledby="mentions-tab" hidden>
+    </div>
+  </div>
 {% endmacro %}
 
 {% macro render_authors() %}

--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -58,6 +58,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
 </script>
 {% endif %}
 {{ super() }}
+<script async src="{{ get_versioned_filename('/static/js/webmentions.js') }}" nonce="{{ csp_nonce() }}"></script>
 {% endblock %}
 
 {# Calls to action for readers who want to engage more with this chapter. #}
@@ -147,6 +148,49 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
   {% endfor %}{{ self.translated_by_after() }}
   </div>
   {% endif %}
+{% endmacro %}
+
+{% macro render_webmentions() %}
+  <h2 id="reactions">
+    <a href="#reactions" class="anchor-link">{{ self.reactions() }}</a>
+    <div class="reactions">
+      <div class="reaction-tabs" role="tablist" aria-label="Reaction Tabs">
+        <button
+          role="tab"
+          aria-selected="true"
+          aria-controls="likes-panel"
+          id="likes-tab"
+          tabindex="0"
+        >
+          <span id="likes-count">0</span> {{ self.likes() }}
+        </button>
+        <button
+          role="tab"
+          aria-selected="false"
+          aria-controls="reposts-panel"
+          id="reposts-tab"
+          tabindex="-1"
+        >
+          <span id="reposts-count">0</span> {{ self.reposts() }}
+        </button>
+        <button
+          role="tab"
+          aria-selected="false"
+          aria-controls="replies-panel"
+          id="replies-tab"
+          tabindex="-1"
+        >
+          <span id="replies-count">0</span> {{ self.replies() }}
+        </button>
+      </div>
+      <div id="likes-panel" role="tabpanel" tabindex="0" aria-labelledby="likes-tab">
+      </div>
+      <div id="reposts-panel" role="tabpanel" tabindex="0" aria-labelledby="reposts-tab" hidden>
+      </div>
+      <div id="replies-panel" role="tabpanel" tabindex="0" aria-labelledby="replies-tab" hidden>
+      </div>
+    </div>
+  </h2>
 {% endmacro %}
 
 {% macro render_authors() %}
@@ -330,6 +374,9 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
         <div class="chapter-links">
           {{ render_actions() }}
         </div>
+        <section class="webmentions">
+          {{ render_webmentions() }}
+        </section>
         <section class="authors">
             {{ render_authors() }}
         </section>

--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -154,7 +154,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
   <h2 id="reactions">
     <a href="#reactions" class="anchor-link">{{ self.reactions() }}</a>
   </h2>
-  <div class="reactions">
+  <div class="reactions" data-source="{{ self.source() }}">
     <div class="reaction-tabs" role="tablist" aria-label="Reaction Tabs">
       <button
         role="tab"
@@ -163,8 +163,8 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
         id="likes-tab"
         tabindex="0"
       >
-        <span id="likes-count">0</span> <span data-translation class="like-singular">{{ self.like() }}</span>
-        <span data-translation class="like-plural">{{ self.likes() }}</span>
+        <span id="likes-count">0</span>
+        <span id="likes-label" data-plural="{{ self.like() }}" data-singular="{{ self.likes() }}">{{ self.likes() }}</span>
       </button>
       <button
         role="tab"
@@ -173,8 +173,8 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
         id="reposts-tab"
         tabindex="-1"
       >
-        <span id="reposts-count">0</span> <span data-translation class="repost-singular">{{ self.repost() }}</span>
-        <span data-translation class="repost-plural">{{ self.reposts() }}</span>
+        <span id="reposts-count">0</span>
+        <span id="reposts-label" data-plural="{{ self.repost() }}" data-singular="{{ self.reposts() }}">{{ self.reposts() }}</span>
       </button>
       <button
         role="tab"
@@ -183,8 +183,8 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
         id="replies-tab"
         tabindex="-1"
       >
-        <span id="replies-count">0</span> <span data-translation class="reply-singular">{{ self.reply() }}</span>
-        <span data-translation class="reply-plural">{{ self.replies() }}</span>
+        <span id="replies-count">0</span>
+        <span id="replies-label" data-plural="{{ self.reply() }}" data-singular="{{ self.replies() }}">{{ self.replies() }}</span>
       </button>
       <button
         role="tab"
@@ -193,8 +193,8 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
         id="mentions-tab"
         tabindex="-1"
       >
-        <span id="mentions-count">0</span> <span data-translation class="mention-singular">{{ self.mention() }}</span>
-        <span data-translation class="mention-plural">{{ self.mentions() }}</span>
+        <span id="mentions-count">0</span>
+        <span id="mentions-label" data-plural="{{ self.mention() }}" data-singular="{{ self.mentions() }}">{{ self.mentions() }}</span>
       </button>
     </div>
     <div id="likes-panel" role="tabpanel" tabindex="0" aria-labelledby="likes-tab" data-like-text="{{ self.like_reaction_text() }}">

--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -58,7 +58,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
 </script>
 {% endif %}
 {{ super() }}
-<script async src="{{ get_versioned_filename('/static/js/webmentions.js') }}" nonce="{{ csp_nonce() }}"></script>
+<script defer src="{{ get_versioned_filename('/static/js/webmentions.js') }}" nonce="{{ csp_nonce() }}"></script>
 {% endblock %}
 
 {# Calls to action for readers who want to engage more with this chapter. #}
@@ -197,13 +197,13 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
         <span id="mentions-label" data-plural="{{ self.mention() }}" data-singular="{{ self.mentions() }}">{{ self.mentions() }}</span>
       </button>
     </div>
-    <div id="likes-panel" role="tabpanel" tabindex="0" aria-labelledby="likes-tab" data-like-text="{{ self.like_reaction_text() }}">
+    <div id="likes-panel" role="tabpanel" tabindex="0" aria-labelledby="likes-tab">
     </div>
-    <div id="reposts-panel" role="tabpanel" tabindex="0" aria-labelledby="reposts-tab" data-repost-text="{{ self.repost_reaction_text() }}" hidden>
+    <div id="reposts-panel" role="tabpanel" tabindex="0" aria-labelledby="reposts-tab" hidden>
     </div>
-    <div id="replies-panel" role="tabpanel" tabindex="0" aria-labelledby="replies-tab" data-reply-text="{{ self.reply_reaction_text() }}" hidden>
+    <div id="replies-panel" role="tabpanel" tabindex="0" aria-labelledby="replies-tab" hidden>
     </div>
-    <div id="mentions-panel" role="tabpanel" tabindex="0" aria-labelledby="mentions-tab" data-mention-text="{{ self.mention_reaction_text() }}" hidden>
+    <div id="mentions-panel" role="tabpanel" tabindex="0" aria-labelledby="mentions-tab" hidden>
     </div>
   </div>
 {% endmacro %}
@@ -389,9 +389,11 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
         <div class="chapter-links">
           {{ render_actions() }}
         </div>
-        <section class="webmentions">
+        {% if year >= 2021 %}
+        <section class="webmentions js-enable hidden">
           {{ render_webmentions() }}
         </section>
+        {% endif %}
         <section class="authors">
             {{ render_authors() }}
         </section>
@@ -404,6 +406,16 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
             </svg>
             <span class="num-comments"><span class="not-mobile">{{ self.comments_fallback() }}</span></span> <span data-translation class="comment-singular visually-hidden-mobile">{{ self.comment() }}</span>
             <span data-translation class="comment-plural visually-hidden-mobile">{{ self.comments() }}</span>
+          </a>
+        </div>
+        {% elif year | int >= 2021 %}
+        <div id="cta-container">
+          <a class="alt btn chapter-cta comment-cta" href="#reactions">
+            <svg width="22" height="22" role="img" aria-hidden="true">
+              <title id="discuss-this-chapter-cta">{{ self.discuss_this_chapter() }}:</title>
+              <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#comment-logo"></use>
+            </svg>
+            {{ self.reactions() }}
           </a>
         </div>
         {% endif %}

--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -156,43 +156,19 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
   </h2>
   <div class="reactions" data-source="{{ self.source() }}">
     <div class="reaction-tabs" role="tablist" aria-label="{{ self.reactions() }}">
-      <button
-        role="tab"
-        aria-selected="true"
-        aria-controls="likes-panel"
-        id="likes-tab"
-        tabindex="0"
-      >
+      <button id="likes-tab" role="tab" aria-selected="true" aria-controls="likes-panel" tabindex="0">
         <span id="likes-count">0</span>
         <span id="likes-label" data-plural="{{ self.like() }}" data-singular="{{ self.likes() }}">{{ self.likes() }}</span>
       </button>
-      <button
-        role="tab"
-        aria-selected="false"
-        aria-controls="reposts-panel"
-        id="reposts-tab"
-        tabindex="-1"
-      >
+      <button id="reposts-tab" role="tab" aria-selected="false" aria-controls="reposts-panel" tabindex="-1">
         <span id="reposts-count">0</span>
         <span id="reposts-label" data-plural="{{ self.repost() }}" data-singular="{{ self.reposts() }}">{{ self.reposts() }}</span>
       </button>
-      <button
-        role="tab"
-        aria-selected="false"
-        aria-controls="replies-panel"
-        id="replies-tab"
-        tabindex="-1"
-      >
+      <button id="replies-tab" role="tab" aria-selected="false" aria-controls="replies-panel" tabindex="-1">
         <span id="replies-count">0</span>
         <span id="replies-label" data-plural="{{ self.reply() }}" data-singular="{{ self.replies() }}">{{ self.replies() }}</span>
       </button>
-      <button
-        role="tab"
-        aria-selected="false"
-        aria-controls="mentions-panel"
-        id="mentions-tab"
-        tabindex="-1"
-      >
+      <button id="mentions-tab" role="tab" aria-selected="false" aria-controls="mentions-panel" tabindex="-1">
         <span id="mentions-count">0</span>
         <span id="mentions-label" data-plural="{{ self.mention() }}" data-singular="{{ self.mentions() }}">{{ self.mentions() }}</span>
       </button>

--- a/src/templates/en/base.html
+++ b/src/templates/en/base.html
@@ -89,10 +89,20 @@ Our mission is to combine the raw stats and trends of the HTTP Archive with the 
 {% block authors %}Authors{% endblock %}
 
 {% block reactions %}Reactions{% endblock %}
+
+{% block like %}Like{% endblock %}
+{% block repost %}Repost{% endblock %}
+{% block reply %}Reply{% endblock %}
+{% block mention %}Mention{% endblock %}
 {% block likes %}Likes{% endblock %}
 {% block reposts %}Reposts{% endblock %}
 {% block replies %}Replies{% endblock %}
 {% block mentions %}Mentions{% endblock %}
+
+{% block like_reaction_text %}liked this chapter{% endblock %}
+{% block repost_reaction_text %}reposted this chapter{% endblock %}
+{% block reply_reaction_text %}View source of reply by{% endblock %}
+{% block mention_reaction_text %}View source of mention by{% endblock %}
 
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} on Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} on GitHub{% endmacro %}

--- a/src/templates/en/base.html
+++ b/src/templates/en/base.html
@@ -100,11 +100,6 @@ Our mission is to combine the raw stats and trends of the HTTP Archive with the 
 {% block replies %}Replies{% endblock %}
 {% block mentions %}Mentions{% endblock %}
 
-{% block like_reaction_text %}liked this chapter{% endblock %}
-{% block repost_reaction_text %}reposted this chapter{% endblock %}
-{% block reply_reaction_text %}View source of reply by{% endblock %}
-{% block mention_reaction_text %}View source of mention by{% endblock %}
-
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} on Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} on GitHub{% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} on LinkedIn{% endmacro %}

--- a/src/templates/en/base.html
+++ b/src/templates/en/base.html
@@ -88,6 +88,11 @@ Our mission is to combine the raw stats and trends of the HTTP Archive with the 
 {% block author %}Author{% endblock %}
 {% block authors %}Authors{% endblock %}
 
+{% block reactions %}Reactions{% endblock %}
+{% block likes %}Likes{% endblock %}
+{% block reposts %}Reposts{% endblock %}
+{% block replies %}Replies{% endblock %}
+
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} on Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} on GitHub{% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} on LinkedIn{% endmacro %}

--- a/src/templates/en/base.html
+++ b/src/templates/en/base.html
@@ -89,6 +89,7 @@ Our mission is to combine the raw stats and trends of the HTTP Archive with the 
 {% block authors %}Authors{% endblock %}
 
 {% block reactions %}Reactions{% endblock %}
+{% block source %}View Source{% endblock %}
 
 {% block like %}Like{% endblock %}
 {% block repost %}Repost{% endblock %}

--- a/src/templates/en/base.html
+++ b/src/templates/en/base.html
@@ -92,6 +92,7 @@ Our mission is to combine the raw stats and trends of the HTTP Archive with the 
 {% block likes %}Likes{% endblock %}
 {% block reposts %}Reposts{% endblock %}
 {% block replies %}Replies{% endblock %}
+{% block mentions %}Mentions{% endblock %}
 
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} on Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} on GitHub{% endmacro %}

--- a/src/templates/en/base.html
+++ b/src/templates/en/base.html
@@ -89,16 +89,16 @@ Our mission is to combine the raw stats and trends of the HTTP Archive with the 
 {% block authors %}Authors{% endblock %}
 
 {% block reactions %}Reactions{% endblock %}
-{% block source %}View Source{% endblock %}
+{% block source %}View source{% endblock %}
 
-{% block like %}Like{% endblock %}
-{% block repost %}Repost{% endblock %}
-{% block reply %}Reply{% endblock %}
-{% block mention %}Mention{% endblock %}
-{% block likes %}Likes{% endblock %}
-{% block reposts %}Reposts{% endblock %}
-{% block replies %}Replies{% endblock %}
-{% block mentions %}Mentions{% endblock %}
+{% block like %}like{% endblock %}
+{% block repost %}repost{% endblock %}
+{% block reply %}reply{% endblock %}
+{% block mention %}mention{% endblock %}
+{% block likes %}likes{% endblock %}
+{% block reposts %}reposts{% endblock %}
+{% block replies %}replies{% endblock %}
+{% block mentions %}mentions{% endblock %}
 
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} on Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} on GitHub{% endmacro %}

--- a/src/templates/es/base.html
+++ b/src/templates/es/base.html
@@ -99,11 +99,6 @@
 {% block replies %}Replies{% endblock %}
 {% block mentions %}Mentions{% endblock %}
 
-{% block like_reaction_text %}liked this chapter{% endblock %}
-{% block repost_reaction_text %}reposted this chapter{% endblock %}
-{% block reply_reaction_text %}View source of reply by{% endblock %}
-{% block mention_reaction_text %}View source of mention by{% endblock %}
-
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} en Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} en GitHub{% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} en LinkedIn{% endmacro %}

--- a/src/templates/es/base.html
+++ b/src/templates/es/base.html
@@ -89,6 +89,7 @@
 {% block authors %}Autores{% endblock %}
 
 {% block reactions %}Reactions{% endblock %}
+{% block source %}View Source{% endblock %}
 
 {% block like %}Like{% endblock %}
 {% block repost %}Repost{% endblock %}

--- a/src/templates/es/base.html
+++ b/src/templates/es/base.html
@@ -88,17 +88,17 @@
 {% block author %}Autor(a){% endblock %}
 {% block authors %}Autores{% endblock %}
 
-{% block reactions %}Reactions{% endblock %}
-{% block source %}View Source{% endblock %}
+{% block reactions %}reacciones{% endblock %}
+{% block source %}ver fuente{% endblock %}
 
-{% block like %}Like{% endblock %}
-{% block repost %}Repost{% endblock %}
-{% block reply %}Reply{% endblock %}
-{% block mention %}Mention{% endblock %}
-{% block likes %}Likes{% endblock %}
-{% block reposts %}Reposts{% endblock %}
-{% block replies %}Replies{% endblock %}
-{% block mentions %}Mentions{% endblock %}
+{% block like %}gusta{% endblock %}
+{% block repost %}repost{% endblock %}
+{% block reply %}respuesta{% endblock %}
+{% block mention %}mencionar{% endblock %}
+{% block likes %}gustos{% endblock %}
+{% block reposts %}reposts{% endblock %}
+{% block replies %}respuestas{% endblock %}
+{% block mentions %}menciones{% endblock %}
 
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} en Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} en GitHub{% endmacro %}

--- a/src/templates/es/base.html
+++ b/src/templates/es/base.html
@@ -88,6 +88,22 @@
 {% block author %}Autor(a){% endblock %}
 {% block authors %}Autores{% endblock %}
 
+{% block reactions %}Reactions{% endblock %}
+
+{% block like %}Like{% endblock %}
+{% block repost %}Repost{% endblock %}
+{% block reply %}Reply{% endblock %}
+{% block mention %}Mention{% endblock %}
+{% block likes %}Likes{% endblock %}
+{% block reposts %}Reposts{% endblock %}
+{% block replies %}Replies{% endblock %}
+{% block mentions %}Mentions{% endblock %}
+
+{% block like_reaction_text %}liked this chapter{% endblock %}
+{% block repost_reaction_text %}reposted this chapter{% endblock %}
+{% block reply_reaction_text %}View source of reply by{% endblock %}
+{% block mention_reaction_text %}View source of mention by{% endblock %}
+
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} en Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} en GitHub{% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} en LinkedIn{% endmacro %}

--- a/src/templates/fr/base.html
+++ b/src/templates/fr/base.html
@@ -88,17 +88,17 @@ Notre mission est de combiner les statistiques brutes et les tendances de HTTP A
 {% block author %}Auteur·ice{% endblock %}
 {% block authors %}Auteur·ice·s{% endblock %}
 
-{% block reactions %}Reactions{% endblock %}
-{% block source %}View Source{% endblock %}
+{% block reactions %}Réactions{% endblock %}
+{% block source %}Voir la source{% endblock %}
 
-{% block like %}Like{% endblock %}
-{% block repost %}Repost{% endblock %}
-{% block reply %}Reply{% endblock %}
-{% block mention %}Mention{% endblock %}
-{% block likes %}Likes{% endblock %}
-{% block reposts %}Reposts{% endblock %}
-{% block replies %}Replies{% endblock %}
-{% block mentions %}Mentions{% endblock %}
+{% block like %}comme{% endblock %}
+{% block repost %}republier{% endblock %}
+{% block reply %}réponse{% endblock %}
+{% block mention %}mention{% endblock %}
+{% block likes %}aime{% endblock %}
+{% block reposts %}republier{% endblock %}
+{% block replies %}réponses{% endblock %}
+{% block mentions %}mentions{% endblock %}
 
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} sur Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} sur GitHub{% endmacro %}

--- a/src/templates/fr/base.html
+++ b/src/templates/fr/base.html
@@ -88,6 +88,22 @@ Notre mission est de combiner les statistiques brutes et les tendances de HTTP A
 {% block author %}Auteur·ice{% endblock %}
 {% block authors %}Auteur·ice·s{% endblock %}
 
+{% block reactions %}Reactions{% endblock %}
+
+{% block like %}Like{% endblock %}
+{% block repost %}Repost{% endblock %}
+{% block reply %}Reply{% endblock %}
+{% block mention %}Mention{% endblock %}
+{% block likes %}Likes{% endblock %}
+{% block reposts %}Reposts{% endblock %}
+{% block replies %}Replies{% endblock %}
+{% block mentions %}Mentions{% endblock %}
+
+{% block like_reaction_text %}liked this chapter{% endblock %}
+{% block repost_reaction_text %}reposted this chapter{% endblock %}
+{% block reply_reaction_text %}View source of reply by{% endblock %}
+{% block mention_reaction_text %}View source of mention by{% endblock %}
+
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} sur Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} sur GitHub{% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} sur LinkedIn{% endmacro %}

--- a/src/templates/fr/base.html
+++ b/src/templates/fr/base.html
@@ -89,6 +89,7 @@ Notre mission est de combiner les statistiques brutes et les tendances de HTTP A
 {% block authors %}Auteur·ice·s{% endblock %}
 
 {% block reactions %}Reactions{% endblock %}
+{% block source %}View Source{% endblock %}
 
 {% block like %}Like{% endblock %}
 {% block repost %}Repost{% endblock %}

--- a/src/templates/fr/base.html
+++ b/src/templates/fr/base.html
@@ -99,11 +99,6 @@ Notre mission est de combiner les statistiques brutes et les tendances de HTTP A
 {% block replies %}Replies{% endblock %}
 {% block mentions %}Mentions{% endblock %}
 
-{% block like_reaction_text %}liked this chapter{% endblock %}
-{% block repost_reaction_text %}reposted this chapter{% endblock %}
-{% block reply_reaction_text %}View source of reply by{% endblock %}
-{% block mention_reaction_text %}View source of mention by{% endblock %}
-
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} sur Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} sur GitHub{% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} sur LinkedIn{% endmacro %}

--- a/src/templates/hi/base.html
+++ b/src/templates/hi/base.html
@@ -88,6 +88,22 @@
 {% block author %}लेखक{% endblock %}
 {% block authors %}लेखकों{% endblock %}
 
+{% block reactions %}Reactions{% endblock %}
+
+{% block like %}Like{% endblock %}
+{% block repost %}Repost{% endblock %}
+{% block reply %}Reply{% endblock %}
+{% block mention %}Mention{% endblock %}
+{% block likes %}Likes{% endblock %}
+{% block reposts %}Reposts{% endblock %}
+{% block replies %}Replies{% endblock %}
+{% block mentions %}Mentions{% endblock %}
+
+{% block like_reaction_text %}liked this chapter{% endblock %}
+{% block repost_reaction_text %}reposted this chapter{% endblock %}
+{% block reply_reaction_text %}View source of reply by{% endblock %}
+{% block mention_reaction_text %}View source of mention by{% endblock %}
+
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} Twitter पर{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} GitHub पर{% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} LinkedIn पर{% endmacro %}

--- a/src/templates/hi/base.html
+++ b/src/templates/hi/base.html
@@ -88,17 +88,17 @@
 {% block author %}लेखक{% endblock %}
 {% block authors %}लेखकों{% endblock %}
 
-{% block reactions %}Reactions{% endblock %}
-{% block source %}View Source{% endblock %}
+{% block reactions %}प्रतिक्रियाओं{% endblock %}
+{% block source %}प्रतिक्रियाओं{% endblock %}
 
-{% block like %}Like{% endblock %}
-{% block repost %}Repost{% endblock %}
-{% block reply %}Reply{% endblock %}
-{% block mention %}Mention{% endblock %}
-{% block likes %}Likes{% endblock %}
-{% block reposts %}Reposts{% endblock %}
-{% block replies %}Replies{% endblock %}
-{% block mentions %}Mentions{% endblock %}
+{% block like %}पसंद{% endblock %}
+{% block repost %}पोस्ट{% endblock %}
+{% block reply %}जवाब{% endblock %}
+{% block mention %}उल्लेख{% endblock %}
+{% block likes %}को यह पसंद है{% endblock %}
+{% block reposts %}रेपोस्ट{% endblock %}
+{% block replies %}जवाब{% endblock %}
+{% block mentions %}का उल्लेख है{% endblock %}
 
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} Twitter पर{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} GitHub पर{% endmacro %}

--- a/src/templates/hi/base.html
+++ b/src/templates/hi/base.html
@@ -99,11 +99,6 @@
 {% block replies %}Replies{% endblock %}
 {% block mentions %}Mentions{% endblock %}
 
-{% block like_reaction_text %}liked this chapter{% endblock %}
-{% block repost_reaction_text %}reposted this chapter{% endblock %}
-{% block reply_reaction_text %}View source of reply by{% endblock %}
-{% block mention_reaction_text %}View source of mention by{% endblock %}
-
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} Twitter पर{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} GitHub पर{% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} LinkedIn पर{% endmacro %}

--- a/src/templates/hi/base.html
+++ b/src/templates/hi/base.html
@@ -89,6 +89,7 @@
 {% block authors %}लेखकों{% endblock %}
 
 {% block reactions %}Reactions{% endblock %}
+{% block source %}View Source{% endblock %}
 
 {% block like %}Like{% endblock %}
 {% block repost %}Repost{% endblock %}

--- a/src/templates/it/base.html
+++ b/src/templates/it/base.html
@@ -88,6 +88,22 @@ La nostra missione è combinare le statistiche grezze e le tendenze del HTTP Arc
 {% block author %}Autore{% endblock %}
 {% block authors %}Autori{% endblock %}
 
+{% block reactions %}Reactions{% endblock %}
+
+{% block like %}Like{% endblock %}
+{% block repost %}Repost{% endblock %}
+{% block reply %}Reply{% endblock %}
+{% block mention %}Mention{% endblock %}
+{% block likes %}Likes{% endblock %}
+{% block reposts %}Reposts{% endblock %}
+{% block replies %}Replies{% endblock %}
+{% block mentions %}Mentions{% endblock %}
+
+{% block like_reaction_text %}liked this chapter{% endblock %}
+{% block repost_reaction_text %}reposted this chapter{% endblock %}
+{% block reply_reaction_text %}View source of reply by{% endblock %}
+{% block mention_reaction_text %}View source of mention by{% endblock %}
+
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} su Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} su GitHub{% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} su LinkedIn{% endmacro %}

--- a/src/templates/it/base.html
+++ b/src/templates/it/base.html
@@ -89,6 +89,7 @@ La nostra missione è combinare le statistiche grezze e le tendenze del HTTP Arc
 {% block authors %}Autori{% endblock %}
 
 {% block reactions %}Reactions{% endblock %}
+{% block source %}View Source{% endblock %}
 
 {% block like %}Like{% endblock %}
 {% block repost %}Repost{% endblock %}

--- a/src/templates/it/base.html
+++ b/src/templates/it/base.html
@@ -88,17 +88,17 @@ La nostra missione è combinare le statistiche grezze e le tendenze del HTTP Arc
 {% block author %}Autore{% endblock %}
 {% block authors %}Autori{% endblock %}
 
-{% block reactions %}Reactions{% endblock %}
-{% block source %}View Source{% endblock %}
+{% block reactions %}Reazioni{% endblock %}
+{% block source %}Vedi la fonte{% endblock %}
 
-{% block like %}Like{% endblock %}
-{% block repost %}Repost{% endblock %}
-{% block reply %}Reply{% endblock %}
-{% block mention %}Mention{% endblock %}
-{% block likes %}Likes{% endblock %}
-{% block reposts %}Reposts{% endblock %}
-{% block replies %}Replies{% endblock %}
-{% block mentions %}Mentions{% endblock %}
+{% block like %}piace{% endblock %}
+{% block repost %}ripubblicare{% endblock %}
+{% block reply %}rispondere{% endblock %}
+{% block mention %}menzionare{% endblock %}
+{% block likes %}piace{% endblock %}
+{% block reposts %}ripubblica{% endblock %}
+{% block replies %}risposte{% endblock %}
+{% block mentions %}menzioni{% endblock %}
 
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} su Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} su GitHub{% endmacro %}

--- a/src/templates/it/base.html
+++ b/src/templates/it/base.html
@@ -99,11 +99,6 @@ La nostra missione è combinare le statistiche grezze e le tendenze del HTTP Arc
 {% block replies %}Replies{% endblock %}
 {% block mentions %}Mentions{% endblock %}
 
-{% block like_reaction_text %}liked this chapter{% endblock %}
-{% block repost_reaction_text %}reposted this chapter{% endblock %}
-{% block reply_reaction_text %}View source of reply by{% endblock %}
-{% block mention_reaction_text %}View source of mention by{% endblock %}
-
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} su Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} su GitHub{% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} su LinkedIn{% endmacro %}

--- a/src/templates/ja/base.html
+++ b/src/templates/ja/base.html
@@ -88,6 +88,22 @@
 {% block author %}著者{% endblock %}
 {% block authors %}著者{% endblock %}
 
+{% block reactions %}Reactions{% endblock %}
+
+{% block like %}Like{% endblock %}
+{% block repost %}Repost{% endblock %}
+{% block reply %}Reply{% endblock %}
+{% block mention %}Mention{% endblock %}
+{% block likes %}Likes{% endblock %}
+{% block reposts %}Reposts{% endblock %}
+{% block replies %}Replies{% endblock %}
+{% block mentions %}Mentions{% endblock %}
+
+{% block like_reaction_text %}liked this chapter{% endblock %}
+{% block repost_reaction_text %}reposted this chapter{% endblock %}
+{% block reply_reaction_text %}View source of reply by{% endblock %}
+{% block mention_reaction_text %}View source of mention by{% endblock %}
+
 {% macro onTwitter(twitterHandle) %}Twitterの@{{twitterHandle}}{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}GitHubの{{gitHubHandle}}{% endmacro %}
 {% macro onLinkedIn(authorName) %}LinkedInの{{authorName}}{% endmacro %}

--- a/src/templates/ja/base.html
+++ b/src/templates/ja/base.html
@@ -89,6 +89,7 @@
 {% block authors %}著者{% endblock %}
 
 {% block reactions %}Reactions{% endblock %}
+{% block source %}View Source{% endblock %}
 
 {% block like %}Like{% endblock %}
 {% block repost %}Repost{% endblock %}

--- a/src/templates/ja/base.html
+++ b/src/templates/ja/base.html
@@ -88,17 +88,17 @@
 {% block author %}著者{% endblock %}
 {% block authors %}著者{% endblock %}
 
-{% block reactions %}Reactions{% endblock %}
-{% block source %}View Source{% endblock %}
+{% block reactions %}反応{% endblock %}
+{% block source %}ソースを見る{% endblock %}
 
-{% block like %}Like{% endblock %}
-{% block repost %}Repost{% endblock %}
-{% block reply %}Reply{% endblock %}
-{% block mention %}Mention{% endblock %}
-{% block likes %}Likes{% endblock %}
-{% block reposts %}Reposts{% endblock %}
-{% block replies %}Replies{% endblock %}
-{% block mentions %}Mentions{% endblock %}
+{% block like %}いいね{% endblock %}
+{% block repost %}再投稿{% endblock %}
+{% block reply %}返信{% endblock %}
+{% block mention %}言及{% endblock %}
+{% block likes %}いいね{% endblock %}
+{% block reposts %}再投稿{% endblock %}
+{% block replies %}返信{% endblock %}
+{% block mentions %}言及{% endblock %}
 
 {% macro onTwitter(twitterHandle) %}Twitterの@{{twitterHandle}}{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}GitHubの{{gitHubHandle}}{% endmacro %}

--- a/src/templates/ja/base.html
+++ b/src/templates/ja/base.html
@@ -99,11 +99,6 @@
 {% block replies %}Replies{% endblock %}
 {% block mentions %}Mentions{% endblock %}
 
-{% block like_reaction_text %}liked this chapter{% endblock %}
-{% block repost_reaction_text %}reposted this chapter{% endblock %}
-{% block reply_reaction_text %}View source of reply by{% endblock %}
-{% block mention_reaction_text %}View source of mention by{% endblock %}
-
 {% macro onTwitter(twitterHandle) %}Twitterの@{{twitterHandle}}{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}GitHubの{{gitHubHandle}}{% endmacro %}
 {% macro onLinkedIn(authorName) %}LinkedInの{{authorName}}{% endmacro %}

--- a/src/templates/nl/base.html
+++ b/src/templates/nl/base.html
@@ -89,6 +89,7 @@
 {% block authors %}Auteurs{% endblock %}
 
 {% block reactions %}Reactions{% endblock %}
+{% block source %}View Source{% endblock %}
 
 {% block like %}Like{% endblock %}
 {% block repost %}Repost{% endblock %}

--- a/src/templates/nl/base.html
+++ b/src/templates/nl/base.html
@@ -99,11 +99,6 @@
 {% block replies %}Replies{% endblock %}
 {% block mentions %}Mentions{% endblock %}
 
-{% block like_reaction_text %}liked this chapter{% endblock %}
-{% block repost_reaction_text %}reposted this chapter{% endblock %}
-{% block reply_reaction_text %}View source of reply by{% endblock %}
-{% block mention_reaction_text %}View source of mention by{% endblock %}
-
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} op Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} op GitHub{% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} op LinkedIn{% endmacro %}

--- a/src/templates/nl/base.html
+++ b/src/templates/nl/base.html
@@ -88,17 +88,17 @@
 {% block author %}Auteur{% endblock %}
 {% block authors %}Auteurs{% endblock %}
 
-{% block reactions %}Reactions{% endblock %}
-{% block source %}View Source{% endblock %}
+{% block reactions %}Reacties{% endblock %}
+{% block source %}Bron bekijken{% endblock %}
 
-{% block like %}Like{% endblock %}
-{% block repost %}Repost{% endblock %}
-{% block reply %}Reply{% endblock %}
-{% block mention %}Mention{% endblock %}
-{% block likes %}Likes{% endblock %}
-{% block reposts %}Reposts{% endblock %}
-{% block replies %}Replies{% endblock %}
-{% block mentions %}Mentions{% endblock %}
+{% block like %}like{% endblock %}
+{% block repost %}repost{% endblock %}
+{% block reply %}antwoord{% endblock %}
+{% block mention %}vermeld{% endblock %}
+{% block likes %}likes{% endblock %}
+{% block reposts %}reposts{% endblock %}
+{% block replies %}antwoorden{% endblock %}
+{% block mentions %}vermeldingen{% endblock %}
 
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} op Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} op GitHub{% endmacro %}

--- a/src/templates/nl/base.html
+++ b/src/templates/nl/base.html
@@ -88,6 +88,22 @@
 {% block author %}Auteur{% endblock %}
 {% block authors %}Auteurs{% endblock %}
 
+{% block reactions %}Reactions{% endblock %}
+
+{% block like %}Like{% endblock %}
+{% block repost %}Repost{% endblock %}
+{% block reply %}Reply{% endblock %}
+{% block mention %}Mention{% endblock %}
+{% block likes %}Likes{% endblock %}
+{% block reposts %}Reposts{% endblock %}
+{% block replies %}Replies{% endblock %}
+{% block mentions %}Mentions{% endblock %}
+
+{% block like_reaction_text %}liked this chapter{% endblock %}
+{% block repost_reaction_text %}reposted this chapter{% endblock %}
+{% block reply_reaction_text %}View source of reply by{% endblock %}
+{% block mention_reaction_text %}View source of mention by{% endblock %}
+
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} op Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} op GitHub{% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} op LinkedIn{% endmacro %}

--- a/src/templates/pt/base.html
+++ b/src/templates/pt/base.html
@@ -89,6 +89,7 @@ Nossa missão é combinar as estatísticas brutas e as tendências do HTTP Archi
 {% block authors %}Autores{% endblock %}
 
 {% block reactions %}Reactions{% endblock %}
+{% block source %}View Source{% endblock %}
 
 {% block like %}Like{% endblock %}
 {% block repost %}Repost{% endblock %}

--- a/src/templates/pt/base.html
+++ b/src/templates/pt/base.html
@@ -88,6 +88,22 @@ Nossa missão é combinar as estatísticas brutas e as tendências do HTTP Archi
 {% block author %}Autor(a){% endblock %}
 {% block authors %}Autores{% endblock %}
 
+{% block reactions %}Reactions{% endblock %}
+
+{% block like %}Like{% endblock %}
+{% block repost %}Repost{% endblock %}
+{% block reply %}Reply{% endblock %}
+{% block mention %}Mention{% endblock %}
+{% block likes %}Likes{% endblock %}
+{% block reposts %}Reposts{% endblock %}
+{% block replies %}Replies{% endblock %}
+{% block mentions %}Mentions{% endblock %}
+
+{% block like_reaction_text %}liked this chapter{% endblock %}
+{% block repost_reaction_text %}reposted this chapter{% endblock %}
+{% block reply_reaction_text %}View source of reply by{% endblock %}
+{% block mention_reaction_text %}View source of mention by{% endblock %}
+
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} no Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} no GitHub{% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} no LinkedIn{% endmacro %}

--- a/src/templates/pt/base.html
+++ b/src/templates/pt/base.html
@@ -88,17 +88,17 @@ Nossa missão é combinar as estatísticas brutas e as tendências do HTTP Archi
 {% block author %}Autor(a){% endblock %}
 {% block authors %}Autores{% endblock %}
 
-{% block reactions %}Reactions{% endblock %}
-{% block source %}View Source{% endblock %}
+{% block reactions %}Reações{% endblock %}
+{% block source %}Ver fonte{% endblock %}
 
-{% block like %}Like{% endblock %}
-{% block repost %}Repost{% endblock %}
-{% block reply %}Reply{% endblock %}
-{% block mention %}Mention{% endblock %}
-{% block likes %}Likes{% endblock %}
-{% block reposts %}Reposts{% endblock %}
-{% block replies %}Replies{% endblock %}
-{% block mentions %}Mentions{% endblock %}
+{% block like %}curtir{% endblock %}
+{% block repost %}repostagem{% endblock %}
+{% block reply %}resposta{% endblock %}
+{% block mention %}menção{% endblock %}
+{% block likes %}curtidas{% endblock %}
+{% block reposts %}repostagens{% endblock %}
+{% block replies %}respostas{% endblock %}
+{% block mentions %}menções{% endblock %}
 
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} no Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} no GitHub{% endmacro %}

--- a/src/templates/pt/base.html
+++ b/src/templates/pt/base.html
@@ -99,11 +99,6 @@ Nossa missão é combinar as estatísticas brutas e as tendências do HTTP Archi
 {% block replies %}Replies{% endblock %}
 {% block mentions %}Mentions{% endblock %}
 
-{% block like_reaction_text %}liked this chapter{% endblock %}
-{% block repost_reaction_text %}reposted this chapter{% endblock %}
-{% block reply_reaction_text %}View source of reply by{% endblock %}
-{% block mention_reaction_text %}View source of mention by{% endblock %}
-
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} no Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} no GitHub{% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} no LinkedIn{% endmacro %}

--- a/src/templates/ru/base.html
+++ b/src/templates/ru/base.html
@@ -88,17 +88,17 @@
 {% block author %}Автор{% endblock %}
 {% block authors %}Авторы{% endblock %}
 
-{% block reactions %}Reactions{% endblock %}
-{% block source %}View Source{% endblock %}
+{% block reactions %}Реакции{% endblock %}
+{% block source %}Посмотреть источник{% endblock %}
 
-{% block like %}Like{% endblock %}
-{% block repost %}Repost{% endblock %}
-{% block reply %}Reply{% endblock %}
-{% block mention %}Mention{% endblock %}
-{% block likes %}Likes{% endblock %}
-{% block reposts %}Reposts{% endblock %}
-{% block replies %}Replies{% endblock %}
-{% block mentions %}Mentions{% endblock %}
+{% block like %}hравится{% endblock %}
+{% block repost %}pепост{% endblock %}
+{% block reply %}oтвет{% endblock %}
+{% block mention %}Упоминание{% endblock %}
+{% block likes %}hравится{% endblock %}
+{% block reposts %}pепосты{% endblock %}
+{% block replies %}oтветы{% endblock %}
+{% block mentions %}yпоминания{% endblock %}
 
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} на Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} на GitHub{% endmacro %}

--- a/src/templates/ru/base.html
+++ b/src/templates/ru/base.html
@@ -88,6 +88,22 @@
 {% block author %}Автор{% endblock %}
 {% block authors %}Авторы{% endblock %}
 
+{% block reactions %}Reactions{% endblock %}
+
+{% block like %}Like{% endblock %}
+{% block repost %}Repost{% endblock %}
+{% block reply %}Reply{% endblock %}
+{% block mention %}Mention{% endblock %}
+{% block likes %}Likes{% endblock %}
+{% block reposts %}Reposts{% endblock %}
+{% block replies %}Replies{% endblock %}
+{% block mentions %}Mentions{% endblock %}
+
+{% block like_reaction_text %}liked this chapter{% endblock %}
+{% block repost_reaction_text %}reposted this chapter{% endblock %}
+{% block reply_reaction_text %}View source of reply by{% endblock %}
+{% block mention_reaction_text %}View source of mention by{% endblock %}
+
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} на Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} на GitHub{% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} на LinkedIn{% endmacro %}

--- a/src/templates/ru/base.html
+++ b/src/templates/ru/base.html
@@ -99,11 +99,6 @@
 {% block replies %}Replies{% endblock %}
 {% block mentions %}Mentions{% endblock %}
 
-{% block like_reaction_text %}liked this chapter{% endblock %}
-{% block repost_reaction_text %}reposted this chapter{% endblock %}
-{% block reply_reaction_text %}View source of reply by{% endblock %}
-{% block mention_reaction_text %}View source of mention by{% endblock %}
-
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} на Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} на GitHub{% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} на LinkedIn{% endmacro %}

--- a/src/templates/ru/base.html
+++ b/src/templates/ru/base.html
@@ -89,6 +89,7 @@
 {% block authors %}Авторы{% endblock %}
 
 {% block reactions %}Reactions{% endblock %}
+{% block source %}View Source{% endblock %}
 
 {% block like %}Like{% endblock %}
 {% block repost %}Repost{% endblock %}

--- a/src/templates/tr/base.html
+++ b/src/templates/tr/base.html
@@ -88,6 +88,22 @@ Misyonumuz, HTTP Archive&#8217;ın ham istatistiklerini ve eğilimlerini web top
 {% block author %}Yazar{% endblock %}
 {% block authors %}Yazarlar{% endblock %}
 
+{% block reactions %}Reactions{% endblock %}
+
+{% block like %}Like{% endblock %}
+{% block repost %}Repost{% endblock %}
+{% block reply %}Reply{% endblock %}
+{% block mention %}Mention{% endblock %}
+{% block likes %}Likes{% endblock %}
+{% block reposts %}Reposts{% endblock %}
+{% block replies %}Replies{% endblock %}
+{% block mentions %}Mentions{% endblock %}
+
+{% block like_reaction_text %}liked this chapter{% endblock %}
+{% block repost_reaction_text %}reposted this chapter{% endblock %}
+{% block reply_reaction_text %}View source of reply by{% endblock %}
+{% block mention_reaction_text %}View source of mention by{% endblock %}
+
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}}Twitter üzerinde{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}}GitHub üzerinde {% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} LinkedIn üzerinde {% endmacro %}

--- a/src/templates/tr/base.html
+++ b/src/templates/tr/base.html
@@ -99,11 +99,6 @@ Misyonumuz, HTTP Archive&#8217;ın ham istatistiklerini ve eğilimlerini web top
 {% block replies %}Replies{% endblock %}
 {% block mentions %}Mentions{% endblock %}
 
-{% block like_reaction_text %}liked this chapter{% endblock %}
-{% block repost_reaction_text %}reposted this chapter{% endblock %}
-{% block reply_reaction_text %}View source of reply by{% endblock %}
-{% block mention_reaction_text %}View source of mention by{% endblock %}
-
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}}Twitter üzerinde{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}}GitHub üzerinde {% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} LinkedIn üzerinde {% endmacro %}

--- a/src/templates/tr/base.html
+++ b/src/templates/tr/base.html
@@ -89,6 +89,7 @@ Misyonumuz, HTTP Archive&#8217;ın ham istatistiklerini ve eğilimlerini web top
 {% block authors %}Yazarlar{% endblock %}
 
 {% block reactions %}Reactions{% endblock %}
+{% block source %}View Source{% endblock %}
 
 {% block like %}Like{% endblock %}
 {% block repost %}Repost{% endblock %}

--- a/src/templates/tr/base.html
+++ b/src/templates/tr/base.html
@@ -88,17 +88,17 @@ Misyonumuz, HTTP Archive&#8217;ın ham istatistiklerini ve eğilimlerini web top
 {% block author %}Yazar{% endblock %}
 {% block authors %}Yazarlar{% endblock %}
 
-{% block reactions %}Reactions{% endblock %}
-{% block source %}View Source{% endblock %}
+{% block reactions %}Reaksiyonlar{% endblock %}
+{% block source %}Kaynağı görüntüle{% endblock %}
 
-{% block like %}Like{% endblock %}
-{% block repost %}Repost{% endblock %}
-{% block reply %}Reply{% endblock %}
-{% block mention %}Mention{% endblock %}
-{% block likes %}Likes{% endblock %}
-{% block reposts %}Reposts{% endblock %}
-{% block replies %}Replies{% endblock %}
-{% block mentions %}Mentions{% endblock %}
+{% block like %}beğenisi{% endblock %}
+{% block repost %}yayınlamak{% endblock %}
+{% block reply %}yanıtı{% endblock %}
+{% block mention %}anma{% endblock %}
+{% block likes %}beğenileri{% endblock %}
+{% block reposts %}gönderileri{% endblock %}
+{% block replies %}yanıtları{% endblock %}
+{% block mentions %}bahseder{% endblock %}
 
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}}Twitter üzerinde{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}}GitHub üzerinde {% endmacro %}

--- a/src/templates/uk/base.html
+++ b/src/templates/uk/base.html
@@ -89,6 +89,7 @@
 {% block authors %}Автори{% endblock %}
 
 {% block reactions %}Reactions{% endblock %}
+{% block source %}View Source{% endblock %}
 
 {% block like %}Like{% endblock %}
 {% block repost %}Repost{% endblock %}

--- a/src/templates/uk/base.html
+++ b/src/templates/uk/base.html
@@ -99,11 +99,6 @@
 {% block replies %}Replies{% endblock %}
 {% block mentions %}Mentions{% endblock %}
 
-{% block like_reaction_text %}liked this chapter{% endblock %}
-{% block repost_reaction_text %}reposted this chapter{% endblock %}
-{% block reply_reaction_text %}View source of reply by{% endblock %}
-{% block mention_reaction_text %}View source of mention by{% endblock %}
-
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} у Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} на GitHub{% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} у LinkedIn{% endmacro %}

--- a/src/templates/uk/base.html
+++ b/src/templates/uk/base.html
@@ -88,6 +88,22 @@
 {% block author %}Автор{% endblock %}
 {% block authors %}Автори{% endblock %}
 
+{% block reactions %}Reactions{% endblock %}
+
+{% block like %}Like{% endblock %}
+{% block repost %}Repost{% endblock %}
+{% block reply %}Reply{% endblock %}
+{% block mention %}Mention{% endblock %}
+{% block likes %}Likes{% endblock %}
+{% block reposts %}Reposts{% endblock %}
+{% block replies %}Replies{% endblock %}
+{% block mentions %}Mentions{% endblock %}
+
+{% block like_reaction_text %}liked this chapter{% endblock %}
+{% block repost_reaction_text %}reposted this chapter{% endblock %}
+{% block reply_reaction_text %}View source of reply by{% endblock %}
+{% block mention_reaction_text %}View source of mention by{% endblock %}
+
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} у Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} на GitHub{% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} у LinkedIn{% endmacro %}

--- a/src/templates/uk/base.html
+++ b/src/templates/uk/base.html
@@ -88,17 +88,17 @@
 {% block author %}Автор{% endblock %}
 {% block authors %}Автори{% endblock %}
 
-{% block reactions %}Reactions{% endblock %}
-{% block source %}View Source{% endblock %}
+{% block reactions %}Реакції{% endblock %}
+{% block source %}Переглянути джерело{% endblock %}
 
-{% block like %}Like{% endblock %}
-{% block repost %}Repost{% endblock %}
-{% block reply %}Reply{% endblock %}
-{% block mention %}Mention{% endblock %}
-{% block likes %}Likes{% endblock %}
-{% block reposts %}Reposts{% endblock %}
-{% block replies %}Replies{% endblock %}
-{% block mentions %}Mentions{% endblock %}
+{% block like %}Подобається{% endblock %}
+{% block repost %}репост{% endblock %}
+{% block reply %}відповідь{% endblock %}
+{% block mention %}згадка{% endblock %}
+{% block likes %}Лайки{% endblock %}
+{% block reposts %}репости{% endblock %}
+{% block replies %}відповідає{% endblock %}
+{% block mentions %}згадує{% endblock %}
 
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} у Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} на GitHub{% endmacro %}

--- a/src/templates/zh-CN/base.html
+++ b/src/templates/zh-CN/base.html
@@ -88,6 +88,22 @@
 {% block author %}作者{% endblock %}
 {% block authors %}作者{% endblock %}
 
+{% block reactions %}Reactions{% endblock %}
+
+{% block like %}Like{% endblock %}
+{% block repost %}Repost{% endblock %}
+{% block reply %}Reply{% endblock %}
+{% block mention %}Mention{% endblock %}
+{% block likes %}Likes{% endblock %}
+{% block reposts %}Reposts{% endblock %}
+{% block replies %}Replies{% endblock %}
+{% block mentions %}Mentions{% endblock %}
+
+{% block like_reaction_text %}liked this chapter{% endblock %}
+{% block repost_reaction_text %}reposted this chapter{% endblock %}
+{% block reply_reaction_text %}View source of reply by{% endblock %}
+{% block mention_reaction_text %}View source of mention by{% endblock %}
+
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} 在 Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} 在 GitHub{% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} 在 LinkedIn{% endmacro %}

--- a/src/templates/zh-CN/base.html
+++ b/src/templates/zh-CN/base.html
@@ -99,11 +99,6 @@
 {% block replies %}Replies{% endblock %}
 {% block mentions %}Mentions{% endblock %}
 
-{% block like_reaction_text %}liked this chapter{% endblock %}
-{% block repost_reaction_text %}reposted this chapter{% endblock %}
-{% block reply_reaction_text %}View source of reply by{% endblock %}
-{% block mention_reaction_text %}View source of mention by{% endblock %}
-
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} 在 Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} 在 GitHub{% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} 在 LinkedIn{% endmacro %}

--- a/src/templates/zh-CN/base.html
+++ b/src/templates/zh-CN/base.html
@@ -88,17 +88,17 @@
 {% block author %}作者{% endblock %}
 {% block authors %}作者{% endblock %}
 
-{% block reactions %}Reactions{% endblock %}
-{% block source %}View Source{% endblock %}
+{% block reactions %}反应{% endblock %}
+{% block source %}查看源代码{% endblock %}
 
-{% block like %}Like{% endblock %}
-{% block repost %}Repost{% endblock %}
-{% block reply %}Reply{% endblock %}
-{% block mention %}Mention{% endblock %}
-{% block likes %}Likes{% endblock %}
-{% block reposts %}Reposts{% endblock %}
-{% block replies %}Replies{% endblock %}
-{% block mentions %}Mentions{% endblock %}
+{% block like %}喜欢{% endblock %}
+{% block repost %}次转发{% endblock %}
+{% block reply %}条回复{% endblock %}
+{% block mention %}提及{% endblock %}
+{% block likes %}个赞{% endblock %}
+{% block reposts %}转帖{% endblock %}
+{% block replies %}回复{% endblock %}
+{% block mentions %}提及{% endblock %}
 
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} 在 Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} 在 GitHub{% endmacro %}

--- a/src/templates/zh-CN/base.html
+++ b/src/templates/zh-CN/base.html
@@ -89,6 +89,7 @@
 {% block authors %}作者{% endblock %}
 
 {% block reactions %}Reactions{% endblock %}
+{% block source %}View Source{% endblock %}
 
 {% block like %}Like{% endblock %}
 {% block repost %}Repost{% endblock %}

--- a/src/templates/zh-TW/base.html
+++ b/src/templates/zh-TW/base.html
@@ -88,17 +88,17 @@
 {% block author %}作者{% endblock %}
 {% block authors %}作者{% endblock %}
 
-{% block reactions %}Reactions{% endblock %}
-{% block source %}View Source{% endblock %}
+{% block reactions %}反應{% endblock %}
+{% block source %}查看源代碼{% endblock %}
 
-{% block like %}Like{% endblock %}
-{% block repost %}Repost{% endblock %}
-{% block reply %}Reply{% endblock %}
-{% block mention %}Mention{% endblock %}
-{% block likes %}Likes{% endblock %}
-{% block reposts %}Reposts{% endblock %}
-{% block replies %}Replies{% endblock %}
-{% block mentions %}Mentions{% endblock %}
+{% block like %}個喜歡{% endblock %}
+{% block repost %}次轉發{% endblock %}
+{% block reply %}條回复{% endblock %}
+{% block mention %}提及{% endblock %}
+{% block likes %}個贊{% endblock %}
+{% block reposts %}轉帖{% endblock %}
+{% block replies %}回复{% endblock %}
+{% block mentions %}提及{% endblock %}
 
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} GitHub{% endmacro %}

--- a/src/templates/zh-TW/base.html
+++ b/src/templates/zh-TW/base.html
@@ -99,11 +99,6 @@
 {% block replies %}Replies{% endblock %}
 {% block mentions %}Mentions{% endblock %}
 
-{% block like_reaction_text %}liked this chapter{% endblock %}
-{% block repost_reaction_text %}reposted this chapter{% endblock %}
-{% block reply_reaction_text %}View source of reply by{% endblock %}
-{% block mention_reaction_text %}View source of mention by{% endblock %}
-
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} GitHub{% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} LinkedIn{% endmacro %}

--- a/src/templates/zh-TW/base.html
+++ b/src/templates/zh-TW/base.html
@@ -88,6 +88,22 @@
 {% block author %}作者{% endblock %}
 {% block authors %}作者{% endblock %}
 
+{% block reactions %}Reactions{% endblock %}
+
+{% block like %}Like{% endblock %}
+{% block repost %}Repost{% endblock %}
+{% block reply %}Reply{% endblock %}
+{% block mention %}Mention{% endblock %}
+{% block likes %}Likes{% endblock %}
+{% block reposts %}Reposts{% endblock %}
+{% block replies %}Replies{% endblock %}
+{% block mentions %}Mentions{% endblock %}
+
+{% block like_reaction_text %}liked this chapter{% endblock %}
+{% block repost_reaction_text %}reposted this chapter{% endblock %}
+{% block reply_reaction_text %}View source of reply by{% endblock %}
+{% block mention_reaction_text %}View source of mention by{% endblock %}
+
 {% macro onTwitter(twitterHandle) %}@{{twitterHandle}} Twitter{% endmacro %}
 {% macro onGitHub(gitHubHandle) %}{{gitHubHandle}} GitHub{% endmacro %}
 {% macro onLinkedIn(authorName) %}{{authorName}} LinkedIn{% endmacro %}

--- a/src/templates/zh-TW/base.html
+++ b/src/templates/zh-TW/base.html
@@ -89,6 +89,7 @@
 {% block authors %}作者{% endblock %}
 
 {% block reactions %}Reactions{% endblock %}
+{% block source %}View Source{% endblock %}
 
 {% block like %}Like{% endblock %}
 {% block repost %}Repost{% endblock %}


### PR DESCRIPTION
Refs #2192 

I have added the UI implementation for the webmention reactions corresponding to like, reposts, replies and mentions of the chapter link. The tabs are keyboard navigable and have aria-notations similar to https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role

Screenshot for likes in 2021 restructured data:
![image](https://user-images.githubusercontent.com/9530293/142866669-db599127-fe13-401b-8dd3-b9089c8c228e.png)

Screenshot for reposts in 2021 restructured data:
![image](https://user-images.githubusercontent.com/9530293/142866709-ac8485f1-b133-4223-8097-bdd525b5d5ed.png)

Screenshot for replies in 2021 restructured data:
![image](https://user-images.githubusercontent.com/9530293/142866745-5ad59875-15cd-4889-8826-071ad70c9951.png)

Screenshot for mention in 2021 restructured data:
![image](https://user-images.githubusercontent.com/9530293/142866825-e82e2d27-e3f8-4c22-95b6-342517ae07e2.png)


Things that can still be improved or added:
- HTML sanitizing or DOM purifying: In the content for replies and mentions, we want to keep some HTML tags but santizie maybe the rest of them to prevent any kind of XSS attack. I know https://github.com/cure53/DOMPurify allows such implementation telling which tags and attributes to allow. Does anyone have any other suggestion?
- Pagination: If the number of replies or mentions become a lot, then it might cause a lot of scroll. Also, in likes and reposts, more number of likes mean more images to load. So might want to think about that?
- Homepage reactions: I and @tunetheweb had a little discussion that it might be worth adding webmentions (like replies and mentions) in the homepage in the form of testimonials like in https://www.11ty.dev/#dont-take-my-word-for-it-%F0%9F%8C%88

Staged URL: https://20211122t101742-dot-webalmanac.uk.r.appspot.com/en/2021/