### PR TITLE
2021 SEO Chapter: fix rule in robots.txt

### DIFF
--- a/src/content/en/2021/seo.md
+++ b/src/content/en/2021/seo.md
@@ -120,7 +120,7 @@ Most robots.txt files are fairly small, weighing between 0-100 kb. However, we d
    )
 }}
 
-You can declare a rule for all robots or specify a rule for specific robots. Bots usually try to follow the most specific rule for their user-agents. `Disallow: Googlebot` will refer to Googlebot only, while `Disallow: *` will refer to all bots that don't have a more specific rule.
+You can declare a rule for all robots or specify a rule for specific robots. Bots usually try to follow the most specific rule for their user-agents. `User-agent: Googlebot` will refer to Googlebot only, while `User-agent: *` will refer to all bots that don't have a more specific rule.
 
 We saw two popular SEO-related robots: `mj12bot` (Majestic) and `ahrefsbot` (Ahrefs) in the top 5 most specified user agents.
 


### PR DESCRIPTION
I think this is a typo. User-agent set with `User-agent`, not with `Disallow`. [Documentation](https://developers.google.com/search/docs/advanced/robots/create-robots-txt).