### PR TITLE
Simplify GitHub avatars

### DIFF
--- a/src/config/2019.json
+++ b/src/config/2019.json
@@ -1000,7 +1000,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "2240689?s=460&v=4&s=200",
+      "avatar_url": "2240689",
       "github": "rmarx",
       "twitter": "programmingart"
     },

--- a/src/config/2019.json
+++ b/src/config/2019.json
@@ -184,7 +184,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/44442451?v=4&s=200",
+      "avatar_url": "44442451",
       "github": "AbbyTsai"
     },
     "kleinab": {
@@ -192,7 +192,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1319324?v=4&s=200",
+      "avatar_url": "1319324",
       "github": "kleinab"
     },
     "argyleink": {
@@ -201,7 +201,7 @@
         "brainstormers",
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1134620?v=4&s=200",
+      "avatar_url": "1134620",
       "website": "https://nerdy.dev",
       "github": "argyleink",
       "twitter": "argyleink"
@@ -211,7 +211,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/110953?v=4&s=200",
+      "avatar_url": "110953",
       "website": "https://www.addyosmani.com",
       "github": "addyosmani",
       "twitter": "addyosmani"
@@ -223,7 +223,7 @@
         "reviewers",
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/960133?v=4&s=200",
+      "avatar_url": "960133",
       "website": "https://ahmadawais.com/",
       "github": "ahmadawais",
       "twitter": "MrAhmadAwais"
@@ -234,7 +234,7 @@
         "brainstormers",
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/5702163?v=4&s=200",
+      "avatar_url": "5702163",
       "website": "https://alankent.me",
       "github": "alankent",
       "twitter": "akent99"
@@ -245,7 +245,7 @@
         "brainstormers",
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/506089?v=4&s=200",
+      "avatar_url": "506089",
       "github": "amedina",
       "twitter": "iAlbMedina"
     },
@@ -255,7 +255,7 @@
         "brainstormers",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/117643?v=4&s=200",
+      "avatar_url": "117643",
       "website": "https://ghedini.me/",
       "github": "ghedo"
     },
@@ -264,7 +264,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/97331?v=4&s=200",
+      "avatar_url": "97331",
       "website": "http://infrequently.org",
       "github": "slightlyoff",
       "twitter": "slightlylate"
@@ -274,7 +274,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/4408379?v=4&s=200",
+      "avatar_url": "4408379",
       "website": "https://lex111.ru/",
       "github": "lex111"
     },
@@ -283,7 +283,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/22891577?v=4&s=200",
+      "avatar_url": "22891577",
       "github": "ndrnmnn"
     },
     "dotjs": {
@@ -292,7 +292,7 @@
         "analysts",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/2914966?v=4&s=200",
+      "avatar_url": "2914966",
       "github": "dotjs",
       "twitter": "dot_js"
     },
@@ -301,7 +301,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/38131750?v=4&s=200",
+      "avatar_url": "38131750",
       "website": "https://artefact.com/gb-en/",
       "github": "andylimn",
       "twitter": "Artefact_Andy"
@@ -311,7 +311,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/7674171?v=4&s=200",
+      "avatar_url": "7674171",
       "github": "anoblet"
     },
     "andydavies": {
@@ -320,7 +320,7 @@
         "authors",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/427052?v=4&s=200",
+      "avatar_url": "427052",
       "website": "http://andydavies.me/",
       "github": "andydavies",
       "twitter": "AndyDavies"
@@ -330,7 +330,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/50932885?v=4&s=200",
+      "avatar_url": "50932885",
       "github": "arigaud-ca",
       "twitter": "arigaud_ca"
     },
@@ -340,7 +340,7 @@
         "authors",
         "brainstormers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/665379?v=4&s=200",
+      "avatar_url": "665379",
       "github": "arturjanc",
       "twitter": "arturjanc"
     },
@@ -350,7 +350,7 @@
         "reviewers",
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/5750656?v=4&s=200",
+      "avatar_url": "5750656",
       "website": "http://www.aymen-loukil.com/en/",
       "github": "AymenLoukil",
       "twitter": "LoukilAymen"
@@ -364,7 +364,7 @@
         "editors",
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/10931297?v=4&s=200",
+      "avatar_url": "10931297",
       "website": "https://www.tunetheweb.com",
       "github": "tunetheweb",
       "linkedin": "tunetheweb",
@@ -376,7 +376,7 @@
         "developers",
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/284742?v=4&s=200",
+      "avatar_url": "284742",
       "website": "https://boris.schapira.dev",
       "github": "borisschapira",
       "twitter": "boostmarks"
@@ -388,7 +388,7 @@
         "authors",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/870501?v=4&s=200",
+      "avatar_url": "870501",
       "website": "https://bkardell.com",
       "github": "bkardell",
       "twitter": "briankardell"
@@ -398,7 +398,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/409841?v=4&s=200",
+      "avatar_url": "409841",
       "website": "http://publishing-project.rivendellweb.net/",
       "github": "caraya",
       "twitter": "elrond25"
@@ -409,7 +409,7 @@
         "developers",
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/6588246?v=4&s=200",
+      "avatar_url": "6588246",
       "github": "c-torres",
       "twitter": "carlos_catb"
     },
@@ -419,7 +419,7 @@
         "reviewers",
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1867900?v=4&s=200",
+      "avatar_url": "1867900",
       "website": "https://catalin.red/",
       "github": "catalinred",
       "twitter": "catalinred"
@@ -429,7 +429,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1461498?v=4&s=200",
+      "avatar_url": "1461498",
       "website": "https://www.chenhuijing.com",
       "github": "huijing",
       "twitter": "hj_chen"
@@ -440,7 +440,7 @@
         "authors",
         "brainstormers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1622597?v=4&s=200",
+      "avatar_url": "1622597",
       "github": "colinbendell",
       "twitter": "colinbendell"
     },
@@ -449,7 +449,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/30398527?v=4&s=200",
+      "avatar_url": "30398527",
       "github": "chengxicn"
     },
     "bagder": {
@@ -457,7 +457,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/177011?v=4&s=200",
+      "avatar_url": "177011",
       "website": "https://daniel.haxx.se/",
       "github": "bagder",
       "twitter": "bagder"
@@ -467,7 +467,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/261579?v=4&s=200",
+      "avatar_url": "261579",
       "website": "http://fonts.google.com",
       "github": "davelab6",
       "twitter": "davelab6"
@@ -481,7 +481,7 @@
         "analysts",
         "editors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/684747?v=4&s=200",
+      "avatar_url": "684747",
       "website": "https://www.lookzook.com",
       "github": "obto",
       "twitter": "theobto"
@@ -493,7 +493,7 @@
         "authors",
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1514288?v=4&s=200",
+      "avatar_url": "1514288",
       "website": "https://dougsillars.com",
       "github": "dougsillars",
       "twitter": "dougsillars"
@@ -503,7 +503,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/17773211?v=4&s=200",
+      "avatar_url": "17773211",
       "website": "https://eduqg.github.io/",
       "github": "eduqg"
     },
@@ -512,7 +512,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/24370436?v=4&s=200",
+      "avatar_url": "24370436",
       "github": "elaynelemos",
       "linkedin": "elaynelemos"
     },
@@ -522,7 +522,7 @@
         "reviewers",
         "editors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/939727?v=4&s=200",
+      "avatar_url": "939727",
       "website": "https://meyerweb.com",
       "github": "meyerweb",
       "twitter": "meyerweb"
@@ -532,7 +532,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/3441390?v=4&s=200",
+      "avatar_url": "3441390",
       "website": "https://ericportis.com",
       "github": "eeeps",
       "twitter": "etportis"
@@ -543,7 +543,7 @@
         "brainstormers",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/6840678?v=4&s=200",
+      "avatar_url": "6840678",
       "website": "https://erik.nygren.org/",
       "github": "enygren",
       "twitter": "akanygren"
@@ -553,7 +553,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/10557131?v=4&s=200",
+      "avatar_url": "10557131",
       "website": "https://fatmabadri.github.io/",
       "github": "fatmabadri",
       "linkedin": "fatmabadri"
@@ -570,7 +570,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/34923063?v=4&s=200",
+      "avatar_url": "34923063",
       "website": "https://giacomo.online",
       "github": "GiacomoPignoni",
       "twitter": "Pigna__"
@@ -580,7 +580,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/25320782?v=4&s=200",
+      "avatar_url": "25320782",
       "website": "https://tanhengyeow.github.io",
       "github": "tanhengyeow",
       "twitter": "tanhengyeow"
@@ -590,7 +590,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/50970808?v=4&s=200",
+      "avatar_url": "50970808",
       "github": "henrihelvetica",
       "twitter": "HenriHelvetica"
     },
@@ -600,7 +600,7 @@
         "brainstormers",
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/12476932?v=4&s=200",
+      "avatar_url": "12476932",
       "website": "https://houssein.me",
       "github": "housseindjirdeh",
       "twitter": "hdjirdeh"
