### PR TITLE
Enhance web vitals script

### DIFF
--- a/src/static/js/send-web-vitals.js
+++ b/src/static/js/send-web-vitals.js
@@ -64,16 +64,16 @@ function sendWebVitals() {
     if ('deviceMemory' in navigator) {
         deviceMemory = navigator.deviceMemory.toString();
     }
-    let hasOSReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches.toString();
-    let systemColourScheme;
+    let prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches.toString();
+    let prefersColorScheme;
     if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      systemColourScheme = 'dark';
+      prefersColorScheme = 'dark';
     } else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
-      systemColourScheme = 'light';
+      prefersColorScheme = 'light';
     } else if (window.matchMedia('(prefers-color-scheme: no preference)').matches) {
-      systemColourScheme = 'no preference';
+      prefersColorScheme = 'no preference';
     } else {
-      systemColourScheme = 'not supported';
+      prefersColorScheme = 'not supported';
     }
 
     gtag('event', name, {
@@ -87,8 +87,8 @@ function sendWebVitals() {
       dimension2: effectiveType,
       dimension3: dataSaver,
       dimension4: deviceMemory,
-      dimension5: hasOSReducedMotion,
-      dimension6: systemColourScheme,
+      dimension5: prefersReducedMotion,
+      dimension6: prefersColorScheme,
     });
   }
 

--- a/src/static/js/send-web-vitals.js
+++ b/src/static/js/send-web-vitals.js
@@ -1,10 +1,94 @@
 function sendWebVitals() {
-  function sendWebVitalsGAEvents({name, delta, id}) {
+
+  function getSelector(node, maxLen = 100) {
+    let sel = '';
+    try {
+      while (node && node.nodeType !== 9) {
+        const part = node.id ? '#' + node.id : node.nodeName.toLowerCase() + (
+          (node.className && node.className.length) ?
+          '.' + Array.from(node.classList.values()).join('.') : '');
+        if (sel.length + part.length > maxLen - 1) return sel || part;
+        sel = sel ? part + '>' + sel : part;
+        if (node.id) break;
+        node = node.parentNode;
+      }
+    } catch (err) {
+      // Do nothing...
+    }
+    return sel;
+  }
+
+  function getLargestLayoutShiftEntry(entries) {
+    return entries.reduce((a, b) => a && a.value > b.value ? a : b);
+  }
+
+  function getLargestLayoutShiftSource(sources) {
+    return sources.reduce((a, b) => {
+      return a.node && a.previousRect.width * a.previousRect.height >
+          b.previousRect.width * b.previousRect.height ? a : b;
+    });
+  }
+
+  function sendWebVitalsGAEvents({name, delta, id, entries}) {
+
+    let webVitalInfo = '(not set)';
+    // Set a custom dimension for more info for any CVW breaches
+    // In some cases there won't be any entries (e.g. if CLS is 0,
+    // or for LCP after a bfcache restore), so we have to check first.
+    if (entries.length) {
+      if (name === 'LCP') {
+         const lastEntry = entries[entries.length - 1];
+         webVitalInfo =  getSelector(lastEntry.element);
+      } else if (name === 'FID') {
+        const firstEntry = entries[0];
+        webVitalInfo = getSelector(firstEntry.target);
+      } else if (name === 'CLS') {
+         const largestEntry = getLargestLayoutShiftEntry(entries);
+         if (largestEntry && largestEntry.sources && largestEntry.sources.length) {
+            const largestSource = getLargestLayoutShiftSource(largestEntry.sources);
+            if (largestSource) {
+              webVitalInfo = getSelector(largestSource.node);
+            }
+         }
+      }
+    }
+
+    // Measure some other user preferences
+    let dataSaver;
+    let effectiveType;
+    if ('connection' in navigator) {
+        dataSaver = navigator.connection.saveData.toString();
+        effectiveType = navigator.connection.effectiveType;
+    }
+    let deviceMemory;
+    if ('deviceMemory' in navigator) {
+        deviceMemory = navigator.deviceMemory.toString();
+    }
+    let hasOSReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches.toString();
+    let systemColourScheme;
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      systemColourScheme = 'dark';
+    } else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+      systemColourScheme = 'light';
+    } else if (window.matchMedia('(prefers-color-scheme: no preference)').matches) {
+      systemColourScheme = 'no preference';
+    } else {
+      systemColourScheme = 'not supported';
+    }
+
     gtag('event', name, {
       event_category: 'Web Vitals',
       value: Math.round(name === 'CLS' ? delta * 1000 : delta),
       event_label: id,
       non_interaction: true,
+
+      // See: https://web.dev/debug-web-vitals-in-the-field/
+      dimension1: webVitalInfo,
+      dimension2: effectiveType,
+      dimension3: dataSaver,
+      dimension4: deviceMemory,
+      dimension5: hasOSReducedMotion,
+      dimension6: systemColourScheme,
     });
   }
 

--- a/src/static/js/send-web-vitals.js
+++ b/src/static/js/send-web-vitals.js
@@ -37,19 +37,19 @@ function sendWebVitals() {
     // or for LCP after a bfcache restore), so we have to check first.
     if (entries.length) {
       if (name === 'LCP') {
-         const lastEntry = entries[entries.length - 1];
-         webVitalInfo =  getSelector(lastEntry.element);
+        const lastEntry = entries[entries.length - 1];
+        webVitalInfo =  getSelector(lastEntry.element);
       } else if (name === 'FID') {
         const firstEntry = entries[0];
         webVitalInfo = getSelector(firstEntry.target);
       } else if (name === 'CLS') {
-         const largestEntry = getLargestLayoutShiftEntry(entries);
-         if (largestEntry && largestEntry.sources && largestEntry.sources.length) {
-            const largestSource = getLargestLayoutShiftSource(largestEntry.sources);
-            if (largestSource) {
-              webVitalInfo = getSelector(largestSource.node);
-            }
-         }
+        const largestEntry = getLargestLayoutShiftEntry(entries);
+        if (largestEntry && largestEntry.sources && largestEntry.sources.length) {
+          const largestSource = getLargestLayoutShiftSource(largestEntry.sources);
+          if (largestSource) {
+            webVitalInfo = getSelector(largestSource.node);
+          }
+        }
       }
     }
 
@@ -57,12 +57,12 @@ function sendWebVitals() {
     let dataSaver;
     let effectiveType;
     if ('connection' in navigator) {
-        dataSaver = navigator.connection.saveData.toString();
-        effectiveType = navigator.connection.effectiveType;
+      dataSaver = navigator.connection.saveData.toString();
+      effectiveType = navigator.connection.effectiveType;
     }
     let deviceMemory;
     if ('deviceMemory' in navigator) {
-        deviceMemory = navigator.deviceMemory.toString();
+      deviceMemory = navigator.deviceMemory.toString();
     }
     let prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches.toString();
     let prefersColorScheme;


### PR DESCRIPTION
We implemented a very basic Web-Vitals scriptinitially. We should track the elements, in case we ever need to debug one.

Also let's track some other user preferences so we can see make up of our users (and whether to spend time implementing a light/dark themes in future for example).

Some of this duplicates some of the events we track in almanac.js, but better done as Custom Dimensions so they update and we only record one per session. Also the existing events drop out at first use so not that userful (e.g. we only record data saver if not in print mode, and wide screen - whereas this will record all of them). Will leave them in place for now but might want to rip them out at some point.