### PR TITLE
Fix a number of issues causing our production tests to fail

### DIFF
--- a/.github/lighthouse/lighthouse-config-dev.json
+++ b/.github/lighthouse/lighthouse-config-dev.json
@@ -15,7 +15,6 @@
         "installable-manifest": "off",
         "interactive": "off",
         "is-crawlable": "off",
-        "is-on-https:": "off",
         "largest-contentful-paint": "off",
         "mainthread-work-breakdown": "off",
         "maskable-icon": "off",

--- a/src/content/nl/2020/privacy.md
+++ b/src/content/nl/2020/privacy.md
@@ -13,7 +13,7 @@ results: https://docs.google.com/spreadsheets/d/16bE70rv4qbmKIqbZS1zUiTRpk5eOlgx
 featured_quote: Privacy is de laatste tijd steeds populairder geworden en heeft de bewustwording bij de gebruikers vergroot. Aan de behoefte aan richtlijnen is voldaan met verschillende regelgeving (zoals GDPR in Europa, LGPD in Brazilië, CCPA in Californië om er maar een paar te noemen). Deze zijn bedoeld om de verantwoordingsplicht van gegevensverwerkers en hun transparantie naar gebruikers te vergroten. In dit hoofdstuk bespreken we de prevalentie van online tracking met verschillende technieken en de acceptatiegraad van cookietoestemmingbanners en het privacybeleid door websites.
 featured_stat_1: 93%
 featured_stat_label_1: Websites die minstens één tracker laden
-featured_stat_2: Negen van de tien
+featured_stat_2: 9 van de 10
 featured_stat_label_2: Top domeinen voor het instellen van cookies die eigendom zijn van Google
 featured_stat_3: 44,8%
 featured_stat_label_3: Websites met een privacybeleid

--- a/src/templates/ja/accessibility_statement.html
+++ b/src/templates/ja/accessibility_statement.html
@@ -66,10 +66,6 @@
           また、一部のインタラクティブな視覚化にはGoogleシートを使用していますが、これもWCAGアクセシビリティ基準に準拠していない可能性があります。これらは<code>iframes</code>を介して読み込まれ、すべての図形に画像を提供していて、クライアントソフトウェアがこれをサポートしている場合のみ、インタラクティブな視覚化を表示します。ブラウザーを使用していて、インタラクティブな視覚化を表示したくない場合、章のいずれかに<code>?print</code>クエリパラメータを追加することで、<a href="./2020/accessibility?print">アクセシビリティの印刷モードで表示</a>できます。必要に応じて、この機能をより簡単に有効化できるようにすることもできますが、すべての視覚化には詳細なテキスト記述があるので、これは必要ないと考えています。<a hreflang="en" href="https://github.com/HTTPArchive/almanac.httparchive.org/issues">間違っていたらお知らせください</a>。
         </p>
 
-        {# TODO - Translate this <p>
-          We recognize that some of the color choices for our visualizations do not meet WCAG color contrast requirements. We make a conscious effort to use the more contrasting colors and labels to reduce the impact of this. We hope the detailed descriptions, as well as access to the underlying data itself can help with this issue. We aim to improve the accessibility of our visualization color schemes in future years.
-        </p> #}
-
         <p>
           私たちは、ビジュアライゼーションのための色の選択の中には、WCAGのカラーコントラスト要件を満たしていないものがあることを認識しています。私たちは、この影響を軽減するために、よりコントラストの高い色やラベルを使用するよう意識的に努力しています。また、詳細な説明や、基礎となるデータ自体へのアクセスが、この問題の解決に役立つことを願っています。今後は、可視化されたデータのカラースキームのアクセシビリティを向上させることを目指します。
         </p>


### PR DESCRIPTION
Couple of small fixes to prevent the weekly prod checks failing.

- One Dutch home page stat was too wide for homescreen, causing a random Lighthouse failure if it was randomly picked.
- Remove TODO from Japanese Accessibility statement to bring line counts back into line.
- Remove HTTPS disable check for dev as now built into Lighthouse.