@@ -610,7 +610,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/16384750?v=4&s=200",
+      "avatar_url": "16384750",
       "github": "SilentJMA",
       "twitter": "SilentJMA"
     },
@@ -619,7 +619,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/658496?v=4&s=200",
+      "avatar_url": "658496",
       "website": "https://jaredwhite.com",
       "github": "jaredcwhite",
       "twitter": "jaredcwhite"
@@ -629,7 +629,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/7421844?v=4&s=200",
+      "avatar_url": "7421844",
       "github": "jrharalson"
     },
     "jeffposnick": {
@@ -638,7 +638,7 @@
         "brainstormers",
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1749548?v=4&s=200",
+      "avatar_url": "1749548",
       "website": "https://jeffy.info",
       "github": "jeffposnick",
       "twitter": "jeffposnick"
@@ -648,7 +648,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/13718746?v=4&s=200",
+      "avatar_url": "13718746",
       "linkedin": "johnfox",
       "github": "clarkeclark"
     },
@@ -659,7 +659,7 @@
         "reviewers",
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/25212653?v=4&s=200",
+      "avatar_url": "25212653",
       "website": "https://gemservers.com",
       "github": "logicalphase",
       "twitter": "jtteag"
@@ -669,7 +669,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/104149?v=4&s=200",
+      "avatar_url": "104149",
       "website": "https://jonathanwold.com",
       "github": "sirjonathan",
       "twitter": "sirjonathan"
@@ -681,7 +681,7 @@
         "reviewers",
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/416456?v=4&s=200",
+      "avatar_url": "416456",
       "website": "https://jmperezperez.com",
       "github": "JMPerez",
       "twitter": "jmperezperez"
@@ -691,7 +691,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/33403964?v=4&s=200",
+      "avatar_url": "33403964",
       "website": "https://segbedji.com/",
       "github": "JustinyAhin",
       "twitter": "justinahinon1"
@@ -701,7 +701,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/3008677?v=4&s=200",
+      "avatar_url": "3008677",
       "github": "welenofsky"
     },
     "KJLarson": {
@@ -709,7 +709,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/42503401?v=4&s=200",
+      "avatar_url": "42503401",
       "website": "https://www.kjlarson.com",
       "github": "KJLarson",
       "twitter": "KaJLa47"
@@ -719,7 +719,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/25080897?v=4&s=200",
+      "avatar_url": "25080897",
       "github": "tymosh",
       "linkedin": "tymosh"
     },
@@ -730,7 +730,7 @@
         "authors",
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/6076184?v=4&s=200",
+      "avatar_url": "6076184",
       "github": "khempenius",
       "twitter": "katiehempenius"
     },
@@ -739,7 +739,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/3392338?v=4&s=200",
+      "avatar_url": "3392338",
       "github": "ljme"
     },
     "chefleo": {
@@ -747,7 +747,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/26022943?v=4&s=200",
+      "avatar_url": "26022943",
       "website": "https://chefleo.dev/",
       "github": "chefleo",
       "twitter": "simdigiorgio"
@@ -758,7 +758,7 @@
         "developers",
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/2183053?v=4&s=200",
+      "avatar_url": "2183053",
       "website": "https://twitter.com/msakamaki2",
       "github": "MSakamaki",
       "twitter": "msakamaki2"
@@ -768,7 +768,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/7148510?v=4&s=200",
+      "avatar_url": "7148510",
       "website": "https://farfetchtechblog.com/en/blog/authors/manuel-garcia/",
       "github": "soulcorrosion",
       "linkedin": "manuel-garcia-12b6928",
@@ -779,7 +779,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/74384?v=4&s=200",
+      "avatar_url": "74384",
       "website": "https://www.mnot.net/",
       "github": "mnot",
       "twitter": "mnot"
@@ -790,7 +790,7 @@
         "brainstormers",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/204268?v=4&s=200",
+      "avatar_url": "204268",
       "website": "https://speedcurve.com",
       "github": "zeman",
       "twitter": "MarkZeman"
@@ -801,7 +801,7 @@
         "authors",
         "brainstormers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/370246?v=4&s=200",
+      "avatar_url": "370246",
       "website": "http://geekonaut.de",
       "github": "AVGP",
       "twitter": "g33konaut"
@@ -812,7 +812,7 @@
         "brainstormers",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/81942?v=4&s=200",
+      "avatar_url": "81942",
       "website": "https://mathiasbynens.be/",
       "github": "mathiasbynens",
       "twitter": "mathias"
@@ -829,7 +829,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/361671?v=4&s=200",
+      "avatar_url": "361671",
       "github": "matthewp"
     },
     "mikegeyser": {
@@ -837,7 +837,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/105242?v=4&s=200",
+      "avatar_url": "105242",
       "website": "https://mikerambl.es",
       "github": "mikegeyser",
       "twitter": "mikegeyser"
@@ -847,7 +847,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1132200?v=4&s=200",
+      "avatar_url": "1132200",
       "website": "http://mor10.com/",
       "github": "mor10",
       "twitter": "mor10"
@@ -863,7 +863,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/2578321?v=4&s=200",
+      "avatar_url": "2578321",
       "website": "https://www.nicolas-hoffmann.net/",
       "github": "nico3333fr",
       "twitter": "Nico3333fr"
@@ -873,7 +873,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/561590?v=4&s=200",
+      "avatar_url": "561590",
       "website": "https://www.noahblon.com",
       "github": "noahblon",
       "twitter": "noahblon"
@@ -883,7 +883,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/46689362?v=4&s=200",
+      "avatar_url": "46689362",
       "github": "noah-vdv",
       "twitter": "noah_aaron_vdv"
     },
@@ -894,7 +894,7 @@
         "authors",
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/2301202?v=4&s=200",
+      "avatar_url": "2301202",
       "website": "http://patrickhulce.com",
       "github": "patrickhulce",
       "twitter": "patrickhulce"
@@ -905,7 +905,7 @@
         "brainstormers",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/444165?v=4&s=200",
+      "avatar_url": "444165",
       "website": "https://www.webpagetest.org/",
       "github": "pmeenan",
       "twitter": "patmeenan"
@@ -919,7 +919,7 @@
         "reviewers",
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/7459458?v=4&s=200",
+      "avatar_url": "7459458",
       "github": "paulcalvano",
       "twitter": "paulcalvano",
       "website": "https://paulcalvano.com"
@@ -929,7 +929,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/6407114?v=4&s=200",
+      "avatar_url": "6407114",
       "github": "Pavel-Evdokimov",
       "twitter": "Pavel_Evdokimov"
     },
@@ -938,7 +938,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/34737190?v=4&s=200",
+      "avatar_url": "34737190",
       "website": "https://praveenpal4232.github.io",
       "github": "PraveenPal4232",
       "twitter": "PraveenPal4232"
@@ -950,7 +950,7 @@
         "authors",
         "editors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/49983543?v=4&s=200",
+      "avatar_url": "49983543",
       "github": "rachellcostello",
       "twitter": "rachellcostello"
     },
@@ -959,7 +959,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/24447527?v=4&s=200",
+      "avatar_url": "24447527",
       "github": "raghuramakrishnan71"
     },
     "raghav": {
@@ -967,7 +967,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/9475742?v=4&s=200",
+      "avatar_url": "9475742",
       "github": "arsenicraghav",
       "twitter": "mail_raghvendra"
     },
@@ -976,7 +976,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/8108643?v=4&s=200",
+      "avatar_url": "8108643",
       "website": "https://reneesvirtualoffice.com",
       "github": "ernee",
       "twitter": "reneesoffice"
@@ -991,7 +991,7 @@
         "developers",
         "editors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1120896?v=4&s=200",
+      "avatar_url": "1120896",
       "github": "rviscomi",
       "twitter": "rick_viscomi"
     },
@@ -1000,7 +1000,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/2240689?s=460&v=4&s=200",
+      "avatar_url": "2240689?s=460&v=4&s=200",
       "github": "rmarx",
       "twitter": "programmingart"
     },
@@ -1015,7 +1015,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1982567?v=4&s=200",
+      "avatar_url": "1982567",
       "website": "https://www.ksakae1216.com/archive",
       "github": "ksakae1216",
       "twitter": "beltway7"
@@ -1026,7 +1026,7 @@
         "brainstormers",
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/205226?v=4&s=200",
+      "avatar_url": "205226",
       "website": "https://simpl.info",
       "github": "samdutton",
       "twitter": "sw12"
@@ -1037,7 +1037,7 @@
         "brainstormers",
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/5352840?v=4&s=200",
+      "avatar_url": "5352840",
       "website": "https://scotthelme.co.uk",
       "github": "ScottHelme",
       "twitter": "Scott_Helme"
@@ -1047,7 +1047,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/3684740?v=4&s=200",
+      "avatar_url": "3684740",
       "website": "https://sebastienallemand.fr/",
       "github": "allemas",
       "twitter": "allema_s"
