### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/add-to-release-notes.yml
+++ b/.github/workflows/add-to-release-notes.yml
@@ -10,8 +10,14 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
+
 jobs:
   release-notes:
+    permissions:
+      contents: write  # for release-drafter/release-drafter to create a github release
+      pull-requests: write  # for release-drafter/release-drafter to add label to PR
     runs-on: ubuntu-20.04
     if: github.repository == 'HTTPArchive/almanac.httparchive.org'
     steps:

--- a/.github/workflows/check-translations-lengths.yml
+++ b/.github/workflows/check-translations-lengths.yml
@@ -24,6 +24,9 @@ on:
       - '**.html'
       - '**.md'
 
+permissions:
+  contents: read
+
 jobs:
   check_lengths:
     name: Check Lengths

--- a/.github/workflows/code-static-analysis.yml
+++ b/.github/workflows/code-static-analysis.yml
@@ -23,9 +23,16 @@ on:
     - cron: '30 1 * * 0'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   CodeQL-Build:
     # CodeQL runs on ubuntu-20.04, windows-latest, and macos-latest
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/analyze to upload SARIF results
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,8 +13,14 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
+
 jobs:
   lint:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      statuses: write  # for github/super-linter to mark status of each linter run
     name: Lint Code Base
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/lintsql.yml
+++ b/.github/workflows/lintsql.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     paths:
       src/requirements.txt
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint SQL

--- a/.github/workflows/predeploy.yml
+++ b/.github/workflows/predeploy.yml
@@ -24,8 +24,14 @@ on:
         required: true
         default: "true"
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     name: Update Timestamps and Generate Ebooks
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
