### PR TITLE
Fix column scoping on CSS chapter

### DIFF
--- a/src/content/en/2021/css.md
+++ b/src/content/en/2021/css.md
@@ -525,9 +525,9 @@ In color formats where the value has historically used commas inside a functiona
    <thead>
     <tr>
       <td></td>
-      <th>Keyword</th>
-      <th>Desktop</th>
-      <th>Mobile</th>
+      <th scope="col">Keyword</th>
+      <th scope="col">Desktop</th>
+      <th scope="col">Mobile</th>
     </tr>
    </thead>
    <tbody>


### PR DESCRIPTION
The PDF is not being accessibly tagged.

The CSS chapter has a mixed table heading as it has an empty cell (which must be `<td></td>` according to PrinceXML:

```html
    <tr>
      <td></td>
      <th>Keyword</th>
      <th>Desktop</th>
      <th>Mobile</th>
    </tr>
   </thead>
```

When we do that we need to add scope to the `<th>` headings to explain to PrinceXML what's going on (this is not necessary for tables with all `<th>` heading columns - only ones mixed with `<td>` and `<th>`).

```html
    <tr>
      <td></td>
      <th scope="col">Keyword</th>
      <th scope="col">Desktop</th>
      <th scope="col">Mobile</th>
    </tr>
   </thead>
```