@@ -1057,7 +1057,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/38076?v=4&s=200",
+      "avatar_url": "38076",
       "website": "http://sergeychernyshev.com/",
       "github": "sergeychernyshev",
       "twitter": "sergeyche"
@@ -1068,7 +1068,7 @@
         "brainstormers",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/244772?v=4&s=200",
+      "avatar_url": "244772",
       "github": "zcorpan",
       "twitter": "zcorpan"
     },
@@ -1085,7 +1085,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/15661032?v=4&s=200",
+      "avatar_url": "15661032",
       "website": "https://speedcurve.com/",
       "github": "tammyeverts",
       "twitter": "tameverts"
@@ -1095,7 +1095,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/2645718?v=4&s=200",
+      "avatar_url": "2645718",
       "github": "tjmonsi"
     },
     "tomayac": {
@@ -1104,7 +1104,7 @@
         "brainstormers",
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/145676?v=4&s=200",
+      "avatar_url": "145676",
       "website": "https://blog.tomayac.com/",
       "github": "tomayac",
       "twitter": "tomayac"
@@ -1114,7 +1114,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/955601?v=4&s=200",
+      "avatar_url": "955601",
       "website": "http://codepen.io/tomhodgins",
       "github": "tomhodgins"
     },
@@ -1124,7 +1124,7 @@
         "brainstormers",
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1693164?v=4&s=200",
+      "avatar_url": "1693164",
       "website": "http://una.im",
       "github": "una",
       "twitter": "una"
@@ -1134,7 +1134,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/2366341?v=4&s=200",
+      "avatar_url": "2366341",
       "website": "https://vamseejasti.com",
       "github": "jasti",
       "twitter": "vamseejasti"
@@ -1145,7 +1145,7 @@
         "brainstormers",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/2698956?v=4&s=200",
+      "avatar_url": "2698956",
       "website": "https://data-seo.com",
       "github": "voltek62"
     },
@@ -1154,7 +1154,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/33907565?v=4&s=200",
+      "avatar_url": "33907565",
       "website": "https://hakacode.github.io",
       "github": "HakaCode",
       "twitter": "hakacode"
@@ -1165,7 +1165,7 @@
         "brainstormers",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/786187?v=4&s=200",
+      "avatar_url": "786187",
       "website": "https://blog.yoav.ws",
       "github": "yoavweiss",
       "twitter": "yoavweiss"
@@ -1175,7 +1175,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/106703?v=4&s=200",
+      "avatar_url": "106703",
       "website": "http://tyohan.me",
       "github": "tyohan",
       "twitter": "tyohan"
@@ -1185,7 +1185,7 @@
       "teams": [
         "brainstormers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/134745?v=4&s=200",
+      "avatar_url": "134745",
       "website": "https://weston.ruter.net/",
       "github": "westonruter",
       "twitter": "westonruter"
@@ -1198,7 +1198,7 @@
         "analysts",
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/91795?v=4&s=200",
+      "avatar_url": "91795",
       "website": "https://build.amsterdam/",
       "github": "ymschaap",
       "twitter": "yvoschaap"
@@ -1209,7 +1209,7 @@
         "brainstormers",
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/39355?v=4&s=200",
+      "avatar_url": "39355",
       "website": "https://zachleat.com/",
       "github": "zachleat",
       "twitter": "zachleat"

--- a/src/config/2020.json
+++ b/src/config/2020.json
@@ -1223,7 +1223,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "2240689?v=4&v=4&s=200&s=200",
+      "avatar_url": "2240689",
       "github": "rmarx",
       "twitter": "programmingart"
     },

--- a/src/config/2020.json
+++ b/src/config/2020.json
@@ -201,7 +201,7 @@
         "translators",
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/44442451?v=4&s=200",
+      "avatar_url": "44442451",
       "github": "AbbyTsai"
     },
     "adityapandey1998": {
@@ -209,7 +209,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/31750960?v=4&s=200",
+      "avatar_url": "31750960",
       "github": "adityapandey1998",
       "twitter": "adityapandey98",
       "linkedin": "adityapandey98"
@@ -219,7 +219,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1376607?v=4&s=200",
+      "avatar_url": "1376607",
       "website": "https://adrianroselli.com/",
       "github": "aardrian",
       "twitter": "aardrian"
@@ -229,7 +229,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/960133?v=4&s=200",
+      "avatar_url": "960133",
       "website": "https://AhmadAwais.com",
       "github": "ahmadawais",
       "twitter": "MrAhmadAwais"
@@ -239,7 +239,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/6799159?v=4&s=200",
+      "avatar_url": "6799159",
       "github": "alangdm",
       "twitter": "AlanGDavalos"
     },
@@ -248,7 +248,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/5702163?v=4&s=200",
+      "avatar_url": "5702163",
       "website": "https://alankent.me",
       "github": "alankent",
       "twitter": "akent99"
@@ -258,7 +258,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/506089?v=4&s=200",
+      "avatar_url": "506089",
       "github": "amedina",
       "twitter": "iAlbMedina"
     },
@@ -267,7 +267,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/3109255?v=4&s=200",
+      "avatar_url": "3109255",
       "website": "https://getellipsis.com",
       "github": "alexdenning",
       "twitter": "AlexDenning"
@@ -277,7 +277,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/24625637?v=4&s=200",
+      "avatar_url": "24625637",
       "website": "https://atfreshsolutions.com",
       "github": "alextait1",
       "twitter": "at_fresh_dev"
@@ -289,7 +289,7 @@
         "editors",
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/4408379?v=4&s=200",
+      "avatar_url": "4408379",
       "website": "https://lex111.ru/",
       "github": "lex111"
     },
@@ -298,7 +298,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/469304?v=4&s=200",
+      "avatar_url": "469304",
       "website": "https://www.aleydasolis.com/en/",
       "github": "aleyda",
       "twitter": "aleyda"
@@ -308,7 +308,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/2914966?v=4&s=200",
+      "avatar_url": "2914966",
       "github": "dotjs",
       "twitter": "dot_js"
     },
@@ -317,7 +317,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/8672583?v=4&s=200",
+      "avatar_url": "8672583",
       "website": "https://hankchizljaw.com/",
       "github": "hankchizljaw",
       "twitter": "hankchizljaw"
@@ -327,7 +327,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/5269414?v=4&s=200",
+      "avatar_url": "5269414",
       "github": "andy0130tw"
     },
     "antoineeripret": {
@@ -335,7 +335,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/9512616?v=4&s=200",
+      "avatar_url": "9512616",
       "github": "antoineeripret"
     },
     "denar90": {
@@ -344,7 +344,7 @@
         "reviewers",
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/6231516?v=4&s=200",
+      "avatar_url": "6231516",
       "github": "denar90",
       "twitter": "denar90_"
     },
@@ -358,7 +358,7 @@
         "leads",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/10931297?v=4&s=200",
+      "avatar_url": "10931297",
       "website": "https://www.tunetheweb.com",
       "github": "tunetheweb",
       "linkedin": "tunetheweb",
@@ -369,7 +369,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/6849494?v=4&s=200",
+      "avatar_url": "6849494",
       "website": "https://benseymour.com",
       "github": "bseymour",
       "twitter": "bseymour",
@@ -380,7 +380,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/43988371?v=4&s=200",
+      "avatar_url": "43988371",
       "website": "https://iambharat.me",
       "github": "bharatagsrwal"
     },
@@ -391,7 +391,7 @@
         "reviewers",
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/284742?v=4&s=200",
+      "avatar_url": "284742",
       "website": "https://boris.schapira.dev",
       "github": "borisschapira",
       "twitter": "boostmarks"
@@ -401,7 +401,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/870501?v=4&s=200",
+      "avatar_url": "870501",
       "website": "https://bkardell.com",
       "github": "bkardell",
       "twitter": "briankardell"
@@ -411,7 +411,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/216712?v=4&s=200",
+      "avatar_url": "216712",
       "website": "https://remotesynthesis.com/",
       "github": "remotesynth",
       "twitter": "remotesynth"
@@ -421,7 +421,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1588185?v=4&s=200",
+      "avatar_url": "1588185",
       "github": "cqueern",
       "twitter": "httpsecheaders"
     },
@@ -430,7 +430,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/62315048?v=4&s=200",
+      "avatar_url": "62315048",
       "website": "https://carloscm.me/en/",
       "github": "carloscastromx",
       "twitter": "mxcarloscastro"
@@ -442,7 +442,7 @@
         "developers",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1867900?v=4&s=200",
+      "avatar_url": "1867900",
       "website": "https://catalin.red/",
       "github": "catalinred",
       "twitter": "catalinred"
