### PR TITLE
Add extra semi-colon to webmentions script

### DIFF
--- a/src/static/js/webmentions.js
+++ b/src/static/js/webmentions.js
@@ -127,7 +127,7 @@ function renderReactions(webmentions, reactionType, wmProperty) {
 
       const reactionTime = document.createElement("time");
       reactionTime.setAttribute("class", "webmention-pub-date");
-      const pubDate = reaction["published"] ? reaction["published"] : reaction["wm-received"]
+      const pubDate = reaction["published"] ? reaction["published"] : reaction["wm-received"];
       if (pubDate) {
         reactionTime.setAttribute("datetime", pubDate);
         reactionTime.textContent = formatDate(pubDate);


### PR DESCRIPTION
Noticed a "security" alert:

![image](https://user-images.githubusercontent.com/10931297/143970231-e6040a7b-d2dc-444d-89df-10aac6dcacb1.png)
