### PR TITLE
Remove extra newline in HTML

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -1,4 +1,4 @@
-{% block html %}
+{% block html -%}
 <!doctype html>
 <html lang="{% block lang %}{{ language.lang_attribute }}{% endblock %}" {% block dir_attribute %}{% endblock %}>
   <head>


### PR DESCRIPTION
Add this when adding RSS but some HTML validators now complain so let's alter slightly to remove the extra newline at the top