@@ -452,7 +452,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/30398527?v=4&s=200",
+      "avatar_url": "30398527",
       "github": "chengxicn"
     },
     "svgeesus": {
@@ -461,7 +461,7 @@
         "authors",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/2506926?v=4&s=200",
+      "avatar_url": "2506926",
       "website": "https://svgees.us/",
       "github": "svgeesus",
       "twitter": "svgeesus"
@@ -471,7 +471,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/6698344?v=4&s=200",
+      "avatar_url": "6698344",
       "website": "https://christianliebel.com",
       "github": "christianliebel",
       "twitter": "christianliebel"
@@ -481,7 +481,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1622597?v=4&s=200",
+      "avatar_url": "1622597",
       "github": "colinbendell",
       "twitter": "colinbendell"
     },
@@ -490,7 +490,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/6782666?v=4&s=200",
+      "avatar_url": "6782666",
       "github": "CYBAI",
       "twitter": "_cybai"
     },
@@ -499,7 +499,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/261579?v=4&s=200",
+      "avatar_url": "261579",
       "website": "https://fonts.google.com",
       "github": "davelab6",
       "twitter": "davelab6"
@@ -509,7 +509,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/11179452?v=4&s=200",
+      "avatar_url": "11179452",
       "website": "https://tamethebots.com/",
       "github": "dwsmart",
       "twitter": "davewsmart"
@@ -519,7 +519,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/3630989?v=4&s=200",
+      "avatar_url": "3630989",
       "website": "https://opensourceseo.org/",
       "github": "dsottimano",
       "twitter": "dsottimano"
@@ -532,7 +532,7 @@
         "leads",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/684747?v=4&s=200",
+      "avatar_url": "684747",
       "website": "https://www.lookzook.com",
       "github": "obto",
       "twitter": "theobto"
@@ -542,7 +542,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1514288?v=4&s=200",
+      "avatar_url": "1514288",
       "website": "https://dougsillars.com",
       "github": "dougsillars",
       "twitter": "dougsillars"
@@ -552,7 +552,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/5795823?v=4&s=200",
+      "avatar_url": "5795823",
       "github": "dsadhanala",
       "twitter": "dsadhanala"
     },
@@ -561,7 +561,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/7061425?v=4&s=200",
+      "avatar_url": "7061425",
       "website": "https://dustinmontgomery.com/",
       "github": "en3r0",
       "twitter": "DustinMontSEO"
@@ -571,7 +571,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/68361682?v=4&s=200",
+      "avatar_url": "68361682",
       "website": "https://edmondwwchan.github.io/",
       "github": "edmondwwchan"
     },
@@ -580,7 +580,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/725717?v=4&s=200",
+      "avatar_url": "725717",
       "website": "http://fantasai.inkedblade.net/",
       "github": "fantasai",
       "twitter": "fantasai"
@@ -590,7 +590,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/20342656?v=4&s=200",
+      "avatar_url": "20342656",
       "website": "https://emanuelgsouza.dev/",
       "github": "emanuelgsouza",
       "twitter": "emanuelgsouza",
@@ -601,7 +601,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/634191?v=4&s=200",
+      "avatar_url": "634191",
       "website": "https://ericwbailey.design/",
       "github": "ericwbailey",
       "twitter": "ericwbailey"
@@ -611,7 +611,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/3441390?v=4&s=200",
+      "avatar_url": "3441390",
       "website": "https://ericportis.com/",
       "github": "eeeps",
       "twitter": "etportis"
@@ -621,7 +621,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/69888?v=4&s=200",
+      "avatar_url": "69888",
       "website": "http://standardista.com/",
       "github": "estelle",
       "twitter": "estellevw"
@@ -631,7 +631,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/10557131?v=4&s=200",
+      "avatar_url": "10557131",
       "website": "https://fatmabadri.github.io/",
       "github": "fatmabadri",
       "linkedin": "fatmabadri"
@@ -642,7 +642,7 @@
         "reviewers",
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1746646?v=4&s=200",
+      "avatar_url": "1746646",
       "github": "giopunt",
       "twitter": "giovannipuntil"
     },
@@ -651,7 +651,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/2944237?v=4&s=200",
+      "avatar_url": "2944237",
       "github": "gokulkrishh"
     },
     "GregBrimble": {
@@ -659,7 +659,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/8484333?v=4&s=200",
+      "avatar_url": "8484333",
       "website": "https://gregbrimble.com/",
       "github": "GregBrimble",
       "twitter": "GregBrimble"
@@ -669,7 +669,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/8494683?v=4&s=200",
+      "avatar_url": "8494683",
       "github": "gregorywolf"
     },
     "hemanth": {
@@ -677,7 +677,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/18315?v=4&s=200",
+      "avatar_url": "18315",
       "website": "https://h3manth.com",
       "github": "hemanth",
       "twitter": "gnumanth"
@@ -687,7 +687,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/50970808?v=4&s=200",
+      "avatar_url": "50970808",
       "github": "henrihelvetica",
       "twitter": "HenriHelvetica"
     },
@@ -696,7 +696,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/286856?v=4&s=200",
+      "avatar_url": "286856",
       "github": "ArvinH"
     },
     "aszx87410": {
@@ -704,7 +704,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/2755720?v=4&s=200",
+      "avatar_url": "2755720",
       "github": "aszx87410"
     },
     "iandevlin": {
@@ -712,7 +712,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/554326?v=4&s=200",
+      "avatar_url": "554326",
       "website": "https://iandevlin.com",
       "github": "iandevlin",
       "twitter": "iandevlin"
@@ -722,7 +722,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/2265232?v=4&s=200",
+      "avatar_url": "2265232",
       "website": "https://learnjavascript.online/",
       "github": "jadjoubran",
       "twitter": "JoubranJad"
@@ -732,7 +732,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/52051775?v=4&s=200",
+      "avatar_url": "52051775",
       "website": "https://not-a-robot.com/",
       "github": "fellowhuman1101",
       "twitter": "Jammer_Volts"
@@ -743,7 +743,7 @@
         "authors",
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/7421844?v=4&s=200",
+      "avatar_url": "7421844",
       "github": "jrharalson"
     },
     "jpamental": {
@@ -751,7 +751,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/537413?v=4&s=200",
+      "avatar_url": "537413",
       "website": "https://rwt.io",
       "github": "jpamental",
       "twitter": "jpamental"
@@ -762,7 +762,7 @@
         "authors",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1700772?v=4&s=200",
+      "avatar_url": "1700772",
       "website": "https://meiert.com/en/",
       "github": "j9t",
       "twitter": "j9t"
@@ -772,7 +772,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/59629525?v=4&s=200",
+      "avatar_url": "59629525",
       "website": "https://www.jessicanicolet.com/",
       "github": "jessnicolet",
       "twitter": "jessica_nicolet"
@@ -782,7 +782,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/104149?v=4&s=200",
+      "avatar_url": "104149",
       "website": "https://jonathanwold.com",
       "github": "sirjonathan",
       "twitter": "sirjonathan"
@@ -792,7 +792,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/2634031?v=4&s=200",
+      "avatar_url": "2634031",
       "github": "jzyang"
     },
     "jyrkialakuijala": {
@@ -800,7 +800,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/9086028?v=4&s=200",
+      "avatar_url": "9086028",
       "github": "jyrkialakuijala"
     },
     "thefoxis": {
@@ -808,7 +808,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/375731?v=4&s=200",
+      "avatar_url": "375731",
       "github": "thefoxis",
       "twitter": "fox"
     },
@@ -817,7 +817,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/25080897?v=4&s=200",
+      "avatar_url": "25080897",
       "github": "tymosh",
       "linkedin": "tymosh"
     },
@@ -826,7 +826,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/6076184?v=4&s=200",
+      "avatar_url": "6076184",
       "github": "khempenius",
       "twitter": "katiehempenius"
     },
@@ -835,7 +835,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/23695083?v=4&s=200",
+      "avatar_url": "23695083",
       "website": "https://ldevernay.github.io/",
       "github": "ldevernay",
       "twitter": "ldevernay"
@@ -846,7 +846,7 @@
         "analysts",
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/175836?v=4&s=200",
+      "avatar_url": "175836",
       "website": "https://lea.verou.me/",
       "github": "LeaVerou",
       "twitter": "leaverou"
@@ -856,7 +856,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/26022943?v=4&s=200&u=64b286deddd79f94a2dc8dee0e7610e0dd2a7b34&v=4",
+      "avatar_url": "26022943&u=64b286deddd79f94a2dc8dee0e7610e0dd2a7b34&v=4",
       "website": "https://chefleo.dev/",
       "github": "chefleo",
       "twitter": "simdigiorgio"
@@ -867,7 +867,7 @@
         "authors",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/829214?v=4&s=200",
+      "avatar_url": "829214",
       "website": "https://twitter.com/zizzamia",
       "github": "Zizzamia",
       "twitter": "Zizzamia"
@@ -877,7 +877,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1896483?v=4&s=200",
+      "avatar_url": "1896483",
       "github": "veluca93"
     },
     "LPardue": {
@@ -885,7 +885,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/6571445?v=4&s=200",
+      "avatar_url": "6571445",
       "website": "https://lucaspardue.com",
       "github": "LPardue",
       "twitter": "SimmerVigor"
@@ -895,7 +895,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/866229?v=4&s=200",
+      "avatar_url": "866229",
       "github": "Super-Fly",
       "twitter": "angelovcode"
     },
