### PR TITLE
Fix WebMentions error breaking build on merge to main

### DIFF
--- a/src/static/js/webmentions.js
+++ b/src/static/js/webmentions.js
@@ -41,7 +41,7 @@ function parseMentions(webmentions, mentionType) {
 function renderReactions(webmentions, reactionType, wmProperty) {
   // Process webmentions
   const reactions = parseMentions(webmentions, wmProperty);
-  if (!reactions.length) {
+  if (!reactions.length || !document.querySelector(`#${reactionType}-count`) || !document.querySelector(`#${reactionType}-label`)) {
     return;
   }
 


### PR DESCRIPTION
2019 or 2020 chapters with webmentions aren't rendered and so don't have HTML and so now throw an error. This fixes that.