### PR TITLE
Remove report-to and refactor report-uri

### DIFF
--- a/src/server/__init__.py
+++ b/src/server/__init__.py
@@ -67,6 +67,7 @@ app.jinja_env.filters['accentless_sort'] = accentless_sort
 
 talisman = Talisman(app,
                     content_security_policy=csp.csp,
+                    content_security_policy_report_uri="https://httparchive.report-uri.com/r/d/csp/enforce'",
                     content_security_policy_nonce_in=['script-src', 'style-src'],
                     feature_policy=feature_policy.feature_policy)
 

--- a/src/server/csp.py
+++ b/src/server/csp.py
@@ -35,11 +35,5 @@ csp = {
     ],
     'base-uri': [
         '\'none\''
-    ],
-    'report-uri': [
-        'https://httparchive.report-uri.com/r/d/csp/enforce'
-    ],
-    'report-to': [
-        'https://httparchive.report-uri.com/r/d/csp/enforce'
     ]
 }

--- a/src/server/search_csp.py
+++ b/src/server/search_csp.py
@@ -42,11 +42,5 @@ csp = {
     ],
     'base-uri': [
         '\'none\''
-    ],
-    'report-uri': [
-        'https://httparchive.report-uri.com/r/d/csp/enforce'
-    ],
-    'report-to': [
-        'https://httparchive.report-uri.com/r/d/csp/enforce'
     ]
 }

--- a/src/server/stories_csp.py
+++ b/src/server/stories_csp.py
@@ -40,11 +40,5 @@ csp = {
     ],
     'base-uri': [
         '\'none\''
-    ],
-    'report-uri': [
-        'https://httparchive.report-uri.com/r/d/csp/enforce'
-    ],
-    'report-to': [
-        'https://httparchive.report-uri.com/r/d/csp/enforce'
     ]
 }


### PR DESCRIPTION
We currently incorrectly set `report-to` to the same as `report-uri`, even though it's a different format, so this is incorrect.

`report-to` is only supported in Chromium browsers and it falls back to `report-uri` anyway.

I've raised https://github.com/wntrblm/flask-talisman/issues/23 to support `report-to` better in the Flask Talisman library but for now easiest just to remove it.