@@ -904,7 +904,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/12712988?v=4&s=200",
+      "avatar_url": "12712988",
       "website": "https://maedahbatool.com/",
       "github": "MaedahBatool",
       "twitter": "maedahbatool"
@@ -914,7 +914,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/11938879?v=4&s=200",
+      "avatar_url": "11938879",
       "website": "https://mandymichael.com/",
       "github": "mandymichael",
       "twitter": "Mandy_Kerr"
@@ -924,7 +924,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1496761?v=4&s=200",
+      "avatar_url": "1496761",
       "website": "https://www.matuzo.at/",
       "github": "matuzo",
       "twitter": "mmatuzo"
@@ -935,7 +935,7 @@
         "analysts",
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1611259?v=4&s=200",
+      "avatar_url": "1611259",
       "website": "https://maxostapenko.com",
       "github": "max-ostapenko",
       "twitter": "themax_o"
@@ -945,7 +945,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/17748781?v=4&s=200",
+      "avatar_url": "17748781",
       "github": "mdiblasio"
     },
     "ipullrank": {
@@ -953,7 +953,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1043031?v=4&s=200",
+      "avatar_url": "1043031",
       "github": "ipullrank",
       "twitter": "IPullRank"
     },
@@ -968,7 +968,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/868584?v=4&s=200",
+      "avatar_url": "868584",
       "linkedin": "miguelcarlosmartinezdiaz",
       "github": "mcmd",
       "twitter": "mcmd"
@@ -978,7 +978,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/4273797?v=4&s=200",
+      "avatar_url": "4273797",
       "github": "MikeBishop"
     },
     "mgechev": {
@@ -986,7 +986,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/455023?v=4&s=200",
+      "avatar_url": "455023",
       "website": "https://blog.mgechev.com/",
       "github": "mgechev",
       "twitter": "mgechev"
@@ -996,7 +996,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/104161?v=4&s=200",
+      "avatar_url": "104161",
       "website": "https://miriamsuzanne.com/",
       "github": "mirisuzanne",
       "twitter": "MiriSuzanne"
@@ -1006,7 +1006,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/3491627?v=4&s=200",
+      "avatar_url": "3491627",
       "website": "https://mo271.github.io/",
       "github": "mo271"
     },
@@ -1015,7 +1015,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/67608345?v=4&s=200",
+      "avatar_url": "67608345",
       "github": "natedame",
       "twitter": "seonate"
     },
@@ -1024,7 +1024,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/69532755?v=4&s=200",
+      "avatar_url": "69532755",
       "website": "http://www.nparthas.com/",
       "github": "Navaneeth-akam",
       "twitter": "Navanee55755217"
@@ -1034,7 +1034,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/2587348?v=4&s=200",
+      "avatar_url": "2587348",
       "website": "https://phacks.dev/",
       "github": "phacks",
       "twitter": "Phacks"
@@ -1044,7 +1044,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/78213?v=4&s=200",
+      "avatar_url": "78213",
       "website": "https://nicolas-hoizey.com/",
       "github": "nhoizey",
       "twitter": "nhoizey"
@@ -1054,7 +1054,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/46689362?v=4&s=200",
+      "avatar_url": "46689362",
       "github": "noah-vdv",
       "twitter": "noah_aaron_vdv"
     },
@@ -1063,7 +1063,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/88566?v=4&s=200",
+      "avatar_url": "88566",
       "github": "noamr",
       "twitter": "nomsternom"
     },
@@ -1072,7 +1072,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/44582272?v=4&s=200",
+      "avatar_url": "44582272",
       "github": "notwillk"
     },
     "nrllh": {
@@ -1081,7 +1081,7 @@
         "analysts",
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/13475745?v=4&s=200",
+      "avatar_url": "13475745",
       "website": "https://internet-sicherheit.de",
       "github": "nrllh",
       "twitter": "nrllah"
@@ -1091,7 +1091,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/3077443?v=4&s=200",
+      "avatar_url": "3077443",
       "website": "https://olu.online/",
       "github": "oluoluoxenfree",
       "twitter": "oluoluoxenfree"
@@ -1101,7 +1101,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/841956?v=4&s=200",
+      "avatar_url": "841956",
       "github": "swissspidy",
       "twitter": "swissspidy",
       "linkedin": "swissspidy"
@@ -1111,7 +1111,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/17054057?v=4&s=200",
+      "avatar_url": "17054057",
       "github": "thepassle"
     },
     "pmeenan": {
@@ -1119,7 +1119,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/444165?v=4&s=200",
+      "avatar_url": "444165",
       "website": "https://www.webpagetest.org/",
       "github": "pmeenan",
       "twitter": "patmeenan"
@@ -1132,7 +1132,7 @@
         "leads",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/7459458?v=4&s=200",
+      "avatar_url": "7459458",
       "github": "paulcalvano",
       "twitter": "paulcalvano",
       "website": "https://paulcalvano.com"
@@ -1142,7 +1142,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1824908?v=4&s=200",
+      "avatar_url": "1824908",
       "github": "pearlbea",
       "twitter": "pblatteier"
     },
@@ -1151,7 +1151,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/124110?v=4&s=200",
+      "avatar_url": "124110",
       "website": "https://pixboost.com",
       "github": "dooman87",
       "twitter": "otherpunk"
@@ -1161,7 +1161,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/34737190?v=4&s=200",
+      "avatar_url": "34737190",
       "website": "https://praveenpal4232.github.io",
       "github": "PraveenPal4232",
       "twitter": "PraveenPal4232"
@@ -1171,7 +1171,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/2764898?v=4&s=200",
+      "avatar_url": "2764898",
       "website": "https://rachelandrew.co.uk/",
       "github": "rachelandrew",
       "twitter": "rachelandrew"
@@ -1182,7 +1182,7 @@
         "authors",
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/24447527?v=4&s=200",
+      "avatar_url": "24447527",
       "github": "raghuramakrishnan71"
     },
     "raphlinus": {
@@ -1190,7 +1190,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/242367?v=4&s=200",
+      "avatar_url": "242367",
       "github": "raphlinus",
       "twitter": "raphlinus",
       "website": "https://levien.com"
@@ -1200,7 +1200,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/8108643?v=4&s=200",
+      "avatar_url": "8108643",
       "website": "https://reneesvirtualoffice.com",
       "github": "ernee",
       "twitter": "reneesoffice"
@@ -1214,7 +1214,7 @@
         "leads",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1120896?v=4&s=200",
+      "avatar_url": "1120896",
       "github": "rviscomi",
       "twitter": "rick_viscomi"
     },
@@ -1223,7 +1223,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/2240689?v=4&v=4&s=200&s=200",
+      "avatar_url": "2240689?v=4&v=4&s=200&s=200",
       "github": "rmarx",
       "twitter": "programmingart"
     },
@@ -1233,7 +1233,7 @@
         "authors",
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1718757?v=4&s=200",
+      "avatar_url": "1718757",
       "github": "rockeynebhwani",
       "twitter": "rnebhwani",
       "linkedin": "rockeynebhwani"
@@ -1250,7 +1250,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/4570664?v=4&s=200",
+      "avatar_url": "4570664",
       "website": "https://pixelambacht.nl/",
       "github": "RoelN",
       "twitter": "PixelAmbacht"
@@ -1260,7 +1260,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/11558891?v=4&s=200",
+      "avatar_url": "11558891",
       "website": "https://romche.com/",
       "github": "roryhewitt",
       "twitter": "roryhewitt3",
@@ -1271,7 +1271,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1982567?v=4&s=200",
+      "avatar_url": "1982567",
       "website": "https://www.ksakae1216.com/archive",
       "github": "ksakae1216",
       "twitter": "beltway7"
@@ -1281,7 +1281,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/16757512?v=4&s=200",
+      "avatar_url": "16757512",
       "github": "sboukortt"
     },
     "saptaks": {
@@ -1289,7 +1289,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/9530293?v=4&s=200",
+      "avatar_url": "9530293",
       "website": "https://saptaks.website/",
       "github": "saptaks",
       "twitter": "Saptak013"
@@ -1300,7 +1300,7 @@
         "developers",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/65147?v=4&s=200",
+      "avatar_url": "65147",
       "website": "https://www.cs.odu.edu/~salam/",
       "github": "ibnesayeed",
       "twitter": "ibnesayeed"
@@ -1311,7 +1311,7 @@
         "editors",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/6392995?v=4&s=200",
+      "avatar_url": "6392995",
       "github": "exterkamp",
       "twitter": "Shane_Exterkamp"
     },
@@ -1320,7 +1320,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/4945616?v=4&s=200",
+      "avatar_url": "4945616",
       "github": "spanicker",
       "twitter": "shubhie"
     },
