### PR TITLE
Fix small capitalisation error on home page

### DIFF
--- a/src/templates/en/base.html
+++ b/src/templates/en/base.html
@@ -116,10 +116,10 @@ Our mission is to combine the raw stats and trends of the HTTP Archive with the 
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
-{% macro read_chapter(chapter) %}Read the <span class="featured-chapter-name">{{ chapter }}</span> Chapter{% endmacro %}
+{% macro read_chapter(chapter) %}Read the <span class="featured-chapter-name">{{ chapter }}</span> chapter{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}Read the {{ year|int-1 }} <span class="featured-chapter-name">{{ chapter }}</span> Chapter{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}Read the {{ year|int-1 }} <span class="featured-chapter-name">{{ chapter }}</span> chapter{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/es/base.html
+++ b/src/templates/es/base.html
@@ -116,10 +116,10 @@
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
-{% macro read_chapter(chapter) %}Lea el Capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
+{% macro read_chapter(chapter) %}Lea el capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}Lea el {{ year|int -1 }} Capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}Lea el {{ year|int -1 }} capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/nl/base.html
+++ b/src/templates/nl/base.html
@@ -116,10 +116,10 @@
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
-{% macro read_chapter(chapter) %}Lees het <span class="featured-chapter-name">{{ chapter }}</span> Hoofdstuk{% endmacro %}
+{% macro read_chapter(chapter) %}Lees het <span class="featured-chapter-name">{{ chapter }}</span> hoofdstuk{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}Lees het {{ year|int-1 }} <span class="featured-chapter-name">{{ chapter }}</span> Hoofdstuk{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}Lees het {{ year|int-1 }} <span class="featured-chapter-name">{{ chapter }}</span> hoofdstuk{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/pt/base.html
+++ b/src/templates/pt/base.html
@@ -116,10 +116,10 @@ Nossa missão é combinar as estatísticas brutas e as tendências do HTTP Archi
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
-{% macro read_chapter(chapter) %}Leia o Capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
+{% macro read_chapter(chapter) %}Leia o capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}Leia o {{ year|int -1 }} Capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}Leia o {{ year|int -1 }} capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}


### PR DESCRIPTION
Use a small C for Chapter

![image](https://user-images.githubusercontent.com/10931297/143684164-018507ae-5449-471e-8ee6-865b9ccd5021.png)