@@ -1329,7 +1329,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/496189?v=4&s=200",
+      "avatar_url": "496189",
       "website": "https://simonhearne.com",
       "github": "simonhearne",
       "twitter": "simonhearne"
@@ -1339,7 +1339,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/244772?v=4&s=200",
+      "avatar_url": "244772",
       "github": "zcorpan",
       "twitter": "zcorpan"
     },
@@ -1348,7 +1348,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/17740806?v=4&s=200",
+      "avatar_url": "17740806",
       "website": "https://www.advancedwebranking.com/",
       "github": "smatei",
       "twitter": "smatei"
@@ -1358,7 +1358,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/10291571?v=4&s=200",
+      "avatar_url": "10291571",
       "github": "sudheendrachari",
       "twitter": "itsmesudheendra",
       "linkedin": "sudheendrachari"
@@ -1368,7 +1368,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/2042718?v=4&s=200",
+      "avatar_url": "2042718",
       "website": "https://tamas.io",
       "github": "tpiros",
       "twitter": "tpiros"
@@ -1379,7 +1379,7 @@
         "analysts",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/145676?v=4&s=200",
+      "avatar_url": "145676",
       "website": "https://blog.tomayac.com/",
       "github": "tomayac"
     },
@@ -1388,7 +1388,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/66536?v=4&s=200",
+      "avatar_url": "66536",
       "github": "tkadlec",
       "website": "https://timkadlec.com/",
       "twitter": "tkadlec"
@@ -1399,7 +1399,7 @@
         "analysts",
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/4355579?v=4&s=200",
+      "avatar_url": "4355579",
       "github": "tomvangoethem",
       "twitter": "tomvangoethem"
     },
@@ -1408,7 +1408,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/4947018?v=4&s=200",
+      "avatar_url": "4947018",
       "website": "https://websiteadvantage.com.au/",
       "github": "Tiggerito",
       "twitter": "TonyMcCreath"
@@ -1418,7 +1418,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/33907565?v=4&s=200",
+      "avatar_url": "33907565",
       "website": "https://hakacode.github.io",
       "github": "HakaCode",
       "twitter": "hakacode"
@@ -1429,7 +1429,7 @@
         "analysts",
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/9135107?v=4&s=200",
+      "avatar_url": "9135107",
       "github": "ydimova"
     },
     "Zuckjet": {
@@ -1437,7 +1437,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/17976139?v=4&s=200",
+      "avatar_url": "17976139",
       "github": "Zuckjet",
       "twitter": "Zuckjet"
     },
@@ -1446,7 +1446,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1439919?v=4&s=200",
+      "avatar_url": "1439919",
       "website": "https://mefody.dev/",
       "github": "MeFoDy",
       "twitter": "dark_mefody"

--- a/src/config/2021.json
+++ b/src/config/2021.json
@@ -211,7 +211,7 @@
       "teams": [
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/44442451?v=4&s=200",
+      "avatar_url": "44442451",
       "github": "AbbyTsai"
     },
     "argyleink": {
@@ -219,7 +219,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1134620?v=4&s=200",
+      "avatar_url": "1134620",
       "website": "https://nerdy.dev",
       "github": "argyleink",
       "twitter": "argyleink"
@@ -229,7 +229,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/32825533?v=4&s=200",
+      "avatar_url": "32825533",
       "github": "tropicadri"
     },
     "alankent": {
@@ -237,7 +237,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/5702163?v=4&s=200",
+      "avatar_url": "5702163",
       "website": "https://alankent.me",
       "github": "alankent",
       "twitter": "akent99"
@@ -247,7 +247,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/36744484?v=4&s=200",
+      "avatar_url": "36744484",
       "website": "https://www.dawntraoz.com/",
       "github": "Dawntraoz",
       "twitter": "dawntraoz"
@@ -257,7 +257,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/690132?v=4&s=200",
+      "avatar_url": "690132",
       "website": "http://alexlakatos.com/",
       "github": "AlexLakatos",
       "twitter": "avolakatos"
@@ -267,7 +267,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/24625637?v=4&s=200",
+      "avatar_url": "24625637",
       "website": "https://atfreshsolutions.com",
       "github": "alextait1",
       "twitter": "at_fresh_dev"
@@ -277,7 +277,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/7407047?v=4&s=200",
+      "avatar_url": "7407047",
       "github": "alonkochba",
       "linkedin": "alonkochba",
       "twitter": "alonkochba"
@@ -287,7 +287,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/173661?v=4&s=200",
+      "avatar_url": "173661",
       "github": "kripken",
       "twitter": "kripken"
     },
@@ -296,7 +296,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/837037?v=4&s=200",
+      "avatar_url": "837037",
       "website": "https://wordlift.io/blog/en/entity/andrea-volpini/",
       "github": "cyberandy",
       "twitter": "cyberandy"
@@ -306,7 +306,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1733592?v=4&s=200",
+      "avatar_url": "1733592",
       "github": "andreban",
       "twitter": "andreban"
     },
@@ -315,7 +315,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/16627210?v=4&s=200",
+      "avatar_url": "16627210",
       "github": "andreylipattsev",
       "twitter": "AndreyLipattsev"
     },
@@ -324,7 +324,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/427052?v=4&s=200",
+      "avatar_url": "427052",
       "website": "http://andydavies.me/",
       "github": "andydavies",
       "twitter": "AndyDavies"
@@ -335,7 +335,7 @@
         "authors",
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/6231516?v=4&s=200",
+      "avatar_url": "6231516",
       "github": "denar90",
       "twitter": "denar90_"
     },
@@ -344,7 +344,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/35119235?v=4&s=200",
+      "avatar_url": "35119235",
       "github": "ashleyish"
     },
     "tunetheweb": {
@@ -357,7 +357,7 @@
         "leads",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/10931297?v=4&s=200",
+      "avatar_url": "10931297",
       "website": "https://www.tunetheweb.com",
       "github": "tunetheweb",
       "linkedin": "tunetheweb",
@@ -368,7 +368,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/870501?v=4&s=200",
+      "avatar_url": "870501",
       "website": "https://bkardell.com",
       "github": "bkardell",
       "twitter": "briankardell"
@@ -378,7 +378,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1588185?v=4&s=200",
+      "avatar_url": "1588185",
       "github": "cqueern",
       "twitter": "httpsecheaders"
     },
@@ -387,7 +387,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/76669481?v=4&s=200",
+      "avatar_url": "76669481",
       "github": "cdixon83"
     },
     "carlopi": {
@@ -395,7 +395,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/842657?v=4&s=200",
+      "avatar_url": "842657",
       "github": "carlopi",
       "twitter": "carlop54002226"
     },
@@ -404,7 +404,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/4480480?v=4&s=200",
+      "avatar_url": "4480480",
       "website": "https://cassey.dev/",
       "github": "clottman"
     },
@@ -420,7 +420,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/2506926?v=4&s=200",
+      "avatar_url": "2506926",
       "website": "https://svgees.us/",
       "github": "svgeesus",
       "twitter": "svgeesus"
@@ -430,7 +430,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/6698344?v=4&s=200",
+      "avatar_url": "6698344",
       "website": "https://christianliebel.com",
       "github": "christianliebel",
       "twitter": "christianliebel"
@@ -440,7 +440,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/11179452?v=4&s=200",
+      "avatar_url": "11179452",
       "website": "https://tamethebots.com/",
       "github": "dwsmart",
       "twitter": "davewsmart"
@@ -452,7 +452,7 @@
         "leads",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/684747?v=4&s=200",
+      "avatar_url": "684747",
       "website": "https://www.lookzook.com",
       "github": "obto",
       "twitter": "theobto"
@@ -463,7 +463,7 @@
         "authors",
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/15170359?v=4&s=200",
+      "avatar_url": "15170359",
       "github": "demianrenzulli",
       "twitter": "drenzulli"
     },
@@ -472,7 +472,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/131131?v=4&s=200",
+      "avatar_url": "131131",
       "twitter": "dominiclovell",
       "linkedin": "dominiclovell"
     },
@@ -482,7 +482,7 @@
         "authors",
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1514288?v=4&s=200",
+      "avatar_url": "1514288",
       "github": "dougsillars"
     },
     "edmondwwchan": {
@@ -490,7 +490,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/68361682?v=4&s=200",
+      "avatar_url": "68361682",
       "github": "edmondwwchan"
     },
     "meyerweb": {
@@ -498,7 +498,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/939727?v=4&s=200",
+      "avatar_url": "939727",
       "github": "meyerweb",
       "website": "http://meyerweb.com/"
     },
@@ -507,7 +507,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/634191?v=4&s=200",
+      "avatar_url": "634191",
       "website": "https://ericwbailey.design/",
       "github": "ericwbailey",
       "twitter": "ericwbailey"
@@ -518,7 +518,7 @@
         "authors",
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/3441390?v=4&s=200",
+      "avatar_url": "3441390",
       "website": "https://ericportis.com/",
       "github": "eeeps"
     },
@@ -527,7 +527,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/69888?v=4&s=200",
+      "avatar_url": "69888",
       "website": "http://standardista.com/",
       "github": "estelle",
       "twitter": "estellevw"
@@ -537,7 +537,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/203457?v=4&s=200",
+      "avatar_url": "203457",
       "github": "eustas"
     },
     "fili": {
@@ -545,7 +545,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/115263?v=4&s=200",
+      "avatar_url": "115263",
       "website": "https://fili.com/",
       "github": "fili",
       "linkedin": "filiwiese",
@@ -563,7 +563,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/5749508?v=4&s=200",
+      "avatar_url": "5749508",
       "github": "gjfr",
       "twitter": "GJFR_"
     },
@@ -579,7 +579,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/8484333?v=4&s=200",
+      "avatar_url": "8484333",
       "website": "https://gregbrimble.com/",
       "github": "GregBrimble",
       "twitter": "gregbrimble"
@@ -589,7 +589,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/751944?v=4&s=200",
+      "avatar_url": "751944",
       "website": "https://csswizardry.com/",
       "github": "csswizardry",
       "twitter": "csswizardry"
@@ -599,7 +599,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/18315?v=4&s=200",
+      "avatar_url": "18315",
       "website": "https://h3manth.com",
       "github": "hemanth",
       "twitter": "gnumanth"
@@ -609,7 +609,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/382649?v=4&s=200",
+      "avatar_url": "382649",
       "github": "wrttnwrd"
     },
     "iulia-m-comsa": {
@@ -617,7 +617,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/14878188?v=4&s=200",
+      "avatar_url": "14878188",
       "website": "https://sites.google.com/view/iuliacomsa/",
       "github": "iulia-m-comsa"
     },
@@ -627,7 +627,7 @@
         "analysts",
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/557590?v=4&s=200",
+      "avatar_url": "557590",
       "website": "https://rreverser.com/",
       "github": "RReverser",
       "twitter": "RReverser"
@@ -638,7 +638,7 @@
         "authors",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/52051775?v=4&s=200",
+      "avatar_url": "52051775",
       "website": "https://not-a-robot.com/",
       "github": "fellowhuman1101",
       "twitter": "Jammer_Volts"
@@ -648,7 +648,7 @@
       "teams": [
         "editors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/7320889?v=4&s=200",
+      "avatar_url": "7320889",
       "github": "jvandriel",
       "twitter": "JarnoVanDriel",
       "linkedin": "jarno-van-driel-36a47075"
@@ -658,7 +658,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/842798?v=4&s=200",
+      "avatar_url": "842798",
       "website": "http://jarrodoverson.com/",
       "github": "jsoverson"
     },
@@ -667,7 +667,7 @@
       "teams": [
         "editors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/58438178?v=4&s=200",
+      "avatar_url": "58438178",
       "github": "JasmineDWillson",
       "twitter": "jasminedwillson"
     },
@@ -676,7 +676,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1749548?v=4&s=200",
+      "avatar_url": "1749548",
       "website": "https://jeffy.info",
       "github": "jeffposnick",
       "twitter": "jeffposnick"
@@ -686,7 +686,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1700772?v=4&s=200",
+      "avatar_url": "1700772",
       "website": "https://meiert.com/en/",
       "github": "j9t",
       "twitter": "j9t"
@@ -696,7 +696,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/17071492?v=4&s=200",
+      "avatar_url": "17071492",
       "website": "https://jessbpeck.com/",
       "github": "jessthebp",
       "twitter": "jessthebp"
@@ -707,7 +707,7 @@
         "authors",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/25212653?v=4&s=200",
+      "avatar_url": "25212653",
       "website": "https://gemservers.com",
       "github": "logicalphase",
       "twitter": "jtteag"
@@ -717,7 +717,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/11629607?v=4&s=200",
+      "avatar_url": "11629607",
       "website": "https://www.jonoalderson.com",
       "github": "jonoalderson",
       "twitter": "jonoalderson"
@@ -727,7 +727,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/10191545?v=4&s=200",
+      "avatar_url": "10191545",
       "website": "https://codeseo.io/",
       "github": "jroakes",
       "twitter": "jroakes"
@@ -747,7 +747,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/9086028?v=4&s=200",
+      "avatar_url": "9086028",
       "github": "jyrkialakuijala",
       "twitter": "jyzg"
     },
@@ -756,7 +756,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/2644614?v=4&s=200",
+      "avatar_url": "2644614",
       "github": "Schweinepriester",
       "twitter": "schweinepriestr"
     },
@@ -767,7 +767,7 @@
         "authors",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/8075326?v=4&s=200",
+      "avatar_url": "8075326",
       "website": "https://imkev.dev",
       "github": "kevinfarrugia",
       "twitter": "imkevdev"
@@ -777,7 +777,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/54685625?v=4&s=200",
+      "avatar_url": "54685625",
       "website": "https://www.flowerstorm.tech/",
       "github": "kachiden"
     },
@@ -786,7 +786,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/772137?v=4&s=200",
+      "avatar_url": "772137",
       "website": "https://www.neok.be/",
       "github": "vdwijngaert",
       "twitter": "vdwijngaert"
@@ -796,7 +796,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/175836?v=4&s=200",
+      "avatar_url": "175836",
       "website": "https://lea.verou.me/",
       "github": "LeaVerou",
       "twitter": "leaverou"
@@ -806,7 +806,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/829214?v=4&s=200",
+      "avatar_url": "829214",
       "website": "https://twitter.com/zizzamia",
       "github": "Zizzamia",
       "twitter": "Zizzamia"
@@ -830,7 +830,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/7148510?v=4&s=200",
+      "avatar_url": "7148510",
       "website": "https://farfetchtechblog.com/en/blog/authors/manuel-garcia/",
       "github": "soulcorrosion",
       "linkedin": "manuel-garcia-12b6928",
@@ -841,7 +841,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/53170037?v=4&s=200",
+      "avatar_url": "53170037",
       "github": "awareseven"
     },
     "maudnals": {
@@ -849,7 +849,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/9762897?v=4&s=200",
+      "avatar_url": "9762897",
       "github": "maudnals"
     },
     "max-ostapenko": {
@@ -857,7 +857,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1611259?v=4&s=200",
+      "avatar_url": "1611259",
       "website": "https://maxostapenko.com",
       "github": "max-ostapenko",
       "twitter": "themax_o"
@@ -867,7 +867,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1560278?v=4&s=200",
+      "avatar_url": "1560278",
       "github": "webmaxru",
       "twitter": "webmaxru"
     },
@@ -882,7 +882,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/455023?v=4&s=200",
+      "avatar_url": "455023",
       "website": "https://blog.mgechev.com/",
       "github": "mgechev",
       "twitter": "mgechev"
@@ -892,7 +892,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/3491627?v=4&s=200",
+      "avatar_url": "3491627",
       "github": "mo271"
     },
     "Navaneeth-akam": {
@@ -900,7 +900,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/69532755?v=4&s=200",
+      "avatar_url": "69532755",
       "github": "Navaneeth-akam",
       "twitter": "Navanee55755217"
     },
@@ -909,7 +909,7 @@
       "teams": [
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1439919?v=4&s=200",
+      "avatar_url": "1439919",
       "website": "https://mefody.dev/",
       "github": "MeFoDy",
       "twitter": "dark_mefody"
@@ -919,7 +919,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/26349046?v=4&s=200",
+      "avatar_url": "26349046",
       "website": "http://unravelweb.dev/",
       "github": "NishuGoel",
       "twitter": "TheNishuGoel"
@@ -929,7 +929,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/670556?v=4&s=200",
+      "avatar_url": "670556",
       "github": "Nithanaroy",
       "linkedin": "nitinpasumarthy",
       "website": "https://nithanaroy.medium.com/"
@@ -939,7 +939,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/13475745?v=4&s=200",
+      "avatar_url": "13475745",
       "website": "https://internet-sicherheit.de",
       "github": "nrllh",
       "twitter": "nrllah"
@@ -949,7 +949,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/3077443?v=4&s=200",
+      "avatar_url": "3077443",
       "website": "https://olu.online/",
       "github": "oluoluoxenfree",
       "twitter": "oluoluoxenfree"
@@ -961,7 +961,7 @@
         "editors",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/5320044?v=4&s=200",
+      "avatar_url": "5320044",
       "website": "https://medium.com/@pankajparkar",
       "github": "pankajparkar",
       "twitter": "pankajparkar"
@@ -971,7 +971,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/17054057?v=4&s=200",
+      "avatar_url": "17054057",
       "github": "thepassle"
     },
     "patrickhulce": {
@@ -979,7 +979,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/2301202?v=4&s=200",
+      "avatar_url": "2301202",
       "website": "http://patrickhulce.com",
       "github": "patrickhulce",
       "twitter": "patrickhulce"
@@ -989,7 +989,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/32576994?v=4&s=200",
+      "avatar_url": "32576994",
       "website": "https://patrickstox.com",
       "github": "patrickstox",
       "twitter": "patrickstox"
@@ -1000,7 +1000,7 @@
         "analysts",
         "leads"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/7459458?v=4&s=200",
+      "avatar_url": "7459458",
       "github": "paulcalvano",
       "twitter": "paulcalvano",
       "website": "https://paulcalvano.com"
@@ -1010,7 +1010,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/658047?v=4&s=200",
+      "avatar_url": "658047",
       "website": "https://blogs.pjjk.net/phil/",
       "github": "philbarker",
       "twitter": "philbarker"
@@ -1035,7 +1035,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/61608378?v=4&s=200",
+      "avatar_url": "61608378",
       "github": "RMHolmlund"
     },
     "rviscomi": {
@@ -1046,7 +1046,7 @@
         "leads",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1120896?v=4&s=200",
+      "avatar_url": "1120896",
       "github": "rviscomi",
       "twitter": "rick_viscomi"
     },
@@ -1055,7 +1055,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/83400777?v=4&s=200",
+      "avatar_url": "83400777",
       "github": "SeoRobt",
       "twitter": "teitelmanrob"
     },
@@ -1064,7 +1064,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/2240689?v=4&s=200",
+      "avatar_url": "2240689",
       "github": "rmarx",
       "twitter": "programmingart"
     },
@@ -1073,7 +1073,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/1718757?v=4&s=200",
+      "avatar_url": "1718757",
       "github": "rockeynebhwani",
       "twitter": "rnebhwani",
       "linkedin": "rockeynebhwani"
@@ -1083,7 +1083,7 @@
       "teams": [
         "analysts"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/62478401?v=4&s=200",
+      "avatar_url": "62478401",
       "website": "https://rvth.blog/",
       "github": "rvth",
       "twitter": "rvtheverett"
@@ -1093,7 +1093,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/802163?v=4&s=200",
+      "avatar_url": "802163",
       "github": "samarpanda"
     },
     "saptaks": {
@@ -1102,7 +1102,7 @@
         "authors",
         "developers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/9530293?v=4&s=200",
+      "avatar_url": "9530293",
       "website": "https://saptaks.website/",
       "github": "saptaks",
       "twitter": "Saptak013"
@@ -1112,7 +1112,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/15577?v=4&s=200",
+      "avatar_url": "15577",
       "github": "scottdavis99"
     },
     "shantsis": {
@@ -1122,7 +1122,7 @@
         "editors",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/22671477?v=4&s=200",
+      "avatar_url": "22671477",
       "github": "shantsis"
     },
     "boosef": {
@@ -1130,7 +1130,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/65818702?v=4&s=200",
+      "avatar_url": "65818702",
       "github": "boosef"
     },
     "GeekBoySupreme": {
@@ -1139,7 +1139,7 @@
         "authors",
         "designers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/15321738?v=4&s=200",
+      "avatar_url": "15321738",
       "github": "GeekBoySupreme",
       "twitter": "shuvam360",
       "website": "https://shuvam.xyz"
@@ -1151,7 +1151,7 @@
         "authors",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/4777393?v=4&s=200",
+      "avatar_url": "4777393",
       "website": "https://sia.codes",
       "github": "siakaramalegos",
       "linkedin": "karamalegos",
@@ -1162,7 +1162,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/496189?v=4&s=200",
+      "avatar_url": "496189",
       "website": "https://simonhearne.com",
       "github": "simonhearne",
       "twitter": "simonhearne"
@@ -1172,7 +1172,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/8614811?v=4&s=200",
+      "avatar_url": "8614811",
       "website": "https://www.thomkrupa.com/",
       "github": "thomkrupa",
       "twitter": "thomkrupa"
@@ -1183,7 +1183,7 @@
         "analysts",
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/145676?v=4&s=200",
+      "avatar_url": "145676",
       "website": "https://blog.tomayac.com/",
       "github": "tomayac"
     },
@@ -1192,7 +1192,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/553566?v=4&s=200",
+      "avatar_url": "553566",
       "website": "https://www.space48.com",
       "github": "bobbyshaw",
       "linkedin": "tomrobertshaw",
@@ -1203,7 +1203,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/4355579?v=4&s=200",
+      "avatar_url": "4355579",
       "github": "tomvangoethem",
       "twitter": "tomvangoethem"
     },
@@ -1212,7 +1212,7 @@
       "teams": [
         "authors"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/37291453?v=4&s=200",
+      "avatar_url": "37291453",
       "github": "Tomek3c",
       "twitter": "TomekRudzki",
       "website": "https://tomekseo.com/"
@@ -1231,7 +1231,7 @@
         "authors",
         "translators"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/6874341?v=4&s=200",
+      "avatar_url": "6874341",
       "github": "VictorLeP",
       "linkedin": "victor-le-pochat",
       "twitter": "VictorLePochat",
@@ -1242,7 +1242,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/134745?v=4&s=200",
+      "avatar_url": "134745",
       "website": "https://weston.ruter.net/",
       "github": "westonruter",
       "twitter": "westonruter"
@@ -1259,7 +1259,7 @@
       "teams": [
         "reviewers"
       ],
-      "avatar_url": "https://avatars.githubusercontent.com/u/60089915?v=4&s=200",
+      "avatar_url": "60089915",
       "github": "ziemek-bucko"
     }
   }

--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -200,7 +200,11 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
       <li>
           <div aria-hidden="true">
             <a href="{{ url_for('contributors', year=year, lang=lang, _anchor=author) }}" tabindex="-1">
+              {% if authordata.avatar_url|int != 0 %}
+              <img class="avatar" alt="{{ authordata.name }} avatar" src="https://avatars.githubusercontent.com/u/{{ authordata.avatar_url }}?v=4&s=200" height="200" width="200" loading="lazy" />
+              {% else %}
               <img class="avatar" alt="{{ authordata.name }} avatar" src="{{ authordata.avatar_url }}" height="200" width="200" loading="lazy" />
+              {% endif %}
             </a>
           </div>
           <div class="info">

--- a/src/templates/base/base_ebook.html
+++ b/src/templates/base/base_ebook.html
@@ -351,7 +351,11 @@
     <ul class="contributors">
     {% for id, contributor in config.contributors.items() %}
       <li class="contributor" id="contributors-{{ id }}">
-        <img class="contributor-avatar" src="{{contributor.avatar_url}}" height="100" width="100" alt="{{ contributor.name }} avatar" />
+        {% if contributor.avatar_url|int != 0 %}
+        <img class="contributor-avatar" src="https://avatars.githubusercontent.com/u/{{ contributor.avatar_url }}?v=4&s=100" height="100" width="100" alt="{{ contributor.name }} avatar" />
+        {% else %}
+        <img class="contributor-avatar" src="{{ contributor.avatar_url }}" height="100" width="100" alt="{{ contributor.name }} avatar" />
+        {% endif %}
         <div>
           <div class="contributor-name">{{ contributor.name }}</div>
           {% if contributor.twitter %}

--- a/src/templates/base/contributors.html
+++ b/src/templates/base/contributors.html
@@ -309,7 +309,13 @@
       </li>
     {% for id, contributor in config.contributors.items() %}
       <li class="contributor {{ ' '.join(contributor.teams) }}" id="{{ id }}" tabindex="-1">
+
+        {% if contributor.avatar_url|int != 0 %}
+        <img class="contributor-avatar" src="https://avatars.githubusercontent.com/u/{{ contributor.avatar_url }}?v=4&s=200" height="100" width="100" alt="{{ contributor.name }} avatar" loading="lazy" />
+        {% else %}
         <img class="contributor-avatar" src="{{contributor.avatar_url}}" height="100" width="100" alt="{{ contributor.name }} avatar" loading="lazy" />
+        {% endif %}
+
         <div class="contributor-name">{{ contributor.name }}</div>
 
         <div class="contributor-social">

--- a/src/templates/base/ebook.ejs.html
+++ b/src/templates/base/ebook.ejs.html
@@ -86,7 +86,11 @@
             {% endif %}
                 {% set authordata = config.contributors[author] if author in config.contributors else None %}
                 <li>
+                    {% if authordata.avatar_url|int != 0 %}
+                    <a class="avatar-link" href="#contributors-{{ author }}"><img class="avatar" alt="{{ authordata.name }} avatar" src="https://avatars.githubusercontent.com/u/{{ authordata.avatar_url }}?v=4&s=200" height="200" width="200" /></a>
+                    {% else %}
                     <a class="avatar-link" href="#contributors-{{ author }}"><img class="avatar" alt="{{ authordata.name }} avatar" src="{{ authordata.avatar_url }}" height="200" width="200" /></a>
+                    {% endif %}
                     <div class="info">
                         <a href="#contributors-{{ author }}"><span class="name">{{ authordata.name }}</span></a>
                         {% if authordata.twitter or authordata.github or authordata.linkedin or authordata.website %}


### PR DESCRIPTION
Fixes #2640 

Also allows smaller Avatars in ebook which allows ebook to generate and be uploaded to GCP