### PR TITLE
Upgrade to SQLFluff 0.13.0 and add consistency check for quoted literals

### DIFF
--- a/sql/.sqlfluff
+++ b/sql/.sqlfluff
@@ -130,3 +130,9 @@ blocked_words = None
 extended_capitalisation_policy = upper
 # Comma separated list of words to ignore for this rule
 ignore_words = None
+
+[sqlfluff:rules:L064]
+# Consistent usage of preferred quotes for quoted literals
+preferred_quoted_literal_style = single_quotes
+# Disabled for dialects that do not support single and double quotes for quoted literals (e.g. Postgres)
+force_enable = False

--- a/sql/2019/accessibility/09_19c.sql
+++ b/sql/2019/accessibility/09_19c.sql
@@ -2,7 +2,7 @@
 # 09_19c: % valid ARIA attributes
 # Valid attributes from https://github.com/dequelabs/axe-core/blob/master/lib/commons/aria/index.js
 CREATE TEMPORARY FUNCTION isValidAttribute(attr STRING) RETURNS BOOLEAN AS
-(attr IN ("aria-atomic", "aria-busy", "aria-controls", "aria-current", "aria-describedby", "aria-disabled", "aria-dropeffect", "aria-flowto", "aria-grabbed", "aria-haspopup", "aria-hidden", "aria-invalid", "aria-keyshortcuts", "aria-label", "aria-labelledby", "aria-live", "aria-owns", "aria-relevant", "aria-roledescription"));
+(attr IN ('aria-atomic', 'aria-busy', 'aria-controls', 'aria-current', 'aria-describedby', 'aria-disabled', 'aria-dropeffect', 'aria-flowto', 'aria-grabbed', 'aria-haspopup', 'aria-hidden', 'aria-invalid', 'aria-keyshortcuts', 'aria-label', 'aria-labelledby', 'aria-live', 'aria-owns', 'aria-relevant', 'aria-roledescription'));
 
 SELECT
   client,

--- a/sql/2019/caching/16_04a.sql
+++ b/sql/2019/caching/16_04a.sql
@@ -24,7 +24,7 @@ FROM
       `httparchive.almanac.requests`
     WHERE
       date = '2019-07-01' AND
-      resp_last_modified != "" AND
+      resp_last_modified != '' AND
       expAge > 0
   )
 GROUP BY

--- a/sql/2019/caching/16_04a_3rd_party.sql
+++ b/sql/2019/caching/16_04a_3rd_party.sql
@@ -26,7 +26,7 @@ FROM
       `httparchive.almanac.requests`
     WHERE
       date = '2019-07-01' AND
-      resp_last_modified != "" AND
+      resp_last_modified != '' AND
       expAge > 0
   )
 GROUP BY

--- a/sql/2019/caching/16_04b.sql
+++ b/sql/2019/caching/16_04b.sql
@@ -23,7 +23,7 @@ FROM
       `httparchive.almanac.requests`
     WHERE
       date = '2019-07-01' AND
-      resp_last_modified != "" AND expAge > 0
+      resp_last_modified != '' AND expAge > 0
   ),
   UNNEST([10, 20, 30, 40, 50, 60, 70, 80, 90]) AS percentile
 GROUP BY

--- a/sql/2019/caching/16_04b_3rd_party.sql
+++ b/sql/2019/caching/16_04b_3rd_party.sql
@@ -25,7 +25,7 @@ FROM
       `httparchive.almanac.requests`
     WHERE
       date = '2019-07-01' AND
-      resp_last_modified != "" AND
+      resp_last_modified != '' AND
       expAge > 0
   ),
   UNNEST([10, 20, 30, 40, 50, 60, 70, 80, 90]) AS percentile

--- a/sql/2019/caching/16_05.sql
+++ b/sql/2019/caching/16_05.sql
@@ -16,8 +16,8 @@ SELECT
 FROM (
   SELECT
     client,
-    TRIM(resp_etag) != "" AS uses_etag,
-    TRIM(resp_last_modified) != "" AS uses_last_modified
+    TRIM(resp_etag) != '' AS uses_etag,
+    TRIM(resp_last_modified) != '' AS uses_last_modified
   FROM
     `httparchive.almanac.requests`
   WHERE

--- a/sql/2019/caching/16_05_3rd_party.sql
+++ b/sql/2019/caching/16_05_3rd_party.sql
@@ -18,8 +18,8 @@ FROM (
   SELECT
     client,
     IF(STRPOS(NET.HOST(url), REGEXP_EXTRACT(NET.REG_DOMAIN(page), r'([\w-]+)')) > 0, 1, 3) AS party,
-    TRIM(resp_etag) != "" AS uses_etag,
-    TRIM(resp_last_modified) != "" AS uses_last_modified
+    TRIM(resp_etag) != '' AS uses_etag,
+    TRIM(resp_last_modified) != '' AS uses_last_modified
   FROM
     `httparchive.almanac.requests`
   WHERE

--- a/sql/2019/caching/16_06.sql
+++ b/sql/2019/caching/16_06.sql
@@ -19,8 +19,8 @@ SELECT
 FROM (
   SELECT
     client,
-    TRIM(resp_date) != "" AS uses_date,
-    TRIM(resp_last_modified) != "" AS uses_last_modified,
+    TRIM(resp_date) != '' AS uses_date,
+    TRIM(resp_last_modified) != '' AS uses_last_modified,
 
     REGEXP_CONTAINS(TRIM(resp_date), r'^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{1,2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT$') AS has_valid_date_header,
     REGEXP_CONTAINS(TRIM(resp_last_modified), r'^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{1,2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT$') AS has_valid_last_modified

--- a/sql/2019/caching/16_06_3rd_party.sql
+++ b/sql/2019/caching/16_06_3rd_party.sql
@@ -21,8 +21,8 @@ FROM (
   SELECT
     client,
     IF(STRPOS(NET.HOST(url), REGEXP_EXTRACT(NET.REG_DOMAIN(page), r'([\w-]+)')) > 0, 1, 3) AS party,
-    TRIM(resp_date) != "" AS uses_date,
-    TRIM(resp_last_modified) != "" AS uses_last_modified,
+    TRIM(resp_date) != '' AS uses_date,
+    TRIM(resp_last_modified) != '' AS uses_last_modified,
 
     REGEXP_CONTAINS(TRIM(resp_date), r'^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{1,2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT$') AS has_valid_date_header,
     REGEXP_CONTAINS(TRIM(resp_last_modified), r'^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{1,2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT$') AS has_valid_last_modified

--- a/sql/2019/caching/16_08.sql
+++ b/sql/2019/caching/16_08.sql
@@ -16,7 +16,7 @@ SELECT
 FROM (
   SELECT
     client,
-    TRIM(resp_expires) != "" AS uses_expires,
+    TRIM(resp_expires) != '' AS uses_expires,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)max-age\s*=') AS uses_max_age
   FROM
     `httparchive.almanac.requests`

--- a/sql/2019/caching/16_08_3rd_party.sql
+++ b/sql/2019/caching/16_08_3rd_party.sql
@@ -18,7 +18,7 @@ FROM (
   SELECT
     client,
     IF(STRPOS(NET.HOST(url), REGEXP_EXTRACT(NET.REG_DOMAIN(page), r'([\w-]+)')) > 0, 1, 3) AS party,
-    TRIM(resp_expires) != "" AS uses_expires,
+    TRIM(resp_expires) != '' AS uses_expires,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)max-age\s*=') AS uses_max_age
   FROM
     `httparchive.almanac.requests`

--- a/sql/2019/caching/16_09.sql
+++ b/sql/2019/caching/16_09.sql
@@ -16,7 +16,7 @@ JOIN (
     date,
     client,
     COUNT(0) AS all_requests,
-    COUNTIF(TRIM(resp_vary) != "") AS total_with_vary
+    COUNTIF(TRIM(resp_vary) != '') AS total_with_vary
   FROM
     `httparchive.almanac.requests`
   WHERE

--- a/sql/2019/caching/16_09_3rd_party.sql
+++ b/sql/2019/caching/16_09_3rd_party.sql
@@ -26,7 +26,7 @@ JOIN (
     client,
     IF(STRPOS(NET.HOST(url), REGEXP_EXTRACT(NET.REG_DOMAIN(page), r'([\w-]+)')) > 0, 1, 3) AS party,
     COUNT(0) AS all_requests,
-    COUNTIF(TRIM(resp_vary) != "") AS total_with_vary
+    COUNTIF(TRIM(resp_vary) != '') AS total_with_vary
   FROM
     `httparchive.almanac.requests`
   WHERE

--- a/sql/2019/caching/16_10.sql
+++ b/sql/2019/caching/16_10.sql
@@ -15,7 +15,7 @@ JOIN (
   SELECT
     client,
     COUNT(0) AS all_requests,
-    COUNTIF(TRIM(resp_cache_control) != "") AS total_using_control
+    COUNTIF(TRIM(resp_cache_control) != '') AS total_using_control
   FROM
     `httparchive.almanac.requests`
   WHERE

--- a/sql/2019/caching/16_10_3rd_party.sql
+++ b/sql/2019/caching/16_10_3rd_party.sql
@@ -26,7 +26,7 @@ JOIN (
     client,
     IF(STRPOS(NET.HOST(url), REGEXP_EXTRACT(NET.REG_DOMAIN(page), r'([\w-]+)')) > 0, 1, 3) AS party,
     COUNT(0) AS all_requests,
-    COUNTIF(TRIM(resp_cache_control) != "") AS total_using_control
+    COUNTIF(TRIM(resp_cache_control) != '') AS total_using_control
   FROM
     `httparchive.almanac.requests`
   WHERE

--- a/sql/2019/caching/16_12.sql
+++ b/sql/2019/caching/16_12.sql
@@ -16,7 +16,7 @@ SELECT
 FROM (
   SELECT
     client,
-    TRIM(resp_cache_control) != "" AS uses_cache_control,
+    TRIM(resp_cache_control) != '' AS uses_cache_control,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)(^\s*|,\s*)public(\s*,|\s*$)') AS uses_public,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)(^\s*|,\s*)private(\s*,|\s*$)') AS uses_private
   FROM

--- a/sql/2019/caching/16_12_3rd_party.sql
+++ b/sql/2019/caching/16_12_3rd_party.sql
@@ -18,7 +18,7 @@ FROM (
   SELECT
     client,
     IF(STRPOS(NET.HOST(url), REGEXP_EXTRACT(NET.REG_DOMAIN(page), r'([\w-]+)')) > 0, 1, 3) AS party,
-    TRIM(resp_cache_control) != "" AS uses_cache_control,
+    TRIM(resp_cache_control) != '' AS uses_cache_control,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)(^\s*|,\s*)public(\s*,|\s*$)') AS uses_public,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)(^\s*|,\s*)private(\s*,|\s*$)') AS uses_private
   FROM

--- a/sql/2019/caching/16_13.sql
+++ b/sql/2019/caching/16_13.sql
@@ -12,7 +12,7 @@ SELECT
 FROM (
   SELECT
     client,
-    TRIM(resp_cache_control) != "" AS uses_cache_control,
+    TRIM(resp_cache_control) != '' AS uses_cache_control,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)(^\s*|,\s*)must-revalidate(\s*,|\s*$)') AS uses_revalidate
   FROM
     `httparchive.almanac.requests`

--- a/sql/2019/caching/16_13_3rd_party.sql
+++ b/sql/2019/caching/16_13_3rd_party.sql
@@ -14,7 +14,7 @@ FROM (
   SELECT
     client,
     IF(STRPOS(NET.HOST(url), REGEXP_EXTRACT(NET.REG_DOMAIN(page), r'([\w-]+)')) > 0, 1, 3) AS party,
-    TRIM(resp_cache_control) != "" AS uses_cache_control,
+    TRIM(resp_cache_control) != '' AS uses_cache_control,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)(^\s*|,\s*)must-revalidate(\s*,|\s*$)') AS uses_revalidate
   FROM
     `httparchive.almanac.requests`

--- a/sql/2019/cdn/17_03.sql
+++ b/sql/2019/cdn/17_03.sql
@@ -12,7 +12,7 @@ SELECT
 FROM (
   SELECT
     client,
-    CAST(JSON_EXTRACT(payload, "$._ttfb_ms") AS INT64) AS ttfb,
+    CAST(JSON_EXTRACT(payload, '$._ttfb_ms') AS INT64) AS ttfb,
     _cdn_provider AS cdn
   FROM
     `httparchive.almanac.requests`

--- a/sql/2019/cdn/17_05.sql
+++ b/sql/2019/cdn/17_05.sql
@@ -3,9 +3,9 @@
 SELECT
   _TABLE_SUFFIX AS client,
   _cdn_provider AS cdn,
-  COUNTIF(LOWER(respOtherHeaders) LIKE "%strict-transport-security%") AS freq,
+  COUNTIF(LOWER(respOtherHeaders) LIKE '%strict-transport-security%') AS freq,
   COUNT(0) AS total,
-  ROUND(COUNTIF(LOWER(respOtherHeaders) LIKE "%strict-transport-security%") * 100 / COUNT(0), 2) AS pct
+  ROUND(COUNTIF(LOWER(respOtherHeaders) LIKE '%strict-transport-security%') * 100 / COUNT(0), 2) AS pct
 FROM
   `httparchive.summary_requests.2019_07_01_*`
 GROUP BY

--- a/sql/2019/cdn/17_06.sql
+++ b/sql/2019/cdn/17_06.sql
@@ -3,9 +3,9 @@
 SELECT
   _TABLE_SUFFIX AS client,
   _cdn_provider AS cdn,
-  COUNTIF(LOWER(respOtherHeaders) LIKE "%timing-allow-origin%") AS freq,
+  COUNTIF(LOWER(respOtherHeaders) LIKE '%timing-allow-origin%') AS freq,
   COUNT(0) AS total,
-  ROUND(COUNTIF(LOWER(respOtherHeaders) LIKE "%timing-allow-origin%") * 100 / COUNT(0), 2) AS pct
+  ROUND(COUNTIF(LOWER(respOtherHeaders) LIKE '%timing-allow-origin%') * 100 / COUNT(0), 2) AS pct
 FROM
   `httparchive.summary_requests.2019_07_01_*`
 GROUP BY

--- a/sql/2019/cdn/17_09.sql
+++ b/sql/2019/cdn/17_09.sql
@@ -3,9 +3,9 @@
 SELECT
   _TABLE_SUFFIX AS client,
   _cdn_provider AS cdn,
-  COUNTIF(LOWER(respOtherHeaders) LIKE "%server-timing%") AS freq,
+  COUNTIF(LOWER(respOtherHeaders) LIKE '%server-timing%') AS freq,
   COUNT(0) AS total,
-  ROUND(COUNTIF(LOWER(respOtherHeaders) LIKE "%server-timing%") * 100 / COUNT(0), 2) AS pct
+  ROUND(COUNTIF(LOWER(respOtherHeaders) LIKE '%server-timing%') * 100 / COUNT(0), 2) AS pct
 FROM
   `httparchive.summary_requests.2019_07_01_*`
 GROUP BY

--- a/sql/2019/cdn/17_10b.sql
+++ b/sql/2019/cdn/17_10b.sql
@@ -7,7 +7,7 @@ SELECT
   COUNT(0) AS total
 FROM
   `httparchive.almanac.requests`,
-  UNNEST(split(REGEXP_REPLACE(REGEXP_REPLACE(LOWER(resp_vary), '\"', ''), '[, ]+|\\\\0', ','), ',')) AS vary
+  UNNEST(split(REGEXP_REPLACE(REGEXP_REPLACE(LOWER(resp_vary), '"', ''), '[, ]+|\\\\0', ','), ',')) AS vary
 WHERE
   date = '2019-07-01'
 GROUP BY

--- a/sql/2019/cdn/17_11.sql
+++ b/sql/2019/cdn/17_11.sql
@@ -3,9 +3,9 @@
 SELECT
   _TABLE_SUFFIX AS client,
   _cdn_provider AS cdn,
-  COUNTIF(LOWER(respOtherHeaders) LIKE "%content-disposition%") AS freq,
+  COUNTIF(LOWER(respOtherHeaders) LIKE '%content-disposition%') AS freq,
   COUNT(0) AS total,
-  ROUND(COUNTIF(LOWER(respOtherHeaders) LIKE "%content-disposition%") * 100 / COUNT(0), 2) AS pct
+  ROUND(COUNTIF(LOWER(respOtherHeaders) LIKE '%content-disposition%') * 100 / COUNT(0), 2) AS pct
 FROM
   `httparchive.summary_requests.2019_07_01_*`
 GROUP BY

--- a/sql/2019/cdn/17_12.sql
+++ b/sql/2019/cdn/17_12.sql
@@ -14,8 +14,8 @@ FROM (
     SELECT
       client, requestid, page, url, firstHtml,
       IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') AS cdn, # sometimes _cdn provider detection includes multiple entries. we bias for the DNS detected entry which is the first entry
-      CAST(JSON_EXTRACT(payload, "$.timings.ssl") AS INT64) AS tlstime,
-      ARRAY_LENGTH(split(JSON_EXTRACT(payload, '$._securityDetails.sanList'), "")) AS sanLength,
+      CAST(JSON_EXTRACT(payload, '$.timings.ssl') AS INT64) AS tlstime,
+      ARRAY_LENGTH(split(JSON_EXTRACT(payload, '$._securityDetails.sanList'), '')) AS sanLength,
       IF(NET.HOST(url) = NET.HOST(page), TRUE, FALSE) AS sameHost,
       IF(NET.HOST(url) = NET.HOST(page) OR NET.REG_DOMAIN(url) = NET.REG_DOMAIN(page), TRUE, FALSE) AS sameDomain # if toplevel reg_domain will return NULL so we group this as sameDomain
     FROM `httparchive.almanac.requests`

--- a/sql/2019/cdn/17_13.sql
+++ b/sql/2019/cdn/17_13.sql
@@ -14,8 +14,8 @@ FROM (
     SELECT
       client, requestid, page, url, firstHtml,
       IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') AS cdn, # sometimes _cdn provider detection includes multiple entries. we bias for the DNS detected entry which is the first entry
-      CAST(JSON_EXTRACT(payload, "$.timings.ssl") AS INT64) AS tlstime,
-      ARRAY_LENGTH(split(JSON_EXTRACT(payload, '$._securityDetails.sanList'), "")) AS sanLength,
+      CAST(JSON_EXTRACT(payload, '$.timings.ssl') AS INT64) AS tlstime,
+      ARRAY_LENGTH(split(JSON_EXTRACT(payload, '$._securityDetails.sanList'), '')) AS sanLength,
       --       length(FROM_BASE64(REPLACE(REGEXP_REPLACE(JSON_EXTRACT_SCALAR(payload, '$._certificates[0]'), ""-----(BEGIN|END) CERTIFICATE-----"", """"), ""\n"", """"))) AS tlscertsize,
       IF(NET.HOST(url) = NET.HOST(page), TRUE, FALSE) AS sameHost,
       IF(NET.HOST(url) = NET.HOST(page) OR NET.REG_DOMAIN(url) = NET.REG_DOMAIN(page), TRUE, FALSE) AS sameDomain # if toplevel reg_domain will return NULL so we group this as sameDomain

--- a/sql/2019/cdn/17_19.sql
+++ b/sql/2019/cdn/17_19.sql
@@ -20,16 +20,16 @@ FROM
     SELECT
       client, page, url, firstHtml,
       # WPT is inconsistent with protocol population.
-      upper(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("HTTP/", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/')))) AS protocol,
+      upper(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat('HTTP/', JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/')))) AS protocol,
       JSON_EXTRACT_SCALAR(payload, '$._tls_version') AS tlsVersion,
 
       # WPT joins CDN detection but we bias to the DNS detection which is the first entry
       IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') AS cdn,
-      CAST(JSON_EXTRACT(payload, "$.timings.ssl") AS INT64) AS tlstime,
+      CAST(JSON_EXTRACT(payload, '$.timings.ssl') AS INT64) AS tlstime,
 
       # isSecure reports what the browser thought it was going to use, but it can get upgraded with STS OR UpgradeInsecure: 1
       IF(STARTS_WITH(url, 'https') OR JSON_EXTRACT_SCALAR(payload, '$._tls_version') IS NOT NULL OR CAST(JSON_EXTRACT(payload, '$._is_secure') AS INT64) = 1, TRUE, FALSE) AS isSecure,
-      CAST(jSON_EXTRACT(payload, "$._socket") AS INT64) AS socket
+      CAST(jSON_EXTRACT(payload, '$._socket') AS INT64) AS socket
     FROM
       `httparchive.almanac.requests3`
     WHERE
@@ -40,15 +40,15 @@ LEFT JOIN
   (
     SELECT
       client, page,
-      CAST(jSON_EXTRACT(payload, "$._socket") AS INT64) AS socket,
-      ANY_VALUE(upper(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("HTTP/", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/'))))) AS protocol,
+      CAST(jSON_EXTRACT(payload, '$._socket') AS INT64) AS socket,
+      ANY_VALUE(upper(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat('HTTP/', JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/'))))) AS protocol,
       ANY_VALUE(JSON_EXTRACT_SCALAR(payload, '$._tls_version')) AS tlsVersion
     FROM
       `httparchive.almanac.requests3`
     WHERE
       JSON_EXTRACT_SCALAR(payload, '$._tls_version') IS NOT NULL AND
-      IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("HTTP/", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/'))) IS NOT NULL AND
-      jSON_EXTRACT(payload, "$._socket") IS NOT NULL
+      IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat('HTTP/', JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/'))) IS NOT NULL AND
+      jSON_EXTRACT(payload, '$._socket') IS NOT NULL
     GROUP BY client, page, socket
   ) b ON (a.client = b.client AND a.page = b.page AND a.socket = b.socket)
 

--- a/sql/2019/cdn/17_19c.sql
+++ b/sql/2019/cdn/17_19c.sql
@@ -9,16 +9,16 @@ FROM
     SELECT
       client, page, url, firstHtml,
       # WPT is inconsistent with protocol population.
-      upper(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("HTTP/", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/')))) AS protocol,
+      upper(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat('HTTP/', JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/')))) AS protocol,
       JSON_EXTRACT_SCALAR(payload, '$._tls_version') AS tlsVersion,
 
       # WPT joins CDN detection but we bias to the DNS detection which is the first entry
       IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') AS cdn,
-      CAST(JSON_EXTRACT(payload, "$.timings.ssl") AS INT64) AS tlstime,
+      CAST(JSON_EXTRACT(payload, '$.timings.ssl') AS INT64) AS tlstime,
 
       # isSecure reports what the browser thought it was going to use, but it can get upgraded with STS OR UpgradeInsecure: 1
       IF(STARTS_WITH(url, 'https') OR JSON_EXTRACT_SCALAR(payload, '$._tls_version') IS NOT NULL OR CAST(JSON_EXTRACT(payload, '$._is_secure') AS INT64) = 1, TRUE, FALSE) AS isSecure,
-      CAST(jSON_EXTRACT(payload, "$._socket") AS INT64) AS socket
+      CAST(jSON_EXTRACT(payload, '$._socket') AS INT64) AS socket
     FROM
       `httparchive.almanac.requests3`
     WHERE
@@ -29,14 +29,14 @@ LEFT JOIN
   (
     SELECT
       client, page,
-      CAST(jSON_EXTRACT(payload, "$._socket") AS INT64) AS socket,
-      ANY_VALUE(upper(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("HTTP/", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/'))))) AS protocol,
+      CAST(jSON_EXTRACT(payload, '$._socket') AS INT64) AS socket,
+      ANY_VALUE(upper(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat('HTTP/', JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/'))))) AS protocol,
       ANY_VALUE(JSON_EXTRACT_SCALAR(payload, '$._tls_version')) AS tlsVersion
     FROM `httparchive.almanac.requests3`
     WHERE
       JSON_EXTRACT_SCALAR(payload, '$._tls_version') IS NOT NULL AND
-      IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("HTTP/", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/'))) IS NOT NULL AND
-      jSON_EXTRACT(payload, "$._socket") IS NOT NULL
+      IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat('HTTP/', JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/'))) IS NOT NULL AND
+      jSON_EXTRACT(payload, '$._socket') IS NOT NULL
     GROUP BY client, page, socket
   ) b ON (a.client = b.client AND a.page = b.page AND a.socket = b.socket)
 

--- a/sql/2019/cdn/17_20.sql
+++ b/sql/2019/cdn/17_20.sql
@@ -3,13 +3,13 @@
 SELECT
   _TABLE_SUFFIX AS client,
   IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') AS cdn,
-  COUNTIF(LOWER(resp_cache_control) LIKE "%s-maxage%") AS freq,
-  COUNTIF(firstHTML AND LOWER(resp_cache_control) LIKE "%s-maxage%") AS firstHtmlFreq,
-  COUNTIF(NOT firstHtml AND LOWER(resp_cache_control) LIKE "%s-maxage%") AS resourceFreq,
+  COUNTIF(LOWER(resp_cache_control) LIKE '%s-maxage%') AS freq,
+  COUNTIF(firstHTML AND LOWER(resp_cache_control) LIKE '%s-maxage%') AS firstHtmlFreq,
+  COUNTIF(NOT firstHtml AND LOWER(resp_cache_control) LIKE '%s-maxage%') AS resourceFreq,
   COUNT(0) AS total,
-  ROUND(COUNTIF(LOWER(resp_cache_control) LIKE "%s-maxage%") * 100 / COUNT(0), 2) AS pct,
-  ROUND(COUNTIF(firstHtml AND LOWER(resp_cache_control) LIKE "%s-maxage%") * 100 / COUNT(0), 2) AS firstHtmlPct,
-  ROUND(COUNTIF(NOT firstHtml AND LOWER(resp_cache_control) LIKE "%s-maxage%") * 100 / COUNT(0), 2) AS ResourcePct
+  ROUND(COUNTIF(LOWER(resp_cache_control) LIKE '%s-maxage%') * 100 / COUNT(0), 2) AS pct,
+  ROUND(COUNTIF(firstHtml AND LOWER(resp_cache_control) LIKE '%s-maxage%') * 100 / COUNT(0), 2) AS firstHtmlPct,
+  ROUND(COUNTIF(NOT firstHtml AND LOWER(resp_cache_control) LIKE '%s-maxage%') * 100 / COUNT(0), 2) AS ResourcePct
 FROM
   `httparchive.summary_requests.2019_07_01_*`
 GROUP BY

--- a/sql/2019/cdn/17_21.sql
+++ b/sql/2019/cdn/17_21.sql
@@ -3,9 +3,9 @@
 SELECT
   _TABLE_SUFFIX AS client,
   _cdn_provider AS cdn,
-  COUNTIF(LOWER(resp_cache_control) LIKE "%stale-while-revalidate%") AS freq,
+  COUNTIF(LOWER(resp_cache_control) LIKE '%stale-while-revalidate%') AS freq,
   COUNT(0) AS total,
-  ROUND(COUNTIF(LOWER(resp_cache_control) LIKE "%stale-while-revalidate%") * 100 / COUNT(0), 2) AS pct
+  ROUND(COUNTIF(LOWER(resp_cache_control) LIKE '%stale-while-revalidate%') * 100 / COUNT(0), 2) AS pct
 FROM
   `httparchive.summary_requests.2019_07_01_*`
 GROUP BY

--- a/sql/2019/cdn/17_22.sql
+++ b/sql/2019/cdn/17_22.sql
@@ -3,9 +3,9 @@
 SELECT
   _TABLE_SUFFIX AS client,
   _cdn_provider AS cdn,
-  COUNTIF(LOWER(respOtherHeaders) LIKE "%nopush%") AS freq,
+  COUNTIF(LOWER(respOtherHeaders) LIKE '%nopush%') AS freq,
   COUNT(0) AS total,
-  ROUND(COUNTIF(LOWER(respOtherHeaders) LIKE "%nopush%") * 100 / COUNT(0), 2) AS pct
+  ROUND(COUNTIF(LOWER(respOtherHeaders) LIKE '%nopush%') * 100 / COUNT(0), 2) AS pct
 FROM
   `httparchive.summary_requests.2019_07_01_*`
 GROUP BY

--- a/sql/2019/cdn/17_23.sql
+++ b/sql/2019/cdn/17_23.sql
@@ -3,9 +3,9 @@
 SELECT
   _TABLE_SUFFIX AS client,
   _cdn_provider AS cdn,
-  COUNTIF(LOWER(resp_cache_control) LIKE "%stale-if-error%") AS freq,
+  COUNTIF(LOWER(resp_cache_control) LIKE '%stale-if-error%') AS freq,
   COUNT(0) AS total,
-  ROUND(COUNTIF(LOWER(resp_cache_control) LIKE "%stale-if-error%") * 100 / COUNT(0), 2) AS pct
+  ROUND(COUNTIF(LOWER(resp_cache_control) LIKE '%stale-if-error%') * 100 / COUNT(0), 2) AS pct
 FROM
   `httparchive.summary_requests.2019_07_01_*`
 GROUP BY

--- a/sql/2019/cdn/17_24.sql
+++ b/sql/2019/cdn/17_24.sql
@@ -3,9 +3,9 @@
 SELECT
   _TABLE_SUFFIX AS client,
   _cdn_provider AS cdn,
-  COUNTIF(LOWER(resp_cache_control) LIKE "%pre-check%") AS freq,
+  COUNTIF(LOWER(resp_cache_control) LIKE '%pre-check%') AS freq,
   COUNT(0) AS total,
-  ROUND(COUNTIF(LOWER(resp_cache_control) LIKE "%pre-check%") * 100 / COUNT(0), 2) AS pct
+  ROUND(COUNTIF(LOWER(resp_cache_control) LIKE '%pre-check%') * 100 / COUNT(0), 2) AS pct
 FROM
   `httparchive.summary_requests.2019_07_01_*`
 GROUP BY

--- a/sql/2019/cdn/17_25.sql
+++ b/sql/2019/cdn/17_25.sql
@@ -3,9 +3,9 @@
 SELECT
   _TABLE_SUFFIX AS client,
   _cdn_provider AS cdn,
-  COUNTIF(LOWER(respOtherHeaders) LIKE "%surrogate-control%") AS freq,
+  COUNTIF(LOWER(respOtherHeaders) LIKE '%surrogate-control%') AS freq,
   COUNT(0) AS total,
-  ROUND(COUNTIF(LOWER(respOtherHeaders) LIKE "%surrogate-control%") * 100 / COUNT(0), 2) AS pct
+  ROUND(COUNTIF(LOWER(respOtherHeaders) LIKE '%surrogate-control%') * 100 / COUNT(0), 2) AS pct
 FROM
   `httparchive.summary_requests.2019_07_01_*`
 GROUP BY

--- a/sql/2019/cms/14_18.sql
+++ b/sql/2019/cms/14_18.sql
@@ -1,7 +1,7 @@
 #standardSQL
 # 14_18: Lighthouse indexability scores
 SELECT
-  JSON_EXTRACT_SCALAR(report, "$.audits.is-crawlable.score") AS crawlable,
+  JSON_EXTRACT_SCALAR(report, '$.audits.is-crawlable.score') AS crawlable,
   COUNT(0) AS freq,
   SUM(COUNT(0)) OVER () AS total,
   ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (), 2) AS pct

--- a/sql/2019/cms/14_19.sql
+++ b/sql/2019/cms/14_19.sql
@@ -1,7 +1,7 @@
 #standardSQL
 # 14_19: Lighthouse PWA scores
 SELECT
-  JSON_EXTRACT_SCALAR(report, "$.categories.pwa.score") AS pwa_score,
+  JSON_EXTRACT_SCALAR(report, '$.categories.pwa.score') AS pwa_score,
   COUNT(0) AS freq,
   SUM(COUNT(0)) OVER () AS total,
   ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (), 2) AS pct

--- a/sql/2019/cms/14_19b.sql
+++ b/sql/2019/cms/14_19b.sql
@@ -2,7 +2,7 @@
 # 14_19b: Lighthouse PWA scores by CMS
 SELECT
   app,
-  APPROX_QUANTILES(CAST(JSON_EXTRACT_SCALAR(report, "$.categories.pwa.score") AS NUMERIC), 1000)[OFFSET(501)] AS median_pwa_score,
+  APPROX_QUANTILES(CAST(JSON_EXTRACT_SCALAR(report, '$.categories.pwa.score') AS NUMERIC), 1000)[OFFSET(501)] AS median_pwa_score,
   COUNT(0) AS pages
 FROM
   `httparchive.lighthouse.2019_07_01_mobile`

--- a/sql/2019/cms/14_20.sql
+++ b/sql/2019/cms/14_20.sql
@@ -1,7 +1,7 @@
 #standardSQL
 # 14_20: Lighthouse A11y scores
 SELECT
-  JSON_EXTRACT_SCALAR(report, "$.categories.accessibility.score") AS a11y_score,
+  JSON_EXTRACT_SCALAR(report, '$.categories.accessibility.score') AS a11y_score,
   COUNT(0) AS freq,
   SUM(COUNT(0)) OVER () AS total,
   ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (), 2) AS pct

--- a/sql/2019/cms/14_20b.sql
+++ b/sql/2019/cms/14_20b.sql
@@ -2,7 +2,7 @@
 # 14_20b: Lighthouse A11y scores by CMS
 SELECT
   app,
-  APPROX_QUANTILES(CAST(JSON_EXTRACT_SCALAR(report, "$.categories.accessibility.score") AS NUMERIC), 1000)[OFFSET(501)] AS median_a11y_score,
+  APPROX_QUANTILES(CAST(JSON_EXTRACT_SCALAR(report, '$.categories.accessibility.score') AS NUMERIC), 1000)[OFFSET(501)] AS median_a11y_score,
   COUNT(0) AS pages
 FROM
   `httparchive.lighthouse.2019_07_01_mobile`

--- a/sql/2019/compression/15_04.sql
+++ b/sql/2019/compression/15_04.sql
@@ -4,12 +4,12 @@ SELECT
   _TABLE_SUFFIX AS client,
   mimeType,
   COUNT(0) AS num_requests,
-  SUM(IF(resp_content_encoding = "gzip", 1, 0)) AS gzip,
-  SUM(IF(resp_content_encoding = "br", 1, 0)) AS brotli,
-  SUM(IF(resp_content_encoding = "deflate", 1, 0)) AS deflate,
-  SUM(IF(resp_content_encoding IN("gzip", "deflate", "br"), 0, 1)) AS no_text_compression,
-  ROUND(SUM(IF(resp_content_encoding IN("gzip", "deflate", "br"), 1, 0)) / COUNT(0), 2) AS pct_compressed,
-  ROUND(SUM(IF(resp_content_encoding = "br", 1, 0)) / COUNT(0), 2) AS pct_compressed_brotli
+  SUM(IF(resp_content_encoding = 'gzip', 1, 0)) AS gzip,
+  SUM(IF(resp_content_encoding = 'br', 1, 0)) AS brotli,
+  SUM(IF(resp_content_encoding = 'deflate', 1, 0)) AS deflate,
+  SUM(IF(resp_content_encoding IN('gzip', 'deflate', 'br'), 0, 1)) AS no_text_compression,
+  ROUND(SUM(IF(resp_content_encoding IN('gzip', 'deflate', 'br'), 1, 0)) / COUNT(0), 2) AS pct_compressed,
+  ROUND(SUM(IF(resp_content_encoding = 'br', 1, 0)) / COUNT(0), 2) AS pct_compressed_brotli
 FROM
   `httparchive.summary_requests.2019_07_01_*`
 GROUP BY

--- a/sql/2019/compression/15_05.sql
+++ b/sql/2019/compression/15_05.sql
@@ -2,7 +2,7 @@
 # 15.05 - Distribution of Text Based Compression Lighthouse Scores
 SELECT
   _TABLE_SUFFIX AS client,
-  JSON_EXTRACT_SCALAR(report, "$.audits.uses-text-compression.score") AS text_compression_score,
+  JSON_EXTRACT_SCALAR(report, '$.audits.uses-text-compression.score') AS text_compression_score,
   COUNT(0) AS num_pages,
   ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX), 2) AS pct_pages
 FROM

--- a/sql/2019/compression/15_06.sql
+++ b/sql/2019/compression/15_06.sql
@@ -2,13 +2,13 @@
 #15_06 - Text Based Compression Byte Savings
 SELECT
   _TABLE_SUFFIX AS client,
-  ROUND(CAST(JSON_EXTRACT_SCALAR(report, "$.audits.uses-text-compression.details.overallSavingsBytes") AS INT64) / 1024 / 1024) AS mbyte_savings,
+  ROUND(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.uses-text-compression.details.overallSavingsBytes') AS INT64) / 1024 / 1024) AS mbyte_savings,
   COUNT(0) AS num_pages,
   ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX), 2) AS pct_pages
 FROM
   `httparchive.lighthouse.2019_07_01_*`
 WHERE
-  JSON_EXTRACT_SCALAR(report, "$.audits.uses-text-compression.score") != "1"
+  JSON_EXTRACT_SCALAR(report, '$.audits.uses-text-compression.score') != '1'
 GROUP BY
   client,
   mbyte_savings

--- a/sql/2019/ecommerce/13_12.sql
+++ b/sql/2019/ecommerce/13_12.sql
@@ -1,7 +1,7 @@
 #standardSQL
 # 13_12: Lighthouse indexability scores
 SELECT
-  JSON_EXTRACT_SCALAR(report, "$.audits.is-crawlable.score") AS crawlable,
+  JSON_EXTRACT_SCALAR(report, '$.audits.is-crawlable.score') AS crawlable,
   COUNT(0) AS freq,
   SUM(COUNT(0)) OVER () AS total,
   ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (), 2) AS pct

--- a/sql/2019/ecommerce/13_13.sql
+++ b/sql/2019/ecommerce/13_13.sql
@@ -1,7 +1,7 @@
 #standardSQL
 # 13_13: Lighthouse PWA scores
 SELECT
-  JSON_EXTRACT_SCALAR(report, "$.categories.pwa.score") AS pwa_score,
+  JSON_EXTRACT_SCALAR(report, '$.categories.pwa.score') AS pwa_score,
   COUNT(0) AS freq,
   SUM(COUNT(0)) OVER () AS total,
   ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (), 2) AS pct

--- a/sql/2019/fonts/06_28b.sql
+++ b/sql/2019/fonts/06_28b.sql
@@ -21,7 +21,7 @@ try {
 
 SELECT
   client,
-  REPLACE(TRIM(LOWER(setting)), '\'', '"') AS setting,
+  REPLACE(TRIM(LOWER(setting)), "'", '"') AS setting,
   COUNT(0) AS freq,
   SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
   ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (PARTITION BY client), 2) AS pct

--- a/sql/2019/http/20_01.sql
+++ b/sql/2019/http/20_01.sql
@@ -3,7 +3,7 @@
 SELECT
   client,
   firstHtml,
-  JSON_EXTRACT_SCALAR(payload, "$._protocol") AS http_version,
+  JSON_EXTRACT_SCALAR(payload, '$._protocol') AS http_version,
   COUNT(0) AS num_requests,
   ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (PARTITION BY client), 2) AS pct
 FROM

--- a/sql/2019/http/20_02.sql
+++ b/sql/2019/http/20_02.sql
@@ -2,12 +2,12 @@
 # 20.2 - Measure of all HTTP versions (0.9, 1.0, 1.1, 2, QUIC) for main page of all sites, and for HTTPS sites. Table for last crawl.
 SELECT
   client,
-  JSON_EXTRACT_SCALAR(payload, "$._protocol") AS protocol,
+  JSON_EXTRACT_SCALAR(payload, '$._protocol') AS protocol,
   COUNT(0) AS num_pages,
   SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
-  COUNTIF(url LIKE "https://%") AS num_https_pages,
+  COUNTIF(url LIKE 'https://%') AS num_https_pages,
   ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (PARTITION BY client), 2) AS pct_pages,
-  ROUND(COUNTIF(url LIKE "https://%") * 100 / SUM(COUNT(0)) OVER (PARTITION BY client), 2) AS pct_https
+  ROUND(COUNTIF(url LIKE 'https://%') * 100 / SUM(COUNT(0)) OVER (PARTITION BY client), 2) AS pct_https
 FROM
   `httparchive.almanac.requests`
 WHERE

--- a/sql/2019/http/20_03.sql
+++ b/sql/2019/http/20_03.sql
@@ -9,10 +9,10 @@ FROM (
     client,
     page,
     COUNT(0) AS num_requests,
-    SUM(IF(JSON_EXTRACT_SCALAR(payload, "$._protocol") = "http/0.9", 1, 0)) AS http_0_9,
-    SUM(IF(JSON_EXTRACT_SCALAR(payload, "$._protocol") = "http/1.0", 1, 0)) AS http_1_0,
-    SUM(IF(JSON_EXTRACT_SCALAR(payload, "$._protocol") = "http/1.1", 1, 0)) AS http_1_1,
-    SUM(IF(JSON_EXTRACT_SCALAR(payload, "$._protocol") = "HTTP/2", 1, 0)) AS http_2
+    SUM(IF(JSON_EXTRACT_SCALAR(payload, '$._protocol') = 'http/0.9', 1, 0)) AS http_0_9,
+    SUM(IF(JSON_EXTRACT_SCALAR(payload, '$._protocol') = 'http/1.0', 1, 0)) AS http_1_0,
+    SUM(IF(JSON_EXTRACT_SCALAR(payload, '$._protocol') = 'http/1.1', 1, 0)) AS http_1_1,
+    SUM(IF(JSON_EXTRACT_SCALAR(payload, '$._protocol') = 'HTTP/2', 1, 0)) AS http_2
   FROM
     `httparchive.almanac.requests`
   WHERE

--- a/sql/2019/http/20_04.sql
+++ b/sql/2019/http/20_04.sql
@@ -23,8 +23,8 @@ FROM
   `httparchive.almanac.requests`
 WHERE
   date = '2019-07-01' AND
-  url LIKE "http://%" AND
-  getUpgradeHeader(payload) LIKE "%h2%"
+  url LIKE 'http://%' AND
+  getUpgradeHeader(payload) LIKE '%h2%'
 GROUP BY
   client,
   firstHtml

--- a/sql/2019/http/20_04a_05a_06a.sql
+++ b/sql/2019/http/20_04a_05a_06a.sql
@@ -18,8 +18,8 @@ LANGUAGE js AS """
 SELECT
   client,
   firstHtml,
-  JSON_EXTRACT_SCALAR(payload, "$._protocol") AS protocol,
-  IF(url LIKE "https://%", "https", "http") AS http_or_https,
+  JSON_EXTRACT_SCALAR(payload, '$._protocol') AS protocol,
+  IF(url LIKE 'https://%', 'https', 'http') AS http_or_https,
   getUpgradeHeader(payload) AS upgrade,
   COUNT(0) AS num_requests
 FROM

--- a/sql/2019/http/20_05.sql
+++ b/sql/2019/http/20_05.sql
@@ -23,9 +23,9 @@ FROM
   `httparchive.almanac.requests`
 WHERE
   date = '2019-07-01' AND
-  url LIKE "https://%" AND
-  JSON_EXTRACT_SCALAR(payload, "$._protocol") = "HTTP/2" AND
-  getUpgradeHeader(payload) LIKE "%h2%"
+  url LIKE 'https://%' AND
+  JSON_EXTRACT_SCALAR(payload, '$._protocol') = 'HTTP/2' AND
+  getUpgradeHeader(payload) LIKE '%h2%'
 GROUP BY
   client,
   firstHtml

--- a/sql/2019/http/20_06.sql
+++ b/sql/2019/http/20_06.sql
@@ -23,9 +23,9 @@ FROM
   `httparchive.almanac.requests`
 WHERE
   date = '2019-07-01' AND
-  url LIKE "https://%" AND
-  JSON_EXTRACT_SCALAR(payload, "$._protocol") != "HTTP/2" AND
-  getUpgradeHeader(payload) LIKE "%h2%"
+  url LIKE 'https://%' AND
+  JSON_EXTRACT_SCALAR(payload, '$._protocol') != 'HTTP/2' AND
+  getUpgradeHeader(payload) LIKE '%h2%'
 GROUP BY
   client,
   firstHtml

--- a/sql/2019/http/20_07.sql
+++ b/sql/2019/http/20_07.sql
@@ -2,8 +2,8 @@
 # 20.07 - % of sites affected by CDN prioritization issues (H2 and served by CDN)
 SELECT
   client,
-  IF(pages.cdn = "", "Not using CDN", pages.cdn) AS CDN,
-  IF(prioritization_status IS NOT NULL, prioritization_status, "Unknown") AS prioritizes_correctly,
+  IF(pages.cdn = '', 'Not using CDN', pages.cdn) AS CDN,
+  IF(prioritization_status IS NOT NULL, prioritization_status, 'Unknown') AS prioritizes_correctly,
   COUNT(0) AS num_pages,
   ROUND(COUNT(0) * 100 / SUM(COUNT(0)) OVER (PARTITION BY client), 2) AS pct
 FROM
@@ -12,12 +12,12 @@ FROM
       date,
       client,
       url,
-      JSON_EXTRACT_SCALAR(payload, "$._cdn_provider") AS cdn
+      JSON_EXTRACT_SCALAR(payload, '$._cdn_provider') AS cdn
     FROM
       `httparchive.almanac.requests`
     WHERE
       date = '2019-07-01' AND
-      JSON_EXTRACT_SCALAR(payload, "$._protocol") = "HTTP/2" AND
+      JSON_EXTRACT_SCALAR(payload, '$._protocol') = 'HTTP/2' AND
       firstHtml
   ) AS pages
 LEFT JOIN

--- a/sql/2019/http/20_08.sql
+++ b/sql/2019/http/20_08.sql
@@ -27,7 +27,7 @@ FROM
 WHERE
   date = '2019-07-01' AND
   firstHtml AND
-  JSON_EXTRACT_SCALAR(payload, "$._protocol") = "HTTP/2"
+  JSON_EXTRACT_SCALAR(payload, '$._protocol') = 'HTTP/2'
 GROUP BY
   client,
   server_header

--- a/sql/2019/http/20_09.sql
+++ b/sql/2019/http/20_09.sql
@@ -27,7 +27,7 @@ FROM
 WHERE
   date = '2019-07-01' AND
   firstHtml AND
-  JSON_EXTRACT_SCALAR(payload, "$._protocol") != "HTTP/2"
+  JSON_EXTRACT_SCALAR(payload, '$._protocol') != 'HTTP/2'
 GROUP BY
   client,
   server_header

--- a/sql/2019/http/20_10.sql
+++ b/sql/2019/http/20_10.sql
@@ -12,8 +12,8 @@ FROM (
     `httparchive.almanac.requests`
   WHERE
     date = '2019-07-01' AND
-    JSON_EXTRACT_SCALAR(payload, "$._protocol") = "HTTP/2" AND
-    JSON_EXTRACT_SCALAR(payload, "$._was_pushed") = "1"
+    JSON_EXTRACT_SCALAR(payload, '$._protocol') = 'HTTP/2' AND
+    JSON_EXTRACT_SCALAR(payload, '$._was_pushed') = '1'
 )
 GROUP BY
   client

--- a/sql/2019/http/20_11.sql
+++ b/sql/2019/http/20_11.sql
@@ -10,14 +10,14 @@ FROM (
   SELECT
     client,
     page,
-    SUM(CAST(JSON_EXTRACT_SCALAR(payload, "$._bytesIn") AS INT64) / 1024) AS kb_transfered,
+    SUM(CAST(JSON_EXTRACT_SCALAR(payload, '$._bytesIn') AS INT64) / 1024) AS kb_transfered,
     COUNT(0) AS num_requests
   FROM
     `httparchive.almanac.requests`
   WHERE
     date = '2019-07-01' AND
-    JSON_EXTRACT_SCALAR(payload, "$._protocol") = "HTTP/2" AND
-    JSON_EXTRACT_SCALAR(payload, "$._was_pushed") = "1"
+    JSON_EXTRACT_SCALAR(payload, '$._protocol') = 'HTTP/2' AND
+    JSON_EXTRACT_SCALAR(payload, '$._was_pushed') = '1'
   GROUP BY
     client,
     page

--- a/sql/2019/http/20_12.sql
+++ b/sql/2019/http/20_12.sql
@@ -11,15 +11,15 @@ FROM (
   SELECT
     client,
     page,
-    JSON_EXTRACT_SCALAR(payload, "$._contentType") AS content_type,
-    SUM(CAST(JSON_EXTRACT_SCALAR(payload, "$._bytesIn") AS INT64) / 1024) AS kb_transfered,
+    JSON_EXTRACT_SCALAR(payload, '$._contentType') AS content_type,
+    SUM(CAST(JSON_EXTRACT_SCALAR(payload, '$._bytesIn') AS INT64) / 1024) AS kb_transfered,
     COUNT(0) AS num_requests
   FROM
     `httparchive.almanac.requests`
   WHERE
     date = '2019-07-01' AND
-    JSON_EXTRACT_SCALAR(payload, "$._protocol") = "HTTP/2" AND
-    JSON_EXTRACT_SCALAR(payload, "$._was_pushed") = "1"
+    JSON_EXTRACT_SCALAR(payload, '$._protocol') = 'HTTP/2' AND
+    JSON_EXTRACT_SCALAR(payload, '$._was_pushed') = '1'
   GROUP BY
     client,
     page,

--- a/sql/2019/http/20_15.sql
+++ b/sql/2019/http/20_15.sql
@@ -1,8 +1,8 @@
 #standardSQL
 # 20.15 - Measure number of TCP Connections per site.
 SELECT
-  "mobile" AS client,
-  JSON_EXTRACT_SCALAR(payload, "$._protocol") AS protocol,
+  'mobile' AS client,
+  JSON_EXTRACT_SCALAR(payload, '$._protocol') AS protocol,
   COUNT(0) AS num_pages,
   APPROX_QUANTILES(_connections, 100)[SAFE_ORDINAL(50)] AS median,
   APPROX_QUANTILES(_connections, 100)[SAFE_ORDINAL(75)] AS p75,
@@ -14,7 +14,7 @@ INNER JOIN
 ON
   requests.url = summary.url
 WHERE
-  JSON_EXTRACT_SCALAR(payload, "$._is_base_page") = "true"
+  JSON_EXTRACT_SCALAR(payload, '$._is_base_page') = 'true'
 GROUP BY
   client,
   protocol
@@ -22,8 +22,8 @@ GROUP BY
 UNION ALL
 
 SELECT
-  "desktop" AS client,
-  JSON_EXTRACT_SCALAR(payload, "$._protocol") AS protocol,
+  'desktop' AS client,
+  JSON_EXTRACT_SCALAR(payload, '$._protocol') AS protocol,
   COUNT(0) AS num_pages,
   APPROX_QUANTILES(_connections, 100)[SAFE_ORDINAL(50)] AS median,
   APPROX_QUANTILES(_connections, 100)[SAFE_ORDINAL(75)] AS p75,
@@ -35,7 +35,7 @@ INNER JOIN
 ON
   requests.url = summary.url
 WHERE
-  JSON_EXTRACT_SCALAR(payload, "$._is_base_page") = "true"
+  JSON_EXTRACT_SCALAR(payload, '$._is_base_page') = 'true'
 GROUP BY
   client,
   protocol

--- a/sql/2019/http/20_16.sql
+++ b/sql/2019/http/20_16.sql
@@ -18,8 +18,8 @@ LANGUAGE js AS """
 SELECT
   client,
   firstHtml,
-  JSON_EXTRACT_SCALAR(payload, "$._protocol") AS protocol,
-  IF(url LIKE "https://%", "https", "http") AS http_or_https,
+  JSON_EXTRACT_SCALAR(payload, '$._protocol') AS protocol,
+  IF(url LIKE 'https://%', 'https', 'http') AS http_or_https,
   getUpgradeHeader(payload) AS upgrade,
   COUNT(0) AS num_requests
 FROM

--- a/sql/2019/markup/03_01b.sql
+++ b/sql/2019/markup/03_01b.sql
@@ -13,7 +13,7 @@ try {
 ''';
 
 CREATE TEMPORARY FUNCTION isDeprecated(element STRING) AS (
-  element IN ("applet", "acronym", "bgsound", "dir", "frame", "frameset", "noframes", "isindex", "keygen", "listing", "menuitem", "nextid", "noembed", "plaintext", "rb", "rtc", "strike", "xmp", "basefont", "big", "blink", "center", "font", "marquee", "multicol", "nobr", "spacer", "tt")
+  element IN ('applet', 'acronym', 'bgsound', 'dir', 'frame', 'frameset', 'noframes', 'isindex', 'keygen', 'listing', 'menuitem', 'nextid', 'noembed', 'plaintext', 'rb', 'rtc', 'strike', 'xmp', 'basefont', 'big', 'blink', 'center', 'font', 'marquee', 'multicol', 'nobr', 'spacer', 'tt')
 );
 
 SELECT

--- a/sql/2019/media/04_09b.sql
+++ b/sql/2019/media/04_09b.sql
@@ -10,7 +10,7 @@ FROM
     SELECT
       client,
       page,
-      replace(regexp_extract(regexp_extract(body, r'(?is)<meta[^><]*Accept-CH\b[^><]*'), r'(?im).*content=[&quot;#32"\']*([^\'"><]*)'), "#32;", '') AS chHTML,
+      replace(regexp_extract(regexp_extract(body, r'(?is)<meta[^><]*Accept-CH\b[^><]*'), r'(?im).*content=[&quot;#32"\']*([^\'"><]*)'), '#32;', '') AS chHTML,
       regexp_extract(regexp_extract(respOtherHeaders, r'(?is)Accept-CH = (.*)'), r'(?im)^([^=]*?)(?:, [a-z-]+ = .*)') AS chHeader
     FROM `httparchive.almanac.summary_response_bodies`
     WHERE

--- a/sql/2019/media/04_09c.sql
+++ b/sql/2019/media/04_09c.sql
@@ -13,7 +13,7 @@ FROM
         SELECT
           client,
           page,
-          replace(regexp_extract(regexp_extract(body, r'(?is)<meta[^><]*Accept-CH\b[^><]*'), r'(?im).*content=[&quot;#32"\']*([^\'"><]*)'), "&#32;", '') AS chHTML,
+          replace(regexp_extract(regexp_extract(body, r'(?is)<meta[^><]*Accept-CH\b[^><]*'), r'(?im).*content=[&quot;#32"\']*([^\'"><]*)'), '&#32;', '') AS chHTML,
           regexp_extract(regexp_extract(respOtherHeaders, r'(?is)Accept-CH = (.*)'), r'(?im)^([^=]*?)(?:, [a-z-]+ = .*)') AS chHeader
         FROM
           `httparchive.almanac.summary_response_bodies`

--- a/sql/2019/performance/07_03d.sql
+++ b/sql/2019/performance/07_03d.sql
@@ -52,7 +52,7 @@ WITH geos AS (
   SELECT *, 'cd' AS geo_code, 'Congo (Democratic Republic of the)' AS geo, 'Africa' AS region, 'Middle Africa' AS subregion FROM `chrome-ux-report.country_cd.201907` UNION ALL
   SELECT *, 'ck' AS geo_code, 'Cook Islands' AS geo, 'Oceania' AS region, 'Polynesia' AS subregion FROM `chrome-ux-report.country_ck.201907` UNION ALL
   SELECT *, 'cr' AS geo_code, 'Costa Rica' AS geo, 'Americas' AS region, 'Central America' AS subregion FROM `chrome-ux-report.country_cr.201907` UNION ALL
-  SELECT *, 'ci' AS geo_code, 'Côte d\'Ivoire' AS geo, 'Africa' AS region, 'Western Africa' AS subregion FROM `chrome-ux-report.country_ci.201907` UNION ALL
+  SELECT *, 'ci' AS geo_code, "Côte d'Ivoire" AS geo, 'Africa' AS region, 'Western Africa' AS subregion FROM `chrome-ux-report.country_ci.201907` UNION ALL
   SELECT *, 'hr' AS geo_code, 'Croatia' AS geo, 'Europe' AS region, 'Southern Europe' AS subregion FROM `chrome-ux-report.country_hr.201907` UNION ALL
   SELECT *, 'cu' AS geo_code, 'Cuba' AS geo, 'Americas' AS region, 'Caribbean' AS subregion FROM `chrome-ux-report.country_cu.201907` UNION ALL
   SELECT *, 'cw' AS geo_code, 'Curaçao' AS geo, 'Americas' AS region, 'Caribbean' AS subregion FROM `chrome-ux-report.country_cw.201907` UNION ALL
@@ -112,11 +112,11 @@ WITH geos AS (
   SELECT *, 'kz' AS geo_code, 'Kazakhstan' AS geo, 'Asia' AS region, 'Central Asia' AS subregion FROM `chrome-ux-report.country_kz.201907` UNION ALL
   SELECT *, 'ke' AS geo_code, 'Kenya' AS geo, 'Africa' AS region, 'Eastern Africa' AS subregion FROM `chrome-ux-report.country_ke.201907` UNION ALL
   SELECT *, 'ki' AS geo_code, 'Kiribati' AS geo, 'Oceania' AS region, 'Micronesia' AS subregion FROM `chrome-ux-report.country_ki.201907` UNION ALL
-  SELECT *, 'kp' AS geo_code, 'Korea (Democratic People\'s Republic of)' AS geo, 'Asia' AS region, 'Eastern Asia' AS subregion FROM `chrome-ux-report.country_kp.201907` UNION ALL
+  SELECT *, 'kp' AS geo_code, "Korea (Democratic People's Republic of)" AS geo, 'Asia' AS region, 'Eastern Asia' AS subregion FROM `chrome-ux-report.country_kp.201907` UNION ALL
   SELECT *, 'kr' AS geo_code, 'Korea (Republic of)' AS geo, 'Asia' AS region, 'Eastern Asia' AS subregion FROM `chrome-ux-report.country_kr.201907` UNION ALL
   SELECT *, 'kw' AS geo_code, 'Kuwait' AS geo, 'Asia' AS region, 'Western Asia' AS subregion FROM `chrome-ux-report.country_kw.201907` UNION ALL
   SELECT *, 'kg' AS geo_code, 'Kyrgyzstan' AS geo, 'Asia' AS region, 'Central Asia' AS subregion FROM `chrome-ux-report.country_kg.201907` UNION ALL
-  SELECT *, 'la' AS geo_code, 'Lao People\'s Democratic Republic' AS geo, 'Asia' AS region, 'South-Eastern Asia' AS subregion FROM `chrome-ux-report.country_la.201907` UNION ALL
+  SELECT *, 'la' AS geo_code, "Lao People's Democratic Republic" AS geo, 'Asia' AS region, 'South-Eastern Asia' AS subregion FROM `chrome-ux-report.country_la.201907` UNION ALL
   SELECT *, 'lv' AS geo_code, 'Latvia' AS geo, 'Europe' AS region, 'Northern Europe' AS subregion FROM `chrome-ux-report.country_lv.201907` UNION ALL
   SELECT *, 'lb' AS geo_code, 'Lebanon' AS geo, 'Asia' AS region, 'Western Asia' AS subregion FROM `chrome-ux-report.country_lb.201907` UNION ALL
   SELECT *, 'ls' AS geo_code, 'Lesotho' AS geo, 'Africa' AS region, 'Southern Africa' AS subregion FROM `chrome-ux-report.country_ls.201907` UNION ALL

--- a/sql/2019/performance/07_04d.sql
+++ b/sql/2019/performance/07_04d.sql
@@ -52,7 +52,7 @@ WITH geos AS (
   SELECT *, 'cd' AS geo_code, 'Congo (Democratic Republic of the)' AS geo, 'Africa' AS region, 'Middle Africa' AS subregion FROM `chrome-ux-report.country_cd.201907` UNION ALL
   SELECT *, 'ck' AS geo_code, 'Cook Islands' AS geo, 'Oceania' AS region, 'Polynesia' AS subregion FROM `chrome-ux-report.country_ck.201907` UNION ALL
   SELECT *, 'cr' AS geo_code, 'Costa Rica' AS geo, 'Americas' AS region, 'Central America' AS subregion FROM `chrome-ux-report.country_cr.201907` UNION ALL
-  SELECT *, 'ci' AS geo_code, 'Côte d\'Ivoire' AS geo, 'Africa' AS region, 'Western Africa' AS subregion FROM `chrome-ux-report.country_ci.201907` UNION ALL
+  SELECT *, 'ci' AS geo_code, "Côte d'Ivoire" AS geo, 'Africa' AS region, 'Western Africa' AS subregion FROM `chrome-ux-report.country_ci.201907` UNION ALL
   SELECT *, 'hr' AS geo_code, 'Croatia' AS geo, 'Europe' AS region, 'Southern Europe' AS subregion FROM `chrome-ux-report.country_hr.201907` UNION ALL
   SELECT *, 'cu' AS geo_code, 'Cuba' AS geo, 'Americas' AS region, 'Caribbean' AS subregion FROM `chrome-ux-report.country_cu.201907` UNION ALL
   SELECT *, 'cw' AS geo_code, 'Curaçao' AS geo, 'Americas' AS region, 'Caribbean' AS subregion FROM `chrome-ux-report.country_cw.201907` UNION ALL
@@ -112,11 +112,11 @@ WITH geos AS (
   SELECT *, 'kz' AS geo_code, 'Kazakhstan' AS geo, 'Asia' AS region, 'Central Asia' AS subregion FROM `chrome-ux-report.country_kz.201907` UNION ALL
   SELECT *, 'ke' AS geo_code, 'Kenya' AS geo, 'Africa' AS region, 'Eastern Africa' AS subregion FROM `chrome-ux-report.country_ke.201907` UNION ALL
   SELECT *, 'ki' AS geo_code, 'Kiribati' AS geo, 'Oceania' AS region, 'Micronesia' AS subregion FROM `chrome-ux-report.country_ki.201907` UNION ALL
-  SELECT *, 'kp' AS geo_code, 'Korea (Democratic People\'s Republic of)' AS geo, 'Asia' AS region, 'Eastern Asia' AS subregion FROM `chrome-ux-report.country_kp.201907` UNION ALL
+  SELECT *, 'kp' AS geo_code, "Korea (Democratic People's Republic of)" AS geo, 'Asia' AS region, 'Eastern Asia' AS subregion FROM `chrome-ux-report.country_kp.201907` UNION ALL
   SELECT *, 'kr' AS geo_code, 'Korea (Republic of)' AS geo, 'Asia' AS region, 'Eastern Asia' AS subregion FROM `chrome-ux-report.country_kr.201907` UNION ALL
   SELECT *, 'kw' AS geo_code, 'Kuwait' AS geo, 'Asia' AS region, 'Western Asia' AS subregion FROM `chrome-ux-report.country_kw.201907` UNION ALL
   SELECT *, 'kg' AS geo_code, 'Kyrgyzstan' AS geo, 'Asia' AS region, 'Central Asia' AS subregion FROM `chrome-ux-report.country_kg.201907` UNION ALL
-  SELECT *, 'la' AS geo_code, 'Lao People\'s Democratic Republic' AS geo, 'Asia' AS region, 'South-Eastern Asia' AS subregion FROM `chrome-ux-report.country_la.201907` UNION ALL
+  SELECT *, 'la' AS geo_code, "Lao People's Democratic Republic" AS geo, 'Asia' AS region, 'South-Eastern Asia' AS subregion FROM `chrome-ux-report.country_la.201907` UNION ALL
   SELECT *, 'lv' AS geo_code, 'Latvia' AS geo, 'Europe' AS region, 'Northern Europe' AS subregion FROM `chrome-ux-report.country_lv.201907` UNION ALL
   SELECT *, 'lb' AS geo_code, 'Lebanon' AS geo, 'Asia' AS region, 'Western Asia' AS subregion FROM `chrome-ux-report.country_lb.201907` UNION ALL
   SELECT *, 'ls' AS geo_code, 'Lesotho' AS geo, 'Africa' AS region, 'Southern Africa' AS subregion FROM `chrome-ux-report.country_ls.201907` UNION ALL

--- a/sql/2019/performance/07_05d.sql
+++ b/sql/2019/performance/07_05d.sql
@@ -52,7 +52,7 @@ WITH geos AS (
   SELECT *, 'cd' AS geo_code, 'Congo (Democratic Republic of the)' AS geo, 'Africa' AS region, 'Middle Africa' AS subregion FROM `chrome-ux-report.country_cd.201907` UNION ALL
   SELECT *, 'ck' AS geo_code, 'Cook Islands' AS geo, 'Oceania' AS region, 'Polynesia' AS subregion FROM `chrome-ux-report.country_ck.201907` UNION ALL
   SELECT *, 'cr' AS geo_code, 'Costa Rica' AS geo, 'Americas' AS region, 'Central America' AS subregion FROM `chrome-ux-report.country_cr.201907` UNION ALL
-  SELECT *, 'ci' AS geo_code, 'Côte d\'Ivoire' AS geo, 'Africa' AS region, 'Western Africa' AS subregion FROM `chrome-ux-report.country_ci.201907` UNION ALL
+  SELECT *, 'ci' AS geo_code, "Côte d'Ivoire" AS geo, 'Africa' AS region, 'Western Africa' AS subregion FROM `chrome-ux-report.country_ci.201907` UNION ALL
   SELECT *, 'hr' AS geo_code, 'Croatia' AS geo, 'Europe' AS region, 'Southern Europe' AS subregion FROM `chrome-ux-report.country_hr.201907` UNION ALL
   SELECT *, 'cu' AS geo_code, 'Cuba' AS geo, 'Americas' AS region, 'Caribbean' AS subregion FROM `chrome-ux-report.country_cu.201907` UNION ALL
   SELECT *, 'cw' AS geo_code, 'Curaçao' AS geo, 'Americas' AS region, 'Caribbean' AS subregion FROM `chrome-ux-report.country_cw.201907` UNION ALL
@@ -112,11 +112,11 @@ WITH geos AS (
   SELECT *, 'kz' AS geo_code, 'Kazakhstan' AS geo, 'Asia' AS region, 'Central Asia' AS subregion FROM `chrome-ux-report.country_kz.201907` UNION ALL
   SELECT *, 'ke' AS geo_code, 'Kenya' AS geo, 'Africa' AS region, 'Eastern Africa' AS subregion FROM `chrome-ux-report.country_ke.201907` UNION ALL
   SELECT *, 'ki' AS geo_code, 'Kiribati' AS geo, 'Oceania' AS region, 'Micronesia' AS subregion FROM `chrome-ux-report.country_ki.201907` UNION ALL
-  SELECT *, 'kp' AS geo_code, 'Korea (Democratic People\'s Republic of)' AS geo, 'Asia' AS region, 'Eastern Asia' AS subregion FROM `chrome-ux-report.country_kp.201907` UNION ALL
+  SELECT *, 'kp' AS geo_code, "Korea (Democratic People's Republic of)" AS geo, 'Asia' AS region, 'Eastern Asia' AS subregion FROM `chrome-ux-report.country_kp.201907` UNION ALL
   SELECT *, 'kr' AS geo_code, 'Korea (Republic of)' AS geo, 'Asia' AS region, 'Eastern Asia' AS subregion FROM `chrome-ux-report.country_kr.201907` UNION ALL
   SELECT *, 'kw' AS geo_code, 'Kuwait' AS geo, 'Asia' AS region, 'Western Asia' AS subregion FROM `chrome-ux-report.country_kw.201907` UNION ALL
   SELECT *, 'kg' AS geo_code, 'Kyrgyzstan' AS geo, 'Asia' AS region, 'Central Asia' AS subregion FROM `chrome-ux-report.country_kg.201907` UNION ALL
-  SELECT *, 'la' AS geo_code, 'Lao People\'s Democratic Republic' AS geo, 'Asia' AS region, 'South-Eastern Asia' AS subregion FROM `chrome-ux-report.country_la.201907` UNION ALL
+  SELECT *, 'la' AS geo_code, "Lao People's Democratic Republic" AS geo, 'Asia' AS region, 'South-Eastern Asia' AS subregion FROM `chrome-ux-report.country_la.201907` UNION ALL
   SELECT *, 'lv' AS geo_code, 'Latvia' AS geo, 'Europe' AS region, 'Northern Europe' AS subregion FROM `chrome-ux-report.country_lv.201907` UNION ALL
   SELECT *, 'lb' AS geo_code, 'Lebanon' AS geo, 'Asia' AS region, 'Western Asia' AS subregion FROM `chrome-ux-report.country_lb.201907` UNION ALL
   SELECT *, 'ls' AS geo_code, 'Lesotho' AS geo, 'Africa' AS region, 'Southern Africa' AS subregion FROM `chrome-ux-report.country_ls.201907` UNION ALL

--- a/sql/2019/performance/07_08d.sql
+++ b/sql/2019/performance/07_08d.sql
@@ -52,7 +52,7 @@ WITH geos AS (
   SELECT *, 'cd' AS geo_code, 'Congo (Democratic Republic of the)' AS geo, 'Africa' AS region, 'Middle Africa' AS subregion FROM `chrome-ux-report.country_cd.201907` UNION ALL
   SELECT *, 'ck' AS geo_code, 'Cook Islands' AS geo, 'Oceania' AS region, 'Polynesia' AS subregion FROM `chrome-ux-report.country_ck.201907` UNION ALL
   SELECT *, 'cr' AS geo_code, 'Costa Rica' AS geo, 'Americas' AS region, 'Central America' AS subregion FROM `chrome-ux-report.country_cr.201907` UNION ALL
-  SELECT *, 'ci' AS geo_code, 'Côte d\'Ivoire' AS geo, 'Africa' AS region, 'Western Africa' AS subregion FROM `chrome-ux-report.country_ci.201907` UNION ALL
+  SELECT *, 'ci' AS geo_code, "Côte d'Ivoire" AS geo, 'Africa' AS region, 'Western Africa' AS subregion FROM `chrome-ux-report.country_ci.201907` UNION ALL
   SELECT *, 'hr' AS geo_code, 'Croatia' AS geo, 'Europe' AS region, 'Southern Europe' AS subregion FROM `chrome-ux-report.country_hr.201907` UNION ALL
   SELECT *, 'cu' AS geo_code, 'Cuba' AS geo, 'Americas' AS region, 'Caribbean' AS subregion FROM `chrome-ux-report.country_cu.201907` UNION ALL
   SELECT *, 'cw' AS geo_code, 'Curaçao' AS geo, 'Americas' AS region, 'Caribbean' AS subregion FROM `chrome-ux-report.country_cw.201907` UNION ALL
@@ -112,11 +112,11 @@ WITH geos AS (
   SELECT *, 'kz' AS geo_code, 'Kazakhstan' AS geo, 'Asia' AS region, 'Central Asia' AS subregion FROM `chrome-ux-report.country_kz.201907` UNION ALL
   SELECT *, 'ke' AS geo_code, 'Kenya' AS geo, 'Africa' AS region, 'Eastern Africa' AS subregion FROM `chrome-ux-report.country_ke.201907` UNION ALL
   SELECT *, 'ki' AS geo_code, 'Kiribati' AS geo, 'Oceania' AS region, 'Micronesia' AS subregion FROM `chrome-ux-report.country_ki.201907` UNION ALL
-  SELECT *, 'kp' AS geo_code, 'Korea (Democratic People\'s Republic of)' AS geo, 'Asia' AS region, 'Eastern Asia' AS subregion FROM `chrome-ux-report.country_kp.201907` UNION ALL
+  SELECT *, 'kp' AS geo_code, "Korea (Democratic People's Republic of)" AS geo, 'Asia' AS region, 'Eastern Asia' AS subregion FROM `chrome-ux-report.country_kp.201907` UNION ALL
   SELECT *, 'kr' AS geo_code, 'Korea (Republic of)' AS geo, 'Asia' AS region, 'Eastern Asia' AS subregion FROM `chrome-ux-report.country_kr.201907` UNION ALL
   SELECT *, 'kw' AS geo_code, 'Kuwait' AS geo, 'Asia' AS region, 'Western Asia' AS subregion FROM `chrome-ux-report.country_kw.201907` UNION ALL
   SELECT *, 'kg' AS geo_code, 'Kyrgyzstan' AS geo, 'Asia' AS region, 'Central Asia' AS subregion FROM `chrome-ux-report.country_kg.201907` UNION ALL
-  SELECT *, 'la' AS geo_code, 'Lao People\'s Democratic Republic' AS geo, 'Asia' AS region, 'South-Eastern Asia' AS subregion FROM `chrome-ux-report.country_la.201907` UNION ALL
+  SELECT *, 'la' AS geo_code, "Lao People's Democratic Republic" AS geo, 'Asia' AS region, 'South-Eastern Asia' AS subregion FROM `chrome-ux-report.country_la.201907` UNION ALL
   SELECT *, 'lv' AS geo_code, 'Latvia' AS geo, 'Europe' AS region, 'Northern Europe' AS subregion FROM `chrome-ux-report.country_lv.201907` UNION ALL
   SELECT *, 'lb' AS geo_code, 'Lebanon' AS geo, 'Asia' AS region, 'Western Asia' AS subregion FROM `chrome-ux-report.country_lb.201907` UNION ALL
   SELECT *, 'ls' AS geo_code, 'Lesotho' AS geo, 'Africa' AS region, 'Southern Africa' AS subregion FROM `chrome-ux-report.country_ls.201907` UNION ALL

--- a/sql/2019/performance/07_15.sql
+++ b/sql/2019/performance/07_15.sql
@@ -6,7 +6,7 @@ SELECT
   ROUND(APPROX_QUANTILES(first_cpu_idle, 1000)[OFFSET(percentile * 10)] / 1000, 2) AS first_cpu_idle
 FROM (
   SELECT
-    CAST(IFNULL(JSON_EXTRACT(report, "$.audits.first-interactive.numericValue"), JSON_EXTRACT(report, "$.audits.first-cpu-idle.numericValue")) AS FLOAT64) AS first_cpu_idle
+    CAST(IFNULL(JSON_EXTRACT(report, '$.audits.first-interactive.numericValue'), JSON_EXTRACT(report, '$.audits.first-cpu-idle.numericValue')) AS FLOAT64) AS first_cpu_idle
   FROM
     `httparchive.lighthouse.2019_07_01_mobile`),
   UNNEST([10, 25, 50, 75, 90]) AS percentile

--- a/sql/2019/performance/07_16.sql
+++ b/sql/2019/performance/07_16.sql
@@ -6,7 +6,7 @@ SELECT
   ROUND(APPROX_QUANTILES(tti, 1000)[OFFSET(percentile * 10)] / 1000, 2) AS tti
 FROM (
   SELECT
-    CAST(IFNULL(JSON_EXTRACT(report, "$.audits.consistently-interactive.numericValue"), JSON_EXTRACT(report, "$.audits.interactive.numericValue")) AS FLOAT64) AS tti
+    CAST(IFNULL(JSON_EXTRACT(report, '$.audits.consistently-interactive.numericValue'), JSON_EXTRACT(report, '$.audits.interactive.numericValue')) AS FLOAT64) AS tti
   FROM
     `httparchive.lighthouse.2019_07_01_mobile`),
   UNNEST([10, 25, 50, 75, 90]) AS percentile

--- a/sql/2019/performance/07_20.sql
+++ b/sql/2019/performance/07_20.sql
@@ -9,16 +9,16 @@ FROM (
   SELECT
     _TABLE_SUFFIX AS client,
     (
-      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.EvaluateScript']"), "0") AS INT64) +
-      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.XHRLoad']"), "0") AS INT64) +
-      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.XHRReadyStateChange']"), "0") AS INT64) +
-      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.TimerFire']"), "0") AS INT64) +
-      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.EventDispatch']"), "0") AS INT64) +
-      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.FunctionCall']"), "0") AS INT64) +
-      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.v8.compile']"), "0") AS INT64) +
-      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.MinorGC']"), "0") AS INT64) +
-      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.FireAnimationFrame']"), "0") AS INT64) +
-      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.MajorGC']"), "0") AS INT64)
+      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.EvaluateScript']"), '0') AS INT64) +
+      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.XHRLoad']"), '0') AS INT64) +
+      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.XHRReadyStateChange']"), '0') AS INT64) +
+      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.TimerFire']"), '0') AS INT64) +
+      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.EventDispatch']"), '0') AS INT64) +
+      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.FunctionCall']"), '0') AS INT64) +
+      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.v8.compile']"), '0') AS INT64) +
+      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.MinorGC']"), '0') AS INT64) +
+      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.FireAnimationFrame']"), '0') AS INT64) +
+      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.MajorGC']"), '0') AS INT64)
     ) AS script_cpu_time
   FROM
     `httparchive.pages.2019_07_01_*`),

--- a/sql/2019/performance/07_21.sql
+++ b/sql/2019/performance/07_21.sql
@@ -9,9 +9,9 @@ FROM (
   SELECT
     _TABLE_SUFFIX AS client,
     (
-      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.ParseAuthorStyleSheet']"), "0") AS INT64) +
-      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.Layout']"), "0") AS INT64) +
-      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.UpdateLayoutTree']"), "0") AS INT64)
+      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.ParseAuthorStyleSheet']"), '0') AS INT64) +
+      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.Layout']"), '0') AS INT64) +
+      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.UpdateLayoutTree']"), '0') AS INT64)
     ) AS layout_cpu_time
   FROM
     `httparchive.pages.2019_07_01_*`),

--- a/sql/2019/performance/07_22.sql
+++ b/sql/2019/performance/07_22.sql
@@ -9,8 +9,8 @@ FROM (
   SELECT
     _TABLE_SUFFIX AS client,
     (
-      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.Paint']"), "0") AS INT64) +
-      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.UpdateLayerTree']"), "0") AS INT64)
+      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.Paint']"), '0') AS INT64) +
+      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.UpdateLayerTree']"), '0') AS INT64)
     ) AS paint_cpu_time
   FROM
     `httparchive.pages.2019_07_01_*`),

--- a/sql/2019/performance/07_23.sql
+++ b/sql/2019/performance/07_23.sql
@@ -9,7 +9,7 @@ FROM (
   SELECT
     _TABLE_SUFFIX AS client,
     (
-      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.ParseHTML']"), "0") AS INT64)
+      CAST(IFNULL(JSON_EXTRACT(payload, "$['_cpu.ParseHTML']"), '0') AS INT64)
     ) AS loading_cpu_time
   FROM
     `httparchive.pages.2019_07_01_*`),

--- a/sql/2019/security/08_03-04.sql
+++ b/sql/2019/security/08_03-04.sql
@@ -1,7 +1,7 @@
 #standardSQL
 # 08_03: and 08_04: - RSA and ECDSA certificates
 CREATE TEMPORARY FUNCTION getHexCert(cert STRING) RETURNS STRING AS (
-  TO_HEX(FROM_BASE64(REPLACE(REGEXP_REPLACE(cert, "-----(BEGIN|END) CERTIFICATE-----", ""), "\n", "")))
+  TO_HEX(FROM_BASE64(REPLACE(REGEXP_REPLACE(cert, '-----(BEGIN|END) CERTIFICATE-----', ''), '\n', '')))
 );
 
 SELECT
@@ -15,11 +15,11 @@ FROM (
   SELECT
     client,
     COUNTIF(IF(tls13,
-      getHexCert(cert) LIKE "%2a8648ce3d0201%",
+      getHexCert(cert) LIKE '%2a8648ce3d0201%',
       REGEXP_CONTAINS(key_exchange, r'ECDSA')
     )) AS is_ecdsa,
     COUNTIF(IF(tls13,
-      getHexCert(cert) LIKE "%2a864886f70d010101%",
+      getHexCert(cert) LIKE '%2a864886f70d010101%',
       REGEXP_CONTAINS(key_exchange, r'RSA')
     )) AS is_rsa,
     COUNT(0) AS total

--- a/sql/2019/security/08_14.sql
+++ b/sql/2019/security/08_14.sql
@@ -14,8 +14,8 @@ FROM (
     client,
     COUNT(0) AS total,
     COUNTIF(REGEXP_CONTAINS(LOWER(respOtherHeaders), r'frame-ancestors') AND REGEXP_CONTAINS(LOWER(respOtherHeaders), 'content-security-policy =')) AS csp_frame_ancestors_count,
-    COUNTIF(REGEXP_CONTAINS(LOWER(respOtherHeaders), r'content-security-policy =') AND ENDS_WITH(REGEXP_EXTRACT(respOtherHeaders, r'(?i)\Wframe-ancestors([^,|;]+)'), '\'none\'')) AS csp_frame_ancestors_none_count,
-    COUNTIF(REGEXP_CONTAINS(LOWER(respOtherHeaders), r'content-security-policy =') AND ENDS_WITH(REGEXP_EXTRACT(respOtherHeaders, r'(?i)\Wframe-ancestors([^,|;]+)'), '\'self\'')) AS csp_frame_ancestors_self_count
+    COUNTIF(REGEXP_CONTAINS(LOWER(respOtherHeaders), r'content-security-policy =') AND ENDS_WITH(REGEXP_EXTRACT(respOtherHeaders, r'(?i)\Wframe-ancestors([^,|;]+)'), "'none'")) AS csp_frame_ancestors_none_count,
+    COUNTIF(REGEXP_CONTAINS(LOWER(respOtherHeaders), r'content-security-policy =') AND ENDS_WITH(REGEXP_EXTRACT(respOtherHeaders, r'(?i)\Wframe-ancestors([^,|;]+)'), "'self'")) AS csp_frame_ancestors_self_count
   FROM
     `httparchive.almanac.requests`
   WHERE

--- a/sql/2020/accessibility/lighthouse_a11y_audits.sql
+++ b/sql/2020/accessibility/lighthouse_a11y_audits.sql
@@ -32,7 +32,7 @@ SELECT
   MAX(audits.description) AS description
 FROM
   `httparchive.lighthouse.2020_08_01_mobile`,
-  UNNEST(getAudits(report, "accessibility")) AS audits
+  UNNEST(getAudits(report, 'accessibility')) AS audits
 WHERE
   LENGTH(report) < 20000000  # necessary to avoid out of memory issues. Excludes 16 very large results
 GROUP BY

--- a/sql/2020/caching/appcache_and_serviceworkers.sql
+++ b/sql/2020/caching/appcache_and_serviceworkers.sql
@@ -2,8 +2,8 @@
 # Use of AppCache and ServiceWorkers
 SELECT
   IF(STARTS_WITH(url, 'https'), 'https', 'http') AS http_type,
-  JSON_EXTRACT_SCALAR(report, "$.audits.appcache-manifest.score") AS using_appcache,
-  JSON_EXTRACT_SCALAR(report, "$.audits.service-worker.score") AS using_serviceworkers,
+  JSON_EXTRACT_SCALAR(report, '$.audits.appcache-manifest.score') AS using_appcache,
+  JSON_EXTRACT_SCALAR(report, '$.audits.service-worker.score') AS using_serviceworkers,
   COUNT(0) AS occurrences,
   SUM(COUNT(0)) OVER () AS total,
   COUNT(0) / SUM(COUNT(0)) OVER () AS pct

--- a/sql/2020/caching/appcache_and_serviceworkers_2019.sql
+++ b/sql/2020/caching/appcache_and_serviceworkers_2019.sql
@@ -2,8 +2,8 @@
 # Use of AppCache and ServiceWorkers
 SELECT
   IF(STARTS_WITH(url, 'https'), 'https', 'http') AS http_type,
-  JSON_EXTRACT_SCALAR(report, "$.audits.appcache-manifest.score") AS using_appcache,
-  JSON_EXTRACT_SCALAR(report, "$.audits.service-worker.score") AS using_serviceworkers,
+  JSON_EXTRACT_SCALAR(report, '$.audits.appcache-manifest.score') AS using_appcache,
+  JSON_EXTRACT_SCALAR(report, '$.audits.service-worker.score') AS using_serviceworkers,
   COUNT(0) AS occurrences,
   SUM(COUNT(0)) OVER () AS total,
   COUNT(0) / SUM(COUNT(0)) OVER () AS pct

--- a/sql/2020/caching/cache_control_and_max_age_and_expires.sql
+++ b/sql/2020/caching/cache_control_and_max_age_and_expires.sql
@@ -22,8 +22,8 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    TRIM(resp_expires) != "" AS uses_expires,
-    TRIM(resp_cache_control) != "" AS uses_cache_control,
+    TRIM(resp_expires) != '' AS uses_expires,
+    TRIM(resp_cache_control) != '' AS uses_cache_control,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)max-age\s*=\s*[0-9]+') AS uses_max_age
   FROM
     `httparchive.summary_requests.2020_08_01_*`

--- a/sql/2020/caching/cache_control_and_max_age_and_expires_2019.sql
+++ b/sql/2020/caching/cache_control_and_max_age_and_expires_2019.sql
@@ -22,8 +22,8 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    TRIM(resp_expires) != "" AS uses_expires,
-    TRIM(resp_cache_control) != "" AS uses_cache_control,
+    TRIM(resp_expires) != '' AS uses_expires,
+    TRIM(resp_cache_control) != '' AS uses_cache_control,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)max-age\s*=\s*[0-9]+') AS uses_max_age
   FROM
     `httparchive.summary_requests.2019_07_01_*`

--- a/sql/2020/caching/cache_control_directives.sql
+++ b/sql/2020/caching/cache_control_directives.sql
@@ -48,7 +48,7 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    TRIM(resp_cache_control) != "" AS uses_cache_control,
+    TRIM(resp_cache_control) != '' AS uses_cache_control,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)max-age\s*=\s*[0-9]+') AS uses_max_age,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)max-age\s*=\s*0') AS uses_max_age_zero,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)public') AS uses_public,

--- a/sql/2020/caching/cache_ttl_and_content_age_diff.sql
+++ b/sql/2020/caching/cache_ttl_and_content_age_diff.sql
@@ -22,7 +22,7 @@ FROM
     FROM
       `httparchive.summary_requests.2020_08_01_*`
     WHERE
-      resp_last_modified != "" AND
+      resp_last_modified != '' AND
       expAge > 0
   ),
   UNNEST([10, 25, 50, 75, 90]) AS percentile

--- a/sql/2020/caching/cache_ttl_lighthouse_score.sql
+++ b/sql/2020/caching/cache_ttl_lighthouse_score.sql
@@ -2,7 +2,7 @@
 # Distribution of cache TTL Lighthouse scores
 SELECT
   _TABLE_SUFFIX AS client,
-  JSON_EXTRACT_SCALAR(report, "$.audits.uses-long-cache-ttl.score") AS caching_score,
+  JSON_EXTRACT_SCALAR(report, '$.audits.uses-long-cache-ttl.score') AS caching_score,
   COUNT(0) AS num_pages,
   SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS total,
   COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct_pages

--- a/sql/2020/caching/cache_wastedbytes_lighthouse.sql
+++ b/sql/2020/caching/cache_wastedbytes_lighthouse.sql
@@ -2,14 +2,14 @@
 # Distribution of bytes wasted (absence of adequate caching) from Lighthouse
 SELECT
   _TABLE_SUFFIX AS client,
-  ROUND(CAST(JSON_EXTRACT_SCALAR(report, "$.audits.uses-long-cache-ttl.details.summary.wastedBytes") AS NUMERIC) / 1024 / 1024) AS mbyte_savings,
+  ROUND(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.uses-long-cache-ttl.details.summary.wastedBytes') AS NUMERIC) / 1024 / 1024) AS mbyte_savings,
   COUNT(0) AS num_pages,
   SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS total,
   COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct_pages
 FROM
   `httparchive.lighthouse.2020_08_01_*`
 WHERE
-  JSON_EXTRACT_SCALAR(report, "$.audits.uses-long-cache-ttl.score") != "1"
+  JSON_EXTRACT_SCALAR(report, '$.audits.uses-long-cache-ttl.score') != '1'
 GROUP BY
   client,
   mbyte_savings

--- a/sql/2020/caching/content_age_older_than_ttl.sql
+++ b/sql/2020/caching/content_age_older_than_ttl.sql
@@ -23,7 +23,7 @@ FROM
     FROM
       `httparchive.summary_requests.2020_08_01_*`
     WHERE
-      resp_last_modified != "" AND
+      resp_last_modified != '' AND
       expAge > 0
   )
 GROUP BY

--- a/sql/2020/caching/content_age_older_than_ttl_by_party.sql
+++ b/sql/2020/caching/content_age_older_than_ttl_by_party.sql
@@ -19,7 +19,7 @@ SELECT
 FROM
   (
     SELECT
-      "desktop" AS client,
+      'desktop' AS client,
       IF(NET.HOST(url) IN (
         SELECT domain FROM `httparchive.almanac.third_parties` WHERE date = '2020-08-01' AND category != 'hosting'
       ), 'third party', 'first party') AS party,
@@ -27,11 +27,11 @@ FROM
     FROM
       `httparchive.summary_requests.2020_08_01_desktop` requests
     WHERE
-      TRIM(requests.resp_last_modified) != "" AND
+      TRIM(requests.resp_last_modified) != '' AND
       expAge > 0
     UNION ALL
     SELECT
-      "mobile" AS client,
+      'mobile' AS client,
       IF(NET.HOST(url) IN (
         SELECT domain FROM `httparchive.almanac.third_parties` WHERE date = '2020-08-01' AND category != 'hosting'
       ), 'third party', 'first party') AS party,
@@ -39,7 +39,7 @@ FROM
     FROM
       `httparchive.summary_requests.2020_08_01_mobile` requests
     WHERE
-      TRIM(requests.resp_last_modified) != "" AND
+      TRIM(requests.resp_last_modified) != '' AND
       expAge > 0
   )
 GROUP BY

--- a/sql/2020/caching/invalid_cache_control_directives.sql
+++ b/sql/2020/caching/invalid_cache_control_directives.sql
@@ -12,7 +12,7 @@ FROM
   (
     (
       SELECT
-        "desktop" AS client,
+        'desktop' AS client,
         total_requests,
         total_using_cache_control,
         directive_name,
@@ -25,7 +25,7 @@ FROM
       CROSS JOIN (
         SELECT
           COUNT(0) AS total_requests,
-          COUNTIF(TRIM(resp_cache_control) != "") AS total_using_cache_control
+          COUNTIF(TRIM(resp_cache_control) != '') AS total_using_cache_control
         FROM
           `httparchive.summary_requests.2020_08_01_desktop`
       )
@@ -38,7 +38,7 @@ FROM
     UNION ALL
     (
       SELECT
-        "mobile" AS client,
+        'mobile' AS client,
         total_requests,
         total_using_cache_control,
         directive_name,
@@ -51,7 +51,7 @@ FROM
       CROSS JOIN (
         SELECT
           COUNT(0) AS total_requests,
-          COUNTIF(TRIM(resp_cache_control) != "") AS total_using_cache_control
+          COUNTIF(TRIM(resp_cache_control) != '') AS total_using_cache_control
         FROM
           `httparchive.summary_requests.2020_08_01_mobile`
       )

--- a/sql/2020/caching/invalid_last_modified_and_expires_and_date.sql
+++ b/sql/2020/caching/invalid_last_modified_and_expires_and_date.sql
@@ -18,9 +18,9 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    TRIM(resp_date) != "" AS uses_date,
-    TRIM(resp_last_modified) != "" AS uses_last_modified,
-    TRIM(resp_expires) != "" AS uses_expires,
+    TRIM(resp_date) != '' AS uses_date,
+    TRIM(resp_last_modified) != '' AS uses_last_modified,
+    TRIM(resp_expires) != '' AS uses_expires,
     REGEXP_CONTAINS(TRIM(resp_date), r'^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{1,2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT$') AS has_valid_date,
     REGEXP_CONTAINS(TRIM(resp_last_modified), r'^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{1,2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT$') AS has_valid_last_modified,
     REGEXP_CONTAINS(TRIM(resp_expires), r'^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{1,2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT$') AS has_valid_expires

--- a/sql/2020/caching/last_modified_and_etag.sql
+++ b/sql/2020/caching/last_modified_and_etag.sql
@@ -22,11 +22,11 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    TRIM(resp_etag) = "" AS uses_no_etag,
-    TRIM(resp_etag) != "" AS uses_etag,
-    TRIM(resp_last_modified) != "" AS uses_last_modified,
-    REGEXP_CONTAINS(TRIM(resp_etag), '^W/\".*\"') AS uses_weak_etag,
-    REGEXP_CONTAINS(TRIM(resp_etag), '^\".*\"') AS uses_strong_etag
+    TRIM(resp_etag) = '' AS uses_no_etag,
+    TRIM(resp_etag) != '' AS uses_etag,
+    TRIM(resp_last_modified) != '' AS uses_last_modified,
+    REGEXP_CONTAINS(TRIM(resp_etag), '^W/".*"') AS uses_weak_etag,
+    REGEXP_CONTAINS(TRIM(resp_etag), '^".*"') AS uses_strong_etag
   FROM
     `httparchive.summary_requests.2020_08_01_*`
 )

--- a/sql/2020/caching/last_modified_and_etag_2019.sql
+++ b/sql/2020/caching/last_modified_and_etag_2019.sql
@@ -22,11 +22,11 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    TRIM(resp_etag) = "" AS uses_no_etag,
-    TRIM(resp_etag) != "" AS uses_etag,
-    TRIM(resp_last_modified) != "" AS uses_last_modified,
-    REGEXP_CONTAINS(TRIM(resp_etag), '^W/\".*\"') AS uses_weak_etag,
-    REGEXP_CONTAINS(TRIM(resp_etag), '^\".*\"') AS uses_strong_etag
+    TRIM(resp_etag) = '' AS uses_no_etag,
+    TRIM(resp_etag) != '' AS uses_etag,
+    TRIM(resp_last_modified) != '' AS uses_last_modified,
+    REGEXP_CONTAINS(TRIM(resp_etag), '^W/".*"') AS uses_weak_etag,
+    REGEXP_CONTAINS(TRIM(resp_etag), '^".*"') AS uses_strong_etag
   FROM
     `httparchive.summary_requests.2019_07_01_*`
 )

--- a/sql/2020/caching/non_cacheable_by_resource_type.sql
+++ b/sql/2020/caching/non_cacheable_by_resource_type.sql
@@ -18,8 +18,8 @@ FROM (
   SELECT
     _TABLE_SUFFIX AS client,
     type AS resource_type,
-    TRIM(resp_cache_control) != "" AS uses_cache_control,
-    TRIM(resp_expires) != "" AS uses_expires,
+    TRIM(resp_cache_control) != '' AS uses_cache_control,
+    TRIM(resp_expires) != '' AS uses_expires,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)no-store') AS uses_no_store,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)max-age\s*=\s*[0-9]+') AS uses_max_age,
     expAge AS exp_age

--- a/sql/2020/caching/resource_age_party_and_type_wise.sql
+++ b/sql/2020/caching/resource_age_party_and_type_wise.sql
@@ -22,7 +22,7 @@ FROM
   `httparchive.summary_requests.2020_08_01_*`,
   UNNEST([10, 25, 50, 75, 90]) AS percentile
 WHERE
-  TRIM(resp_last_modified) != ""
+  TRIM(resp_last_modified) != ''
 GROUP BY
   percentile,
   client,

--- a/sql/2020/caching/resource_age_party_and_type_wise_groups.sql
+++ b/sql/2020/caching/resource_age_party_and_type_wise_groups.sql
@@ -40,7 +40,7 @@ FROM
     FROM
       `httparchive.summary_requests.2020_08_01_*`
     WHERE
-      TRIM(resp_last_modified) != ""
+      TRIM(resp_last_modified) != ''
   )
 GROUP BY
   client,

--- a/sql/2020/caching/ttl.sql
+++ b/sql/2020/caching/ttl.sql
@@ -16,8 +16,8 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    TRIM(resp_cache_control) != "" AS uses_cache_control,
-    TRIM(resp_expires) != "" AS uses_expires,
+    TRIM(resp_cache_control) != '' AS uses_cache_control,
+    TRIM(resp_expires) != '' AS uses_expires,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)no-store') AS uses_no_store,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)max-age\s*=\s*[0-9]+') AS uses_max_age,
     expAge AS exp_age

--- a/sql/2020/caching/valid_if_modified_since_returns_304.sql
+++ b/sql/2020/caching/valid_if_modified_since_returns_304.sql
@@ -14,9 +14,9 @@ FROM (
     _TABLE_SUFFIX AS client,
     status,
     TRIM(resp_last_modified) = TRIM(req_if_modified_since) AS no_change,
-    TRIM(resp_last_modified) != "" AS uses_last_modified,
-    TRIM(req_if_modified_since) != "" AS uses_if_modified,
-    TRIM(resp_etag) != "" AS uses_etag
+    TRIM(resp_last_modified) != '' AS uses_last_modified,
+    TRIM(req_if_modified_since) != '' AS uses_if_modified,
+    TRIM(resp_etag) != '' AS uses_etag
   FROM
     `httparchive.summary_requests.2020_08_01_*`
 )

--- a/sql/2020/caching/valid_if_none_match_returns_304.sql
+++ b/sql/2020/caching/valid_if_none_match_returns_304.sql
@@ -13,8 +13,8 @@ FROM (
     _TABLE_SUFFIX AS client,
     status,
     TRIM(resp_etag) = TRIM(req_if_none_match) AS no_change,
-    TRIM(resp_etag) != "" AS uses_etag,
-    TRIM(req_if_none_match) != "" AS uses_if_non_match
+    TRIM(resp_etag) != '' AS uses_etag,
+    TRIM(req_if_none_match) != '' AS uses_if_non_match
   FROM
     `httparchive.summary_requests.2020_08_01_*`
 )

--- a/sql/2020/caching/vary_headers.sql
+++ b/sql/2020/caching/vary_headers.sql
@@ -14,7 +14,7 @@ FROM
   (
     (
       SELECT
-        "desktop" AS client,
+        'desktop' AS client,
         total_requests,
         total_using_vary,
         total_using_both,
@@ -28,8 +28,8 @@ FROM
       CROSS JOIN (
         SELECT
           COUNT(0) AS total_requests,
-          COUNTIF(TRIM(resp_vary) != "") AS total_using_vary,
-          COUNTIF(TRIM(resp_vary) != "" AND TRIM(resp_cache_control) != "") AS total_using_both
+          COUNTIF(TRIM(resp_vary) != '') AS total_using_vary,
+          COUNTIF(TRIM(resp_vary) != '' AND TRIM(resp_cache_control) != '') AS total_using_both
         FROM
           `httparchive.summary_requests.2020_08_01_desktop`
       )
@@ -43,7 +43,7 @@ FROM
     UNION ALL
     (
       SELECT
-        "mobile" AS client,
+        'mobile' AS client,
         total_requests,
         total_using_vary,
         total_using_both,
@@ -57,8 +57,8 @@ FROM
       CROSS JOIN (
         SELECT
           COUNT(0) AS total_requests,
-          COUNTIF(TRIM(resp_vary) != "") AS total_using_vary,
-          COUNTIF(TRIM(resp_vary) != "" AND TRIM(resp_cache_control) != "") AS total_using_both
+          COUNTIF(TRIM(resp_vary) != '') AS total_using_vary,
+          COUNTIF(TRIM(resp_vary) != '' AND TRIM(resp_cache_control) != '') AS total_using_both
         FROM
           `httparchive.summary_requests.2020_08_01_mobile`
       )

--- a/sql/2020/capabilities/durable_storage_estimate_usage.sql
+++ b/sql/2020/capabilities/durable_storage_estimate_usage.sql
@@ -1,14 +1,14 @@
 #standardSQL
 SELECT
-  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
-  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  REGEXP_REPLACE(yyyymmdd, r'(\d{4})(\d{2})(\d{2})', '\\1_\\2_\\3') AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r'(\d{4})(\d{2})(\d{2})', '\\1-\\2-\\3') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
   ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE
-  id = "1371" OR feature = "DurableStorageEstimate"
+  id = '1371' OR feature = 'DurableStorageEstimate'
 GROUP BY
   date,
   timestamp,

--- a/sql/2020/capabilities/durable_storage_persist_usage.sql
+++ b/sql/2020/capabilities/durable_storage_persist_usage.sql
@@ -1,14 +1,14 @@
 #standardSQL
 SELECT
-  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
-  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  REGEXP_REPLACE(yyyymmdd, r'(\d{4})(\d{2})(\d{2})', '\\1_\\2_\\3') AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r'(\d{4})(\d{2})(\d{2})', '\\1-\\2-\\3') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
   ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE
-  id = "1369" OR feature = "DurableStoragePersist"
+  id = '1369' OR feature = 'DurableStoragePersist'
 GROUP BY
   date,
   timestamp,

--- a/sql/2020/capabilities/get_installed_related_apps_usage.sql
+++ b/sql/2020/capabilities/get_installed_related_apps_usage.sql
@@ -1,14 +1,14 @@
 #standardSQL
 SELECT
-  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
-  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  REGEXP_REPLACE(yyyymmdd, r'(\d{4})(\d{2})(\d{2})', '\\1_\\2_\\3') AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r'(\d{4})(\d{2})(\d{2})', '\\1-\\2-\\3') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
   ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE
-  id = "1870" OR feature = "V8Navigator_GetInstalledRelatedApps_Method"
+  id = '1870' OR feature = 'V8Navigator_GetInstalledRelatedApps_Method'
 GROUP BY
   date,
   timestamp,

--- a/sql/2020/capabilities/periodic_background_sync_usage.sql
+++ b/sql/2020/capabilities/periodic_background_sync_usage.sql
@@ -1,14 +1,14 @@
 #standardSQL
 SELECT
-  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
-  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  REGEXP_REPLACE(yyyymmdd, r'(\d{4})(\d{2})(\d{2})', '\\1_\\2_\\3') AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r'(\d{4})(\d{2})(\d{2})', '\\1-\\2-\\3') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
   ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE
-  id = "2930" OR feature = "PeriodicBackgroundSync"
+  id = '2930' OR feature = 'PeriodicBackgroundSync'
 GROUP BY
   date,
   timestamp,

--- a/sql/2020/capabilities/wake_lock_acquire_screen_lock_usage.sql
+++ b/sql/2020/capabilities/wake_lock_acquire_screen_lock_usage.sql
@@ -1,14 +1,14 @@
 #standardSQL
 SELECT
-  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
-  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  REGEXP_REPLACE(yyyymmdd, r'(\d{4})(\d{2})(\d{2})', '\\1_\\2_\\3') AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r'(\d{4})(\d{2})(\d{2})', '\\1-\\2-\\3') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
   ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE
-  id = "3005" OR feature = "WakeLockAcquireScreenLock"
+  id = '3005' OR feature = 'WakeLockAcquireScreenLock'
 GROUP BY
   date,
   timestamp,

--- a/sql/2020/compression/19_02.byte_saving_of_text_compression.sql
+++ b/sql/2020/compression/19_02.byte_saving_of_text_compression.sql
@@ -2,9 +2,9 @@
 #Text Based Compression Byte Savings
 SELECT
   _TABLE_SUFFIX AS client,
-  IF(JSON_EXTRACT_SCALAR(report, "$.audits.uses-text-compression.score") != "1", 'compression', 'non_compression') AS compression,
+  IF(JSON_EXTRACT_SCALAR(report, '$.audits.uses-text-compression.score') != '1', 'compression', 'non_compression') AS compression,
   percents,
-  APPROX_QUANTILES(( CAST(JSON_EXTRACT_SCALAR(report, "$.audits.uses-text-compression.details.overallSavingsBytes") AS INT64) / 1024), 1000)[OFFSET(percents * 10)] AS kbyte_savings
+  APPROX_QUANTILES(( CAST(JSON_EXTRACT_SCALAR(report, '$.audits.uses-text-compression.details.overallSavingsBytes') AS INT64) / 1024), 1000)[OFFSET(percents * 10)] AS kbyte_savings
 FROM
   `httparchive.lighthouse.2020_08_01_*`,
   unnest([10, 25, 50, 75, 90]) AS percents

--- a/sql/2020/compression/19_04.distribution_of_text_compression_lighthouse.sql
+++ b/sql/2020/compression/19_04.distribution_of_text_compression_lighthouse.sql
@@ -2,7 +2,7 @@
 #Distribution of Text Based Compression Lighthouse Scores
 SELECT
   _TABLE_SUFFIX AS client,
-  JSON_EXTRACT_SCALAR(report, "$.audits.uses-text-compression.score") AS text_compression_score,
+  JSON_EXTRACT_SCALAR(report, '$.audits.uses-text-compression.score') AS text_compression_score,
   COUNT(0) AS num_pages,
   SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS total,
   COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct_pages

--- a/sql/2020/compression/19_05.static_dynamic_compression.sql
+++ b/sql/2020/compression/19_05.static_dynamic_compression.sql
@@ -3,7 +3,7 @@
 SELECT
   client,
   resp_content_encoding,
-  IF(LOWER(resp_cache_control) LIKE "%no-store%", 'dynamic', 'static') AS static_or_dynamic,
+  IF(LOWER(resp_cache_control) LIKE '%no-store%', 'dynamic', 'static') AS static_or_dynamic,
   COUNT(0) AS num_requests,
   SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
   COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct

--- a/sql/2020/ecommerce/webpush_adoption_by_ecommsites.sql
+++ b/sql/2020/ecommerce/webpush_adoption_by_ecommsites.sql
@@ -12,7 +12,7 @@ FROM
 JOIN (
     SELECT DISTINCT
       _TABLE_SUFFIX AS client,
-      RTRIM(url, "/") AS origin
+      RTRIM(url, '/') AS origin
     FROM
       `httparchive.technologies.2020_08_01_*`
     WHERE category = 'Ecommerce')

--- a/sql/2020/ecommerce/webpushstats_ecommsites.sql
+++ b/sql/2020/ecommerce/webpushstats_ecommsites.sql
@@ -38,7 +38,7 @@ FROM
 JOIN (
     SELECT DISTINCT
       _TABLE_SUFFIX AS client,
-      RTRIM(url, "/") AS origin
+      RTRIM(url, '/') AS origin
     FROM
       `httparchive.technologies.2020_08_01_*`
     WHERE category = 'Ecommerce')

--- a/sql/2020/fonts/04_08.font_unicode_range_with_fcp.sql
+++ b/sql/2020/fonts/04_08.font_unicode_range_with_fcp.sql
@@ -29,8 +29,8 @@ try {
 SELECT
   client,
   CASE
-    WHEN unicode != " " THEN "unicode_ranges"
-    ELSE "none"
+    WHEN unicode != ' ' THEN 'unicode_ranges'
+    ELSE 'none'
   END AS use_unicode,
   COUNT(DISTINCT page) AS pages,
   SUM(COUNT(DISTINCT page)) OVER (PARTITION BY client) AS total,

--- a/sql/2020/http/count_of_h2_and_h3_sites_grouped_by_server.sql
+++ b/sql/2020/http/count_of_h2_and_h3_sites_grouped_by_server.sql
@@ -14,10 +14,10 @@ WHERE
   date = '2020-08-01' AND
   firstHtml AND
   (
-    LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/2" OR
-    LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "%quic%" OR
-    LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "h3%" OR
-    LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/3%"
+    LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) LIKE 'http/2' OR
+    LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) LIKE '%quic%' OR
+    LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) LIKE 'h3%' OR
+    LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) LIKE 'http/3%'
   )
 GROUP BY
   client,

--- a/sql/2020/http/count_of_h2_and_h3_sites_using_push.sql
+++ b/sql/2020/http/count_of_h2_and_h3_sites_using_push.sql
@@ -17,10 +17,10 @@ FROM (
   WHERE
     date = '2020-08-01' AND
     (
-      LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/2" OR
-      LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "%quic%" OR
-      LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "h3%" OR
-      LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/3%"
+      LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) LIKE 'http/2' OR
+      LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) LIKE '%quic%' OR
+      LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) LIKE 'h3%' OR
+      LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) LIKE 'http/3%'
     )
 )
 GROUP BY

--- a/sql/2020/http/count_of_non_h2_and_h3_sites_grouped_by_server.sql
+++ b/sql/2020/http/count_of_non_h2_and_h3_sites_grouped_by_server.sql
@@ -13,10 +13,10 @@ FROM
 WHERE
   date = '2020-08-01' AND
   firstHtml AND
-  LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) NOT LIKE "http/2" AND
-  LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) NOT LIKE "%quic%" AND
-  LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) NOT LIKE "h3%" AND
-  LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) NOT LIKE "http/3%"
+  LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) NOT LIKE 'http/2' AND
+  LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) NOT LIKE '%quic%' AND
+  LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) NOT LIKE 'h3%' AND
+  LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) NOT LIKE 'http/3%'
 GROUP BY
   client,
   http_version,

--- a/sql/2020/http/number_of_h2_and_h3_pushed_resources_and_bytes_by_content_type.sql
+++ b/sql/2020/http/number_of_h2_and_h3_pushed_resources_and_bytes_by_content_type.sql
@@ -14,18 +14,18 @@ FROM (
     page,
     JSON_EXTRACT_SCALAR(payload, '$._protocol') AS http_version,
     type,
-    SUM(CAST(JSON_EXTRACT_SCALAR(payload, "$._bytesIn") AS INT64) / 1024) AS kb_transfered,
+    SUM(CAST(JSON_EXTRACT_SCALAR(payload, '$._bytesIn') AS INT64) / 1024) AS kb_transfered,
     COUNT(0) AS num_requests
   FROM
     `httparchive.almanac.requests`
   WHERE
     date = '2020-08-01' AND
-    JSON_EXTRACT_SCALAR(payload, "$._was_pushed") = "1" AND
+    JSON_EXTRACT_SCALAR(payload, '$._was_pushed') = '1' AND
     (
-      LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/2" OR
-      LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "%quic%" OR
-      LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "h3%" OR
-      LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/3%"
+      LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) LIKE 'http/2' OR
+      LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) LIKE '%quic%' OR
+      LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) LIKE 'h3%' OR
+      LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) LIKE 'http/3%'
     )
   GROUP BY
     client,

--- a/sql/2020/http/number_of_h2_and_h3_pushed_resources_and_bytes_transferred.sql
+++ b/sql/2020/http/number_of_h2_and_h3_pushed_resources_and_bytes_transferred.sql
@@ -20,10 +20,10 @@ FROM (
       date = '2020-08-01' AND
       JSON_EXTRACT_SCALAR(payload, '$._was_pushed') = '1' AND
       (
-        LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/2" OR
-        LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "%quic%" OR
-        LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "h3%" OR
-        LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/3%"
+        LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) LIKE 'http/2' OR
+        LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) LIKE '%quic%' OR
+        LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) LIKE 'h3%' OR
+        LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) LIKE 'http/3%'
       )
     GROUP BY
       client,

--- a/sql/2020/http/number_of_http_requests_returning_upgrade_http_header_containing_h2.sql
+++ b/sql/2020/http/number_of_http_requests_returning_upgrade_http_header_containing_h2.sql
@@ -18,13 +18,13 @@ SELECT
   client,
   firstHtml,
   JSON_EXTRACT_SCALAR(payload, '$._protocol') AS http_version,
-  COUNTIF(getUpgradeHeader(payload) LIKE "%h2%") AS num_requests,
+  COUNTIF(getUpgradeHeader(payload) LIKE '%h2%') AS num_requests,
   COUNT(0) AS total
 FROM
   `httparchive.almanac.requests`
 WHERE
   date = '2020-08-01' AND
-  url LIKE "http://%"
+  url LIKE 'http://%'
 GROUP BY
   client,
   firstHtml,

--- a/sql/2020/http/number_of_https_requests_not_using_h2_or_h3_returning_upgrade_http_upgrade_header_containing_h2.sql
+++ b/sql/2020/http/number_of_https_requests_not_using_h2_or_h3_returning_upgrade_http_upgrade_header_containing_h2.sql
@@ -19,17 +19,17 @@ SELECT
   client,
   firstHtml,
   JSON_EXTRACT_SCALAR(payload, '$._protocol') AS http_version,
-  COUNTIF(getUpgradeHeader(payload) LIKE "%h2%") AS num_requests,
+  COUNTIF(getUpgradeHeader(payload) LIKE '%h2%') AS num_requests,
   COUNT(0) AS total
 FROM
   `httparchive.almanac.requests`
 WHERE
   date = '2020-08-01' AND
-  url LIKE "https://%" AND
-  LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) NOT LIKE "http/2" AND
-  LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) NOT LIKE "%quic%" AND
-  LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) NOT LIKE "h3%" AND
-  LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) NOT LIKE "http/3%"
+  url LIKE 'https://%' AND
+  LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) NOT LIKE 'http/2' AND
+  LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) NOT LIKE '%quic%' AND
+  LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) NOT LIKE 'h3%' AND
+  LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) NOT LIKE 'http/3%'
 GROUP BY
   client,
   firstHtml,

--- a/sql/2020/http/number_of_https_requests_using_h2_returning_upgrade_http_header_containing_h2.sql
+++ b/sql/2020/http/number_of_https_requests_using_h2_returning_upgrade_http_header_containing_h2.sql
@@ -19,14 +19,14 @@ SELECT
   client,
   firstHtml,
   JSON_EXTRACT_SCALAR(payload, '$._protocol') AS http_version,
-  COUNTIF(getUpgradeHeader(payload) LIKE "%h2%") AS num_requests,
+  COUNTIF(getUpgradeHeader(payload) LIKE '%h2%') AS num_requests,
   COUNT(0) AS total
 FROM
   `httparchive.almanac.requests`
 WHERE
   date = '2020-08-01' AND
-  url LIKE "https://%" AND
-  JSON_EXTRACT_SCALAR(payload, "$._protocol") = "HTTP/2"
+  url LIKE 'https://%' AND
+  JSON_EXTRACT_SCALAR(payload, '$._protocol') = 'HTTP/2'
 GROUP BY
   client,
   firstHtml,

--- a/sql/2020/http/percentage_of_h2_and_h3_sites_affected_by_cdn_prioritization.sql
+++ b/sql/2020/http/percentage_of_h2_and_h3_sites_affected_by_cdn_prioritization.sql
@@ -3,8 +3,8 @@
 SELECT
   client,
   http_version,
-  IF(pages.cdn = "", "Not using CDN", pages.cdn) AS CDN,
-  IF(prioritization_status IS NOT NULL, prioritization_status, "Unknown") AS prioritizes_correctly,
+  IF(pages.cdn = '', 'Not using CDN', pages.cdn) AS CDN,
+  IF(prioritization_status IS NOT NULL, prioritization_status, 'Unknown') AS prioritizes_correctly,
   COUNT(0) AS num_pages,
   ROUND(COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client), 4) AS pct
 FROM (
@@ -20,10 +20,10 @@ FROM (
       date = '2020-08-01' AND
       firstHtml AND
       (
-        LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/2" OR
-        LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "%quic%" OR
-        LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "h3%" OR
-        LOWER(JSON_EXTRACT_SCALAR(payload, "$._protocol")) LIKE "http/3%"
+        LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) LIKE 'http/2' OR
+        LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) LIKE '%quic%' OR
+        LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) LIKE 'h3%' OR
+        LOWER(JSON_EXTRACT_SCALAR(payload, '$._protocol')) LIKE 'http/3%'
       )
 ) AS pages
 LEFT JOIN

--- a/sql/2020/jamstack/adoption_of_image_formats_in_ssgs.sql
+++ b/sql/2020/jamstack/adoption_of_image_formats_in_ssgs.sql
@@ -23,10 +23,10 @@ JOIN (
   FROM
     `httparchive.technologies.2020_08_01_*`
   WHERE
-    LOWER(category) = "static site generator" OR
-    app = "Next.js" OR
-    app = "Nuxt.js" OR
-    app = "Docusaurus")
+    LOWER(category) = 'static site generator' OR
+    app = 'Next.js' OR
+    app = 'Nuxt.js' OR
+    app = 'Docusaurus')
 USING
   (client, page)
 GROUP BY

--- a/sql/2020/jamstack/core_web_vitals_distribution.sql
+++ b/sql/2020/jamstack/core_web_vitals_distribution.sql
@@ -62,10 +62,10 @@ JOIN (
   FROM
     `httparchive.technologies.2020_08_01_*`
   WHERE
-    LOWER(category) = "static site generator" OR
-    app = "Next.js" OR
-    app = "Nuxt.js" OR
-    app = "Docusaurus"
+    LOWER(category) = 'static site generator' OR
+    app = 'Next.js' OR
+    app = 'Nuxt.js' OR
+    app = 'Docusaurus'
   )
 USING (client, url)
 WHERE

--- a/sql/2020/jamstack/core_web_vitals_passing.sql
+++ b/sql/2020/jamstack/core_web_vitals_passing.sql
@@ -82,10 +82,10 @@ JOIN (
   FROM
     `httparchive.technologies.2020_08_01_*`
   WHERE
-    LOWER(category) = "static site generator" OR
-    app = "Next.js" OR
-    app = "Nuxt.js" OR
-    app = "Docusaurus"
+    LOWER(category) = 'static site generator' OR
+    app = 'Next.js' OR
+    app = 'Nuxt.js' OR
+    app = 'Docusaurus'
   )
 USING (client, url)
 WHERE

--- a/sql/2020/jamstack/distribution_of_page_weight_requests_and_co2_grams_per_ssg_web_page.sql
+++ b/sql/2020/jamstack/distribution_of_page_weight_requests_and_co2_grams_per_ssg_web_page.sql
@@ -41,10 +41,10 @@ FROM (
     FROM
       `httparchive.technologies.2020_08_01_*`
     WHERE
-      LOWER(category) = "static site generator" OR
-      app = "Next.js" OR
-      app = "Nuxt.js" OR
-      app = "Docusaurus"
+      LOWER(category) = 'static site generator' OR
+      app = 'Next.js' OR
+      app = 'Nuxt.js' OR
+      app = 'Docusaurus'
   )
   USING
     (_TABLE_SUFFIX, url)),

--- a/sql/2020/jamstack/median_lighthouse_score.sql
+++ b/sql/2020/jamstack/median_lighthouse_score.sql
@@ -14,10 +14,10 @@ JOIN
 USING
   (_TABLE_SUFFIX, url)
 WHERE
-  LOWER(category) = "static site generator" OR
-  app = "Next.js" OR
-  app = "Nuxt.js" OR
-  app = "Docusaurus"
+  LOWER(category) = 'static site generator' OR
+  app = 'Next.js' OR
+  app = 'Nuxt.js' OR
+  app = 'Docusaurus'
 GROUP BY
   ssg,
   client

--- a/sql/2020/jamstack/ssg_compared_to_2019.sql
+++ b/sql/2020/jamstack/ssg_compared_to_2019.sql
@@ -20,10 +20,10 @@ JOIN (
 USING
   (_TABLE_SUFFIX)
 WHERE
-  LOWER(category) = "static site generator" OR
-  app = "Next.js" OR
-  app = "Nuxt.js" OR
-  app = "Docusaurus"
+  LOWER(category) = 'static site generator' OR
+  app = 'Next.js' OR
+  app = 'Nuxt.js' OR
+  app = 'Docusaurus'
 GROUP BY
   client,
   total,
@@ -49,10 +49,10 @@ JOIN (
 USING
   (_TABLE_SUFFIX)
 WHERE
-  LOWER(category) = "static site generator" OR
-  app = "Next.js" OR
-  app = "Nuxt.js" OR
-  app = "Docusaurus"
+  LOWER(category) = 'static site generator' OR
+  app = 'Next.js' OR
+  app = 'Nuxt.js' OR
+  app = 'Docusaurus'
 GROUP BY
   client,
   total,

--- a/sql/2020/jamstack/third_party_bytes_and_requests_on_ssgs.sql
+++ b/sql/2020/jamstack/third_party_bytes_and_requests_on_ssgs.sql
@@ -27,10 +27,10 @@ FROM (
     FROM
       `httparchive.technologies.2020_08_01_*`
     WHERE
-      LOWER(category) = "static site generator" OR
-      app = "Next.js" OR
-      app = "Nuxt.js" OR
-      app = "Docusaurus")
+      LOWER(category) = 'static site generator' OR
+      app = 'Next.js' OR
+      app = 'Nuxt.js' OR
+      app = 'Docusaurus')
   USING
     (client, page)
   WHERE

--- a/sql/2020/javascript/avg_pct_per_page_scripts_using_async_defer_module_nomodule.sql
+++ b/sql/2020/javascript/avg_pct_per_page_scripts_using_async_defer_module_nomodule.sql
@@ -20,7 +20,7 @@ FROM (
       client,
       page,
       url,
-      REGEXP_EXTRACT_ALL(body, "(?i)(<script [^>]*)") AS scripts
+      REGEXP_EXTRACT_ALL(body, '(?i)(<script [^>]*)') AS scripts
     FROM
       `httparchive.almanac.summary_response_bodies`
     WHERE

--- a/sql/2020/javascript/breakdown_of_scripts_using_async_defer_module_nomodule.sql
+++ b/sql/2020/javascript/breakdown_of_scripts_using_async_defer_module_nomodule.sql
@@ -3,25 +3,25 @@
 SELECT
   client,
   COUNT(0) AS total_scripts,
-  SUM(IF(script NOT LIKE "%src%", 1, 0)) AS inline_script,
-  SUM(IF(script LIKE "%src%", 1, 0)) AS external_script,
-  SUM(IF(script LIKE "%src%", 1, 0)) / COUNT(0) AS pct_external_script,
-  SUM(IF(script NOT LIKE "%src%", 1, 0)) / COUNT(0) AS pct_inline_script,
-  SUM(IF(script LIKE "%async%", 1, 0)) AS async,
-  SUM(IF(script LIKE "%defer%", 1, 0)) AS defer,
-  SUM(IF(script LIKE "%module%", 1, 0)) AS module,
-  SUM(IF(script LIKE "%nomodule%", 1, 0)) AS nomodule,
-  SUM(IF(script LIKE "%async%", 1, 0)) / SUM(IF(script LIKE "%src%", 1, 0)) AS pct_external_async,
-  SUM(IF(script LIKE "%defer%", 1, 0)) / SUM(IF(script LIKE "%src%", 1, 0)) AS pct_external_defer,
-  SUM(IF(script LIKE "%module%", 1, 0)) / SUM(IF(script LIKE "%src%", 1, 0)) AS pct_external_module,
-  SUM(IF(script LIKE "%nomodule%", 1, 0)) / SUM(IF(script LIKE "%src%", 1, 0)) AS pct_external_nomodule
+  SUM(IF(script NOT LIKE '%src%', 1, 0)) AS inline_script,
+  SUM(IF(script LIKE '%src%', 1, 0)) AS external_script,
+  SUM(IF(script LIKE '%src%', 1, 0)) / COUNT(0) AS pct_external_script,
+  SUM(IF(script NOT LIKE '%src%', 1, 0)) / COUNT(0) AS pct_inline_script,
+  SUM(IF(script LIKE '%async%', 1, 0)) AS async,
+  SUM(IF(script LIKE '%defer%', 1, 0)) AS defer,
+  SUM(IF(script LIKE '%module%', 1, 0)) AS module,
+  SUM(IF(script LIKE '%nomodule%', 1, 0)) AS nomodule,
+  SUM(IF(script LIKE '%async%', 1, 0)) / SUM(IF(script LIKE '%src%', 1, 0)) AS pct_external_async,
+  SUM(IF(script LIKE '%defer%', 1, 0)) / SUM(IF(script LIKE '%src%', 1, 0)) AS pct_external_defer,
+  SUM(IF(script LIKE '%module%', 1, 0)) / SUM(IF(script LIKE '%src%', 1, 0)) AS pct_external_module,
+  SUM(IF(script LIKE '%nomodule%', 1, 0)) / SUM(IF(script LIKE '%src%', 1, 0)) AS pct_external_nomodule
 FROM
   (
     SELECT
       client,
       page,
       url,
-      REGEXP_EXTRACT_ALL(LOWER(body), "(<script [^>]*)") AS scripts
+      REGEXP_EXTRACT_ALL(LOWER(body), '(<script [^>]*)') AS scripts
     FROM
       `httparchive.almanac.summary_response_bodies`
     WHERE

--- a/sql/2020/javascript/dist_pct_per_page_scripts_using_async_defer_module_nomodule.sql
+++ b/sql/2020/javascript/dist_pct_per_page_scripts_using_async_defer_module_nomodule.sql
@@ -13,21 +13,21 @@ FROM
       client,
       page,
       COUNT(0) AS external_scripts,
-      SUM(IF(script LIKE "%async%", 1, 0)) AS async,
-      SUM(IF(script LIKE "%defer%", 1, 0)) AS defer,
-      SUM(IF(script LIKE "%module%", 1, 0)) AS module,
-      SUM(IF(script LIKE "%nomodule%", 1, 0)) AS nomodule,
-      SUM(IF(script LIKE "%async%", 1, 0)) / COUNT(0) AS pct_external_async,
-      SUM(IF(script LIKE "%defer%", 1, 0)) / COUNT(0) AS pct_external_defer,
-      SUM(IF(script LIKE "%module%", 1, 0)) / COUNT(0) AS pct_external_module,
-      SUM(IF(script LIKE "%nomodule%", 1, 0)) / COUNT(0) AS pct_external_nomodule
+      SUM(IF(script LIKE '%async%', 1, 0)) AS async,
+      SUM(IF(script LIKE '%defer%', 1, 0)) AS defer,
+      SUM(IF(script LIKE '%module%', 1, 0)) AS module,
+      SUM(IF(script LIKE '%nomodule%', 1, 0)) AS nomodule,
+      SUM(IF(script LIKE '%async%', 1, 0)) / COUNT(0) AS pct_external_async,
+      SUM(IF(script LIKE '%defer%', 1, 0)) / COUNT(0) AS pct_external_defer,
+      SUM(IF(script LIKE '%module%', 1, 0)) / COUNT(0) AS pct_external_module,
+      SUM(IF(script LIKE '%nomodule%', 1, 0)) / COUNT(0) AS pct_external_nomodule
     FROM
       (
         SELECT
           client,
           page,
           url,
-          REGEXP_EXTRACT_ALL(LOWER(body), "(<script [^>]*)") AS scripts
+          REGEXP_EXTRACT_ALL(LOWER(body), '(<script [^>]*)') AS scripts
         FROM
           `httparchive.almanac.summary_response_bodies`
         WHERE
@@ -37,7 +37,7 @@ FROM
     CROSS JOIN
       UNNEST(scripts) AS script
     WHERE
-      script LIKE "%src%"
+      script LIKE '%src%'
     GROUP BY
       client,
       page

--- a/sql/2020/javascript/unused_js_bytes_distribution.sql
+++ b/sql/2020/javascript/unused_js_bytes_distribution.sql
@@ -2,7 +2,7 @@
 # Distribution of unused JS request bytes per page
 SELECT
   percentile,
-  APPROX_QUANTILES(CAST(JSON_EXTRACT_SCALAR(report, "$.audits.unused-javascript.details.overallSavingsBytes") AS INT64) / 1024, 1000)[OFFSET(percentile * 10)] AS js_kilobytes
+  APPROX_QUANTILES(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.unused-javascript.details.overallSavingsBytes') AS INT64) / 1024, 1000)[OFFSET(percentile * 10)] AS js_kilobytes
 FROM
   `httparchive.lighthouse.2020_08_01_mobile`,
   UNNEST([10, 25, 50, 75, 90, 100]) AS percentile

--- a/sql/2020/markup/pages_element_count_by_device_and_obsolete_elements.sql
+++ b/sql/2020/markup/pages_element_count_by_device_and_obsolete_elements.sql
@@ -23,7 +23,7 @@ try {
 ''';
 
 CREATE TEMPORARY FUNCTION is_obsolete(element STRING) AS (
-  element IN ("applet", "acronym", "bgsound", "dir", "frame", "frameset", "noframes", "isindex", "keygen", "listing", "menuitem", "nextid", "noembed", "plaintext", "rb", "rtc", "strike", "xmp", "basefont", "big", "blink", "center", "font", "marquee", "multicol", "nobr", "spacer", "tt")
+  element IN ('applet', 'acronym', 'bgsound', 'dir', 'frame', 'frameset', 'noframes', 'isindex', 'keygen', 'listing', 'menuitem', 'nextid', 'noembed', 'plaintext', 'rb', 'rtc', 'strike', 'xmp', 'basefont', 'big', 'blink', 'center', 'font', 'marquee', 'multicol', 'nobr', 'spacer', 'tt')
 );
 
 SELECT

--- a/sql/2020/markup/pages_markup_by_device.sql
+++ b/sql/2020/markup/pages_markup_by_device.sql
@@ -157,13 +157,13 @@ SELECT
   AS_PERCENT(COUNTIF(LENGTH(markup_info.dirs_html_dir) > 0), COUNT(0)) AS pct_html_dir_set_m410,
 
   # pages with html dir set to ltr M411
-  AS_PERCENT(COUNTIF(markup_info.dirs_html_dir = "ltr"), COUNT(0)) AS pct_html_dir_ltr_m411,
+  AS_PERCENT(COUNTIF(markup_info.dirs_html_dir = 'ltr'), COUNT(0)) AS pct_html_dir_ltr_m411,
 
   # pages with html dir set to rtl M412
-  AS_PERCENT(COUNTIF(markup_info.dirs_html_dir = "rtl"), COUNT(0)) AS pct_html_dir_rtl_m412,
+  AS_PERCENT(COUNTIF(markup_info.dirs_html_dir = 'rtl'), COUNT(0)) AS pct_html_dir_rtl_m412,
 
   # pages with html dir set to auto M413
-  AS_PERCENT(COUNTIF(markup_info.dirs_html_dir = "auto"), COUNT(0)) AS pct_html_dir_auto_m413,
+  AS_PERCENT(COUNTIF(markup_info.dirs_html_dir = 'auto'), COUNT(0)) AS pct_html_dir_auto_m413,
 
   # pages with dir on other elements M414
   AS_PERCENT(COUNTIF(markup_info.dirs_body_nodes_dir_total > 0), COUNT(0)) AS pct_body_nodes_dir_set_m414

--- a/sql/2020/markup/summary_pages_by_device_and_doctype.sql
+++ b/sql/2020/markup/summary_pages_by_device_and_doctype.sql
@@ -7,7 +7,7 @@ CREATE TEMP FUNCTION AS_PERCENT (freq FLOAT64, total FLOAT64) RETURNS FLOAT64 AS
 
 SELECT
   _TABLE_SUFFIX AS client,
-  LOWER(REGEXP_REPLACE(TRIM(doctype), r" +", " ")) AS doctype, # remove extra spaces and make lower case
+  LOWER(REGEXP_REPLACE(TRIM(doctype), r' +', ' ')) AS doctype, # remove extra spaces and make lower case
   COUNT(0) AS freq,
   AS_PERCENT(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX)) AS pct_m101
 FROM

--- a/sql/2020/media/video_preload_values.sql
+++ b/sql/2020/media/video_preload_values.sql
@@ -9,7 +9,7 @@ SELECT
 FROM
   `httparchive.almanac.summary_response_bodies`,
   # extract preload attribute value, or empty if none
-  UNNEST(REGEXP_EXTRACT_ALL(body, '<video[^>]*?preload=*(?:\"|\')*(.*?)(?:\"|\'|\\s|>)')) AS preload_value
+  UNNEST(REGEXP_EXTRACT_ALL(body, '<video[^>]*?preload=*(?:"|\')*(.*?)(?:"|\'|\\s|>)')) AS preload_value
 WHERE
   date = '2020-08-01' AND
   firstHtml

--- a/sql/2020/performance/lighthouse_performace_audits.sql
+++ b/sql/2020/performance/lighthouse_performace_audits.sql
@@ -32,7 +32,7 @@ SELECT
   MAX(audits.description) AS description
 FROM
   `httparchive.lighthouse.2020_09_01_mobile`,
-  UNNEST(getAudits(report, "performance")) AS audits
+  UNNEST(getAudits(report, 'performance')) AS audits
 WHERE
   LENGTH(report) < 20000000  # necessary to avoid out of memory issues. Excludes 16 very large results
 GROUP BY

--- a/sql/2020/privacy/percent_of_websites_using_each_cmp.sql
+++ b/sql/2020/privacy/percent_of_websites_using_each_cmp.sql
@@ -5,7 +5,7 @@ WITH apps AS (
   SELECT
     _TABLE_SUFFIX AS client,
     url,
-    IF(category = "Cookie compliance", app, "") AS cmp_app
+    IF(category = 'Cookie compliance', app, '') AS cmp_app
   FROM `httparchive.technologies.2020_08_01_*`
   GROUP BY
     client,
@@ -36,7 +36,7 @@ SELECT
 FROM
   base
 WHERE
-  cmp_app != ""
+  cmp_app != ''
 GROUP BY
   client,
   cmp_app

--- a/sql/2020/privacy/percent_of_websites_with_cmp.sql
+++ b/sql/2020/privacy/percent_of_websites_with_cmp.sql
@@ -5,7 +5,7 @@ WITH base AS (
   SELECT
     _TABLE_SUFFIX AS client,
     url,
-    LOGICAL_OR(category = "Cookie compliance") AS with_cmp
+    LOGICAL_OR(category = 'Cookie compliance') AS with_cmp
   FROM `httparchive.technologies.2020_08_01_*`
   GROUP BY
     client,

--- a/sql/2020/privacy/percent_of_websites_with_fingerprinting.sql
+++ b/sql/2020/privacy/percent_of_websites_with_fingerprinting.sql
@@ -14,7 +14,7 @@ base AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total_pages,
-    COUNT(DISTINCT IF(url LIKE "%fingerprint2.min.js%" OR url LIKE "%fingerprintjs2%", page, NULL)) AS fingerprint_pages
+    COUNT(DISTINCT IF(url LIKE '%fingerprint2.min.js%' OR url LIKE '%fingerprintjs2%', page, NULL)) AS fingerprint_pages
   FROM
     requests
   GROUP BY

--- a/sql/2020/privacy/percent_of_websites_with_iab_tcf_banner.sql
+++ b/sql/2020/privacy/percent_of_websites_with_iab_tcf_banner.sql
@@ -4,7 +4,7 @@
 WITH pages_privacy AS (
   SELECT
     _TABLE_SUFFIX AS client,
-    JSON_EXTRACT_SCALAR(payload, "$._privacy") AS metrics
+    JSON_EXTRACT_SCALAR(payload, '$._privacy') AS metrics
   FROM
     `httparchive.pages.2020_08_01_*`
 )
@@ -12,8 +12,8 @@ WITH pages_privacy AS (
 SELECT
   client,
   COUNT(0) AS total_websites,
-  COUNTIF(JSON_EXTRACT_SCALAR(metrics, "$.iab_tcf") = "1") AS websites_with_iab,
-  COUNTIF(JSON_EXTRACT_SCALAR(metrics, "$.iab_tcf") = "1") / COUNT(0) AS pct_iab_banner_pages
+  COUNTIF(JSON_EXTRACT_SCALAR(metrics, '$.iab_tcf') = '1') AS websites_with_iab,
+  COUNTIF(JSON_EXTRACT_SCALAR(metrics, '$.iab_tcf') = '1') / COUNT(0) AS pct_iab_banner_pages
 FROM
   pages_privacy
 GROUP BY

--- a/sql/2020/privacy/percent_of_websites_with_privacy_links.sql
+++ b/sql/2020/privacy/percent_of_websites_with_privacy_links.sql
@@ -4,7 +4,7 @@
 WITH pages_privacy AS (
   SELECT
     _TABLE_SUFFIX AS client,
-    JSON_EXTRACT_SCALAR(payload, "$._privacy") AS metrics
+    JSON_EXTRACT_SCALAR(payload, '$._privacy') AS metrics
   FROM
     `httparchive.pages.2020_08_01_*`
 )
@@ -12,8 +12,8 @@ WITH pages_privacy AS (
 SELECT
   client,
   COUNT(0) AS total_websites,
-  COUNTIF(CAST(JSON_EXTRACT_SCALAR(metrics, "$.privacy_wording_links") AS INT64) > 0) AS websites_with_privacy_link,
-  COUNTIF(CAST(JSON_EXTRACT_SCALAR(metrics, "$.privacy_wording_links") AS INT64) > 0) / COUNT(0) AS pct_websites_with_privacy_link
+  COUNTIF(CAST(JSON_EXTRACT_SCALAR(metrics, '$.privacy_wording_links') AS INT64) > 0) AS websites_with_privacy_link,
+  COUNTIF(CAST(JSON_EXTRACT_SCALAR(metrics, '$.privacy_wording_links') AS INT64) > 0) / COUNT(0) AS pct_websites_with_privacy_link
 FROM
   pages_privacy
 GROUP BY

--- a/sql/2020/privacy/top100_cookies_set_from_header.sql
+++ b/sql/2020/privacy/top100_cookies_set_from_header.sql
@@ -45,7 +45,7 @@ cookies AS (
     UNNEST(cookie_names) AS cookie
   WHERE
     cookie IS NOT NULL AND
-    cookie != ""
+    cookie != ''
   GROUP BY
     client,
     request,

--- a/sql/2020/pwa/lighthouse_pwa_audits.sql
+++ b/sql/2020/pwa/lighthouse_pwa_audits.sql
@@ -32,7 +32,7 @@ SELECT
   MAX(audits.description) AS description
 FROM
   `httparchive.lighthouse.2020_08_01_mobile`,
-  UNNEST(getAudits(report, "pwa")) AS audits
+  UNNEST(getAudits(report, 'pwa')) AS audits
 WHERE
   LENGTH(report) < 20000000  # necessary to avoid out of memory issues. Excludes 16 very large results
 GROUP BY

--- a/sql/2020/pwa/lighthouse_pwa_audits_sw.sql
+++ b/sql/2020/pwa/lighthouse_pwa_audits_sw.sql
@@ -33,7 +33,7 @@ SELECT
 FROM
   `httparchive.lighthouse.2020_08_01_mobile` l,
   `httparchive.almanac.service_workers`,
-  UNNEST(getAudits(report, "pwa")) AS audits
+  UNNEST(getAudits(report, 'pwa')) AS audits
 WHERE
   date = '2020-08-01' AND
   client = 'mobile' AND

--- a/sql/2020/resource-hints/lighthouse_offscreen_images.sql
+++ b/sql/2020/resource-hints/lighthouse_offscreen_images.sql
@@ -1,7 +1,7 @@
 #standardSQL
 # 21_13: Distribution of Lighthouse scores for the 'Defer offscreen images' audit
 SELECT
-  JSON_EXTRACT_SCALAR(report, "$.audits.offscreen-images.score") AS score,
+  JSON_EXTRACT_SCALAR(report, '$.audits.offscreen-images.score') AS score,
   COUNT(0) AS freq,
   SUM(COUNT(0)) OVER () AS total,
   COUNT(0) / SUM(COUNT(0)) OVER () AS pct

--- a/sql/2020/resource-hints/lighthouse_preconnect.sql
+++ b/sql/2020/resource-hints/lighthouse_preconnect.sql
@@ -1,7 +1,7 @@
 #standardSQL
 # 21_11a: Distribution of Lighthouse scores for the 'Preconnect to required origins' audit
 SELECT
-  JSON_EXTRACT_SCALAR(report, "$.audits.uses-rel-preconnect.score") AS score,
+  JSON_EXTRACT_SCALAR(report, '$.audits.uses-rel-preconnect.score') AS score,
   COUNT(0) AS freq,
   SUM(COUNT(0)) OVER () AS total,
   COUNT(0) / SUM(COUNT(0)) OVER () AS pct

--- a/sql/2020/resource-hints/lighthouse_preload.sql
+++ b/sql/2020/resource-hints/lighthouse_preload.sql
@@ -1,7 +1,7 @@
 #standardSQL
 # 21_11b: Distribution of Lighthouse scores for the 'Preload key requests' audit
 SELECT
-  JSON_EXTRACT_SCALAR(report, "$.audits.uses-rel-preload.score") AS score,
+  JSON_EXTRACT_SCALAR(report, '$.audits.uses-rel-preload.score') AS score,
   COUNT(0) AS freq,
   SUM(COUNT(0)) OVER () AS total,
   COUNT(0) / SUM(COUNT(0)) OVER () AS pct

--- a/sql/2020/security/csp_allowed_host_frequency.sql
+++ b/sql/2020/security/csp_allowed_host_frequency.sql
@@ -26,7 +26,7 @@ FROM (
   FROM
     `httparchive.almanac.requests`
   WHERE
-    date = "2020-08-01" AND
+    date = '2020-08-01' AND
     firstHtml
 ),
 UNNEST(REGEXP_EXTRACT_ALL(csp_header, r'(?i)(https*://[^\s;]+)[\s;]')) AS csp_allowed_host

--- a/sql/2020/security/csp_directives_usage.sql
+++ b/sql/2020/security/csp_directives_usage.sql
@@ -25,7 +25,7 @@ FROM (
   FROM
     `httparchive.almanac.requests`
   WHERE
-    date = "2020-08-01" AND
+    date = '2020-08-01' AND
     firstHtml
 ),
 UNNEST(['child-src', 'connect-src', 'default-src', 'font-src', 'frame-src', 'img-src', 'manifest-src', 'media-src', 'object-src', 'prefetch-src', 'script-src', 'script-src-elem', 'script-src-attr', 'style-src', 'style-src-elem', 'style-src-attr', 'worker-src', 'base-uri', 'plugin-types', 'sandbox', 'form-action', 'frame-ancestors', 'navigate-to', 'report-uri', 'report-to', 'block-all-mixed-content', 'referrer', 'require-sri-for', 'require-trusted-types-for', 'trusted-types', 'upgrade-insecure-requests']) AS directive

--- a/sql/2020/security/csp_most_common_header.sql
+++ b/sql/2020/security/csp_most_common_header.sql
@@ -25,7 +25,7 @@ FROM (
   FROM
     `httparchive.almanac.requests`
   WHERE
-    date = "2020-08-01" AND
+    date = '2020-08-01' AND
     firstHtml
 )
 WHERE

--- a/sql/2020/security/csp_number_of_allowed_hosts.sql
+++ b/sql/2020/security/csp_number_of_allowed_hosts.sql
@@ -31,7 +31,7 @@ FROM (
   FROM
     `httparchive.almanac.requests`
   WHERE
-    date = "2020-08-01" AND
+    date = '2020-08-01' AND
     firstHtml
 ),
 UNNEST([10, 25, 50, 75, 90, 100]) AS percentile

--- a/sql/2020/security/csp_script_source_list_keywords.sql
+++ b/sql/2020/security/csp_script_source_list_keywords.sql
@@ -48,7 +48,7 @@ FROM (
     FROM
       `httparchive.almanac.requests`
     WHERE
-      date = "2020-08-01" AND
+      date = '2020-08-01' AND
       firstHtml
   )
   GROUP BY

--- a/sql/2020/security/hsts_max_age_percentiles.sql
+++ b/sql/2020/security/hsts_max_age_percentiles.sql
@@ -11,7 +11,7 @@ FROM (
   FROM
     `httparchive.almanac.requests`
   WHERE
-    date = "2020-08-01"
+    date = '2020-08-01'
 ),
 UNNEST([10, 25, 50, 75, 90, 100]) AS percentile
 GROUP BY

--- a/sql/2020/security/iframe_allow_directives.sql
+++ b/sql/2020/security/iframe_allow_directives.sql
@@ -4,7 +4,7 @@ CREATE TEMP FUNCTION getNumWithAllowAttribute(payload STRING) AS ((
   SELECT
     COUNT(0)
   FROM
-    UNNEST(JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.iframe-allow-sandbox")) AS iframeAttr
+    UNNEST(JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.iframe-allow-sandbox')) AS iframeAttr
   WHERE
     JSON_EXTRACT_SCALAR(iframeAttr, '$.allow') IS NOT NULL
 ));
@@ -18,7 +18,7 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.iframe-allow-sandbox") AS iframeAttrs
+    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.iframe-allow-sandbox') AS iframeAttrs
   FROM
     `httparchive.pages.2020_08_01_*`),
   UNNEST(iframeAttrs) AS iframeAttr,

--- a/sql/2020/security/iframe_attribute_popular_hosts.sql
+++ b/sql/2020/security/iframe_attribute_popular_hosts.sql
@@ -25,7 +25,7 @@ FROM (
   FROM (
     SELECT
       _TABLE_SUFFIX AS client,
-      JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.iframe-allow-sandbox") AS iframeAttrs
+      JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.iframe-allow-sandbox') AS iframeAttrs
     FROM
       `httparchive.pages.2020_08_01_*`),
     UNNEST(iframeAttrs) AS iframeAttr,
@@ -34,7 +34,7 @@ FROM (
 JOIN (
   SELECT
     _TABLE_SUFFIX AS client,
-    SUM(ARRAY_LENGTH(JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.iframe-allow-sandbox"))) AS total_iframes
+    SUM(ARRAY_LENGTH(JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.iframe-allow-sandbox'))) AS total_iframes
   FROM
     `httparchive.pages.2020_08_01_*`
   GROUP BY

--- a/sql/2020/security/iframe_attributes_usage.sql
+++ b/sql/2020/security/iframe_attributes_usage.sql
@@ -24,7 +24,7 @@ FROM (
     SELECT
       _TABLE_SUFFIX AS client,
       url,
-      JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.iframe-allow-sandbox") AS iframeAttrs
+      JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.iframe-allow-sandbox') AS iframeAttrs
     FROM
       `httparchive.pages.2020_08_01_*`)
   LEFT JOIN UNNEST(iframeAttrs) AS iframeAttr

--- a/sql/2020/security/iframe_sandbox_directives.sql
+++ b/sql/2020/security/iframe_sandbox_directives.sql
@@ -4,7 +4,7 @@ CREATE TEMP FUNCTION getNumWithSandboxAttribute(payload STRING) AS ((
   SELECT
     COUNT(0)
   FROM
-    UNNEST(JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.iframe-allow-sandbox")) AS iframeAttr
+    UNNEST(JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.iframe-allow-sandbox')) AS iframeAttr
   WHERE
     JSON_EXTRACT_SCALAR(iframeAttr, '$.sandbox') IS NOT NULL
 ));
@@ -18,7 +18,7 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.iframe-allow-sandbox") AS iframeAttrs
+    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.iframe-allow-sandbox') AS iframeAttrs
   FROM
     `httparchive.pages.2020_08_01_*`),
   UNNEST(iframeAttrs) AS iframeAttr,

--- a/sql/2020/security/security_headers_prevalence.sql
+++ b/sql/2020/security/security_headers_prevalence.sql
@@ -26,7 +26,7 @@ FROM (
   FROM
     `httparchive.almanac.requests`
   WHERE
-    (date = "2020-08-01" OR date = "2019-07-01") AND
+    (date = '2020-08-01' OR date = '2019-07-01') AND
     NET.HOST(urlShort) = NET.HOST(page)
 ),
 UNNEST(['Content-Security-Policy', 'Cross-Origin-Embedder-Policy', 'Cross-Origin-Opener-Policy', 'Cross-Origin-Resource-Policy', 'Expect-CT', 'Feature-Policy', 'Permissions-Policy', 'Referrer-Policy', 'Report-To', 'Strict-Transport-Security', 'X-Content-Type-Options', 'X-Frame-Options', 'X-XSS-Protection']) AS headername

--- a/sql/2020/security/sri_coverage_per_page.sql
+++ b/sql/2020/security/sri_coverage_per_page.sql
@@ -11,7 +11,7 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.sri-integrity") AS sris,
+    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.sri-integrity') AS sris,
     SAFE_CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._element_count'), '$.script') AS INT64) AS num_scripts
   FROM
     `httparchive.pages.2020_08_01_*`),

--- a/sql/2020/security/sri_hash_functions.sql
+++ b/sql/2020/security/sri_hash_functions.sql
@@ -9,7 +9,7 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.sri-integrity") AS sris
+    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.sri-integrity') AS sris
   FROM
     `httparchive.pages.2020_08_01_*`),
   UNNEST(sris) AS sri,

--- a/sql/2020/security/sri_popular_hosts.sql
+++ b/sql/2020/security/sri_popular_hosts.sql
@@ -13,7 +13,7 @@ FROM (
   SELECT
     _TABLE_SUFFIX AS client,
     url,
-    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.sri-integrity") AS sris
+    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.sri-integrity') AS sris
   FROM
     `httparchive.pages.2020_08_01_*`),
   UNNEST(sris) AS sri

--- a/sql/2020/security/sri_usage.sql
+++ b/sql/2020/security/sri_usage.sql
@@ -18,7 +18,7 @@ FROM (
   SELECT
     _TABLE_SUFFIX AS client,
     url,
-    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.sri-integrity") AS sris
+    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.sri-integrity') AS sris
   FROM
     `httparchive.pages.2020_08_01_*`)
 LEFT JOIN UNNEST(sris) AS sri

--- a/sql/2020/seo/pages_wpt_bodies_by_device.sql
+++ b/sql/2020/seo/pages_wpt_bodies_by_device.sql
@@ -440,7 +440,7 @@ SELECT
   AS_PERCENT(COUNTIF(wpt_bodies_info.rendering_changes_structured_data), COUNT(0)) AS pct_rendering_changes_structured_data,
 
   # http or https
-  AS_PERCENT(COUNTIF(protocol = "https"), COUNT(0)) AS pct_https,
+  AS_PERCENT(COUNTIF(protocol = 'https'), COUNT(0)) AS pct_https,
 
   # meta robots
   AS_PERCENT(COUNTIF(wpt_bodies_info.rendered_otherbot_status_index), COUNT(0)) AS pct_rendered_otherbot_status_index,
@@ -480,7 +480,7 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    SPLIT(url, ":")[OFFSET(0)] AS protocol,
+    SPLIT(url, ':')[OFFSET(0)] AS protocol,
     get_wpt_bodies_info(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
   FROM
     `httparchive.pages.2020_08_01_*`

--- a/sql/2020/seo/summary_requests_by_device_and_http_vary.sql
+++ b/sql/2020/seo/summary_requests_by_device_and_http_vary.sql
@@ -7,7 +7,7 @@ CREATE TEMP FUNCTION AS_PERCENT (freq FLOAT64, total FLOAT64) RETURNS FLOAT64 AS
 
 SELECT
   _TABLE_SUFFIX AS client,
-  REGEXP_CONTAINS(LOWER(resp_vary), r"user-agent") AS resp_vary_user_agent,
+  REGEXP_CONTAINS(LOWER(resp_vary), r'user-agent') AS resp_vary_user_agent,
   COUNT(0) AS freq,
   AS_PERCENT(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX)) AS pct
 FROM

--- a/sql/2020/third-parties/percent_of_third_party_with_security_headers.sql
+++ b/sql/2020/third-parties/percent_of_third_party_with_security_headers.sql
@@ -33,10 +33,10 @@ base AS (
   SELECT
     req_origin,
     req_category,
-    IF(STRPOS(respOtherHeaders, "strict-transport-security") > 0, 1, 0) AS hsts_header,
-    IF(STRPOS(respOtherHeaders, "x-content-type-options") > 0, 1, 0) AS x_content_type_options_header,
-    IF(STRPOS(respOtherHeaders, "x-frame-options") > 0, 1, 0) AS x_frame_options_header,
-    IF(STRPOS(respOtherHeaders, "x-xss-protection") > 0, 1, 0) AS x_xss_protection_header
+    IF(STRPOS(respOtherHeaders, 'strict-transport-security') > 0, 1, 0) AS hsts_header,
+    IF(STRPOS(respOtherHeaders, 'x-content-type-options') > 0, 1, 0) AS x_content_type_options_header,
+    IF(STRPOS(respOtherHeaders, 'x-frame-options') > 0, 1, 0) AS x_frame_options_header,
+    IF(STRPOS(respOtherHeaders, 'x-xss-protection') > 0, 1, 0) AS x_xss_protection_header
   FROM headers
 )
 

--- a/sql/2020/third-parties/tao_by_third_party.sql
+++ b/sql/2020/third-parties/tao_by_third_party.sql
@@ -66,8 +66,8 @@ base AS (
     req_category,
     IF(
       page_origin = req_origin OR
-      timing_allow_origin = "*, " OR
-      STRPOS(timing_allow_origin, CONCAT(page_origin, ", ")) > 0,
+      timing_allow_origin = '*, ' OR
+      STRPOS(timing_allow_origin, CONCAT(page_origin, ', ')) > 0,
       1, 0) AS timing_allowed
   FROM headers
 )

--- a/sql/2021/accessibility/a11y_overall_tech_usage_by_domain_rank.sql
+++ b/sql/2021/accessibility/a11y_overall_tech_usage_by_domain_rank.sql
@@ -14,7 +14,7 @@ FROM (
   FROM
     `httparchive.technologies.2021_07_01_*`
   WHERE
-    category = "Accessibility"
+    category = 'Accessibility'
 )
 LEFT OUTER JOIN (
   SELECT

--- a/sql/2021/accessibility/a11y_technology_usage.sql
+++ b/sql/2021/accessibility/a11y_technology_usage.sql
@@ -12,7 +12,7 @@ FROM (
   FROM
     `httparchive.technologies.2021_07_01_*`
   WHERE
-    category = "Accessibility"
+    category = 'Accessibility'
   GROUP BY
     client
 )

--- a/sql/2021/accessibility/a11y_technology_usage_by_domain_rank.sql
+++ b/sql/2021/accessibility/a11y_technology_usage_by_domain_rank.sql
@@ -16,7 +16,7 @@ FROM (
   FROM
     `httparchive.technologies.2021_07_01_*`
   WHERE
-    category = "Accessibility"
+    category = 'Accessibility'
 )
 LEFT OUTER JOIN (
   SELECT

--- a/sql/2021/accessibility/captcha_usage.sql
+++ b/sql/2021/accessibility/captcha_usage.sql
@@ -12,7 +12,7 @@ FROM (
   FROM
     `httparchive.technologies.2021_07_01_*`
   WHERE
-    app = "reCAPTCHA" OR app = "hCaptcha"
+    app = 'reCAPTCHA' OR app = 'hCaptcha'
   GROUP BY
     client
 )

--- a/sql/2021/accessibility/lighthouse_a11y_audits.sql
+++ b/sql/2021/accessibility/lighthouse_a11y_audits.sql
@@ -32,7 +32,7 @@ SELECT
   MAX(audits.description) AS description
 FROM
   `httparchive.lighthouse.2021_07_01_mobile`,
-  UNNEST(getAudits(report, "accessibility")) AS audits
+  UNNEST(getAudits(report, 'accessibility')) AS audits
 WHERE
   LENGTH(report) < 20000000  # necessary to avoid out of memory issues. Excludes very large results
 GROUP BY

--- a/sql/2021/caching/cache_control_directives.sql
+++ b/sql/2021/caching/cache_control_directives.sql
@@ -48,7 +48,7 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    TRIM(resp_cache_control) != "" AS uses_cache_control,
+    TRIM(resp_cache_control) != '' AS uses_cache_control,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)max-age\s*=\s*[0-9]+') AS uses_max_age,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)max-age\s*=\s*0') AS uses_max_age_zero,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)public') AS uses_public,

--- a/sql/2021/caching/cache_ttl_and_content_age_diff.sql
+++ b/sql/2021/caching/cache_ttl_and_content_age_diff.sql
@@ -21,7 +21,7 @@ FROM (
   FROM
     `httparchive.summary_requests.2021_07_01_*`
   WHERE
-    resp_last_modified != "" AND
+    resp_last_modified != '' AND
     expAge > 0),
   UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY

--- a/sql/2021/caching/cache_ttl_lighthouse_score.sql
+++ b/sql/2021/caching/cache_ttl_lighthouse_score.sql
@@ -2,7 +2,7 @@
 # Distribution of cache TTL Lighthouse scores
 SELECT
   _TABLE_SUFFIX AS client,
-  JSON_EXTRACT_SCALAR(report, "$.audits.uses-long-cache-ttl.score") AS caching_score,
+  JSON_EXTRACT_SCALAR(report, '$.audits.uses-long-cache-ttl.score') AS caching_score,
   COUNT(0) AS num_pages,
   SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS total,
   COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct_pages

--- a/sql/2021/caching/cache_wastedbytes_lighthouse.sql
+++ b/sql/2021/caching/cache_wastedbytes_lighthouse.sql
@@ -2,7 +2,7 @@
 # Distribution of bytes wasted (absence of adequate caching) from Lighthouse
 SELECT
   _TABLE_SUFFIX AS client,
-  ROUND(CAST(JSON_EXTRACT_SCALAR(report, "$.audits.uses-long-cache-ttl.details.summary.wastedBytes") AS NUMERIC) / 1024 / 1024) AS mbyte_savings,
+  ROUND(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.uses-long-cache-ttl.details.summary.wastedBytes') AS NUMERIC) / 1024 / 1024) AS mbyte_savings,
   COUNT(0) AS num_pages,
   SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS total,
   COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct_pages

--- a/sql/2021/caching/content_age_older_than_ttl.sql
+++ b/sql/2021/caching/content_age_older_than_ttl.sql
@@ -22,7 +22,7 @@ FROM (
   FROM
     `httparchive.summary_requests.2021_07_01_*`
   WHERE
-    resp_last_modified != "" AND
+    resp_last_modified != '' AND
     expAge > 0)
 GROUP BY
   client

--- a/sql/2021/caching/content_age_older_than_ttl_by_party.sql
+++ b/sql/2021/caching/content_age_older_than_ttl_by_party.sql
@@ -26,7 +26,7 @@ FROM (
   FROM
     `httparchive.summary_requests.2021_07_01_*` requests
   WHERE
-    TRIM(requests.resp_last_modified) != "" AND
+    TRIM(requests.resp_last_modified) != '' AND
     expAge > 0)
 GROUP BY
   client,

--- a/sql/2021/caching/header_trends.sql
+++ b/sql/2021/caching/header_trends.sql
@@ -67,14 +67,14 @@ FROM (
   SELECT
     year,
     client,
-    TRIM(resp_expires) != "" AS uses_expires,
-    TRIM(resp_cache_control) != "" AS uses_cache_control,
+    TRIM(resp_expires) != '' AS uses_expires,
+    TRIM(resp_cache_control) != '' AS uses_cache_control,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)max-age\s*=\s*[0-9]+') AS uses_max_age,
-    TRIM(resp_etag) = "" AS uses_no_etag,
-    TRIM(resp_etag) != "" AS uses_etag,
-    TRIM(resp_last_modified) != "" AS uses_last_modified,
-    REGEXP_CONTAINS(TRIM(resp_etag), '^W/\".*\"') AS uses_weak_etag,
-    REGEXP_CONTAINS(TRIM(resp_etag), '^\".*\"') AS uses_strong_etag
+    TRIM(resp_etag) = '' AS uses_no_etag,
+    TRIM(resp_etag) != '' AS uses_etag,
+    TRIM(resp_last_modified) != '' AS uses_last_modified,
+    REGEXP_CONTAINS(TRIM(resp_etag), '^W/".*"') AS uses_weak_etag,
+    REGEXP_CONTAINS(TRIM(resp_etag), '^".*"') AS uses_strong_etag
   FROM
     summary_requests
 )

--- a/sql/2021/caching/invalid_last_modified_and_expires_and_date.sql
+++ b/sql/2021/caching/invalid_last_modified_and_expires_and_date.sql
@@ -18,9 +18,9 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    TRIM(resp_date) != "" AS uses_date,
-    TRIM(resp_last_modified) != "" AS uses_last_modified,
-    TRIM(resp_expires) != "" AS uses_expires,
+    TRIM(resp_date) != '' AS uses_date,
+    TRIM(resp_last_modified) != '' AS uses_last_modified,
+    TRIM(resp_expires) != '' AS uses_expires,
     REGEXP_CONTAINS(TRIM(resp_date), r'^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{1,2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT$') AS has_valid_date,
     REGEXP_CONTAINS(TRIM(resp_last_modified), r'^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{1,2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT$') AS has_valid_last_modified,
     REGEXP_CONTAINS(TRIM(resp_expires), r'^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{1,2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT$') AS has_valid_expires

--- a/sql/2021/caching/non_cacheable_by_resource_type.sql
+++ b/sql/2021/caching/non_cacheable_by_resource_type.sql
@@ -18,8 +18,8 @@ FROM (
   SELECT
     _TABLE_SUFFIX AS client,
     type AS resource_type,
-    TRIM(resp_cache_control) != "" AS uses_cache_control,
-    TRIM(resp_expires) != "" AS uses_expires,
+    TRIM(resp_cache_control) != '' AS uses_cache_control,
+    TRIM(resp_expires) != '' AS uses_expires,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)no-store') AS uses_no_store,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)max-age\s*=\s*[0-9]+') AS uses_max_age,
     expAge AS exp_age

--- a/sql/2021/caching/resource_age_party_and_type_wise.sql
+++ b/sql/2021/caching/resource_age_party_and_type_wise.sql
@@ -22,7 +22,7 @@ FROM
   `httparchive.summary_requests.2021_07_01_*`,
   UNNEST([10, 25, 50, 75, 90]) AS percentile
 WHERE
-  TRIM(resp_last_modified) != ""
+  TRIM(resp_last_modified) != ''
 GROUP BY
   percentile,
   client,

--- a/sql/2021/caching/resource_age_party_and_type_wise_groups.sql
+++ b/sql/2021/caching/resource_age_party_and_type_wise_groups.sql
@@ -40,7 +40,7 @@ FROM
     FROM
       `httparchive.summary_requests.2021_07_01_*`
     WHERE
-      TRIM(resp_last_modified) != ""
+      TRIM(resp_last_modified) != ''
   )
 GROUP BY
   client,

--- a/sql/2021/caching/ttl.sql
+++ b/sql/2021/caching/ttl.sql
@@ -16,8 +16,8 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    TRIM(resp_cache_control) != "" AS uses_cache_control,
-    TRIM(resp_expires) != "" AS uses_expires,
+    TRIM(resp_cache_control) != '' AS uses_cache_control,
+    TRIM(resp_expires) != '' AS uses_expires,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)no-store') AS uses_no_store,
     REGEXP_CONTAINS(resp_cache_control, r'(?i)max-age\s*=\s*[0-9]+') AS uses_max_age,
     expAge AS exp_age

--- a/sql/2021/caching/valid_if_modified_since_returns_304.sql
+++ b/sql/2021/caching/valid_if_modified_since_returns_304.sql
@@ -14,9 +14,9 @@ FROM (
     _TABLE_SUFFIX AS client,
     status,
     TRIM(resp_last_modified) = TRIM(req_if_modified_since) AS no_change,
-    TRIM(resp_last_modified) != "" AS uses_last_modified,
-    TRIM(req_if_modified_since) != "" AS uses_if_modified,
-    TRIM(resp_etag) != "" AS uses_etag
+    TRIM(resp_last_modified) != '' AS uses_last_modified,
+    TRIM(req_if_modified_since) != '' AS uses_if_modified,
+    TRIM(resp_etag) != '' AS uses_etag
   FROM
     `httparchive.summary_requests.2021_07_01_*`
 )

--- a/sql/2021/caching/valid_if_none_match_returns_304.sql
+++ b/sql/2021/caching/valid_if_none_match_returns_304.sql
@@ -13,8 +13,8 @@ FROM (
     _TABLE_SUFFIX AS client,
     status,
     TRIM(resp_etag) = TRIM(req_if_none_match) AS no_change,
-    TRIM(resp_etag) != "" AS uses_etag,
-    TRIM(req_if_none_match) != "" AS uses_if_non_match
+    TRIM(resp_etag) != '' AS uses_etag,
+    TRIM(req_if_none_match) != '' AS uses_if_non_match
   FROM
     `httparchive.summary_requests.2021_07_01_*`
 )

--- a/sql/2021/capabilities/fugu.sql
+++ b/sql/2021/capabilities/fugu.sql
@@ -27,7 +27,7 @@ USING
   (_TABLE_SUFFIX),
   UNNEST(getFuguAPIs(JSON_QUERY(payload, '$."_fugu-apis"'))) AS fuguAPI
 WHERE
-  JSON_QUERY(payload, '$."_fugu-apis"') != "[]"
+  JSON_QUERY(payload, '$."_fugu-apis"') != '[]'
 GROUP BY
   fuguAPI,
   client,

--- a/sql/2021/capabilities/top.sql
+++ b/sql/2021/capabilities/top.sql
@@ -14,7 +14,7 @@ FROM
   `httparchive.pages.2021_07_01_*`,
   UNNEST(getFuguAPIs(JSON_QUERY(payload, '$."_fugu-apis"'))) AS fuguAPI
 WHERE
-  JSON_QUERY(payload, '$."_fugu-apis"') != "[]"
+  JSON_QUERY(payload, '$."_fugu-apis"') != '[]'
 GROUP BY
   client,
   url

--- a/sql/2021/cdn/cdn_usage_by_site_rank.sql
+++ b/sql/2021/cdn/cdn_usage_by_site_rank.sql
@@ -11,7 +11,7 @@ SELECT
 FROM (
   SELECT
     client,
-    IF(IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') = "ORIGIN", "ORIGIN", "CDN") AS cdn,
+    IF(IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') = 'ORIGIN', 'ORIGIN', 'CDN') AS cdn,
     rank
   FROM
     `httparchive.almanac.requests`

--- a/sql/2021/cdn/distribution_of_compression_types_cdn_vs_origin.sql
+++ b/sql/2021/cdn/distribution_of_compression_types_cdn_vs_origin.sql
@@ -11,7 +11,7 @@ SELECT
 FROM (
   SELECT
     client,
-    IF( IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') = "ORIGIN", "ORIGIN", "CDN") AS cdn,
+    IF( IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') = 'ORIGIN', 'ORIGIN', 'CDN') AS cdn,
     CASE
       WHEN resp_content_encoding = 'gzip' THEN 'Gzip'
       WHEN resp_content_encoding = 'br' THEN 'Brotli'

--- a/sql/2021/cdn/distribution_of_http_versions.sql
+++ b/sql/2021/cdn/distribution_of_http_versions.sql
@@ -27,16 +27,16 @@ FROM
       url,
       firstHtml,
       # WPT is inconsistent with protocol population.
-      UPPER(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(CONCAT("HTTP/", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/')))) AS protocol,
+      UPPER(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(CONCAT('HTTP/', JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/')))) AS protocol,
       JSON_EXTRACT_SCALAR(payload, '$._tls_version') AS tlsVersion,
 
       # WPT joins CDN detection but we bias to the DNS detection which is the first entry
       IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') AS cdn,
-      CAST(JSON_EXTRACT(payload, "$.timings.ssl") AS INT64) AS tlstime,
+      CAST(JSON_EXTRACT(payload, '$.timings.ssl') AS INT64) AS tlstime,
 
       # isSecure reports what the browser thought it was going to use, but it can get upgraded with STS OR UpgradeInsecure: 1
       IF(STARTS_WITH(url, 'https') OR JSON_EXTRACT_SCALAR(payload, '$._tls_version') IS NOT NULL OR CAST(JSON_EXTRACT(payload, '$._is_secure') AS INT64) = 1, TRUE, FALSE) AS isSecure,
-      CAST(JSON_EXTRACT(payload, "$._socket") AS INT64) AS socket
+      CAST(JSON_EXTRACT(payload, '$._socket') AS INT64) AS socket
     FROM
       `httparchive.almanac.requests`
     --`httparchive.sample_data.requests`
@@ -50,16 +50,16 @@ LEFT JOIN
     SELECT
       client,
       page,
-      CAST(JSON_EXTRACT(payload, "$._socket") AS INT64) AS socket,
-      ANY_VALUE(UPPER(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("HTTP/", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/'))))) AS protocol,
+      CAST(JSON_EXTRACT(payload, '$._socket') AS INT64) AS socket,
+      ANY_VALUE(UPPER(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat('HTTP/', JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/'))))) AS protocol,
       ANY_VALUE(JSON_EXTRACT_SCALAR(payload, '$._tls_version')) AS tlsVersion
     FROM
       `httparchive.almanac.requests`
     WHERE
       JSON_EXTRACT_SCALAR(payload, '$._tls_version') IS NOT NULL AND
-      IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("HTTP/",
+      IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat('HTTP/',
         JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/'))) IS NOT NULL AND
-      JSON_EXTRACT(payload, "$._socket") IS NOT NULL AND
+      JSON_EXTRACT(payload, '$._socket') IS NOT NULL AND
       date = '2021-07-01'
     GROUP BY
       client,

--- a/sql/2021/cdn/distribution_of_http_versions_cdn_vs_origin.sql
+++ b/sql/2021/cdn/distribution_of_http_versions_cdn_vs_origin.sql
@@ -2,7 +2,7 @@
 # 17_19: Percentage of HTTPS responses by protocol
 SELECT
   a.client,
-  IF(cdn = "ORIGIN", "ORIGIN", "CDN") AS cdn, firstHtml,
+  IF(cdn = 'ORIGIN', 'ORIGIN', 'CDN') AS cdn, firstHtml,
   COUNTIF(IFNULL(a.protocol, b.protocol) = 'HTTP/0.9') AS http09,
   COUNTIF(IFNULL(a.protocol, b.protocol) = 'HTTP/1.0') AS http10,
   COUNTIF(IFNULL(a.protocol, b.protocol) = 'HTTP/1.1') AS http11,
@@ -26,16 +26,16 @@ FROM
       url,
       firstHtml,
       # WPT is inconsistent with protocol population.
-      UPPER(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat("HTTP/", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/')))) AS protocol,
+      UPPER(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(concat('HTTP/', JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/')))) AS protocol,
       JSON_EXTRACT_SCALAR(payload, '$._tls_version') AS tlsVersion,
 
       # WPT joins CDN detection but we bias to the DNS detection which is the first entry
       IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') AS cdn,
-      CAST(JSON_EXTRACT(payload, "$.timings.ssl") AS INT64) AS tlstime,
+      CAST(JSON_EXTRACT(payload, '$.timings.ssl') AS INT64) AS tlstime,
 
       # isSecure reports what the browser thought it was going to use, but it can get upgraded with STS OR UpgradeInsecure: 1
       IF(STARTS_WITH(url, 'https') OR JSON_EXTRACT_SCALAR(payload, '$._tls_version') IS NOT NULL OR CAST(JSON_EXTRACT(payload, '$._is_secure') AS INT64) = 1, TRUE, FALSE) AS isSecure,
-      CAST(JSON_EXTRACT(payload, "$._socket") AS INT64) AS socket
+      CAST(JSON_EXTRACT(payload, '$._socket') AS INT64) AS socket
     FROM
       `httparchive.almanac.requests`
     WHERE
@@ -48,16 +48,16 @@ LEFT JOIN
     SELECT
       client,
       page,
-      CAST(jSON_EXTRACT(payload, "$._socket") AS INT64) AS socket,
-      ANY_VALUE(UPPER(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(CONCAT("HTTP/", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/'))))) AS protocol,
+      CAST(jSON_EXTRACT(payload, '$._socket') AS INT64) AS socket,
+      ANY_VALUE(UPPER(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(CONCAT('HTTP/', JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/'))))) AS protocol,
       ANY_VALUE(JSON_EXTRACT_SCALAR(payload, '$._tls_version')) AS tlsVersion
     FROM
       `httparchive.almanac.requests`
     WHERE
       JSON_EXTRACT_SCALAR(payload, '$._tls_version') IS NOT NULL AND
-      IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(CONCAT("HTTP/",
+      IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(CONCAT('HTTP/',
         JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'HTTP/'))) IS NOT NULL AND
-      JSON_EXTRACT(payload, "$._socket") IS NOT NULL AND
+      JSON_EXTRACT(payload, '$._socket') IS NOT NULL AND
       date = '2021-07-01'
     GROUP BY client, page, socket
   ) b ON (a.client = b.client AND a.page = b.page AND a.socket = b.socket)

--- a/sql/2021/cdn/distribution_of_tls_time_by_cdn.sql
+++ b/sql/2021/cdn/distribution_of_tls_time_by_cdn.sql
@@ -18,8 +18,8 @@ FROM (
       url,
       firstHtml,
       IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') AS cdn, # sometimes _cdn provider detection includes multiple entries. we bias for the DNS detected entry which is the first entry
-      CAST(JSON_EXTRACT(payload, "$.timings.ssl") AS INT64) AS tlstime,
-      ARRAY_LENGTH(split(JSON_EXTRACT(payload, '$._securityDetails.sanList'), "")) AS sanLength,
+      CAST(JSON_EXTRACT(payload, '$.timings.ssl') AS INT64) AS tlstime,
+      ARRAY_LENGTH(split(JSON_EXTRACT(payload, '$._securityDetails.sanList'), '')) AS sanLength,
       IF(NET.HOST(url) = NET.HOST(page), TRUE, FALSE) AS sameHost,
       IF(NET.HOST(url) = NET.HOST(page) OR NET.REG_DOMAIN(url) = NET.REG_DOMAIN(page), TRUE, FALSE) AS sameDomain # if toplevel reg_domain will return NULL so we group this as sameDomain
     FROM

--- a/sql/2021/cdn/distribution_of_tls_time_cdn_vs_origin.sql
+++ b/sql/2021/cdn/distribution_of_tls_time_cdn_vs_origin.sql
@@ -2,7 +2,7 @@
 # distribution_of_tls_time_cdn_vs_origin.sql : Distribution of TLS negotiation for CDN vs Origin (ie, no CDN)
 SELECT
   client,
-  IF(cdn = "ORIGIN", "ORIGIN", "CDN") AS cdn,
+  IF(cdn = 'ORIGIN', 'ORIGIN', 'CDN') AS cdn,
   firstHtml,
   COUNT(0) AS requests,
   APPROX_QUANTILES(tlstime, 1000)[OFFSET(100)] AS p10,
@@ -18,8 +18,8 @@ FROM (
       url,
       firstHtml,
       IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') AS cdn, # sometimes _cdn provider detection includes multiple entries. we bias for the DNS detected entry which is the first entry
-      CAST(JSON_EXTRACT(payload, "$.timings.ssl") AS INT64) AS tlstime,
-      ARRAY_LENGTH(split(JSON_EXTRACT(payload, '$._securityDetails.sanList'), "")) AS sanLength,
+      CAST(JSON_EXTRACT(payload, '$.timings.ssl') AS INT64) AS tlstime,
+      ARRAY_LENGTH(split(JSON_EXTRACT(payload, '$._securityDetails.sanList'), '')) AS sanLength,
       IF(NET.HOST(url) = NET.HOST(page), TRUE, FALSE) AS sameHost,
       IF(NET.HOST(url) = NET.HOST(page) OR NET.REG_DOMAIN(url) = NET.REG_DOMAIN(page), TRUE, FALSE) AS sameDomain # if toplevel reg_domain will return NULL so we group this as sameDomain
     FROM

--- a/sql/2021/cdn/distribution_of_tls_versions.sql
+++ b/sql/2021/cdn/distribution_of_tls_versions.sql
@@ -21,16 +21,16 @@ FROM
       url,
       firstHtml,
       # WPT is inconsistent with protocol population.
-      UPPER(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(CONCAT("TLS ", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'TLS ')))) AS protocol,
+      UPPER(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(CONCAT('TLS ', JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'TLS ')))) AS protocol,
       JSON_EXTRACT_SCALAR(payload, '$._tls_version') AS tlsVersion,
 
       # WPT joins CDN detection but we bias to the DNS detection which is the first entry
       IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') AS cdn,
-      CAST(JSON_EXTRACT(payload, "$.timings.ssl") AS INT64) AS tlstime,
+      CAST(JSON_EXTRACT(payload, '$.timings.ssl') AS INT64) AS tlstime,
 
       # isSecure reports what the browser thought it was going to use, but it can get upgraded with STS OR UpgradeInsecure: 1
       IF(STARTS_WITH(url, 'https') OR JSON_EXTRACT_SCALAR(payload, '$._tls_version') IS NOT NULL OR CAST(JSON_EXTRACT(payload, '$._is_secure') AS INT64) = 1, TRUE, FALSE) AS isSecure,
-      CAST(JSON_EXTRACT(payload, "$._socket") AS INT64) AS socket
+      CAST(JSON_EXTRACT(payload, '$._socket') AS INT64) AS socket
     FROM
       `httparchive.almanac.requests`
     WHERE
@@ -41,14 +41,14 @@ FROM
 LEFT JOIN (
   SELECT
     client, page,
-    CAST(JSON_EXTRACT(payload, "$._socket") AS INT64) AS socket,
-    ANY_VALUE(UPPER(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(CONCAT("TLS ", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'TLS '))))) AS protocol,
+    CAST(JSON_EXTRACT(payload, '$._socket') AS INT64) AS socket,
+    ANY_VALUE(UPPER(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(CONCAT('TLS ', JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'TLS '))))) AS protocol,
     ANY_VALUE(JSON_EXTRACT_SCALAR(payload, '$._tls_version')) AS tlsVersion
   FROM `httparchive.almanac.requests`
   WHERE
     JSON_EXTRACT_SCALAR(payload, '$._tls_version') IS NOT NULL AND
-    IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(CONCAT("TLS ", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'TLS '))) IS NOT NULL AND
-    JSON_EXTRACT(payload, "$._socket") IS NOT NULL AND
+    IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(CONCAT('TLS ', JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'TLS '))) IS NOT NULL AND
+    JSON_EXTRACT(payload, '$._socket') IS NOT NULL AND
     date = '2021-07-01'
   GROUP BY
     client,

--- a/sql/2021/cdn/distribution_of_tls_versions_cdn_vs_origin.sql
+++ b/sql/2021/cdn/distribution_of_tls_versions_cdn_vs_origin.sql
@@ -2,7 +2,7 @@
 # distribution_of_tls_versions_cdn_vs_origin: Percentage of HTTPS responses by TLS Version with and without CDN
 SELECT
   a.client,
-  IF(cdn = "ORIGIN", "ORIGIN", "CDN") AS cdn, firstHtml,
+  IF(cdn = 'ORIGIN', 'ORIGIN', 'CDN') AS cdn, firstHtml,
   COUNTIF(IFNULL(a.tlsVersion, b.tlsVersion) = 'TLS 1.0') AS tls10,
   COUNTIF(IFNULL(a.tlsVersion, b.tlsVersion) = 'TLS 1.1') AS tls11,
   COUNTIF(IFNULL(a.tlsVersion, b.tlsVersion) = 'TLS 1.2') AS tls12,
@@ -20,16 +20,16 @@ FROM
       url,
       firstHtml,
       # WPT is inconsistent with protocol population.
-      UPPER(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(CONCAT("TLS ", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'TLS ')))) AS protocol,
+      UPPER(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(CONCAT('TLS ', JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'TLS ')))) AS protocol,
       JSON_EXTRACT_SCALAR(payload, '$._tls_version') AS tlsVersion,
 
       # WPT joins CDN detection but we bias to the DNS detection which is the first entry
       IFNULL(NULLIF(REGEXP_EXTRACT(_cdn_provider, r'^([^,]*).*'), ''), 'ORIGIN') AS cdn,
-      CAST(JSON_EXTRACT(payload, "$.timings.ssl") AS INT64) AS tlstime,
+      CAST(JSON_EXTRACT(payload, '$.timings.ssl') AS INT64) AS tlstime,
 
       # isSecure reports what the browser thought it was going to use, but it can get upgraded with STS OR UpgradeInsecure: 1
       IF(STARTS_WITH(url, 'https') OR JSON_EXTRACT_SCALAR(payload, '$._tls_version') IS NOT NULL OR CAST(JSON_EXTRACT(payload, '$._is_secure') AS INT64) = 1, TRUE, FALSE) AS isSecure,
-      CAST(JSON_EXTRACT(payload, "$._socket") AS INT64) AS socket
+      CAST(JSON_EXTRACT(payload, '$._socket') AS INT64) AS socket
     FROM
       `httparchive.almanac.requests`
     WHERE
@@ -41,14 +41,14 @@ LEFT JOIN (
   SELECT
     client,
     page,
-    CAST(JSON_EXTRACT(payload, "$._socket") AS INT64) AS socket,
-    ANY_VALUE(UPPER(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(CONCAT("TLS ", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'TLS '))))) AS protocol,
+    CAST(JSON_EXTRACT(payload, '$._socket') AS INT64) AS socket,
+    ANY_VALUE(UPPER(IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(CONCAT('TLS ', JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'TLS '))))) AS protocol,
     ANY_VALUE(JSON_EXTRACT_SCALAR(payload, '$._tls_version')) AS tlsVersion
   FROM `httparchive.almanac.requests`
   WHERE
     JSON_EXTRACT_SCALAR(payload, '$._tls_version') IS NOT NULL AND
-    IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(CONCAT("TLS ", JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'TLS '))) IS NOT NULL AND
-    JSON_EXTRACT(payload, "$._socket") IS NOT NULL AND
+    IFNULL(JSON_EXTRACT_SCALAR(payload, '$._protocol'), IFNULL(NULLIF(JSON_EXTRACT_SCALAR(payload, '$._tls_next_proto'), 'unknown'), NULLIF(CONCAT('TLS ', JSON_EXTRACT_SCALAR(payload, '$.response.httpVersion')), 'TLS '))) IS NOT NULL AND
+    JSON_EXTRACT(payload, '$._socket') IS NOT NULL AND
     date = '2021-07-01'
   GROUP BY
     client,

--- a/sql/2021/cdn/top_cdns.sql
+++ b/sql/2021/cdn/top_cdns.sql
@@ -32,7 +32,7 @@ FROM
     FROM
       `httparchive.almanac.requests`
     WHERE
-      date = "2021-07-01"
+      date = '2021-07-01'
   )
 GROUP BY
   client,

--- a/sql/2021/compression/lighthouse_compression_byte_savings.sql
+++ b/sql/2021/compression/lighthouse_compression_byte_savings.sql
@@ -2,13 +2,13 @@
 # lighthouse_compression_byte_savings.sql :  Text Based Compression Byte Savings
 SELECT
   _TABLE_SUFFIX AS client,
-  ROUND(CAST(JSON_EXTRACT_SCALAR(report, "$.audits.uses-text-compression.details.overallSavingsBytes") AS INT64) / 1024 / 1024) AS mbyte_savings,
+  ROUND(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.uses-text-compression.details.overallSavingsBytes') AS INT64) / 1024 / 1024) AS mbyte_savings,
   COUNT(0) AS num_pages,
   COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct_pages
 FROM
   `httparchive.lighthouse.2021_07_01_*`
 WHERE
-  JSON_EXTRACT_SCALAR(report, "$.audits.uses-text-compression.score") != "1"
+  JSON_EXTRACT_SCALAR(report, '$.audits.uses-text-compression.score') != '1'
 GROUP BY
   client,
   mbyte_savings

--- a/sql/2021/compression/lighthouse_compression_scores.sql
+++ b/sql/2021/compression/lighthouse_compression_scores.sql
@@ -2,7 +2,7 @@
 # lighthouse_compression_scores.sql Distribution of Text Based Compression Lighthouse Scores
 SELECT
   _TABLE_SUFFIX AS client,
-  JSON_EXTRACT_SCALAR(report, "$.audits.uses-text-compression.score") AS text_compression_score,
+  JSON_EXTRACT_SCALAR(report, '$.audits.uses-text-compression.score') AS text_compression_score,
   COUNT(0) AS num_pages,
   SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS total,
   COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct_pages

--- a/sql/2021/ecommerce/webpush_adoption_by_ecommsites.sql
+++ b/sql/2021/ecommerce/webpush_adoption_by_ecommsites.sql
@@ -12,7 +12,7 @@ FROM
 JOIN (
     SELECT DISTINCT
       _TABLE_SUFFIX AS client,
-      RTRIM(url, "/") AS origin
+      RTRIM(url, '/') AS origin
     FROM
       `httparchive.technologies.2021_07_01_*`
     WHERE

--- a/sql/2021/ecommerce/webpushstats_ecommsites.sql
+++ b/sql/2021/ecommerce/webpushstats_ecommsites.sql
@@ -33,7 +33,7 @@ FROM
 JOIN (
     SELECT DISTINCT
       _TABLE_SUFFIX AS client,
-      RTRIM(url, "/") AS origin
+      RTRIM(url, '/') AS origin
     FROM
       `httparchive.technologies.2021_07_01_*`
     WHERE

--- a/sql/2021/http/count_of_h2_and_h3_sites_using_push.sql
+++ b/sql/2021/http/count_of_h2_and_h3_sites_using_push.sql
@@ -17,10 +17,10 @@ FROM
       `httparchive.almanac.requests`
     WHERE
       date = '2021-07-01' AND
-      (LOWER(protocol) = "http/2" OR
-        LOWER(protocol) LIKE "%quic%" OR
-        LOWER(protocol) LIKE "h3%" OR
-        LOWER(protocol) = "http/3")
+      (LOWER(protocol) = 'http/2' OR
+        LOWER(protocol) LIKE '%quic%' OR
+        LOWER(protocol) LIKE 'h3%' OR
+        LOWER(protocol) = 'http/3')
   )
 JOIN
   (

--- a/sql/2021/http/count_of_non_h2_and_h3_sites_grouped_by_server.sql
+++ b/sql/2021/http/count_of_non_h2_and_h3_sites_grouped_by_server.sql
@@ -29,10 +29,10 @@ USING (client)
 WHERE
   date = '2021-07-01' AND
   firstHtml AND
-  LOWER(protocol) != "http/2" AND
-  LOWER(protocol) NOT LIKE "%quic%" AND
-  LOWER(protocol) NOT LIKE "h3%" AND
-  LOWER(protocol) != "http/3"
+  LOWER(protocol) != 'http/2' AND
+  LOWER(protocol) NOT LIKE '%quic%' AND
+  LOWER(protocol) NOT LIKE 'h3%' AND
+  LOWER(protocol) != 'http/3'
 GROUP BY
   client,
   http_version,

--- a/sql/2021/http/count_of_preload_http_headers_with_nopush_attribute_set.sql
+++ b/sql/2021/http/count_of_preload_http_headers_with_nopush_attribute_set.sql
@@ -22,7 +22,7 @@ SELECT
 FROM (
   SELECT
     client,
-    extractHTTPHeaders(response_headers, "link") AS link_headers
+    extractHTTPHeaders(response_headers, 'link') AS link_headers
   FROM
     `httparchive.almanac.requests`
   WHERE

--- a/sql/2021/http/detailed_alt_svc_headers_pages.sql
+++ b/sql/2021/http/detailed_alt_svc_headers_pages.sql
@@ -18,7 +18,7 @@ SELECT
   client,
   protocol,
   IF(url LIKE 'https://%', 'https', 'http') AS http_or_https,
-  NORMALIZE_AND_CASEFOLD(extractHTTPHeader(response_headers, "alt-svc")) AS altsvc,
+  NORMALIZE_AND_CASEFOLD(extractHTTPHeader(response_headers, 'alt-svc')) AS altsvc,
   COUNT(0) AS num_pages,
   SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
   COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct

--- a/sql/2021/http/detailed_alt_svc_headers_requests.sql
+++ b/sql/2021/http/detailed_alt_svc_headers_requests.sql
@@ -18,7 +18,7 @@ SELECT
   client,
   protocol,
   IF(url LIKE 'https://%', 'https', 'http') AS http_or_https,
-  NORMALIZE_AND_CASEFOLD(extractHTTPHeader(response_headers, "alt-svc")) AS altsvc,
+  NORMALIZE_AND_CASEFOLD(extractHTTPHeader(response_headers, 'alt-svc')) AS altsvc,
   COUNT(0) AS num_requests,
   SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
   COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct

--- a/sql/2021/http/detailed_upgrade_headers.sql
+++ b/sql/2021/http/detailed_upgrade_headers.sql
@@ -18,7 +18,7 @@ SELECT
   client,
   protocol,
   IF(url LIKE 'https://%', 'https', 'http') AS http_or_https,
-  NORMALIZE_AND_CASEFOLD(extractHTTPHeader(response_headers, "upgrade")) AS upgrade,
+  NORMALIZE_AND_CASEFOLD(extractHTTPHeader(response_headers, 'upgrade')) AS upgrade,
   COUNT(0) AS num_requests,
   SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
   COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct

--- a/sql/2021/http/http3_support_by_rank.sql
+++ b/sql/2021/http/http3_support_by_rank.sql
@@ -36,7 +36,7 @@ FROM
       firstHTML AND
       (
         LOWER(protocol) IN ('http/3', 'quic', 'h3-29', 'h3-q050') OR
-        extractHTTPHeader(response_headers, "alt-svc") LIKE '%h3%'
+        extractHTTPHeader(response_headers, 'alt-svc') LIKE '%h3%'
       )
   ),
   UNNEST([1000, 10000, 100000, 1000000, 10000000]) AS rank_grouping

--- a/sql/2021/http/number_of_h2_and_h3_pushed_resources_and_bytes_by_content_type.sql
+++ b/sql/2021/http/number_of_h2_and_h3_pushed_resources_and_bytes_by_content_type.sql
@@ -19,12 +19,12 @@ FROM
       `httparchive.almanac.requests`
     WHERE
       date = '2021-07-01' AND
-      pushed = "1" AND
+      pushed = '1' AND
       (
-        LOWER(protocol) = "http/2" OR
-        LOWER(protocol) LIKE "%quic%" OR
-        LOWER(protocol) LIKE "h3%" OR
-        LOWER(protocol) = "http/3"
+        LOWER(protocol) = 'http/2' OR
+        LOWER(protocol) LIKE '%quic%' OR
+        LOWER(protocol) LIKE 'h3%' OR
+        LOWER(protocol) = 'http/3'
       )
     GROUP BY
       client,

--- a/sql/2021/http/number_of_h2_and_h3_pushed_resources_and_bytes_transferred.sql
+++ b/sql/2021/http/number_of_h2_and_h3_pushed_resources_and_bytes_transferred.sql
@@ -19,10 +19,10 @@ FROM
       date = '2021-07-01' AND
       pushed = '1' AND
       (
-        LOWER(protocol) = "http/2" OR
-        LOWER(protocol) LIKE "%quic%" OR
-        LOWER(protocol) LIKE "h3%" OR
-        LOWER(protocol) = "http/3"
+        LOWER(protocol) = 'http/2' OR
+        LOWER(protocol) LIKE '%quic%' OR
+        LOWER(protocol) LIKE 'h3%' OR
+        LOWER(protocol) = 'http/3'
       )
     GROUP BY
       client,

--- a/sql/2021/http/number_of_http_requests_returning_upgrade_http_header_containing_h2.sql
+++ b/sql/2021/http/number_of_http_requests_returning_upgrade_http_header_containing_h2.sql
@@ -18,13 +18,13 @@ SELECT
   client,
   firstHtml,
   protocol AS http_version,
-  COUNTIF(extractHTTPHeader(response_headers, "upgrade") LIKE "%h2%") AS num_requests,
+  COUNTIF(extractHTTPHeader(response_headers, 'upgrade') LIKE '%h2%') AS num_requests,
   COUNT(0) AS total
 FROM
   `httparchive.almanac.requests`
 WHERE
   date = '2021-07-01' AND
-  url LIKE "http://%"
+  url LIKE 'http://%'
 GROUP BY
   client,
   firstHtml,

--- a/sql/2021/http/number_of_https_requests_not_using_h2_or_h3_returning_upgrade_http_upgrade_header_containing_h2.sql
+++ b/sql/2021/http/number_of_https_requests_not_using_h2_or_h3_returning_upgrade_http_upgrade_header_containing_h2.sql
@@ -17,17 +17,17 @@ try {
 SELECT
   client,
   firstHtml,
-  COUNTIF(extractHTTPHeader(response_headers, "upgrade") LIKE "%h2%") AS num_requests,
+  COUNTIF(extractHTTPHeader(response_headers, 'upgrade') LIKE '%h2%') AS num_requests,
   COUNT(0) AS total
 FROM
   `httparchive.almanac.requests`
 WHERE
   date = '2021-07-01' AND
-  url LIKE "https://%" AND
-  LOWER(protocol) != "http/2" AND
-  LOWER(protocol) NOT LIKE "%quic%" AND
-  LOWER(protocol) NOT LIKE "h3%" AND
-  LOWER(protocol) != "http/3"
+  url LIKE 'https://%' AND
+  LOWER(protocol) != 'http/2' AND
+  LOWER(protocol) NOT LIKE '%quic%' AND
+  LOWER(protocol) NOT LIKE 'h3%' AND
+  LOWER(protocol) != 'http/3'
 GROUP BY
   client,
   firstHtml

--- a/sql/2021/http/number_of_https_requests_using_h2_returning_upgrade_http_header_containing_h2.sql
+++ b/sql/2021/http/number_of_https_requests_using_h2_returning_upgrade_http_header_containing_h2.sql
@@ -18,15 +18,15 @@ SELECT
   client,
   firstHtml,
   protocol AS http_version,
-  COUNTIF(extractHTTPHeader(response_headers, "upgrade") LIKE "%h2%") AS num_requests,
+  COUNTIF(extractHTTPHeader(response_headers, 'upgrade') LIKE '%h2%') AS num_requests,
   COUNT(0) AS total,
-  COUNTIF(extractHTTPHeader(response_headers, "upgrade") LIKE "%h2%") / COUNT(0) AS pct
+  COUNTIF(extractHTTPHeader(response_headers, 'upgrade') LIKE '%h2%') / COUNT(0) AS pct
 FROM
   `httparchive.almanac.requests`
 WHERE
   date = '2021-07-01' AND
-  url LIKE "https://%" AND
-  LOWER(protocol) = "http/2"
+  url LIKE 'https://%' AND
+  LOWER(protocol) = 'http/2'
 GROUP BY
   client,
   firstHtml,

--- a/sql/2021/http/percentage_of_h2_and_h3_sites_affected_by_cdn_prioritization.sql
+++ b/sql/2021/http/percentage_of_h2_and_h3_sites_affected_by_cdn_prioritization.sql
@@ -2,8 +2,8 @@
 # Percentage of H2 and H3 sites affected by CDN prioritization issues
 SELECT
   client,
-  IF(pages.cdn = "", "Not using CDN", pages.cdn) AS CDN,
-  IF(prioritization_status IS NOT NULL, prioritization_status, "Unknown") AS prioritizes_correctly,
+  IF(pages.cdn = '', 'Not using CDN', pages.cdn) AS CDN,
+  IF(prioritization_status IS NOT NULL, prioritization_status, 'Unknown') AS prioritizes_correctly,
   COUNT(0) AS num_pages,
   COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct
 FROM (
@@ -19,10 +19,10 @@ FROM (
       date = '2021-07-01' AND
       firstHtml AND
       (
-        LOWER(protocol) = "http/2" OR
-        LOWER(protocol) LIKE "%quic%" OR
-        LOWER(protocol) LIKE "h3%" OR
-        LOWER(protocol) = "http/3"
+        LOWER(protocol) = 'http/2' OR
+        LOWER(protocol) LIKE '%quic%' OR
+        LOWER(protocol) LIKE 'h3%' OR
+        LOWER(protocol) = 'http/3'
       )
 ) AS pages
 LEFT JOIN

--- a/sql/2021/http/response_headers_type_percentile_size.sql
+++ b/sql/2021/http/response_headers_type_percentile_size.sql
@@ -11,8 +11,8 @@ FROM
     SELECT
       client,
       url,
-      JSON_EXTRACT_SCALAR(header, "$.name") AS header_name,
-      LENGTH(JSON_EXTRACT_SCALAR(header, "$.value")) AS header_length
+      JSON_EXTRACT_SCALAR(header, '$.name') AS header_name,
+      LENGTH(JSON_EXTRACT_SCALAR(header, '$.value')) AS header_length
     FROM
       `httparchive.almanac.requests`,
       UNNEST(JSON_EXTRACT_ARRAY(response_headers)) AS header

--- a/sql/2021/jamstack/adoption.sql
+++ b/sql/2021/jamstack/adoption.sql
@@ -19,9 +19,9 @@ JOIN (
 USING
   (_TABLE_SUFFIX)
 WHERE
-  LOWER(category) = "static site generator" OR
-  app = "Next.js" OR
-  app = "Nuxt.js"
+  LOWER(category) = 'static site generator' OR
+  app = 'Next.js' OR
+  app = 'Nuxt.js'
 GROUP BY
   client,
   total
@@ -45,9 +45,9 @@ JOIN (
 USING
   (_TABLE_SUFFIX)
 WHERE
-  LOWER(category) = "static site generator" OR
-  app = "Next.js" OR
-  app = "Nuxt.js"
+  LOWER(category) = 'static site generator' OR
+  app = 'Next.js' OR
+  app = 'Nuxt.js'
 GROUP BY
   client,
   total
@@ -71,9 +71,9 @@ JOIN (
 USING
   (_TABLE_SUFFIX)
 WHERE
-  LOWER(category) = "static site generator" OR
-  app = "Next.js" OR
-  app = "Nuxt.js"
+  LOWER(category) = 'static site generator' OR
+  app = 'Next.js' OR
+  app = 'Nuxt.js'
 GROUP BY
   client,
   total

--- a/sql/2021/jamstack/adoption_by_geo.sql
+++ b/sql/2021/jamstack/adoption_by_geo.sql
@@ -44,9 +44,9 @@ FROM (
     FROM
       `httparchive.technologies.2021_07_01_*`
     WHERE
-      LOWER(category) = "static site generator" OR
-      app = "Next.js" OR
-      app = "Nuxt.js"
+      LOWER(category) = 'static site generator' OR
+      app = 'Next.js' OR
+      app = 'Nuxt.js'
   ) USING (client, url)
   GROUP BY
     app,

--- a/sql/2021/jamstack/adoption_by_region.sql
+++ b/sql/2021/jamstack/adoption_by_region.sql
@@ -1240,9 +1240,9 @@ FROM (
     FROM
       `httparchive.technologies.2021_07_01_*`
     WHERE
-      LOWER(category) = "static site generator" OR
-      app = "Next.js" OR
-      app = "Nuxt.js"
+      LOWER(category) = 'static site generator' OR
+      app = 'Next.js' OR
+      app = 'Nuxt.js'
   ) USING (client, url)
   GROUP BY
     app,

--- a/sql/2021/jamstack/adoption_by_subregion.sql
+++ b/sql/2021/jamstack/adoption_by_subregion.sql
@@ -1240,9 +1240,9 @@ FROM (
     FROM
       `httparchive.technologies.2021_07_01_*`
     WHERE
-      LOWER(category) = "static site generator" OR
-      app = "Next.js" OR
-      app = "Nuxt.js"
+      LOWER(category) = 'static site generator' OR
+      app = 'Next.js' OR
+      app = 'Nuxt.js'
   ) USING (client, url)
   GROUP BY
     app,

--- a/sql/2021/jamstack/adoption_of_image_formats_in_ssgs.sql
+++ b/sql/2021/jamstack/adoption_of_image_formats_in_ssgs.sql
@@ -23,9 +23,9 @@ JOIN (
   FROM
     `httparchive.technologies.2021_07_01_*`
   WHERE
-    LOWER(category) = "static site generator" OR
-    app = "Next.js" OR
-    app = "Nuxt.js")
+    LOWER(category) = 'static site generator' OR
+    app = 'Next.js' OR
+    app = 'Nuxt.js')
 USING
   (client, page)
 GROUP BY

--- a/sql/2021/jamstack/cdn-ssg-distribution.sql
+++ b/sql/2021/jamstack/cdn-ssg-distribution.sql
@@ -40,9 +40,9 @@ JOIN (
   FROM
     `httparchive.technologies.2021_07_01_*`
   WHERE
-    LOWER(category) = "static site generator" OR
-    app = "Next.js" OR
-    app = "Nuxt.js"
+    LOWER(category) = 'static site generator' OR
+    app = 'Next.js' OR
+    app = 'Nuxt.js'
   )
 USING (client, url)
 WHERE

--- a/sql/2021/jamstack/core_web_vitals_distribution.sql
+++ b/sql/2021/jamstack/core_web_vitals_distribution.sql
@@ -46,9 +46,9 @@ JOIN (
   FROM
     `httparchive.technologies.2021_07_01_*`
   WHERE
-    LOWER(category) = "static site generator" OR
-    app = "Next.js" OR
-    app = "Nuxt.js"
+    LOWER(category) = 'static site generator' OR
+    app = 'Next.js' OR
+    app = 'Nuxt.js'
   )
 USING (client, url)
 GROUP BY

--- a/sql/2021/jamstack/core_web_vitals_distribution_cdn.sql
+++ b/sql/2021/jamstack/core_web_vitals_distribution_cdn.sql
@@ -60,9 +60,9 @@ JOIN (
   FROM
     `httparchive.technologies.2021_07_01_*`
   WHERE
-    LOWER(category) = "static site generator" OR
-    app = "Next.js" OR
-    app = "Nuxt.js"
+    LOWER(category) = 'static site generator' OR
+    app = 'Next.js' OR
+    app = 'Nuxt.js'
   )
 USING (client, url)
 WHERE

--- a/sql/2021/jamstack/core_web_vitals_passing.sql
+++ b/sql/2021/jamstack/core_web_vitals_passing.sql
@@ -65,9 +65,9 @@ JOIN (
   FROM
     `httparchive.technologies.2021_07_01_*`
   WHERE
-    LOWER(category) = "static site generator" OR
-    app = "Next.js" OR
-    app = "Nuxt.js"
+    LOWER(category) = 'static site generator' OR
+    app = 'Next.js' OR
+    app = 'Nuxt.js'
   )
 USING (client, url)
 GROUP BY

--- a/sql/2021/jamstack/core_web_vitals_passing_cdn.sql
+++ b/sql/2021/jamstack/core_web_vitals_passing_cdn.sql
@@ -79,9 +79,9 @@ JOIN (
   FROM
     `httparchive.technologies.2021_07_01_*`
   WHERE
-    LOWER(category) = "static site generator" OR
-    app = "Next.js" OR
-    app = "Nuxt.js"
+    LOWER(category) = 'static site generator' OR
+    app = 'Next.js' OR
+    app = 'Nuxt.js'
   )
 USING (client, url)
 WHERE

--- a/sql/2021/jamstack/distribution_of_page_weight_requests_and_co2_grams_per_ssg_web_page.sql
+++ b/sql/2021/jamstack/distribution_of_page_weight_requests_and_co2_grams_per_ssg_web_page.sql
@@ -41,9 +41,9 @@ FROM (
     FROM
       `httparchive.technologies.2021_07_01_*`
     WHERE
-      LOWER(category) = "static site generator" OR
-      app = "Next.js" OR
-      app = "Nuxt.js"
+      LOWER(category) = 'static site generator' OR
+      app = 'Next.js' OR
+      app = 'Nuxt.js'
   )
   USING
     (_TABLE_SUFFIX, url)),

--- a/sql/2021/jamstack/framework_libraries.sql
+++ b/sql/2021/jamstack/framework_libraries.sql
@@ -19,9 +19,9 @@ ssg AS (
   FROM
     `httparchive.technologies.2021_07_01_*`
   WHERE
-    LOWER(category) = "static site generator" OR
-    app = "Next.js" OR
-    app = "Nuxt.js"
+    LOWER(category) = 'static site generator' OR
+    app = 'Next.js' OR
+    app = 'Nuxt.js'
 ),
 
 total_ssg AS (
@@ -31,9 +31,9 @@ total_ssg AS (
   FROM
     `httparchive.technologies.2021_07_01_*`
   WHERE
-    LOWER(category) = "static site generator" OR
-    app = "Next.js" OR
-    app = "Nuxt.js"
+    LOWER(category) = 'static site generator' OR
+    app = 'Next.js' OR
+    app = 'Nuxt.js'
   GROUP BY
     _TABLE_SUFFIX
 ),
@@ -46,9 +46,9 @@ total_ssg_app AS (
   FROM
     `httparchive.technologies.2021_07_01_*`
   WHERE
-    LOWER(category) = "static site generator" OR
-    app = "Next.js" OR
-    app = "Nuxt.js"
+    LOWER(category) = 'static site generator' OR
+    app = 'Next.js' OR
+    app = 'Nuxt.js'
   GROUP BY
     _TABLE_SUFFIX,
     app

--- a/sql/2021/jamstack/median_lighthouse_score.sql
+++ b/sql/2021/jamstack/median_lighthouse_score.sql
@@ -21,9 +21,9 @@ JOIN (
   FROM
     `httparchive.technologies.2021_07_01_mobile`
   WHERE
-    LOWER(category) = "static site generator" OR
-    app = "Next.js" OR
-    app = "Nuxt.js")
+    LOWER(category) = 'static site generator' OR
+    app = 'Next.js' OR
+    app = 'Nuxt.js')
 USING
   (url)
 GROUP BY

--- a/sql/2021/jamstack/resource_weights.sql
+++ b/sql/2021/jamstack/resource_weights.sql
@@ -18,9 +18,9 @@ FROM (
   FROM
     `httparchive.technologies.2021_07_01_*`
   WHERE
-    LOWER(category) = "static site generator" OR
-    app = "Next.js" OR
-    app = "Nuxt.js"
+    LOWER(category) = 'static site generator' OR
+    app = 'Next.js' OR
+    app = 'Nuxt.js'
 )
 JOIN (
   SELECT

--- a/sql/2021/jamstack/ssg_compared_to_2020.sql
+++ b/sql/2021/jamstack/ssg_compared_to_2020.sql
@@ -20,9 +20,9 @@ JOIN (
 USING
   (_TABLE_SUFFIX)
 WHERE
-  LOWER(category) = "static site generator" OR
-  app = "Next.js" OR
-  app = "Nuxt.js"
+  LOWER(category) = 'static site generator' OR
+  app = 'Next.js' OR
+  app = 'Nuxt.js'
 GROUP BY
   client,
   total,
@@ -48,9 +48,9 @@ JOIN (
 USING
   (_TABLE_SUFFIX)
 WHERE
-  LOWER(category) = "static site generator" OR
-  app = "Next.js" OR
-  app = "Nuxt.js"
+  LOWER(category) = 'static site generator' OR
+  app = 'Next.js' OR
+  app = 'Nuxt.js'
 GROUP BY
   client,
   total,

--- a/sql/2021/jamstack/third_party_bytes_and_requests_on_ssgs.sql
+++ b/sql/2021/jamstack/third_party_bytes_and_requests_on_ssgs.sql
@@ -27,9 +27,9 @@ FROM (
     FROM
       `httparchive.technologies.2021_07_01_*`
     WHERE
-      LOWER(category) = "static site generator" OR
-      app = "Next.js" OR
-      app = "Nuxt.js")
+      LOWER(category) = 'static site generator' OR
+      app = 'Next.js' OR
+      app = 'Nuxt.js')
   USING
     (client, page)
   WHERE

--- a/sql/2021/javascript/unused_js_bytes_distribution.sql
+++ b/sql/2021/javascript/unused_js_bytes_distribution.sql
@@ -2,7 +2,7 @@
 # Distribution of unused JS request bytes per page
 SELECT
   percentile,
-  APPROX_QUANTILES(CAST(JSON_EXTRACT_SCALAR(report, "$.audits.unused-javascript.details.overallSavingsBytes") AS INT64) / 1024, 1000)[OFFSET(percentile * 10)] AS js_kilobytes
+  APPROX_QUANTILES(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.unused-javascript.details.overallSavingsBytes') AS INT64) / 1024, 1000)[OFFSET(percentile * 10)] AS js_kilobytes
 FROM
   `httparchive.lighthouse.2021_07_01_mobile`,
   UNNEST([10, 25, 50, 75, 90, 100]) AS percentile

--- a/sql/2021/markup/doctype.sql
+++ b/sql/2021/markup/doctype.sql
@@ -3,7 +3,7 @@
 
 SELECT
   _TABLE_SUFFIX AS client,
-  LOWER(REGEXP_REPLACE(TRIM(doctype), r" +", " ")) AS doctype, # remove extra spaces and make lower case
+  LOWER(REGEXP_REPLACE(TRIM(doctype), r' +', ' ')) AS doctype, # remove extra spaces and make lower case
   COUNT(0) AS freq,
   COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct
 FROM

--- a/sql/2021/markup/markup.sql
+++ b/sql/2021/markup/markup.sql
@@ -152,13 +152,13 @@ SELECT
   SAFE_DIVIDE(COUNTIF(LENGTH(markup_info.dirs_html_dir) > 0), COUNT(0)) AS pct_html_dir_set,
 
   # pages with html dir set to ltr
-  SAFE_DIVIDE(COUNTIF(markup_info.dirs_html_dir = "ltr"), COUNT(0)) AS pct_html_dir_ltr,
+  SAFE_DIVIDE(COUNTIF(markup_info.dirs_html_dir = 'ltr'), COUNT(0)) AS pct_html_dir_ltr,
 
   # pages with html dir set to rtl
-  SAFE_DIVIDE(COUNTIF(markup_info.dirs_html_dir = "rtl"), COUNT(0)) AS pct_html_dir_rtl,
+  SAFE_DIVIDE(COUNTIF(markup_info.dirs_html_dir = 'rtl'), COUNT(0)) AS pct_html_dir_rtl,
 
   # pages with html dir set to auto
-  SAFE_DIVIDE(COUNTIF(markup_info.dirs_html_dir = "auto"), COUNT(0)) AS pct_html_dir_auto,
+  SAFE_DIVIDE(COUNTIF(markup_info.dirs_html_dir = 'auto'), COUNT(0)) AS pct_html_dir_auto,
 
   # pages with dir on other elements
   SAFE_DIVIDE(COUNTIF(markup_info.dirs_body_nodes_dir_total > 0), COUNT(0)) AS pct_body_nodes_dir_set

--- a/sql/2021/markup/monetization_by_host.sql
+++ b/sql/2021/markup/monetization_by_host.sql
@@ -36,7 +36,7 @@ FROM (
     `httparchive.pages.2021_07_01_*`
 )
 WHERE
-  monetization != ""
+  monetization != ''
 GROUP BY
   client,
   host

--- a/sql/2021/markup/top_obsolete_elements.sql
+++ b/sql/2021/markup/top_obsolete_elements.sql
@@ -18,7 +18,7 @@ try {
 ''';
 
 CREATE TEMPORARY FUNCTION is_obsolete(element STRING) AS (
-  element IN ("applet", "acronym", "bgsound", "dir", "frame", "frameset", "noframes", "isindex", "keygen", "listing", "menuitem", "nextid", "noembed", "plaintext", "rb", "rtc", "strike", "xmp", "basefont", "big", "blink", "center", "font", "marquee", "multicol", "nobr", "spacer", "tt")
+  element IN ('applet', 'acronym', 'bgsound', 'dir', 'frame', 'frameset', 'noframes', 'isindex', 'keygen', 'listing', 'menuitem', 'nextid', 'noembed', 'plaintext', 'rb', 'rtc', 'strike', 'xmp', 'basefont', 'big', 'blink', 'center', 'font', 'marquee', 'multicol', 'nobr', 'spacer', 'tt')
 );
 
 SELECT

--- a/sql/2021/media/img_xdomain.sql
+++ b/sql/2021/media/img_xdomain.sql
@@ -24,8 +24,8 @@ FROM (
   SELECT
     _TABLE_SUFFIX AS client,
     a.url AS pageUrl,
-    FORMAT("%T", NET.REG_DOMAIN(a.url)) AS pageDomain,
-    FORMAT("%T", NET.REG_DOMAIN(imageurl.url)) AS imageDomain
+    FORMAT('%T', NET.REG_DOMAIN(a.url)) AS pageDomain,
+    FORMAT('%T', NET.REG_DOMAIN(imageurl.url)) AS imageDomain
   FROM
     `httparchive.pages.2021_07_01_*` a,
     UNNEST(get_images(JSON_EXTRACT_SCALAR(payload, '$._Images'))) AS imageurl)

--- a/sql/2021/media/video_adoption.sql
+++ b/sql/2021/media/video_adoption.sql
@@ -6,7 +6,7 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    CAST(JSON_VALUE(JSON_VALUE(payload, "$._media"), "$.num_video_nodes") AS INT64) AS num_video_nodes
+    CAST(JSON_VALUE(JSON_VALUE(payload, '$._media'), '$.num_video_nodes') AS INT64) AS num_video_nodes
   FROM
     `httparchive.pages.2021_07_01_*`)
 GROUP BY

--- a/sql/2021/media/video_attribute_count.sql
+++ b/sql/2021/media/video_attribute_count.sql
@@ -5,13 +5,13 @@ WITH videonotes AS (
   SELECT
     _TABLE_SUFFIX AS client,
     url AS pageURL,
-    JSON_VALUE(payload, "$._media") AS media,
-    CAST(JSON_VALUE(JSON_VALUE(payload, "$._media"), "$.num_video_nodes") AS INT64) AS num_video_nodes,
-    (JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_durations")) AS video_duration,
-    (JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_display_style")) AS video_display_style,
-    ARRAY_TO_STRING(JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_attributes_values_counts"), " ") AS video_attributes_values_counts,
-    (JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_source_format_count")) AS video_source_format_count,
-    (JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_source_format_type")) AS video_source_format_type
+    JSON_VALUE(payload, '$._media') AS media,
+    CAST(JSON_VALUE(JSON_VALUE(payload, '$._media'), '$.num_video_nodes') AS INT64) AS num_video_nodes,
+    (JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_durations')) AS video_duration,
+    (JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_display_style')) AS video_display_style,
+    ARRAY_TO_STRING(JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_attributes_values_counts'), ' ') AS video_attributes_values_counts,
+    (JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_source_format_count')) AS video_source_format_count,
+    (JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_source_format_type')) AS video_source_format_type
   FROM
     `httparchive.pages.2021_07_01_*`
 ),
@@ -31,9 +31,9 @@ video_attributes AS (
   SELECT
     client,
     pageURL,
-    JSON_VALUE(video_attributes_values_counts, "$.attribute") AS attribute,
-    JSON_VALUE(video_attributes_values_counts, "$.value") AS value,
-    CAST(JSON_VALUE(video_attributes_values_counts, "$.count") AS INT64) AS cnt,
+    JSON_VALUE(video_attributes_values_counts, '$.attribute') AS attribute,
+    JSON_VALUE(video_attributes_values_counts, '$.value') AS value,
+    CAST(JSON_VALUE(video_attributes_values_counts, '$.count') AS INT64) AS cnt,
     video_attributes_values_counts
   FROM
     videonotes

--- a/sql/2021/media/video_attribute_names.sql
+++ b/sql/2021/media/video_attribute_names.sql
@@ -3,13 +3,13 @@ WITH videonotes AS (
   SELECT
     _TABLE_SUFFIX AS client,
     url AS pageURL,
-    JSON_VALUE(payload, "$._media") AS media,
-    CAST(JSON_VALUE(JSON_VALUE(payload, "$._media"), "$.num_video_nodes") AS INT64) AS num_video_nodes,
-    (JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_durations")) AS video_duration,
-    (JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_display_style")) AS video_display_style,
-    ARRAY_TO_STRING(JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_attributes_values_counts"), " ") AS video_attributes_values_counts,
-    (JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_source_format_count")) AS video_source_format_count,
-    (JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_source_format_type")) AS video_source_format_type
+    JSON_VALUE(payload, '$._media') AS media,
+    CAST(JSON_VALUE(JSON_VALUE(payload, '$._media'), '$.num_video_nodes') AS INT64) AS num_video_nodes,
+    (JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_durations')) AS video_duration,
+    (JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_display_style')) AS video_display_style,
+    ARRAY_TO_STRING(JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_attributes_values_counts'), ' ') AS video_attributes_values_counts,
+    (JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_source_format_count')) AS video_source_format_count,
+    (JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_source_format_type')) AS video_source_format_type
   FROM
     `httparchive.pages.2021_07_01_*`
 ),
@@ -18,9 +18,9 @@ video_attributes AS (
   SELECT
     client,
     pageURL,
-    JSON_VALUE(video_attributes_values_counts, "$.attribute") AS attribute,
-    JSON_VALUE(video_attributes_values_counts, "$.value") AS value,
-    CAST(JSON_VALUE(video_attributes_values_counts, "$.count") AS INT64) AS cnt,
+    JSON_VALUE(video_attributes_values_counts, '$.attribute') AS attribute,
+    JSON_VALUE(video_attributes_values_counts, '$.value') AS value,
+    CAST(JSON_VALUE(video_attributes_values_counts, '$.count') AS INT64) AS cnt,
     video_attributes_values_counts
   FROM
     videonotes

--- a/sql/2021/media/video_attribute_widths.sql
+++ b/sql/2021/media/video_attribute_widths.sql
@@ -12,13 +12,13 @@ WITH videonotes AS (
   SELECT
     _TABLE_SUFFIX AS client,
     url AS pageURL,
-    JSON_VALUE(payload, "$._media") AS media,
-    CAST(JSON_VALUE(JSON_VALUE(payload, "$._media"), "$.num_video_nodes") AS INT64) AS num_video_nodes,
-    (JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_durations")) AS video_duration,
-    (JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_display_style")) AS video_display_style,
-    ARRAY_TO_STRING(JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_attributes_values_counts"), " ") AS video_attributes_values_counts,
-    (JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_source_format_count")) AS video_source_format_count,
-    (JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_source_format_type")) AS video_source_format_type
+    JSON_VALUE(payload, '$._media') AS media,
+    CAST(JSON_VALUE(JSON_VALUE(payload, '$._media'), '$.num_video_nodes') AS INT64) AS num_video_nodes,
+    (JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_durations')) AS video_duration,
+    (JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_display_style')) AS video_display_style,
+    ARRAY_TO_STRING(JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_attributes_values_counts'), ' ') AS video_attributes_values_counts,
+    (JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_source_format_count')) AS video_source_format_count,
+    (JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_source_format_type')) AS video_source_format_type
   FROM
     `httparchive.pages.2021_07_01_*`
 ),
@@ -27,9 +27,9 @@ video_attributes AS (
   SELECT
     client,
     pageURL,
-    JSON_VALUE(video_attributes_values_counts, "$.attribute") AS attribute,
-    JSON_VALUE(video_attributes_values_counts, "$.value") AS value,
-    CAST(JSON_VALUE(video_attributes_values_counts, "$.count") AS INT64) AS cnt,
+    JSON_VALUE(video_attributes_values_counts, '$.attribute') AS attribute,
+    JSON_VALUE(video_attributes_values_counts, '$.value') AS value,
+    CAST(JSON_VALUE(video_attributes_values_counts, '$.count') AS INT64) AS cnt,
     video_attributes_values_counts
   FROM
     videonotes

--- a/sql/2021/media/video_durations.sql
+++ b/sql/2021/media/video_durations.sql
@@ -6,31 +6,31 @@ WITH videonotes AS (
     pageURL,
     CAST(durations AS FLOAT64) AS durations,
     CASE
-      WHEN CAST(durations AS FLOAT64) <= 1 THEN "under1"
-      WHEN (CAST(durations AS FLOAT64) > 1 AND CAST(durations AS FLOAT64) <= 5) THEN "under5"
-      WHEN (CAST(durations AS FLOAT64) > 5 AND CAST(durations AS FLOAT64) <= 10) THEN "under10"
-      WHEN (CAST(durations AS FLOAT64) > 10 AND CAST(durations AS FLOAT64) <= 20) THEN "under20"
-      WHEN (CAST(durations AS FLOAT64) > 20 AND CAST(durations AS FLOAT64) <= 30) THEN "under30"
-      WHEN (CAST(durations AS FLOAT64) > 30 AND CAST(durations AS FLOAT64) <= 45) THEN "under45"
-      WHEN (CAST(durations AS FLOAT64) > 45 AND CAST(durations AS FLOAT64) <= 60) THEN "under60"
-      WHEN (CAST(durations AS FLOAT64) > 60 AND CAST(durations AS FLOAT64) <= 90) THEN "under90"
-      WHEN (CAST(durations AS FLOAT64) > 90 AND CAST(durations AS FLOAT64) <= 120) THEN "under120"
-      WHEN (CAST(durations AS FLOAT64) > 120 AND CAST(durations AS FLOAT64) <= 180) THEN "under180"
-      WHEN (CAST(durations AS FLOAT64) > 180 AND CAST(durations AS FLOAT64) <= 300) THEN "under300"
-      WHEN (CAST(durations AS FLOAT64) > 300 AND CAST(durations AS FLOAT64) <= 600) THEN "under600"
-      ELSE "over600"
+      WHEN CAST(durations AS FLOAT64) <= 1 THEN 'under1'
+      WHEN (CAST(durations AS FLOAT64) > 1 AND CAST(durations AS FLOAT64) <= 5) THEN 'under5'
+      WHEN (CAST(durations AS FLOAT64) > 5 AND CAST(durations AS FLOAT64) <= 10) THEN 'under10'
+      WHEN (CAST(durations AS FLOAT64) > 10 AND CAST(durations AS FLOAT64) <= 20) THEN 'under20'
+      WHEN (CAST(durations AS FLOAT64) > 20 AND CAST(durations AS FLOAT64) <= 30) THEN 'under30'
+      WHEN (CAST(durations AS FLOAT64) > 30 AND CAST(durations AS FLOAT64) <= 45) THEN 'under45'
+      WHEN (CAST(durations AS FLOAT64) > 45 AND CAST(durations AS FLOAT64) <= 60) THEN 'under60'
+      WHEN (CAST(durations AS FLOAT64) > 60 AND CAST(durations AS FLOAT64) <= 90) THEN 'under90'
+      WHEN (CAST(durations AS FLOAT64) > 90 AND CAST(durations AS FLOAT64) <= 120) THEN 'under120'
+      WHEN (CAST(durations AS FLOAT64) > 120 AND CAST(durations AS FLOAT64) <= 180) THEN 'under180'
+      WHEN (CAST(durations AS FLOAT64) > 180 AND CAST(durations AS FLOAT64) <= 300) THEN 'under300'
+      WHEN (CAST(durations AS FLOAT64) > 300 AND CAST(durations AS FLOAT64) <= 600) THEN 'under600'
+      ELSE 'over600'
     END AS duration_bucket
   FROM (
       SELECT
         _TABLE_SUFFIX AS client,
         url AS pageURL,
-        JSON_VALUE(payload, "$._media") AS media,
-        CAST(JSON_VALUE(JSON_VALUE(payload, "$._media"), "$.num_video_nodes") AS INT64) AS num_video_nodes,
-        (JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_durations")) AS video_duration,
-        (JSON_QUERY(JSON_VALUE(payload, "$._media"), "$.video_display_style")) AS video_display_style,
-        (JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_attributes_values_counts")) AS video_attributes_values_counts,
-        (JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_source_format_count")) AS video_source_format_count,
-        (JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_source_format_type")) AS video_source_format_type
+        JSON_VALUE(payload, '$._media') AS media,
+        CAST(JSON_VALUE(JSON_VALUE(payload, '$._media'), '$.num_video_nodes') AS INT64) AS num_video_nodes,
+        (JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_durations')) AS video_duration,
+        (JSON_QUERY(JSON_VALUE(payload, '$._media'), '$.video_display_style')) AS video_display_style,
+        (JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_attributes_values_counts')) AS video_attributes_values_counts,
+        (JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_source_format_count')) AS video_source_format_count,
+        (JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_source_format_type')) AS video_source_format_type
       FROM
         `httparchive.pages.2021_07_01_*`
     )
@@ -38,7 +38,7 @@ WITH videonotes AS (
     UNNEST(video_duration) AS durations
   WHERE
     num_video_nodes > 0 AND
-    durations != "null"
+    durations != 'null'
   ORDER BY
     durations DESC
 )

--- a/sql/2021/media/video_ext.sql
+++ b/sql/2021/media/video_ext.sql
@@ -1,5 +1,5 @@
 SELECT _TABLE_SUFFIX AS client, ext, COUNT(ext) AS cnt
 FROM `httparchive.summary_requests.2021_07_01_*`
-WHERE mimetype LIKE "%video%"
+WHERE mimetype LIKE '%video%'
 GROUP BY client, ext
 ORDER BY cnt DESC

--- a/sql/2021/media/video_number_of_sources.sql
+++ b/sql/2021/media/video_number_of_sources.sql
@@ -13,13 +13,13 @@ WITH videonotes AS (
       SELECT
         _TABLE_SUFFIX AS client,
         url AS pageURL,
-        JSON_VALUE(payload, "$._media") AS media,
-        CAST(JSON_VALUE(JSON_VALUE(payload, "$._media"), "$.num_video_nodes") AS INT64) AS num_video_nodes,
-        (JSON_QUERY(JSON_VALUE(payload, "$._media"), "$.video_durations")) AS video_duration,
-        (JSON_QUERY(JSON_VALUE(payload, "$._media"), "$.video_display_style")) AS video_display_style,
-        (JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_attributes_values_counts")) AS video_attributes_values_counts,
-        (JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_source_format_count")) AS video_source_format_count,
-        (JSON_QUERY(JSON_VALUE(payload, "$._media"), "$.video_source_format_type")) AS video_source_format_type
+        JSON_VALUE(payload, '$._media') AS media,
+        CAST(JSON_VALUE(JSON_VALUE(payload, '$._media'), '$.num_video_nodes') AS INT64) AS num_video_nodes,
+        (JSON_QUERY(JSON_VALUE(payload, '$._media'), '$.video_durations')) AS video_duration,
+        (JSON_QUERY(JSON_VALUE(payload, '$._media'), '$.video_display_style')) AS video_display_style,
+        (JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_attributes_values_counts')) AS video_attributes_values_counts,
+        (JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_source_format_count')) AS video_source_format_count,
+        (JSON_QUERY(JSON_VALUE(payload, '$._media'), '$.video_source_format_type')) AS video_source_format_type
       FROM
         `httparchive.pages.2021_07_01_*`
     )

--- a/sql/2021/media/video_source_formats.sql
+++ b/sql/2021/media/video_source_formats.sql
@@ -13,13 +13,13 @@ WITH videonotes AS (
       SELECT
         _TABLE_SUFFIX AS client,
         url AS pageURL,
-        JSON_VALUE(payload, "$._media") AS media,
-        CAST(JSON_VALUE(JSON_VALUE(payload, "$._media"), "$.num_video_nodes") AS INT64) AS num_video_nodes,
-        (JSON_QUERY(JSON_VALUE(payload, "$._media"), "$.video_durations")) AS video_duration,
-        (JSON_QUERY(JSON_VALUE(payload, "$._media"), "$.video_display_style")) AS video_display_style,
-        (JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_attributes_values_counts")) AS video_attributes_values_counts,
-        (JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_source_format_count")) AS video_source_format_count,
-        (JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_source_format_type")) AS video_source_format_type
+        JSON_VALUE(payload, '$._media') AS media,
+        CAST(JSON_VALUE(JSON_VALUE(payload, '$._media'), '$.num_video_nodes') AS INT64) AS num_video_nodes,
+        (JSON_QUERY(JSON_VALUE(payload, '$._media'), '$.video_durations')) AS video_duration,
+        (JSON_QUERY(JSON_VALUE(payload, '$._media'), '$.video_display_style')) AS video_display_style,
+        (JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_attributes_values_counts')) AS video_attributes_values_counts,
+        (JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_source_format_count')) AS video_source_format_count,
+        (JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_source_format_type')) AS video_source_format_type
       FROM
         `httparchive.pages.2021_07_01_*`
     )

--- a/sql/2021/media/video_styles.sql
+++ b/sql/2021/media/video_styles.sql
@@ -10,13 +10,13 @@ WITH videonotes AS (
     SELECT
       _TABLE_SUFFIX AS client,
       url AS pageURL,
-      JSON_VALUE(payload, "$._media") AS media,
-      CAST(JSON_VALUE(JSON_VALUE(payload, "$._media"), "$.num_video_nodes") AS INT64) AS num_video_nodes,
-      JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_durations") AS video_duration,
-      JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_display_style") AS video_display_style,
-      JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_attributes_values_counts") AS video_attributes_values_counts,
-      JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_source_format_count") AS video_source_format_count,
-      JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._media"), "$.video_source_format_type") AS video_source_format_type
+      JSON_VALUE(payload, '$._media') AS media,
+      CAST(JSON_VALUE(JSON_VALUE(payload, '$._media'), '$.num_video_nodes') AS INT64) AS num_video_nodes,
+      JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_durations') AS video_duration,
+      JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_display_style') AS video_display_style,
+      JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_attributes_values_counts') AS video_attributes_values_counts,
+      JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_source_format_count') AS video_source_format_count,
+      JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._media'), '$.video_source_format_type') AS video_source_format_type
     FROM
       `httparchive.pages.2021_07_01_*`
     )

--- a/sql/2021/mobile-web/client_hints.sql
+++ b/sql/2021/mobile-web/client_hints.sql
@@ -42,7 +42,7 @@ FROM (
     `httparchive.almanac.requests`,
     UNNEST(getClientHints(JSON_EXTRACT(payload, '$.response.headers'))) AS ch_directive
   WHERE
-    date = "2021-07-01" AND
+    date = '2021-07-01' AND
     firstHtml
 )
 LEFT JOIN (

--- a/sql/2021/performance/lcp_element.sql
+++ b/sql/2021/performance/lcp_element.sql
@@ -4,7 +4,7 @@
 
 SELECT
   _TABLE_SUFFIX AS client,
-  JSON_EXTRACT_SCALAR(payload, "$._performance.lcp_elem_stats[0].nodeName") AS lcp_node,
+  JSON_EXTRACT_SCALAR(payload, '$._performance.lcp_elem_stats[0].nodeName') AS lcp_node,
   COUNT(DISTINCT url) AS pages,
   ANY_VALUE(total) AS total,
   COUNT(DISTINCT url) / ANY_VALUE(total) AS pct

--- a/sql/2021/performance/lcp_element_data.sql
+++ b/sql/2021/performance/lcp_element_data.sql
@@ -40,16 +40,16 @@ lcp_stats AS (
   SELECT
     _TABLE_SUFFIX AS client,
     url,
-    JSON_EXTRACT_SCALAR(payload, "$._performance.lcp_elem_stats[0].nodeName") AS nodeName,
-    JSON_EXTRACT_SCALAR(payload, "$._performance.lcp_elem_stats[0].url") AS elementUrl,
-    CAST(JSON_EXTRACT_SCALAR(payload, "$._performance.lcp_elem_stats[0].size") AS INT64) AS size,
-    CAST(JSON_EXTRACT_SCALAR(payload, "$._performance.lcp_elem_stats[0].loadTime") AS FLOAT64) AS loadTime,
-    CAST(JSON_EXTRACT_SCALAR(payload, "$._performance.lcp_elem_stats[0].startTime") AS FLOAT64) AS startTime,
-    CAST(JSON_EXTRACT_SCALAR(payload, "$._performance.lcp_elem_stats[0].renderTime") AS FLOAT64) AS renderTime,
-    JSON_EXTRACT(payload, "$._performance.lcp_elem_stats[0].attributes") AS attributes,
-    getLoadingAttr(JSON_EXTRACT(payload, "$._performance.lcp_elem_stats[0].attributes")) AS loading,
-    getDecodingAttr(JSON_EXTRACT(payload, "$._performance.lcp_elem_stats[0].attributes")) AS decoding,
-    getLoadingClasses(JSON_EXTRACT(payload, "$._performance.lcp_elem_stats[0].attributes")) AS classWithLazyload
+    JSON_EXTRACT_SCALAR(payload, '$._performance.lcp_elem_stats[0].nodeName') AS nodeName,
+    JSON_EXTRACT_SCALAR(payload, '$._performance.lcp_elem_stats[0].url') AS elementUrl,
+    CAST(JSON_EXTRACT_SCALAR(payload, '$._performance.lcp_elem_stats[0].size') AS INT64) AS size,
+    CAST(JSON_EXTRACT_SCALAR(payload, '$._performance.lcp_elem_stats[0].loadTime') AS FLOAT64) AS loadTime,
+    CAST(JSON_EXTRACT_SCALAR(payload, '$._performance.lcp_elem_stats[0].startTime') AS FLOAT64) AS startTime,
+    CAST(JSON_EXTRACT_SCALAR(payload, '$._performance.lcp_elem_stats[0].renderTime') AS FLOAT64) AS renderTime,
+    JSON_EXTRACT(payload, '$._performance.lcp_elem_stats[0].attributes') AS attributes,
+    getLoadingAttr(JSON_EXTRACT(payload, '$._performance.lcp_elem_stats[0].attributes')) AS loading,
+    getDecodingAttr(JSON_EXTRACT(payload, '$._performance.lcp_elem_stats[0].attributes')) AS decoding,
+    getLoadingClasses(JSON_EXTRACT(payload, '$._performance.lcp_elem_stats[0].attributes')) AS classWithLazyload
   FROM
     `httparchive.pages.2021_07_01_*`
 )
@@ -60,16 +60,16 @@ SELECT
   COUNT(DISTINCT url) AS pages,
   ANY_VALUE(total) AS total,
   COUNT(DISTINCT url) / ANY_VALUE(total) AS pct,
-  COUNTIF(elementUrl != "") AS haveImages,
-  COUNTIF(elementUrl != "") / COUNT(DISTINCT url) AS pct_haveImages,
-  COUNTIF(loading = "eager") AS native_eagerload,
-  COUNTIF(loading = "lazy") AS native_lazyload,
-  COUNTIF(classWithLazyload != "") AS lazyload_class,
-  COUNTIF(classWithLazyload != "" OR loading = "lazy") AS probably_lazyLoaded,
-  COUNTIF(classWithLazyload != "" OR loading = "lazy") / COUNT(DISTINCT url) AS pct_prob_lazyloaded,
-  COUNTIF(decoding = "async") AS async_decoding,
-  COUNTIF(decoding = "sync") AS sync_decoding,
-  COUNTIF(decoding = "auto") AS auto_decoding
+  COUNTIF(elementUrl != '') AS haveImages,
+  COUNTIF(elementUrl != '') / COUNT(DISTINCT url) AS pct_haveImages,
+  COUNTIF(loading = 'eager') AS native_eagerload,
+  COUNTIF(loading = 'lazy') AS native_lazyload,
+  COUNTIF(classWithLazyload != '') AS lazyload_class,
+  COUNTIF(classWithLazyload != '' OR loading = 'lazy') AS probably_lazyLoaded,
+  COUNTIF(classWithLazyload != '' OR loading = 'lazy') / COUNT(DISTINCT url) AS pct_prob_lazyloaded,
+  COUNTIF(decoding = 'async') AS async_decoding,
+  COUNTIF(decoding = 'sync') AS sync_decoding,
+  COUNTIF(decoding = 'auto') AS auto_decoding
 FROM
   lcp_stats
 JOIN (

--- a/sql/2021/performance/max_tbt.sql
+++ b/sql/2021/performance/max_tbt.sql
@@ -2,6 +2,6 @@
 # Max TBT
 
 SELECT
-  MAX(CAST(JSON_EXTRACT_SCALAR(report, "$.audits.total-blocking-time.numericValue") AS FLOAT64)) AS maxTbt
+  MAX(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.total-blocking-time.numericValue') AS FLOAT64)) AS maxTbt
 FROM
   `httparchive.lighthouse.2021_07_01_mobile`

--- a/sql/2021/performance/tbt.sql
+++ b/sql/2021/performance/tbt.sql
@@ -4,8 +4,8 @@
 WITH tbt_stats AS (
   SELECT
     url,
-    CAST(JSON_EXTRACT_SCALAR(report, "$.audits.total-blocking-time.numericValue") AS FLOAT64) AS tbtValue,
-    CAST(JSON_EXTRACT_SCALAR(report, "$.audits.total-blocking-time.score") AS FLOAT64) AS tbtScore
+    CAST(JSON_EXTRACT_SCALAR(report, '$.audits.total-blocking-time.numericValue') AS FLOAT64) AS tbtValue,
+    CAST(JSON_EXTRACT_SCALAR(report, '$.audits.total-blocking-time.score') AS FLOAT64) AS tbtScore
   FROM
     `httparchive.lighthouse.2021_07_01_mobile`
 )

--- a/sql/2021/performance/unused_css_histogram.sql
+++ b/sql/2021/performance/unused_css_histogram.sql
@@ -11,7 +11,7 @@ SELECT
 FROM (
   SELECT
     url AS page,
-    CAST(JSON_EXTRACT(report, "$.audits.unused-css-rules.details.overallSavingsBytes") AS INT64) / 1024 AS unused_css_kbytes
+    CAST(JSON_EXTRACT(report, '$.audits.unused-css-rules.details.overallSavingsBytes') AS INT64) / 1024 AS unused_css_kbytes
   FROM
     `httparchive.lighthouse.2021_07_01_mobile`)
 GROUP BY

--- a/sql/2021/performance/unused_css_js.sql
+++ b/sql/2021/performance/unused_css_js.sql
@@ -3,8 +3,8 @@
 
 SELECT
   percentile,
-  APPROX_QUANTILES(CAST(JSON_EXTRACT_SCALAR(report, "$.audits.unused-javascript.details.overallSavingsBytes") AS INT64) / 1024, 1000)[OFFSET(percentile * 10)] AS js_kilobytes,
-  APPROX_QUANTILES(CAST(JSON_EXTRACT_SCALAR(report, "$.audits.unused-css-rules.details.overallSavingsBytes") AS INT64) / 1024, 1000)[OFFSET(percentile * 10)] AS css_kilobytes
+  APPROX_QUANTILES(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.unused-javascript.details.overallSavingsBytes') AS INT64) / 1024, 1000)[OFFSET(percentile * 10)] AS js_kilobytes,
+  APPROX_QUANTILES(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.unused-css-rules.details.overallSavingsBytes') AS INT64) / 1024, 1000)[OFFSET(percentile * 10)] AS css_kilobytes
 FROM
   `httparchive.lighthouse.2021_07_01_mobile`,
   UNNEST([10, 25, 50, 75, 90, 100]) AS percentile

--- a/sql/2021/performance/unused_js_histogram.sql
+++ b/sql/2021/performance/unused_js_histogram.sql
@@ -11,7 +11,7 @@ SELECT
 FROM (
   SELECT
     url AS page,
-    CAST(JSON_EXTRACT(report, "$.audits.unused-javascript.details.overallSavingsBytes") AS INT64) / 1024 AS unused_js_kbytes
+    CAST(JSON_EXTRACT(report, '$.audits.unused-javascript.details.overallSavingsBytes') AS INT64) / 1024 AS unused_js_kbytes
   FROM
     `httparchive.lighthouse.2021_07_01_mobile`)
 GROUP BY

--- a/sql/2021/privacy/data_breaches_pwned_websites_per_date_and_breach_sensitivity.sql
+++ b/sql/2021/privacy/data_breaches_pwned_websites_per_date_and_breach_sensitivity.sql
@@ -5,7 +5,7 @@
 
 SELECT
   DATE_TRUNC(DATE(BreachDate), MONTH) AS breach_date,
-  IF(isSensitive, "Sensitive", "Not sensitive") AS sensitivity,
+  IF(isSensitive, 'Sensitive', 'Not sensitive') AS sensitivity,
   COUNT(DISTINCT Title) AS number_of_breaches,
   SUM(PwnCount) AS number_of_affected_accounts
 FROM

--- a/sql/2021/privacy/most_common_cmps_for_iab_tcf_v2.sql
+++ b/sql/2021/privacy/most_common_cmps_for_iab_tcf_v2.sql
@@ -14,7 +14,7 @@ WITH totals AS (
 
 SELECT
   _TABLE_SUFFIX AS client,
-  JSON_VALUE(JSON_VALUE(payload, "$._privacy"), '$.iab_tcf_v2.data.cmpId') AS cmpId,
+  JSON_VALUE(JSON_VALUE(payload, '$._privacy'), '$.iab_tcf_v2.data.cmpId') AS cmpId,
   COUNT(0) AS number_of_websites,
   total_websites,
   COUNT(0) / total_websites AS pct_websites
@@ -24,7 +24,7 @@ JOIN
   totals
 USING (_TABLE_SUFFIX)
 WHERE
-  JSON_VALUE(JSON_VALUE(payload, "$._privacy"), '$.iab_tcf_v2.data.cmpId') IS NOT NULL
+  JSON_VALUE(JSON_VALUE(payload, '$._privacy'), '$.iab_tcf_v2.data.cmpId') IS NOT NULL
 GROUP BY
   client,
   total_websites,

--- a/sql/2021/privacy/most_common_countries_for_iab_tcf_v2.sql
+++ b/sql/2021/privacy/most_common_countries_for_iab_tcf_v2.sql
@@ -17,7 +17,7 @@ WITH totals AS (
 
 SELECT
   _TABLE_SUFFIX AS client,
-  LOWER(JSON_VALUE(JSON_VALUE(payload, "$._privacy"), "$.iab_tcf_v2.data.publisherCC")) AS publisherCC,
+  LOWER(JSON_VALUE(JSON_VALUE(payload, '$._privacy'), '$.iab_tcf_v2.data.publisherCC')) AS publisherCC,
   COUNT(0) AS number_of_websites,
   total_websites,
   COUNT(0) / total_websites AS pct_websites
@@ -27,7 +27,7 @@ JOIN
   totals
 USING (_TABLE_SUFFIX)
 WHERE
-  JSON_VALUE(JSON_VALUE(payload, "$._privacy"), "$.iab_tcf_v2.data.publisherCC") IS NOT NULL
+  JSON_VALUE(JSON_VALUE(payload, '$._privacy'), '$.iab_tcf_v2.data.publisherCC') IS NOT NULL
 GROUP BY
   client,
   total_websites,

--- a/sql/2021/privacy/most_common_featurepolicy_permissionspolicy_directive_values.sql
+++ b/sql/2021/privacy/most_common_featurepolicy_permissionspolicy_directive_values.sql
@@ -37,11 +37,11 @@ meta_tags AS (
     SELECT
       _TABLE_SUFFIX AS client,
       url,
-      JSON_VALUE(payload, "$._almanac") AS metrics
+      JSON_VALUE(payload, '$._almanac') AS metrics
     FROM
       `httparchive.pages.2021_07_01_*`
     ),
-    UNNEST(JSON_QUERY_ARRAY(metrics, "$.meta-nodes.nodes")) meta_node
+    UNNEST(JSON_QUERY_ARRAY(metrics, '$.meta-nodes.nodes')) meta_node
   WHERE
     JSON_VALUE(meta_node, '$.http-equiv') IS NOT NULL
 ),
@@ -97,7 +97,7 @@ normalized_feature_policy AS (  -- normalize
   SELECT
     client,
     page,
-    REPLACE(feature_policy_value, "'", "") AS policy_value  -- remove quotes
+    REPLACE(feature_policy_value, "'", '') AS policy_value  -- remove quotes
   FROM
     merged_feature_policy
 ),
@@ -112,10 +112,10 @@ normalized_permissions_policy AS (  -- normalize
               REPLACE(
                 REPLACE(permissions_policy_value, ',', ';'),  -- swap directive delimiter
                 '=', ' '), -- drop name/value delimiter
-              "()", "none" -- special case for feature disabling
+              '()', 'none' -- special case for feature disabling
             ),
-            "(", ""), ")", ""), -- remove parentheses
-        '"', ""), "'", "") -- remove quotes
+            '(', ''), ')', ''), -- remove parentheses
+        '"', ''), "'", '') -- remove quotes
     AS policy_value
   FROM
     merged_permissions_policy
@@ -125,7 +125,7 @@ normalized_permissions_policy AS (  -- normalize
 SELECT
   client,
   rank_grouping,
-  RTRIM(SPLIT(TRIM(directive), ' ')[OFFSET(0)], ":") AS directive_name,
+  RTRIM(SPLIT(TRIM(directive), ' ')[OFFSET(0)], ':') AS directive_name,
   TRIM(origin) AS origin,
   COUNT(DISTINCT page) AS number_of_websites_with_directive,
   total_websites,
@@ -145,7 +145,7 @@ USING (client, page)
 JOIN
   totals
 USING (client, rank_grouping),
-  UNNEST(SPLIT(policy_value, ";")) directive,
+  UNNEST(SPLIT(policy_value, ';')) directive,
   UNNEST(  -- Directive may specify explicit origins or not.
     IF(
       ARRAY_LENGTH(SPLIT(TRIM(directive), ' ')) = 1,  -- test if any explicit origin is provided
@@ -155,7 +155,7 @@ USING (client, rank_grouping),
     )
   ) AS origin WITH OFFSET AS offset
 WHERE
-  TRIM(directive) != "" AND
+  TRIM(directive) != '' AND
   offset > 0 AND
   rank <= rank_grouping
 GROUP BY

--- a/sql/2021/privacy/most_common_featurepolicy_permissionspolicy_directives.sql
+++ b/sql/2021/privacy/most_common_featurepolicy_permissionspolicy_directives.sql
@@ -37,11 +37,11 @@ meta_tags AS (
     SELECT
       _TABLE_SUFFIX AS client,
       url,
-      JSON_VALUE(payload, "$._almanac") AS metrics
+      JSON_VALUE(payload, '$._almanac') AS metrics
     FROM
       `httparchive.pages.2021_07_01_*`
     ),
-    UNNEST(JSON_QUERY_ARRAY(metrics, "$.meta-nodes.nodes")) meta_node
+    UNNEST(JSON_QUERY_ARRAY(metrics, '$.meta-nodes.nodes')) meta_node
   WHERE
     JSON_VALUE(meta_node, '$.http-equiv') IS NOT NULL
 ),
@@ -97,10 +97,10 @@ feature_policy_directives AS (
   SELECT
     client,
     page,
-    ARRAY_AGG(TRIM(SPLIT(TRIM(feature_policy_directive), " ")[OFFSET(0)])) AS directives
+    ARRAY_AGG(TRIM(SPLIT(TRIM(feature_policy_directive), ' ')[OFFSET(0)])) AS directives
   FROM
     merged_feature_policy,
-    UNNEST(SPLIT(feature_policy_value, ";")) feature_policy_directive
+    UNNEST(SPLIT(feature_policy_value, ';')) feature_policy_directive
   GROUP BY
     client,
     page
@@ -110,10 +110,10 @@ permissions_policy_directives AS (
   SELECT
     client,
     page,
-    ARRAY_AGG(TRIM(SPLIT(TRIM(permissions_policy_directive), "=")[OFFSET(0)])) AS directives
+    ARRAY_AGG(TRIM(SPLIT(TRIM(permissions_policy_directive), '=')[OFFSET(0)])) AS directives
   FROM
     merged_permissions_policy,
-    UNNEST(SPLIT(permissions_policy_value, ",")) permissions_policy_directive
+    UNNEST(SPLIT(permissions_policy_value, ',')) permissions_policy_directive
   GROUP BY
     client,
     page
@@ -130,7 +130,7 @@ site_directives AS (
       FROM
         UNNEST(ARRAY_CONCAT(feature_policy_directives.directives, permissions_policy_directives.directives)) d
       WHERE
-        TRIM(d) != ""
+        TRIM(d) != ''
       ORDER BY
         d
     ) AS directives

--- a/sql/2021/privacy/most_common_privacy_link_keywords.sql
+++ b/sql/2021/privacy/most_common_privacy_link_keywords.sql
@@ -6,7 +6,7 @@ WITH privacy_link_keywords AS (
     _TABLE_SUFFIX AS client,
     ARRAY(
       SELECT DISTINCT LOWER(kw) FROM
-        UNNEST(JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._privacy"), "$.privacy_wording_links")) AS p,
+        UNNEST(JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._privacy'), '$.privacy_wording_links')) AS p,
         UNNEST(JSON_VALUE_ARRAY(p, '$.keywords')) kw
     ) AS keywords_per_site
   FROM

--- a/sql/2021/privacy/most_common_privacy_link_texts.sql
+++ b/sql/2021/privacy/most_common_privacy_link_texts.sql
@@ -8,7 +8,7 @@ WITH privacy_link_texts AS (
       SELECT DISTINCT
         LOWER(JSON_VALUE(p, '$.text'))
       FROM
-        UNNEST(JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._privacy"), "$.privacy_wording_links")) AS p
+        UNNEST(JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._privacy'), '$.privacy_wording_links')) AS p
     ) AS texts_per_site
   FROM
     `httparchive.pages.2021_07_01_*`

--- a/sql/2021/privacy/most_common_purposes_for_iab_tcf_v2.sql
+++ b/sql/2021/privacy/most_common_purposes_for_iab_tcf_v2.sql
@@ -25,15 +25,15 @@ WITH pages_iab_tcf_v2 AS (
   SELECT
     _TABLE_SUFFIX AS client,
     JSON_QUERY(
-      JSON_VALUE(payload, "$._privacy"),
-      "$.iab_tcf_v2.data"
+      JSON_VALUE(payload, '$._privacy'),
+      '$.iab_tcf_v2.data'
     ) AS metrics
   FROM
     `httparchive.pages.2021_07_01_*`
   WHERE
     JSON_QUERY(
-      JSON_VALUE(payload, "$._privacy"),
-      "$.iab_tcf_v2.data"
+      JSON_VALUE(payload, '$._privacy'),
+      '$.iab_tcf_v2.data'
     ) IS NOT NULL
 )
 

--- a/sql/2021/privacy/most_common_referrerpolicy_values.sql
+++ b/sql/2021/privacy/most_common_referrerpolicy_values.sql
@@ -15,7 +15,7 @@ referrer_policy_custom_metrics AS (
   SELECT
     _TABLE_SUFFIX AS client,
     url,
-    JSON_VALUE(JSON_VALUE(payload, "$._privacy"), "$.referrerPolicy.entire_document_policy") AS entire_document_policy_meta
+    JSON_VALUE(JSON_VALUE(payload, '$._privacy'), '$.referrerPolicy.entire_document_policy') AS entire_document_policy_meta
   FROM
     `httparchive.pages.2021_07_01_*`
 ),

--- a/sql/2021/privacy/most_common_strings_for_iab_usp.sql
+++ b/sql/2021/privacy/most_common_strings_for_iab_usp.sql
@@ -15,8 +15,8 @@ WITH totals AS (
 SELECT
   _TABLE_SUFFIX AS client,
   JSON_QUERY(
-    JSON_VALUE(payload, "$._privacy"),
-    "$.iab_usp.privacy_string.uspString"
+    JSON_VALUE(payload, '$._privacy'),
+    '$.iab_usp.privacy_string.uspString'
   ) AS uspString,
   COUNT(0) AS nb_websites,
   total_websites,
@@ -26,8 +26,8 @@ FROM
 JOIN totals USING (_TABLE_SUFFIX)
 WHERE
   JSON_QUERY(
-    JSON_VALUE(payload, "$._privacy"),
-    "$.iab_usp.privacy_string.uspString"
+    JSON_VALUE(payload, '$._privacy'),
+    '$.iab_usp.privacy_string.uspString'
   ) IS NOT NULL
 GROUP BY
   client,

--- a/sql/2021/privacy/most_common_tracker_categories.sql
+++ b/sql/2021/privacy/most_common_tracker_categories.sql
@@ -42,7 +42,7 @@ JOIN
   totals
 USING (client)
 WHERE
-  date = "2021-07-01" AND
+  date = '2021-07-01' AND
   NET.REG_DOMAIN(page) != NET.REG_DOMAIN(urlShort) -- third party
 GROUP BY
   client,
@@ -67,7 +67,7 @@ JOIN
   totals
 USING (client)
 WHERE
-  date = "2021-07-01" AND
+  date = '2021-07-01' AND
   NET.REG_DOMAIN(page) != NET.REG_DOMAIN(urlShort) -- third party
 GROUP BY
   client,
@@ -91,7 +91,7 @@ JOIN
   totals
 USING (client)
 WHERE
-  date = "2021-07-01" AND
+  date = '2021-07-01' AND
   NET.REG_DOMAIN(page) != NET.REG_DOMAIN(urlShort) AND -- third party
   (
     -- categories selected from https://whotracks.me/blog/tracker_categories.html

--- a/sql/2021/privacy/most_common_trackers.sql
+++ b/sql/2021/privacy/most_common_trackers.sql
@@ -54,7 +54,7 @@ JOIN
   totals
 USING (client)
 WHERE
-  date = "2021-07-01" AND
+  date = '2021-07-01' AND
   NET.REG_DOMAIN(page) != NET.REG_DOMAIN(urlShort) -- third party
 GROUP BY
   client,

--- a/sql/2021/privacy/most_common_user_agent_client_hints.sql
+++ b/sql/2021/privacy/most_common_user_agent_client_hints.sql
@@ -26,11 +26,11 @@ meta_tags AS (
     SELECT
       _TABLE_SUFFIX AS client,
       url,
-      JSON_VALUE(payload, "$._almanac") AS metrics
+      JSON_VALUE(payload, '$._almanac') AS metrics
     FROM
       `httparchive.pages.2021_07_01_*`
     ),
-    UNNEST(JSON_QUERY_ARRAY(metrics, "$.meta-nodes.nodes")) meta_node
+    UNNEST(JSON_QUERY_ARRAY(metrics, '$.meta-nodes.nodes')) meta_node
   WHERE
     JSON_VALUE(meta_node, '$.http-equiv') IS NOT NULL
 ),

--- a/sql/2021/privacy/nb_sites_with_cname_tracking.sql
+++ b/sql/2021/privacy/nb_sites_with_cname_tracking.sql
@@ -3,19 +3,19 @@ WITH websites_using_cname_tracking AS (
     NET.REG_DOMAIN(domain) AS domain,
     tracker,
     CASE
-      WHEN (tracker = "sc.omtrdc.net" OR tracker = ".2o7.net") THEN "Adobe Experience Cloud"
-      WHEN tracker = "pi.pardot.com" THEN "Pardot"
-      WHEN tracker = "hs.eloqua.com" THEN "Oracle Eloqua"
-      WHEN tracker = ".wizaly.com" THEN "Wizaly"
-      WHEN tracker = "k.keyade.com" THEN "Keyade"
-      WHEN tracker = "partner.intentmedia.net" THEN "Intent"
-      WHEN tracker = "dnsdelegation.io" THEN "Criteo"
-      WHEN (tracker = "afc4d9aa2a91d11e997c60ac8a4ec150-2082092489.eu-central-1.elb.amazonaws.com" OR tracker = "a88045584548111e997c60ac8a4ec150-1610510072.eu-central-1.elb.amazonaws.com") THEN "Tracedock"
-      WHEN tracker = ".at-o.net" THEN "AT Internet"
-      WHEN tracker = ".affex.org" THEN "Ingenious Technologies"
-      WHEN (tracker = ".wt-eu02.net" OR tracker = ".webtrekk.net") THEN "Webtrekk"
-      WHEN tracker = ".actonsoftware.com" THEN "Act-On Software"
-      WHEN tracker = ".eulerian.net" THEN "Eulerian"
+      WHEN (tracker = 'sc.omtrdc.net' OR tracker = '.2o7.net') THEN 'Adobe Experience Cloud'
+      WHEN tracker = 'pi.pardot.com' THEN 'Pardot'
+      WHEN tracker = 'hs.eloqua.com' THEN 'Oracle Eloqua'
+      WHEN tracker = '.wizaly.com' THEN 'Wizaly'
+      WHEN tracker = 'k.keyade.com' THEN 'Keyade'
+      WHEN tracker = 'partner.intentmedia.net' THEN 'Intent'
+      WHEN tracker = 'dnsdelegation.io' THEN 'Criteo'
+      WHEN (tracker = 'afc4d9aa2a91d11e997c60ac8a4ec150-2082092489.eu-central-1.elb.amazonaws.com' OR tracker = 'a88045584548111e997c60ac8a4ec150-1610510072.eu-central-1.elb.amazonaws.com') THEN 'Tracedock'
+      WHEN tracker = '.at-o.net' THEN 'AT Internet'
+      WHEN tracker = '.affex.org' THEN 'Ingenious Technologies'
+      WHEN (tracker = '.wt-eu02.net' OR tracker = '.webtrekk.net') THEN 'Webtrekk'
+      WHEN tracker = '.actonsoftware.com' THEN 'Act-On Software'
+      WHEN tracker = '.eulerian.net' THEN 'Eulerian'
       ELSE tracker
     END AS company
   FROM

--- a/sql/2021/privacy/number_of_websites_using_each_cmp.sql
+++ b/sql/2021/privacy/number_of_websites_using_each_cmp.sql
@@ -25,8 +25,8 @@ FROM
   `httparchive.technologies.2021_07_01_*`
 JOIN totals USING (_TABLE_SUFFIX)
 WHERE
-  category = "Cookie compliance" AND
-  app != ""
+  category = 'Cookie compliance' AND
+  app != ''
 GROUP BY
   client,
   total_websites,

--- a/sql/2021/privacy/number_of_websites_using_each_fingerprinting.sql
+++ b/sql/2021/privacy/number_of_websites_using_each_fingerprinting.sql
@@ -23,8 +23,8 @@ FROM
   `httparchive.technologies.2021_07_01_*`
 JOIN totals USING (_TABLE_SUFFIX)
 WHERE
-  category = "Browser fingerprinting" AND
-  app != ""
+  category = 'Browser fingerprinting' AND
+  app != ''
 GROUP BY
   client,
   total_websites,

--- a/sql/2021/privacy/number_of_websites_using_each_geolocation.sql
+++ b/sql/2021/privacy/number_of_websites_using_each_geolocation.sql
@@ -23,8 +23,8 @@ FROM
   `httparchive.technologies.2021_07_01_*`
 JOIN totals USING (_TABLE_SUFFIX)
 WHERE
-  category = "Geolocation" AND
-  app != ""
+  category = 'Geolocation' AND
+  app != ''
 GROUP BY
   client,
   total_websites,

--- a/sql/2021/privacy/number_of_websites_using_each_retargeting.sql
+++ b/sql/2021/privacy/number_of_websites_using_each_retargeting.sql
@@ -23,8 +23,8 @@ FROM
   `httparchive.technologies.2021_07_01_*`
 JOIN totals USING (_TABLE_SUFFIX)
 WHERE
-  category = "Retargeting" AND
-  app != ""
+  category = 'Retargeting' AND
+  app != ''
 GROUP BY
   client,
   total_websites,

--- a/sql/2021/privacy/number_of_websites_with_ats_metadata.sql
+++ b/sql/2021/privacy/number_of_websites_with_ats_metadata.sql
@@ -4,8 +4,8 @@
 SELECT
   _TABLE_SUFFIX AS client,
   COUNT(0) AS number_of_websites,
-  COUNTIF(JSON_VALUE(JSON_VALUE(payload, "$._privacy"), "$.ads_transparency_spotlight.present") = "true") AS number_of_websites_ats,
-  COUNTIF(JSON_VALUE(JSON_VALUE(payload, "$._privacy"), "$.ads_transparency_spotlight.present") = "true") / COUNT(0) AS pct_websites_ats
+  COUNTIF(JSON_VALUE(JSON_VALUE(payload, '$._privacy'), '$.ads_transparency_spotlight.present') = 'true') AS number_of_websites_ats,
+  COUNTIF(JSON_VALUE(JSON_VALUE(payload, '$._privacy'), '$.ads_transparency_spotlight.present') = 'true') / COUNT(0) AS pct_websites_ats
 FROM
   `httparchive.pages.2021_07_01_*`
 GROUP BY

--- a/sql/2021/privacy/number_of_websites_with_device_sensor_events.sql
+++ b/sql/2021/privacy/number_of_websites_with_device_sensor_events.sql
@@ -17,7 +17,7 @@ WITH pages_events AS (
   SELECT
     _TABLE_SUFFIX AS client,
     url,
-    JSON_QUERY(payload, "$._event-names") AS events
+    JSON_QUERY(payload, '$._event-names') AS events
   FROM
     `httparchive.pages.2021_07_01_*`
 ),

--- a/sql/2021/privacy/number_of_websites_with_featurepolicy_permissionspolicy.sql
+++ b/sql/2021/privacy/number_of_websites_with_featurepolicy_permissionspolicy.sql
@@ -37,11 +37,11 @@ meta_tags AS (
     SELECT
       _TABLE_SUFFIX AS client,
       url,
-      JSON_VALUE(payload, "$._almanac") AS metrics
+      JSON_VALUE(payload, '$._almanac') AS metrics
     FROM
       `httparchive.pages.2021_07_01_*`
     ),
-    UNNEST(JSON_QUERY_ARRAY(metrics, "$.meta-nodes.nodes")) meta_node
+    UNNEST(JSON_QUERY_ARRAY(metrics, '$.meta-nodes.nodes')) meta_node
   WHERE
     JSON_VALUE(meta_node, '$.http-equiv') IS NOT NULL
 )

--- a/sql/2021/privacy/number_of_websites_with_features_based_on_string_search.sql
+++ b/sql/2021/privacy/number_of_websites_with_features_based_on_string_search.sql
@@ -6,11 +6,11 @@
 WITH privacy_custom_metrics_data AS (
   SELECT
     _TABLE_SUFFIX AS client,
-    JSON_VALUE(payload, "$._privacy") AS metrics
+    JSON_VALUE(payload, '$._privacy') AS metrics
   FROM
     `httparchive.pages.2021_07_01_*`
   WHERE
-    JSON_VALUE(payload, "$._privacy") IS NOT NULL
+    JSON_VALUE(payload, '$._privacy') IS NOT NULL
 )
 
 SELECT
@@ -44,47 +44,47 @@ FROM (
     client,
     COUNT(0) AS number_of_websites,
     COUNTIF(
-      JSON_VALUE(metrics, "$.document_interestCohort") = "true"
+      JSON_VALUE(metrics, '$.document_interestCohort') = 'true'
     ) AS number_of_websites_document_interestCohort,
     COUNTIF(
-      JSON_VALUE(metrics, "$.navigator_doNotTrack") = "true"
+      JSON_VALUE(metrics, '$.navigator_doNotTrack') = 'true'
     ) AS number_of_websites_navigator_doNotTrack,
     COUNTIF(
-      JSON_VALUE(metrics, "$.navigator_globalPrivacyControl") = "true"
+      JSON_VALUE(metrics, '$.navigator_globalPrivacyControl') = 'true'
     ) AS number_of_websites_navigator_globalPrivacyControl,
     COUNTIF(
-      JSON_VALUE(metrics, "$.document_permissionsPolicy") = "true"
+      JSON_VALUE(metrics, '$.document_permissionsPolicy') = 'true'
     ) AS number_of_websites_document_permissionsPolicy,
     COUNTIF(
-      JSON_VALUE(metrics, "$.document_featurePolicy") = "true"
+      JSON_VALUE(metrics, '$.document_featurePolicy') = 'true'
     ) AS number_of_websites_document_featurePolicy,
 
     COUNTIF(
-      JSON_VALUE(metrics, "$.media_devices.navigator_mediaDevices_enumerateDevices") = "true"
+      JSON_VALUE(metrics, '$.media_devices.navigator_mediaDevices_enumerateDevices') = 'true'
     ) AS number_of_websites_navigator_mediaDevices_enumerateDevices,
     COUNTIF(
-      JSON_VALUE(metrics, "$.media_devices.navigator_mediaDevices_getUserMedia") = "true"
+      JSON_VALUE(metrics, '$.media_devices.navigator_mediaDevices_getUserMedia') = 'true'
     ) AS number_of_websites_navigator_mediaDevices_getUserMedia,
     COUNTIF(
-      JSON_VALUE(metrics, "$.media_devices.navigator_mediaDevices_getDisplayMedia") = "true"
+      JSON_VALUE(metrics, '$.media_devices.navigator_mediaDevices_getDisplayMedia') = 'true'
     ) AS number_of_websites_navigator_mediaDevices_getDisplayMedia,
 
     COUNTIF(
-      JSON_VALUE(metrics, "$.media_devices.navigator_mediaDevices_enumerateDevices") = "true" OR
-      JSON_VALUE(metrics, "$.media_devices.navigator_mediaDevices_getUserMedia") = "true" OR
-      JSON_VALUE(metrics, "$.media_devices.navigator_mediaDevices_getDisplayMedia") = "true"
+      JSON_VALUE(metrics, '$.media_devices.navigator_mediaDevices_enumerateDevices') = 'true' OR
+      JSON_VALUE(metrics, '$.media_devices.navigator_mediaDevices_getUserMedia') = 'true' OR
+      JSON_VALUE(metrics, '$.media_devices.navigator_mediaDevices_getDisplayMedia') = 'true'
     ) AS number_of_websites_navigator_mediaDevices_any,
 
     COUNTIF(
-      JSON_VALUE(metrics, "$.geolocation.navigator_geolocation_getCurrentPosition") = "true"
+      JSON_VALUE(metrics, '$.geolocation.navigator_geolocation_getCurrentPosition') = 'true'
     ) AS number_of_websites_navigator_geolocation_getCurrentPosition,
     COUNTIF(
-      JSON_VALUE(metrics, "$.geolocation.navigator_geolocation_watchPosition") = "true"
+      JSON_VALUE(metrics, '$.geolocation.navigator_geolocation_watchPosition') = 'true'
     ) AS number_of_websites_navigator_geolocation_watchPosition,
 
     COUNTIF(
-      JSON_VALUE(metrics, "$.geolocation.navigator_geolocation_getCurrentPosition") = "true" OR
-      JSON_VALUE(metrics, "$.geolocation.navigator_geolocation_watchPosition") = "true"
+      JSON_VALUE(metrics, '$.geolocation.navigator_geolocation_getCurrentPosition') = 'true' OR
+      JSON_VALUE(metrics, '$.geolocation.navigator_geolocation_watchPosition') = 'true'
     ) AS number_of_websites_navigator_geolocation_any
 
   FROM

--- a/sql/2021/privacy/number_of_websites_with_floc_opt_out.sql
+++ b/sql/2021/privacy/number_of_websites_with_floc_opt_out.sql
@@ -26,11 +26,11 @@ meta_tags AS (
     SELECT
       _TABLE_SUFFIX AS client,
       url,
-      JSON_VALUE(payload, "$._almanac") AS metrics
+      JSON_VALUE(payload, '$._almanac') AS metrics
     FROM
       `httparchive.pages.2021_07_01_*`
     ),
-    UNNEST(JSON_QUERY_ARRAY(metrics, "$.meta-nodes.nodes")) meta_node
+    UNNEST(JSON_QUERY_ARRAY(metrics, '$.meta-nodes.nodes')) meta_node
   WHERE
     JSON_VALUE(meta_node, '$.http-equiv') IS NOT NULL
 ),

--- a/sql/2021/privacy/number_of_websites_with_gpc_well_known.sql
+++ b/sql/2021/privacy/number_of_websites_with_gpc_well_known.sql
@@ -20,7 +20,7 @@ FROM
   `httparchive.pages.2021_07_01_*`
 JOIN totals USING (_TABLE_SUFFIX)
 WHERE
-  JSON_VALUE(payload, '$._well-known."/.well-known/gpc.json".found') = "true"
+  JSON_VALUE(payload, '$._well-known."/.well-known/gpc.json".found') = 'true'
 GROUP BY
   client,
   total_websites

--- a/sql/2021/privacy/number_of_websites_with_iab.sql
+++ b/sql/2021/privacy/number_of_websites_with_iab.sql
@@ -4,11 +4,11 @@
 WITH privacy_custom_metrics_data AS (
   SELECT
     _TABLE_SUFFIX AS client,
-    JSON_VALUE(payload, "$._privacy") AS metrics
+    JSON_VALUE(payload, '$._privacy') AS metrics
   FROM
     `httparchive.pages.2021_07_01_*`
   WHERE
-    JSON_VALUE(payload, "$._privacy") IS NOT NULL
+    JSON_VALUE(payload, '$._privacy') IS NOT NULL
 )
 
 SELECT
@@ -24,25 +24,25 @@ FROM (
   SELECT
     client,
     COUNT(0) AS number_of_websites,
-    COUNTIF(JSON_VALUE(metrics, "$.iab_tcf_v1.present") = "true") AS number_of_websites_with_iab_tcf_v1,
-    COUNTIF(JSON_VALUE(metrics, "$.iab_tcf_v2.present") = "true") AS number_of_websites_with_iab_tcf_v2,
+    COUNTIF(JSON_VALUE(metrics, '$.iab_tcf_v1.present') = 'true') AS number_of_websites_with_iab_tcf_v1,
+    COUNTIF(JSON_VALUE(metrics, '$.iab_tcf_v2.present') = 'true') AS number_of_websites_with_iab_tcf_v2,
     COUNTIF(
-      JSON_VALUE(metrics, "$.iab_tcf_v1.present") = "true" OR
-      JSON_VALUE(metrics, "$.iab_tcf_v2.present") = "true"
+      JSON_VALUE(metrics, '$.iab_tcf_v1.present') = 'true' OR
+      JSON_VALUE(metrics, '$.iab_tcf_v2.present') = 'true'
     ) AS number_of_websites_with_iab_tcf_any,
-    COUNTIF(JSON_VALUE(metrics, "$.iab_usp.present") = "true") AS number_of_websites_with_iab_usp,
+    COUNTIF(JSON_VALUE(metrics, '$.iab_usp.present') = 'true') AS number_of_websites_with_iab_usp,
     COUNTIF(
-      JSON_VALUE(metrics, "$.iab_tcf_v1.present") = "true" OR
-      JSON_VALUE(metrics, "$.iab_tcf_v2.present") = "true" OR
-      JSON_VALUE(metrics, "$.iab_usp.present") = "true"
+      JSON_VALUE(metrics, '$.iab_tcf_v1.present') = 'true' OR
+      JSON_VALUE(metrics, '$.iab_tcf_v2.present') = 'true' OR
+      JSON_VALUE(metrics, '$.iab_usp.present') = 'true'
     ) AS number_of_websites_with_iab_any,
     COUNTIF(
-      JSON_VALUE(metrics, "$.iab_tcf_v1.present") = "true" AND
-      JSON_VALUE(metrics, "$.iab_tcf_v1.compliant_setup") = "true"
+      JSON_VALUE(metrics, '$.iab_tcf_v1.present') = 'true' AND
+      JSON_VALUE(metrics, '$.iab_tcf_v1.compliant_setup') = 'true'
     ) AS number_of_websites_with_iab_tcf_v1_compliant,
     COUNTIF(
-      JSON_VALUE(metrics, "$.iab_tcf_v2.present") = "true" AND
-      JSON_VALUE(metrics, "$.iab_tcf_v2.compliant_setup") = "true"
+      JSON_VALUE(metrics, '$.iab_tcf_v2.present') = 'true' AND
+      JSON_VALUE(metrics, '$.iab_tcf_v2.compliant_setup') = 'true'
     ) AS number_of_websites_with_iab_tcf_v2_compliant
   FROM
     privacy_custom_metrics_data

--- a/sql/2021/privacy/number_of_websites_with_nb_trackers.sql
+++ b/sql/2021/privacy/number_of_websites_with_nb_trackers.sql
@@ -45,7 +45,7 @@ FROM (
     ENDS_WITH(NET.HOST(urlShort), CONCAT('.', domain))
   )
   WHERE
-    date = "2021-07-01" AND
+    date = '2021-07-01' AND
     NET.REG_DOMAIN(page) != NET.REG_DOMAIN(urlShort) -- third party
   GROUP BY
     client,
@@ -80,7 +80,7 @@ FROM (
     ENDS_WITH(NET.HOST(urlShort), CONCAT('.', domain))
   )
   WHERE
-    date = "2021-07-01" AND
+    date = '2021-07-01' AND
     NET.REG_DOMAIN(page) != NET.REG_DOMAIN(urlShort) AND -- third party
     (
       -- categories selected from https://whotracks.me/blog/tracker_categories.html

--- a/sql/2021/privacy/number_of_websites_with_origin_trial_from_token.sql
+++ b/sql/2021/privacy/number_of_websites_with_origin_trial_from_token.sql
@@ -150,7 +150,7 @@ WITH pages_origin_trials AS (
   SELECT
     _TABLE_SUFFIX AS client,
     url,
-    JSON_VALUE(payload, "$._origin-trials") AS metrics
+    JSON_VALUE(payload, '$._origin-trials') AS metrics
   FROM
     `httparchive.pages.2021_07_01_*`
 ),
@@ -179,11 +179,11 @@ meta_tags AS (
     SELECT
       _TABLE_SUFFIX AS client,
       url,
-      JSON_VALUE(payload, "$._almanac") AS metrics
+      JSON_VALUE(payload, '$._almanac') AS metrics
     FROM
       `httparchive.pages.2021_07_01_*`
     ),
-    UNNEST(JSON_QUERY_ARRAY(metrics, "$.meta-nodes.nodes")) meta_node
+    UNNEST(JSON_QUERY_ARRAY(metrics, '$.meta-nodes.nodes')) meta_node
   WHERE
     JSON_VALUE(meta_node, '$.http-equiv') IS NOT NULL
 ),
@@ -192,7 +192,7 @@ extracted_origin_trials_from_custom_metric AS (
   SELECT
     client,
     url AS site, -- the home page that was crawled
-    retrieveOriginTrials(JSON_VALUE(metric, "$.token")) AS origin_trials_from_custom_metric
+    retrieveOriginTrials(JSON_VALUE(metric, '$.token')) AS origin_trials_from_custom_metric
   FROM
     pages_origin_trials, UNNEST(JSON_QUERY_ARRAY(metrics)) metric
 ),

--- a/sql/2021/privacy/number_of_websites_with_privacy_links.sql
+++ b/sql/2021/privacy/number_of_websites_with_privacy_links.sql
@@ -5,10 +5,10 @@ SELECT
   _TABLE_SUFFIX AS client,
   COUNT(0) AS total_websites,
   COUNTIF(
-    ARRAY_LENGTH(JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._privacy"), "$.privacy_wording_links")) > 0
+    ARRAY_LENGTH(JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._privacy'), '$.privacy_wording_links')) > 0
   ) AS websites_with_privacy_link,
   COUNTIF(
-    ARRAY_LENGTH(JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._privacy"), "$.privacy_wording_links")) > 0
+    ARRAY_LENGTH(JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._privacy'), '$.privacy_wording_links')) > 0
   ) / COUNT(0) AS pct_websites_with_privacy_link
 FROM
   `httparchive.pages.2021_07_01_*`

--- a/sql/2021/privacy/number_of_websites_with_privacy_service.sql
+++ b/sql/2021/privacy/number_of_websites_with_privacy_service.sql
@@ -5,14 +5,14 @@
 SELECT
   _TABLE_SUFFIX AS client,
   COUNT(DISTINCT url) AS total_pages,
-  COUNT(DISTINCT IF(category = "Cookie compliance", url, NULL)) AS number_of_websites_with_cookie_compliance,
-  COUNT(DISTINCT IF(category = "Cookie compliance", url, NULL)) / COUNT(DISTINCT url) AS pct_websites_with_cookie_compliance,
-  COUNT(DISTINCT IF(category = "Browser fingerprinting", url, NULL)) AS number_of_websites_with_browser_fingerprinting,
-  COUNT(DISTINCT IF(category = "Browser fingerprinting", url, NULL)) / COUNT(DISTINCT url) AS pct_websites_with_browser_fingerprinting,
-  COUNT(DISTINCT IF(category = "Retargeting", url, NULL)) AS number_of_websites_with_retargeting,
-  COUNT(DISTINCT IF(category = "Retargeting", url, NULL)) / COUNT(DISTINCT url) AS pct_websites_with_retargeting,
-  COUNT(DISTINCT IF(category = "Geolocation", url, NULL)) AS number_of_websites_with_geolocation,
-  COUNT(DISTINCT IF(category = "Geolocation", url, NULL)) / COUNT(DISTINCT url) AS pct_websites_with_geolocation
+  COUNT(DISTINCT IF(category = 'Cookie compliance', url, NULL)) AS number_of_websites_with_cookie_compliance,
+  COUNT(DISTINCT IF(category = 'Cookie compliance', url, NULL)) / COUNT(DISTINCT url) AS pct_websites_with_cookie_compliance,
+  COUNT(DISTINCT IF(category = 'Browser fingerprinting', url, NULL)) AS number_of_websites_with_browser_fingerprinting,
+  COUNT(DISTINCT IF(category = 'Browser fingerprinting', url, NULL)) / COUNT(DISTINCT url) AS pct_websites_with_browser_fingerprinting,
+  COUNT(DISTINCT IF(category = 'Retargeting', url, NULL)) AS number_of_websites_with_retargeting,
+  COUNT(DISTINCT IF(category = 'Retargeting', url, NULL)) / COUNT(DISTINCT url) AS pct_websites_with_retargeting,
+  COUNT(DISTINCT IF(category = 'Geolocation', url, NULL)) AS number_of_websites_with_geolocation,
+  COUNT(DISTINCT IF(category = 'Geolocation', url, NULL)) / COUNT(DISTINCT url) AS pct_websites_with_geolocation
 FROM `httparchive.technologies.2021_07_01_*`
 GROUP BY
   client

--- a/sql/2021/privacy/number_of_websites_with_referrerpolicy.sql
+++ b/sql/2021/privacy/number_of_websites_with_referrerpolicy.sql
@@ -5,9 +5,9 @@ WITH referrer_policy_custom_metrics AS (
   SELECT
     _TABLE_SUFFIX AS client,
     url AS page,
-    JSON_VALUE(JSON_VALUE(payload, "$._privacy"), "$.referrerPolicy.entire_document_policy") AS entire_document_policy_meta,
-    JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._privacy"), "$.referrerPolicy.individual_requests") AS individual_requests,
-    JSON_QUERY_ARRAY(JSON_VALUE(payload, "$._privacy"), "$.referrerPolicy.link_relations") AS link_relations
+    JSON_VALUE(JSON_VALUE(payload, '$._privacy'), '$.referrerPolicy.entire_document_policy') AS entire_document_policy_meta,
+    JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._privacy'), '$.referrerPolicy.individual_requests') AS individual_requests,
+    JSON_QUERY_ARRAY(JSON_VALUE(payload, '$._privacy'), '$.referrerPolicy.link_relations') AS link_relations
   FROM
     `httparchive.pages.2021_07_01_*`
 ),

--- a/sql/2021/privacy/number_of_websites_with_user_agent_client_hints.sql
+++ b/sql/2021/privacy/number_of_websites_with_user_agent_client_hints.sql
@@ -26,11 +26,11 @@ meta_tags AS (
     SELECT
       _TABLE_SUFFIX AS client,
       url,
-      JSON_VALUE(payload, "$._almanac") AS metrics
+      JSON_VALUE(payload, '$._almanac') AS metrics
     FROM
       `httparchive.pages.2021_07_01_*`
     ),
-    UNNEST(JSON_QUERY_ARRAY(metrics, "$.meta-nodes.nodes")) meta_node
+    UNNEST(JSON_QUERY_ARRAY(metrics, '$.meta-nodes.nodes')) meta_node
   WHERE
     JSON_VALUE(meta_node, '$.http-equiv') IS NOT NULL
 ),

--- a/sql/2021/privacy/top100_cookies_set_from_header.sql
+++ b/sql/2021/privacy/top100_cookies_set_from_header.sql
@@ -58,7 +58,7 @@ cookies AS (
     UNNEST(cookie_names) AS cookie
   WHERE
     cookie IS NOT NULL AND
-    cookie != ""
+    cookie != ''
   GROUP BY
     client,
     request,

--- a/sql/2021/privacy/top100_domains_that_set_cookies_via_response_header.sql
+++ b/sql/2021/privacy/top100_domains_that_set_cookies_via_response_header.sql
@@ -57,7 +57,7 @@ cookies AS (
     UNNEST(cookie_names) AS cookie
   WHERE
     cookie IS NOT NULL AND
-    cookie != ""
+    cookie != ''
   GROUP BY
     client,
     domain,

--- a/sql/2021/pwa/assetlink_usage.sql
+++ b/sql/2021/pwa/assetlink_usage.sql
@@ -17,16 +17,16 @@ JOIN
     FROM
       `httparchive.pages.2021_07_01_*`
     WHERE
-      JSON_EXTRACT(payload, '$._pwa.manifests') != "[]" AND
-      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true"
+      JSON_EXTRACT(payload, '$._pwa.manifests') != '[]' AND
+      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true'
     GROUP BY
       _TABLE_SUFFIX
   )
 USING (_TABLE_SUFFIX)
 WHERE
-  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true" AND
-  JSON_EXTRACT(payload, '$._pwa.manifests') != "[]" AND
-  JSON_EXTRACT_SCALAR(JSON_VALUE(payload, "$._well-known"), "$['/.well-known/assetlinks.json'].found") = 'true'
+  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true' AND
+  JSON_EXTRACT(payload, '$._pwa.manifests') != '[]' AND
+  JSON_EXTRACT_SCALAR(JSON_VALUE(payload, '$._well-known'), "$['/.well-known/assetlinks.json'].found") = 'true'
 GROUP BY
   client,
   total
@@ -51,7 +51,7 @@ JOIN
   )
 USING (_TABLE_SUFFIX)
 WHERE
-  JSON_EXTRACT_SCALAR(JSON_VALUE(payload, "$._well-known"), "$['/.well-known/assetlinks.json'].found") = 'true'
+  JSON_EXTRACT_SCALAR(JSON_VALUE(payload, '$._well-known'), "$['/.well-known/assetlinks.json'].found") = 'true'
 GROUP BY
   client,
   total

--- a/sql/2021/pwa/install_events.sql
+++ b/sql/2021/pwa/install_events.sql
@@ -48,15 +48,15 @@ JOIN
     WHERE
       -- This condition filters out tests that might have broken when running the 'pwa' metric
       -- as even pages without any pwa capabilities will have a _pwa object with empty fields
-      JSON_EXTRACT(payload, '$._pwa') != "[]"
+      JSON_EXTRACT(payload, '$._pwa') != '[]'
     GROUP BY
       _TABLE_SUFFIX
   )
 USING (_TABLE_SUFFIX)
 WHERE
   (
-    JSON_EXTRACT(payload, '$._pwa.windowEventListenersInfo') != "[]" OR
-    JSON_EXTRACT(payload, '$._pwa.windowPropertiesInfo') != "[]"
+    JSON_EXTRACT(payload, '$._pwa.windowEventListenersInfo') != '[]' OR
+    JSON_EXTRACT(payload, '$._pwa.windowPropertiesInfo') != '[]'
   ) AND
   install_event != '' AND
   install_event != '[]'

--- a/sql/2021/pwa/lighthouse_pwa_audits.sql
+++ b/sql/2021/pwa/lighthouse_pwa_audits.sql
@@ -39,8 +39,8 @@ JOIN
     FROM
       `httparchive.pages.2021_07_01_mobile`
     WHERE
-      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true" AND
-      JSON_EXTRACT(payload, '$._pwa.manifests') != "[]"
+      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true' AND
+      JSON_EXTRACT(payload, '$._pwa.manifests') != '[]'
   )
 USING (url)
 GROUP BY

--- a/sql/2021/pwa/lighthouse_pwa_score.sql
+++ b/sql/2021/pwa/lighthouse_pwa_score.sql
@@ -19,8 +19,8 @@ JOIN
     FROM
       `httparchive.pages.2021_07_01_mobile`
     WHERE
-      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true" AND
-      JSON_EXTRACT(payload, '$._pwa.manifests') != "[]"
+      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true' AND
+      JSON_EXTRACT(payload, '$._pwa.manifests') != '[]'
   )
 USING (url),
   UNNEST([10, 25, 50, 75, 90]) AS percentile

--- a/sql/2021/pwa/manifests_and_service_workers.sql
+++ b/sql/2021/pwa/manifests_and_service_workers.sql
@@ -10,8 +10,8 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    IF(JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true", 1, 0) AS ServiceWorker,
-    IF(JSON_EXTRACT(payload, '$._pwa.manifests') != "[]", 1, 0) AS manifests
+    IF(JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true', 1, 0) AS ServiceWorker,
+    IF(JSON_EXTRACT(payload, '$._pwa.manifests') != '[]', 1, 0) AS manifests
   FROM
     `httparchive.pages.2021_07_01_*`
   )

--- a/sql/2021/pwa/manifests_not_json_parsable.sql
+++ b/sql/2021/pwa/manifests_not_json_parsable.sql
@@ -27,8 +27,8 @@ SELECT
 FROM
   `httparchive.pages.2021_07_01_*`
 WHERE
-  JSON_EXTRACT(payload, '$._pwa.manifests') != "[]" AND
-  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true"
+  JSON_EXTRACT(payload, '$._pwa.manifests') != '[]' AND
+  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true'
 GROUP BY
   client,
   can_parse

--- a/sql/2021/pwa/manifests_preferring_native_apps.sql
+++ b/sql/2021/pwa/manifests_preferring_native_apps.sql
@@ -21,8 +21,8 @@ SELECT
 FROM
   `httparchive.pages.2021_07_01_*`
 WHERE
-  JSON_EXTRACT(payload, '$._pwa.manifests') != "[]" AND
-  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true"
+  JSON_EXTRACT(payload, '$._pwa.manifests') != '[]' AND
+  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true'
 GROUP BY
   client,
   prefersNative

--- a/sql/2021/pwa/popular_pwa_libraries.sql
+++ b/sql/2021/pwa/popular_pwa_libraries.sql
@@ -74,8 +74,8 @@ FROM
       `httparchive.pages.2021_07_01_*`,
       UNNEST(getSWLibraries(JSON_EXTRACT(payload, '$._pwa.importScriptsInfo'))) AS script
     WHERE
-      JSON_EXTRACT(payload, '$._pwa.importScriptsInfo') != "[]" AND
-      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true"
+      JSON_EXTRACT(payload, '$._pwa.importScriptsInfo') != '[]' AND
+      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true'
     GROUP BY
       _TABLE_SUFFIX,
       url
@@ -88,7 +88,7 @@ JOIN
     FROM
       `httparchive.pages.2021_07_01_*`
     WHERE
-      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true"
+      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true'
     GROUP BY
       client
   )

--- a/sql/2021/pwa/popular_pwa_libraries_helper.sql
+++ b/sql/2021/pwa/popular_pwa_libraries_helper.sql
@@ -29,8 +29,8 @@ FROM
   `httparchive.pages.2021_07_01_*`,
   UNNEST(getSWLibraries(JSON_EXTRACT(payload, '$._pwa.importScriptsInfo'))) AS script
 WHERE
-  JSON_EXTRACT(payload, '$._pwa.importScriptsInfo') != "[]" AND
-  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true" AND
+  JSON_EXTRACT(payload, '$._pwa.importScriptsInfo') != '[]' AND
+  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true' AND
   LOWER(script) NOT LIKE '%workbox%' AND
   LOWER(script) NOT LIKE '%sw-toolbox%' AND
   LOWER(script) NOT LIKE '%firebase%' AND

--- a/sql/2021/pwa/pwa_notification_acceptance_rates.sql
+++ b/sql/2021/pwa/pwa_notification_acceptance_rates.sql
@@ -16,12 +16,12 @@ JOIN
   (
     SELECT
       _TABLE_SUFFIX AS client,
-      RTRIM(url, "/") AS origin,
+      RTRIM(url, '/') AS origin,
       COUNT(0) AS total
     FROM
       `httparchive.pages.2021_07_01_*`
     WHERE
-      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true"
+      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true'
     GROUP BY
       _TABLE_SUFFIX,
       url

--- a/sql/2021/pwa/sw_events.sql
+++ b/sql/2021/pwa/sw_events.sql
@@ -30,13 +30,13 @@ JOIN
     FROM
       `httparchive.pages.2021_07_01_*`
     WHERE
-      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true"
+      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true'
     GROUP BY
       _TABLE_SUFFIX
   )
 USING (_TABLE_SUFFIX)
 WHERE
-  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true"
+  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true'
 GROUP BY
   client,
   total,

--- a/sql/2021/pwa/sw_methods.sql
+++ b/sql/2021/pwa/sw_methods.sql
@@ -27,14 +27,14 @@ JOIN
     FROM
       `httparchive.pages.2021_07_01_*`
     WHERE
-      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true"
+      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true'
     GROUP BY
       _TABLE_SUFFIX
   )
 USING (_TABLE_SUFFIX)
 WHERE
-  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true" AND
-  JSON_EXTRACT(payload, '$._pwa.swMethodsInfo') != "[]"
+  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true' AND
+  JSON_EXTRACT(payload, '$._pwa.swMethodsInfo') != '[]'
 GROUP BY
   client,
   total,

--- a/sql/2021/pwa/sw_objects.sql
+++ b/sql/2021/pwa/sw_objects.sql
@@ -30,14 +30,14 @@ JOIN
     FROM
       `httparchive.pages.2021_07_01_*`
     WHERE
-      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true"
+      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true'
     GROUP BY
       _TABLE_SUFFIX
   )
 USING (_TABLE_SUFFIX)
 WHERE
-  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true" AND
-  JSON_EXTRACT(payload, '$._pwa.swObjectsInfo') != "[]"
+  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true' AND
+  JSON_EXTRACT(payload, '$._pwa.swObjectsInfo') != '[]'
 GROUP BY
   client,
   total,

--- a/sql/2021/pwa/sw_objects_name_only.sql
+++ b/sql/2021/pwa/sw_objects_name_only.sql
@@ -30,14 +30,14 @@ JOIN
     FROM
       `httparchive.pages.2021_07_01_*`
     WHERE
-      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true"
+      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true'
     GROUP BY
       _TABLE_SUFFIX
   )
 USING (_TABLE_SUFFIX)
 WHERE
-  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true" AND
-  JSON_EXTRACT(payload, '$._pwa.swObjectsInfo') != "[]"
+  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true' AND
+  JSON_EXTRACT(payload, '$._pwa.swObjectsInfo') != '[]'
 GROUP BY
   client,
   total,

--- a/sql/2021/pwa/sw_registration_properties.sql
+++ b/sql/2021/pwa/sw_registration_properties.sql
@@ -31,14 +31,14 @@ JOIN
     FROM
       `httparchive.pages.2021_07_01_*`
     WHERE
-      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true"
+      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true'
     GROUP BY
       _TABLE_SUFFIX
   )
 USING (_TABLE_SUFFIX)
 WHERE
-  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true" AND
-  JSON_EXTRACT(payload, '$._pwa.swRegistrationPropertiesInfo') != "[]"
+  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true' AND
+  JSON_EXTRACT(payload, '$._pwa.swRegistrationPropertiesInfo') != '[]'
 GROUP BY
   client,
   total,

--- a/sql/2021/pwa/sw_registration_properties_name_only.sql
+++ b/sql/2021/pwa/sw_registration_properties_name_only.sql
@@ -31,14 +31,14 @@ JOIN
     FROM
       `httparchive.pages.2021_07_01_*`
     WHERE
-      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true"
+      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true'
     GROUP BY
       _TABLE_SUFFIX
   )
 USING (_TABLE_SUFFIX)
 WHERE
-  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true" AND
-  JSON_EXTRACT(payload, '$._pwa.swRegistrationPropertiesInfo') != "[]"
+  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true' AND
+  JSON_EXTRACT(payload, '$._pwa.swRegistrationPropertiesInfo') != '[]'
 GROUP BY
   client,
   total,

--- a/sql/2021/pwa/top_manifest_categories.sql
+++ b/sql/2021/pwa/top_manifest_categories.sql
@@ -18,11 +18,11 @@ WITH totals AS (
   SELECT
     _TABLE_SUFFIX,
     COUNT(0) AS total,
-    COUNTIF(JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true") AS pwa_total
+    COUNTIF(JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true') AS pwa_total
   FROM
     `httparchive.pages.2021_07_01_*`
   WHERE
-    JSON_EXTRACT(payload, '$._pwa.manifests') != "[]"
+    JSON_EXTRACT(payload, '$._pwa.manifests') != '[]'
   GROUP BY
     _TABLE_SUFFIX
 ),
@@ -35,9 +35,9 @@ manifests_categories AS (
     COUNT(DISTINCT url) AS freq,
     total,
     COUNT(DISTINCT url) / total AS pct,
-    COUNTIF(JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true") AS pwa_freq,
+    COUNTIF(JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true') AS pwa_freq,
     pwa_total,
-    COUNTIF(JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true") / pwa_total AS pwa_pct
+    COUNTIF(JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true') / pwa_total AS pwa_pct
   FROM
     `httparchive.pages.2021_07_01_*`,
     UNNEST(getCategories(JSON_EXTRACT(payload, '$._pwa.manifests'))) AS category
@@ -45,7 +45,7 @@ manifests_categories AS (
     totals
   USING (_TABLE_SUFFIX)
   WHERE
-    JSON_EXTRACT(payload, '$._pwa.manifests') != "[]"
+    JSON_EXTRACT(payload, '$._pwa.manifests') != '[]'
   GROUP BY
     client,
     category,

--- a/sql/2021/pwa/top_manifest_display_values.sql
+++ b/sql/2021/pwa/top_manifest_display_values.sql
@@ -14,7 +14,7 @@ try {
 ''';
 
 SELECT
-  "PWA Sites" AS type,
+  'PWA Sites' AS type,
   _TABLE_SUFFIX AS client,
   getDisplay(JSON_EXTRACT(payload, '$._pwa.manifests')) AS display,
   COUNT(0) AS freq,
@@ -23,8 +23,8 @@ SELECT
 FROM
   `httparchive.pages.2021_07_01_*`
 WHERE
-  JSON_EXTRACT(payload, '$._pwa.manifests') != "[]" AND
-  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true"
+  JSON_EXTRACT(payload, '$._pwa.manifests') != '[]' AND
+  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true'
 GROUP BY
   client,
   display
@@ -33,7 +33,7 @@ QUALIFY
   freq > 100
 UNION ALL
 SELECT
-  "All Sites" AS type,
+  'All Sites' AS type,
   _TABLE_SUFFIX AS client,
   getDisplay(JSON_EXTRACT(payload, '$._pwa.manifests')) AS display,
   COUNT(0) AS freq,
@@ -42,7 +42,7 @@ SELECT
 FROM
   `httparchive.pages.2021_07_01_*`
 WHERE
-  JSON_EXTRACT(payload, '$._pwa.manifests') != "[]"
+  JSON_EXTRACT(payload, '$._pwa.manifests') != '[]'
 GROUP BY
   client,
   display

--- a/sql/2021/pwa/top_manifest_icon_sizes.sql
+++ b/sql/2021/pwa/top_manifest_icon_sizes.sql
@@ -14,11 +14,11 @@ WITH totals AS (
   SELECT
     _TABLE_SUFFIX,
     COUNT(0) AS total,
-    COUNTIF(JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true") AS pwa_total
+    COUNTIF(JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true') AS pwa_total
   FROM
     `httparchive.pages.2021_07_01_*`
   WHERE
-    JSON_EXTRACT(payload, '$._pwa.manifests') != "[]"
+    JSON_EXTRACT(payload, '$._pwa.manifests') != '[]'
   GROUP BY
     _TABLE_SUFFIX
 ),
@@ -31,9 +31,9 @@ manifests_icon_sizes AS (
     COUNT(DISTINCT url) AS freq,
     total,
     COUNT(DISTINCT url) / total AS pct,
-    COUNTIF(JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true") AS pwa_freq,
+    COUNTIF(JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true') AS pwa_freq,
     pwa_total,
-    COUNTIF(JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true") / pwa_total AS pwa_pct
+    COUNTIF(JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true') / pwa_total AS pwa_pct
   FROM
     `httparchive.pages.2021_07_01_*`,
     UNNEST(getIconSizes(JSON_EXTRACT(payload, '$._pwa.manifests'))) AS size
@@ -41,7 +41,7 @@ manifests_icon_sizes AS (
     totals
   USING (_TABLE_SUFFIX)
   WHERE
-    JSON_EXTRACT(payload, '$._pwa.manifests') != "[]"
+    JSON_EXTRACT(payload, '$._pwa.manifests') != '[]'
   GROUP BY
     client,
     size,

--- a/sql/2021/pwa/top_manifest_orientations.sql
+++ b/sql/2021/pwa/top_manifest_orientations.sql
@@ -14,7 +14,7 @@ try {
 ''';
 
 SELECT
-  "PWA Sites" AS type,
+  'PWA Sites' AS type,
   _TABLE_SUFFIX AS client,
   getOrientation(JSON_EXTRACT(payload, '$._pwa.manifests')) AS orientation,
   COUNT(0) AS freq,
@@ -23,15 +23,15 @@ SELECT
 FROM
   `httparchive.pages.2021_07_01_*`
 WHERE
-  JSON_EXTRACT(payload, '$._pwa.manifests') != "[]" AND
-  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true"
+  JSON_EXTRACT(payload, '$._pwa.manifests') != '[]' AND
+  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true'
 GROUP BY
   type,
   client,
   orientation
 UNION ALL
 SELECT
-  "All Sites" AS type,
+  'All Sites' AS type,
   _TABLE_SUFFIX AS client,
   getOrientation(JSON_EXTRACT(payload, '$._pwa.manifests')) AS orientation,
   COUNT(0) AS freq,
@@ -40,7 +40,7 @@ SELECT
 FROM
   `httparchive.pages.2021_07_01_*`
 WHERE
-  JSON_EXTRACT(payload, '$._pwa.manifests') != "[]"
+  JSON_EXTRACT(payload, '$._pwa.manifests') != '[]'
 GROUP BY
   type,
   client,

--- a/sql/2021/pwa/top_manifest_properties.sql
+++ b/sql/2021/pwa/top_manifest_properties.sql
@@ -18,11 +18,11 @@ WITH totals AS (
   SELECT
     _TABLE_SUFFIX,
     COUNT(0) AS total,
-    COUNTIF(JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true") AS pwa_total
+    COUNTIF(JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true') AS pwa_total
   FROM
     `httparchive.pages.2021_07_01_*`
   WHERE
-    JSON_EXTRACT(payload, '$._pwa.manifests') != "[]"
+    JSON_EXTRACT(payload, '$._pwa.manifests') != '[]'
   GROUP BY
     _TABLE_SUFFIX
 ),
@@ -35,9 +35,9 @@ manifests_properties AS (
     COUNT(DISTINCT url) AS freq,
     total,
     COUNT(DISTINCT url) / total AS pct,
-    COUNTIF(JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true") AS pwa_freq,
+    COUNTIF(JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true') AS pwa_freq,
     pwa_total,
-    COUNTIF(JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true") / pwa_total AS pwa_pct
+    COUNTIF(JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true') / pwa_total AS pwa_pct
   FROM
     `httparchive.pages.2021_07_01_*`,
     UNNEST(getManifestProps(JSON_EXTRACT(payload, '$._pwa.manifests'))) AS property
@@ -45,7 +45,7 @@ manifests_properties AS (
     totals
   USING (_TABLE_SUFFIX)
   WHERE
-    JSON_EXTRACT(payload, '$._pwa.manifests') != "[]"
+    JSON_EXTRACT(payload, '$._pwa.manifests') != '[]'
   GROUP BY
     client,
     property,

--- a/sql/2021/pwa/workbox_methods.sql
+++ b/sql/2021/pwa/workbox_methods.sql
@@ -44,14 +44,14 @@ JOIN
     FROM
       `httparchive.pages.2021_07_01_*`
     WHERE
-      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true"
+      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true'
     GROUP BY
       _TABLE_SUFFIX
   )
 USING (_TABLE_SUFFIX)
 WHERE
-  JSON_EXTRACT(payload, '$._pwa.workboxInfo') != "[]" AND
-  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true"
+  JSON_EXTRACT(payload, '$._pwa.workboxInfo') != '[]' AND
+  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true'
 GROUP BY
   client,
   workbox_method,

--- a/sql/2021/pwa/workbox_packages.sql
+++ b/sql/2021/pwa/workbox_packages.sql
@@ -43,14 +43,14 @@ JOIN
     FROM
       `httparchive.pages.2021_07_01_*`
     WHERE
-      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true"
+      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true'
     GROUP BY
       _TABLE_SUFFIX
   )
 USING (_TABLE_SUFFIX)
 WHERE
-  JSON_EXTRACT(payload, '$._pwa.workboxInfo') != "[]" AND
-  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true"
+  JSON_EXTRACT(payload, '$._pwa.workboxInfo') != '[]' AND
+  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true'
 GROUP BY
   client,
   workbox_package,

--- a/sql/2021/pwa/workbox_usage.sql
+++ b/sql/2021/pwa/workbox_usage.sql
@@ -3,14 +3,14 @@
 
 SELECT
   _TABLE_SUFFIX AS client,
-  COUNTIF(JSON_EXTRACT(payload, '$._pwa.workboxInfo') != "[]") AS freq,
+  COUNTIF(JSON_EXTRACT(payload, '$._pwa.workboxInfo') != '[]') AS freq,
   SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS total,
-  COUNTIF(JSON_EXTRACT(payload, '$._pwa.workboxInfo') != "[]") / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct
+  COUNTIF(JSON_EXTRACT(payload, '$._pwa.workboxInfo') != '[]') / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct
 FROM
   `httparchive.pages.2021_07_01_*`
 WHERE
-  JSON_EXTRACT(payload, '$._pwa.manifests') != "[]" AND
-  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true"
+  JSON_EXTRACT(payload, '$._pwa.manifests') != '[]' AND
+  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true'
 GROUP BY
   client
 ORDER BY

--- a/sql/2021/pwa/workbox_versions.sql
+++ b/sql/2021/pwa/workbox_versions.sql
@@ -43,14 +43,14 @@ JOIN
     FROM
       `httparchive.pages.2021_07_01_*`
     WHERE
-      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true"
+      JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true'
     GROUP BY
       _TABLE_SUFFIX
   )
 USING (_TABLE_SUFFIX)
 WHERE
-  JSON_EXTRACT(payload, '$._pwa.workboxInfo') != "[]" AND
-  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = "true"
+  JSON_EXTRACT(payload, '$._pwa.workboxInfo') != '[]' AND
+  JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true'
 GROUP BY
   _TABLE_SUFFIX,
   workbox_version,

--- a/sql/2021/resource-hints/consoleLog_incorrect_crossorigin.sql
+++ b/sql/2021/resource-hints/consoleLog_incorrect_crossorigin.sql
@@ -33,7 +33,7 @@ FROM (
   FROM (
     SELECT
       _TABLE_SUFFIX AS client,
-      JSON_EXTRACT(payload, "$._consoleLog") AS consoleLog,
+      JSON_EXTRACT(payload, '$._consoleLog') AS consoleLog,
       getResourceHints(payload) AS hints
     FROM
       `httparchive.pages.2021_07_01_*`

--- a/sql/2021/resource-hints/consoleLog_incorrect_crossorigin_type.sql
+++ b/sql/2021/resource-hints/consoleLog_incorrect_crossorigin_type.sql
@@ -5,14 +5,14 @@
 CREATE TEMPORARY FUNCTION getType (href STRING) RETURNS STRING AS (
   IF(
     REGEXP_CONTAINS(href, r'fonts\.googleapis\.com'),
-    "fonts.googleapis.com",
+    'fonts.googleapis.com',
     TRIM(TRIM(REGEXP_EXTRACT(href, r'\.[0-9a-z]+(?:[\?#]|$)'), '?'), '#')
   )
 );
 
 SELECT
   client,
-  getType(TRIM(href, '\'')) AS type,
+  getType(TRIM(href, "'")) AS type,
   COUNT(0) AS freq,
   SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
   COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct
@@ -23,7 +23,7 @@ FROM (
   FROM (
     SELECT
       _TABLE_SUFFIX AS client,
-      JSON_EXTRACT(payload, "$._consoleLog") AS consoleLog
+      JSON_EXTRACT(payload, '$._consoleLog') AS consoleLog
     FROM
       `httparchive.pages.2021_07_01_*`
   )

--- a/sql/2021/resource-hints/consoleLog_incorrect_type.sql
+++ b/sql/2021/resource-hints/consoleLog_incorrect_type.sql
@@ -33,7 +33,7 @@ FROM (
   FROM (
     SELECT
       _TABLE_SUFFIX AS client,
-      JSON_EXTRACT(payload, "$._consoleLog") AS consoleLog,
+      JSON_EXTRACT(payload, '$._consoleLog') AS consoleLog,
       getResourceHints(payload) AS hints
     FROM
       `httparchive.pages.2021_07_01_*`

--- a/sql/2021/resource-hints/consoleLog_unused_preload.sql
+++ b/sql/2021/resource-hints/consoleLog_unused_preload.sql
@@ -33,7 +33,7 @@ FROM (
   FROM (
     SELECT
       _TABLE_SUFFIX AS client,
-      JSON_EXTRACT(payload, "$._consoleLog") AS consoleLog,
+      JSON_EXTRACT(payload, '$._consoleLog') AS consoleLog,
       getResourceHints(payload) AS hints
     FROM
       `httparchive.pages.2021_07_01_*`

--- a/sql/2021/resource-hints/dns-prefetch_host_by_url.sql
+++ b/sql/2021/resource-hints/dns-prefetch_host_by_url.sql
@@ -40,7 +40,7 @@ FROM (
             NET.HOST(href) AS host
           FROM
             `httparchive.pages.2021_07_01_*`,
-            UNNEST(getResourceHintsHrefs(payload, "dns-prefetch")) AS href
+            UNNEST(getResourceHintsHrefs(payload, 'dns-prefetch')) AS href
         )
       GROUP BY
         client,

--- a/sql/2021/resource-hints/offscreen-images.sql
+++ b/sql/2021/resource-hints/offscreen-images.sql
@@ -3,7 +3,7 @@
 
 
 SELECT
-  JSON_EXTRACT_SCALAR(report, "$.audits.offscreen-images.score") AS score,
+  JSON_EXTRACT_SCALAR(report, '$.audits.offscreen-images.score') AS score,
   COUNT(0) AS freq,
   SUM(COUNT(0)) OVER () AS total,
   COUNT(0) / SUM(COUNT(0)) OVER () AS pct

--- a/sql/2021/resource-hints/preconnect_host_by_url.sql
+++ b/sql/2021/resource-hints/preconnect_host_by_url.sql
@@ -40,7 +40,7 @@ FROM (
             NET.HOST(href) AS host
           FROM
             `httparchive.pages.2021_07_01_*`,
-            UNNEST(getResourceHintsHrefs(payload, "preconnect")) AS href
+            UNNEST(getResourceHintsHrefs(payload, 'preconnect')) AS href
         )
       GROUP BY
         client,

--- a/sql/2021/resource-hints/preload-fonts.sql
+++ b/sql/2021/resource-hints/preload-fonts.sql
@@ -3,7 +3,7 @@
 
 
 SELECT
-  JSON_EXTRACT_SCALAR(report, "$.audits.preload-fonts.score") AS score,
+  JSON_EXTRACT_SCALAR(report, '$.audits.preload-fonts.score') AS score,
   COUNT(0) AS freq,
   SUM(COUNT(0)) OVER () AS total,
   COUNT(0) / SUM(COUNT(0)) OVER () AS pct

--- a/sql/2021/resource-hints/preload-lcp-image.sql
+++ b/sql/2021/resource-hints/preload-lcp-image.sql
@@ -3,7 +3,7 @@
 
 
 SELECT
-  JSON_EXTRACT_SCALAR(report, "$.audits.preload-lcp-image.score") AS score,
+  JSON_EXTRACT_SCALAR(report, '$.audits.preload-lcp-image.score') AS score,
   COUNT(0) AS freq,
   SUM(COUNT(0)) OVER () AS total,
   COUNT(0) / SUM(COUNT(0)) OVER () AS pct

--- a/sql/2021/resource-hints/preload_host_by_url.sql
+++ b/sql/2021/resource-hints/preload_host_by_url.sql
@@ -40,7 +40,7 @@ FROM (
             NET.HOST(href) AS host
           FROM
             `httparchive.pages.2021_07_01_*`,
-            UNNEST(getResourceHintsHrefs(payload, "preload")) AS href
+            UNNEST(getResourceHintsHrefs(payload, 'preload')) AS href
         )
       GROUP BY
         client,

--- a/sql/2021/resource-hints/uses-rel-preconnect.sql
+++ b/sql/2021/resource-hints/uses-rel-preconnect.sql
@@ -3,7 +3,7 @@
 
 
 SELECT
-  JSON_EXTRACT_SCALAR(report, "$.audits.uses-rel-preconnect.score") AS score,
+  JSON_EXTRACT_SCALAR(report, '$.audits.uses-rel-preconnect.score') AS score,
   COUNT(0) AS freq,
   SUM(COUNT(0)) OVER () AS total,
   COUNT(0) / SUM(COUNT(0)) OVER () AS pct

--- a/sql/2021/resource-hints/uses-rel-preload.sql
+++ b/sql/2021/resource-hints/uses-rel-preload.sql
@@ -3,7 +3,7 @@
 
 
 SELECT
-  JSON_EXTRACT_SCALAR(report, "$.audits.uses-rel-preload.score") AS score,
+  JSON_EXTRACT_SCALAR(report, '$.audits.uses-rel-preload.score') AS score,
   COUNT(0) AS freq,
   SUM(COUNT(0)) OVER () AS total,
   COUNT(0) / SUM(COUNT(0)) OVER () AS pct

--- a/sql/2021/security/cookie_age_percentiles.sql
+++ b/sql/2021/security/cookie_age_percentiles.sql
@@ -40,7 +40,7 @@ WITH age_values AS (
   FROM
     `httparchive.almanac.requests`
   WHERE
-    date = "2021-07-01"
+    date = '2021-07-01'
 ),
 
 max_age_values AS (
@@ -49,7 +49,7 @@ max_age_values AS (
     percentile,
     APPROX_QUANTILES(SAFE_CAST(max_age_value AS NUMERIC), 1000 IGNORE NULLS)[OFFSET(percentile * 10)] AS max_age
   FROM age_values,
-    UNNEST(JSON_QUERY_ARRAY(values, "$.maxAge")) AS max_age_value,
+    UNNEST(JSON_QUERY_ARRAY(values, '$.maxAge')) AS max_age_value,
     UNNEST([10, 25, 50, 75, 90, 100]) AS percentile
   GROUP BY
     percentile,
@@ -65,7 +65,7 @@ expires_values AS (
     percentile,
     APPROX_QUANTILES(SAFE_CAST(expires_value AS NUMERIC), 1000 IGNORE NULLS)[OFFSET(percentile * 10)] AS expires
   FROM age_values,
-    UNNEST(JSON_QUERY_ARRAY(values, "$.expires")) AS expires_value,
+    UNNEST(JSON_QUERY_ARRAY(values, '$.expires')) AS expires_value,
     UNNEST([10, 25, 50, 75, 90, 100]) AS percentile
   GROUP BY
     percentile,
@@ -81,7 +81,7 @@ real_age_values AS (
     percentile,
     APPROX_QUANTILES(SAFE_CAST(real_age_value AS NUMERIC), 1000 IGNORE NULLS)[OFFSET(percentile * 10)] AS real_age
   FROM age_values,
-    UNNEST(JSON_QUERY_ARRAY(values, "$.realAge")) AS real_age_value,
+    UNNEST(JSON_QUERY_ARRAY(values, '$.realAge')) AS real_age_value,
     UNNEST([10, 25, 50, 75, 90, 100]) AS percentile
   GROUP BY
     percentile,

--- a/sql/2021/security/cookie_max_age_expires_top_values.sql
+++ b/sql/2021/security/cookie_max_age_expires_top_values.sql
@@ -33,9 +33,9 @@ WITH max_age_values AS (
     max_age_value
   FROM
     `httparchive.almanac.requests`,
-    UNNEST(JSON_QUERY_ARRAY(getCookieAgeValues(response_headers, startedDateTime), "$.maxAge")) AS max_age_value
+    UNNEST(JSON_QUERY_ARRAY(getCookieAgeValues(response_headers, startedDateTime), '$.maxAge')) AS max_age_value
   WHERE
-    date = "2021-07-01"
+    date = '2021-07-01'
 ),
 
 expires_values AS (
@@ -44,15 +44,15 @@ expires_values AS (
     expires_value
   FROM
     `httparchive.almanac.requests`,
-    UNNEST(JSON_QUERY_ARRAY(getCookieAgeValues(response_headers, startedDateTime), "$.expires")) AS expires_value
+    UNNEST(JSON_QUERY_ARRAY(getCookieAgeValues(response_headers, startedDateTime), '$.expires')) AS expires_value
   WHERE
-    date = "2021-07-01"
+    date = '2021-07-01'
 ),
 
 max_age AS (
   SELECT
     client,
-    "max-age" AS type,
+    'max-age' AS type,
     total_cookies_with_max_age AS total,
     COUNT(0) AS freq,
     COUNT(0) / total_cookies_with_max_age AS pct,
@@ -82,7 +82,7 @@ max_age AS (
 expires AS (
   SELECT
     client,
-    "expires" AS type,
+    'expires' AS type,
     total_cookies_with_expires AS total,
     COUNT(0) AS freq,
     COUNT(0) / total_cookies_with_expires AS pct,

--- a/sql/2021/security/corp_header_prevalence.sql
+++ b/sql/2021/security/corp_header_prevalence.sql
@@ -25,7 +25,7 @@ FROM (
   FROM
     `httparchive.almanac.requests`
   WHERE
-    date = "2021-07-01"
+    date = '2021-07-01'
 )
 WHERE
   corp_header IS NOT NULL

--- a/sql/2021/security/csp_allowed_host_frequency.sql
+++ b/sql/2021/security/csp_allowed_host_frequency.sql
@@ -18,7 +18,7 @@ WITH totals AS (
   FROM
     `httparchive.almanac.requests`
   WHERE
-    date = "2021-07-01" AND
+    date = '2021-07-01' AND
     firstHtml
   GROUP BY
     client
@@ -38,7 +38,7 @@ FROM (
   FROM
     `httparchive.almanac.requests`
   WHERE
-    date = "2021-07-01" AND
+    date = '2021-07-01' AND
     firstHtml
 )
 JOIN

--- a/sql/2021/security/csp_directives_usage.sql
+++ b/sql/2021/security/csp_directives_usage.sql
@@ -24,7 +24,7 @@ FROM (
   FROM
     `httparchive.almanac.requests`
   WHERE
-    date = "2021-07-01" AND
+    date = '2021-07-01' AND
     firstHtml
 ),
 UNNEST(['child-src', 'connect-src', 'default-src', 'font-src', 'frame-src', 'img-src', 'manifest-src', 'media-src', 'object-src', 'prefetch-src', 'script-src', 'script-src-elem', 'script-src-attr', 'style-src', 'style-src-elem', 'style-src-attr', 'worker-src', 'base-uri', 'plugin-types', 'sandbox', 'form-action', 'frame-ancestors', 'navigate-to', 'report-uri', 'report-to', 'block-all-mixed-content', 'referrer', 'require-sri-for', 'require-trusted-types-for', 'trusted-types', 'upgrade-insecure-requests']) AS directive

--- a/sql/2021/security/csp_most_common_header.sql
+++ b/sql/2021/security/csp_most_common_header.sql
@@ -24,7 +24,7 @@ FROM (
   FROM
     `httparchive.almanac.requests`
   WHERE
-    date = "2021-07-01" AND
+    date = '2021-07-01' AND
     firstHtml
 )
 WHERE

--- a/sql/2021/security/csp_number_of_allowed_hosts.sql
+++ b/sql/2021/security/csp_number_of_allowed_hosts.sql
@@ -30,7 +30,7 @@ FROM (
   FROM
     `httparchive.almanac.requests`
   WHERE
-    date = "2021-07-01" AND
+    date = '2021-07-01' AND
     firstHtml
 ),
 UNNEST([10, 25, 50, 75, 90, 100]) AS percentile

--- a/sql/2021/security/csp_script_source_list_keywords.sql
+++ b/sql/2021/security/csp_script_source_list_keywords.sql
@@ -47,7 +47,7 @@ FROM (
     FROM
       `httparchive.almanac.requests`
     WHERE
-      date = "2021-07-01" AND
+      date = '2021-07-01' AND
       firstHtml
   )
   GROUP BY

--- a/sql/2021/security/hsts_max_age_percentiles.sql
+++ b/sql/2021/security/hsts_max_age_percentiles.sql
@@ -11,7 +11,7 @@ FROM (
   FROM
     `httparchive.almanac.requests`
   WHERE
-    date = "2021-07-01"
+    date = '2021-07-01'
 ),
 UNNEST([10, 25, 50, 75, 90, 100]) AS percentile
 GROUP BY

--- a/sql/2021/security/https_server_redirects.sql
+++ b/sql/2021/security/https_server_redirects.sql
@@ -4,14 +4,14 @@ SELECT
   client,
   date,
   COUNT(DISTINCT url) AS total_urls_on_page,
-  COUNT(DISTINCT(CASE WHEN url LIKE "http://%" THEN url END)) AS count_http_urls_on_page,
-  COUNT(DISTINCT(CASE WHEN url LIKE "http://%" THEN url END)) / COUNT(DISTINCT url) AS pct_http_urls_on_page,
-  COUNT(DISTINCT(CASE WHEN url LIKE "http://%" AND resp_location LIKE "https://%" AND status BETWEEN 300 AND 399 THEN url END)) AS count_http_urls_with_https_redirect_on_page,
-  COUNT(DISTINCT(CASE WHEN url LIKE "http://%" AND resp_location LIKE "https://%" AND status BETWEEN 300 AND 399 THEN url END)) / COUNT(DISTINCT(CASE WHEN url LIKE "http://%" THEN url END)) AS pct_http_urls_with_https_redirect_on_page
+  COUNT(DISTINCT(CASE WHEN url LIKE 'http://%' THEN url END)) AS count_http_urls_on_page,
+  COUNT(DISTINCT(CASE WHEN url LIKE 'http://%' THEN url END)) / COUNT(DISTINCT url) AS pct_http_urls_on_page,
+  COUNT(DISTINCT(CASE WHEN url LIKE 'http://%' AND resp_location LIKE 'https://%' AND status BETWEEN 300 AND 399 THEN url END)) AS count_http_urls_with_https_redirect_on_page,
+  COUNT(DISTINCT(CASE WHEN url LIKE 'http://%' AND resp_location LIKE 'https://%' AND status BETWEEN 300 AND 399 THEN url END)) / COUNT(DISTINCT(CASE WHEN url LIKE 'http://%' THEN url END)) AS pct_http_urls_with_https_redirect_on_page
 FROM
   `httparchive.almanac.requests`
 WHERE
-  "2021-01-01" <= date AND date <= "2021-07-01"
+  '2021-01-01' <= date AND date <= '2021-07-01'
 GROUP BY
   client,
   date

--- a/sql/2021/security/iframe_allow_directive_values.sql
+++ b/sql/2021/security/iframe_allow_directive_values.sql
@@ -4,7 +4,7 @@ CREATE TEMP FUNCTION getNumWithAllowAttribute(payload STRING) AS ((
   SELECT
     COUNT(0)
   FROM
-    UNNEST(JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.iframe-allow-sandbox")) AS iframeAttr
+    UNNEST(JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.iframe-allow-sandbox')) AS iframeAttr
   WHERE
     JSON_EXTRACT_SCALAR(iframeAttr, '$.allow') IS NOT NULL
 ));
@@ -19,7 +19,7 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.iframe-allow-sandbox") AS iframeAttrs
+    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.iframe-allow-sandbox') AS iframeAttrs
   FROM
     `httparchive.pages.2021_07_01_*`),
   UNNEST(iframeAttrs) AS iframeAttr,

--- a/sql/2021/security/iframe_allow_directives.sql
+++ b/sql/2021/security/iframe_allow_directives.sql
@@ -4,7 +4,7 @@ CREATE TEMP FUNCTION getNumWithAllowAttribute(payload STRING) AS ((
   SELECT
     COUNT(0)
   FROM
-    UNNEST(JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.iframe-allow-sandbox")) AS iframeAttr
+    UNNEST(JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.iframe-allow-sandbox')) AS iframeAttr
   WHERE
     JSON_EXTRACT_SCALAR(iframeAttr, '$.allow') IS NOT NULL
 ));
@@ -18,7 +18,7 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.iframe-allow-sandbox") AS iframeAttrs
+    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.iframe-allow-sandbox') AS iframeAttrs
   FROM
     `httparchive.pages.2021_07_01_*`),
   UNNEST(iframeAttrs) AS iframeAttr,

--- a/sql/2021/security/iframe_attribute_popular_hosts.sql
+++ b/sql/2021/security/iframe_attribute_popular_hosts.sql
@@ -23,7 +23,7 @@ FROM (
   FROM (
     SELECT
       _TABLE_SUFFIX AS client,
-      JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.iframe-allow-sandbox") AS iframeAttrs
+      JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.iframe-allow-sandbox') AS iframeAttrs
     FROM
       `httparchive.pages.2021_07_01_*`),
     UNNEST(iframeAttrs) AS iframeAttr,
@@ -32,7 +32,7 @@ FROM (
 JOIN (
   SELECT
     _TABLE_SUFFIX AS client,
-    SUM(ARRAY_LENGTH(JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.iframe-allow-sandbox"))) AS total_iframes
+    SUM(ARRAY_LENGTH(JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.iframe-allow-sandbox'))) AS total_iframes
   FROM
     `httparchive.pages.2021_07_01_*`
   GROUP BY

--- a/sql/2021/security/iframe_attributes_usage.sql
+++ b/sql/2021/security/iframe_attributes_usage.sql
@@ -24,7 +24,7 @@ FROM (
     SELECT
       _TABLE_SUFFIX AS client,
       url,
-      JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.iframe-allow-sandbox") AS iframeAttrs
+      JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.iframe-allow-sandbox') AS iframeAttrs
     FROM
       `httparchive.pages.2021_07_01_*`)
   LEFT JOIN UNNEST(iframeAttrs) AS iframeAttr

--- a/sql/2021/security/iframe_sandbox_directives.sql
+++ b/sql/2021/security/iframe_sandbox_directives.sql
@@ -4,7 +4,7 @@ CREATE TEMP FUNCTION getNumWithSandboxAttribute(payload STRING) AS ((
   SELECT
     COUNT(0)
   FROM
-    UNNEST(JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.iframe-allow-sandbox")) AS iframeAttr
+    UNNEST(JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.iframe-allow-sandbox')) AS iframeAttr
   WHERE
     JSON_EXTRACT_SCALAR(iframeAttr, '$.sandbox') IS NOT NULL
 ));
@@ -18,7 +18,7 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.iframe-allow-sandbox") AS iframeAttrs
+    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.iframe-allow-sandbox') AS iframeAttrs
   FROM
     `httparchive.pages.2021_07_01_*`),
   UNNEST(iframeAttrs) AS iframeAttr,

--- a/sql/2021/security/meta_policies_allowed_vs_disallowed.sql
+++ b/sql/2021/security/meta_policies_allowed_vs_disallowed.sql
@@ -9,11 +9,11 @@ FROM (
   SELECT
     _TABLE_SUFFIX AS client,
     url AS page,
-    JSON_VALUE(payload, "$._almanac") AS metrics
+    JSON_VALUE(payload, '$._almanac') AS metrics
   FROM
     `httparchive.pages.2021_07_01_*`
 ),
-UNNEST(JSON_QUERY_ARRAY(metrics, "$.meta-nodes.nodes")) meta_node,
+UNNEST(JSON_QUERY_ARRAY(metrics, '$.meta-nodes.nodes')) meta_node,
 UNNEST(['Content-Security-Policy', 'Content-Security-Policy-Report-Only', 'Cross-Origin-Embedder-Policy', 'Cross-Origin-Opener-Policy', 'Cross-Origin-Resource-Policy', 'Expect-CT', 'Feature-Policy', 'Permissions-Policy', 'Referrer-Policy', 'referrer', 'Report-To', 'Strict-Transport-Security', 'X-Content-Type-Options', 'X-Frame-Options', 'X-XSS-Protection']) AS policy
 GROUP BY
   client,

--- a/sql/2021/security/mimetype_file_extension_mismatch.sql
+++ b/sql/2021/security/mimetype_file_extension_mismatch.sql
@@ -10,7 +10,7 @@ WITH mimtype_file_ext_pairs AS (
   FROM
     `httparchive.almanac.requests`
   WHERE
-    date = "2021-07-01"
+    date = '2021-07-01'
   GROUP BY
     client,
     mimetype,
@@ -30,14 +30,14 @@ FROM
   mimtype_file_ext_pairs
 WHERE
   mimetype IS NOT NULL AND
-  mimetype != "" AND
+  mimetype != '' AND
   file_extension IS NOT NULL AND
-  file_extension != "" AND
-  mimetype NOT LIKE CONCAT("%", file_extension) AND
-  NOT (REGEXP_CONTAINS(mimetype, "(application|text)/(x-)*javascript") AND REGEXP_CONTAINS(file_extension, r"(?i)^m?js$")) AND
-  NOT (mimetype = "image/svg+xml" AND REGEXP_CONTAINS(file_extension, r"(?i)^svg$")) AND
-  NOT (mimetype = "audio/mpeg" AND REGEXP_CONTAINS(file_extension, r"(?i)^mp3$")) AND
-  NOT (STARTS_WITH(mimetype, "image/") AND REGEXP_CONTAINS(file_extension, r"(?i)^(apng|avif|bmp|cur|gif|jpeg|jpg|jfif|ico|pjpeg|pjp|png|tif|tiff|webp)$"))
+  file_extension != '' AND
+  mimetype NOT LIKE CONCAT('%', file_extension) AND
+  NOT (REGEXP_CONTAINS(mimetype, '(application|text)/(x-)*javascript') AND REGEXP_CONTAINS(file_extension, r'(?i)^m?js$')) AND
+  NOT (mimetype = 'image/svg+xml' AND REGEXP_CONTAINS(file_extension, r'(?i)^svg$')) AND
+  NOT (mimetype = 'audio/mpeg' AND REGEXP_CONTAINS(file_extension, r'(?i)^mp3$')) AND
+  NOT (STARTS_WITH(mimetype, 'image/') AND REGEXP_CONTAINS(file_extension, r'(?i)^(apng|avif|bmp|cur|gif|jpeg|jpg|jfif|ico|pjpeg|pjp|png|tif|tiff|webp)$'))
 GROUP BY
   client,
   total_requests,

--- a/sql/2021/security/robot_header_and_meta_tag_prevalence.sql
+++ b/sql/2021/security/robot_header_and_meta_tag_prevalence.sql
@@ -9,12 +9,12 @@ WITH meta_tags AS (
     SELECT
       _TABLE_SUFFIX AS client,
       url,
-      JSON_VALUE(payload, "$._almanac") AS metrics
+      JSON_VALUE(payload, '$._almanac') AS metrics
     FROM
       `httparchive.pages.2021_07_01_*`
     ),
-    UNNEST(JSON_QUERY_ARRAY(metrics, "$.meta-nodes.nodes")) meta_node
-  WHERE LOWER(JSON_VALUE(meta_node, '$.name')) = "robots"
+    UNNEST(JSON_QUERY_ARRAY(metrics, '$.meta-nodes.nodes')) meta_node
+  WHERE LOWER(JSON_VALUE(meta_node, '$.name')) = 'robots'
 ),
 
 robot_headers AS (
@@ -35,7 +35,7 @@ robot_headers AS (
     ),
     UNNEST(JSON_QUERY_ARRAY(response_headers)) AS response_header
   WHERE
-    LOWER(JSON_VALUE(response_header, '$.name')) = "x-robots-tag"
+    LOWER(JSON_VALUE(response_header, '$.name')) = 'x-robots-tag'
 ),
 
 total_nb_pages AS (

--- a/sql/2021/security/robot_txt_sensitive_disallow.sql
+++ b/sql/2021/security/robot_txt_sensitive_disallow.sql
@@ -15,20 +15,20 @@ LANGUAGE js AS '''
 SELECT
   client,
   COUNT(DISTINCT page) AS total_pages,
-  COUNT(DISTINCT(CASE WHEN has_robots_txt = "true" THEN page END)) AS count_robots_txt,
-  COUNT(DISTINCT(CASE WHEN has_robots_txt = "true" THEN page END)) / COUNT(DISTINCT page) AS pct_robots_txt,
+  COUNT(DISTINCT(CASE WHEN has_robots_txt = 'true' THEN page END)) AS count_robots_txt,
+  COUNT(DISTINCT(CASE WHEN has_robots_txt = 'true' THEN page END)) / COUNT(DISTINCT page) AS pct_robots_txt,
   COUNT(DISTINCT(CASE WHEN REGEXP_CONTAINS(disallowed_endpoint, r'.*/admin/.*') THEN page END)) AS count_disallow_admin,
-  COUNT(DISTINCT(CASE WHEN REGEXP_CONTAINS(disallowed_endpoint, r'.*/admin/.*') THEN page END)) / COUNT(DISTINCT(CASE WHEN has_robots_txt = "true" THEN page END)) AS pct_disallow_admin,
+  COUNT(DISTINCT(CASE WHEN REGEXP_CONTAINS(disallowed_endpoint, r'.*/admin/.*') THEN page END)) / COUNT(DISTINCT(CASE WHEN has_robots_txt = 'true' THEN page END)) AS pct_disallow_admin,
   COUNT(DISTINCT(CASE WHEN REGEXP_CONTAINS(disallowed_endpoint, r'.*/log-*in/.*') THEN page END)) AS count_disallow_login,
-  COUNT(DISTINCT(CASE WHEN REGEXP_CONTAINS(disallowed_endpoint, r'.*/log-*in/.*') THEN page END)) / COUNT(DISTINCT(CASE WHEN has_robots_txt = "true" THEN page END)) AS pct_disallow_login,
+  COUNT(DISTINCT(CASE WHEN REGEXP_CONTAINS(disallowed_endpoint, r'.*/log-*in/.*') THEN page END)) / COUNT(DISTINCT(CASE WHEN has_robots_txt = 'true' THEN page END)) AS pct_disallow_login,
   COUNT(DISTINCT(CASE WHEN REGEXP_CONTAINS(disallowed_endpoint, r'.*/sign-*in/.*') THEN page END)) AS count_disallow_signin,
-  COUNT(DISTINCT(CASE WHEN REGEXP_CONTAINS(disallowed_endpoint, r'.*/sign-*in/.*') THEN page END)) / COUNT(DISTINCT(CASE WHEN has_robots_txt = "true" THEN page END)) AS pct_disallow_signin,
+  COUNT(DISTINCT(CASE WHEN REGEXP_CONTAINS(disallowed_endpoint, r'.*/sign-*in/.*') THEN page END)) / COUNT(DISTINCT(CASE WHEN has_robots_txt = 'true' THEN page END)) AS pct_disallow_signin,
   COUNT(DISTINCT(CASE WHEN REGEXP_CONTAINS(disallowed_endpoint, r'.*/auth./*') THEN page END)) AS count_disallow_auth,
-  COUNT(DISTINCT(CASE WHEN REGEXP_CONTAINS(disallowed_endpoint, r'.*/auth/.*') THEN page END)) / COUNT(DISTINCT(CASE WHEN has_robots_txt = "true" THEN page END)) AS pct_disallow_auth,
+  COUNT(DISTINCT(CASE WHEN REGEXP_CONTAINS(disallowed_endpoint, r'.*/auth/.*') THEN page END)) / COUNT(DISTINCT(CASE WHEN has_robots_txt = 'true' THEN page END)) AS pct_disallow_auth,
   COUNT(DISTINCT(CASE WHEN REGEXP_CONTAINS(disallowed_endpoint, r'.*/sso/.*') THEN page END)) AS count_disallow_sso,
-  COUNT(DISTINCT(CASE WHEN REGEXP_CONTAINS(disallowed_endpoint, r'.*/sso/.*') THEN page END)) / COUNT(DISTINCT(CASE WHEN has_robots_txt = "true" THEN page END)) AS pct_disallow_sso,
+  COUNT(DISTINCT(CASE WHEN REGEXP_CONTAINS(disallowed_endpoint, r'.*/sso/.*') THEN page END)) / COUNT(DISTINCT(CASE WHEN has_robots_txt = 'true' THEN page END)) AS pct_disallow_sso,
   COUNT(DISTINCT(CASE WHEN REGEXP_CONTAINS(disallowed_endpoint, r'.*/account/.*') THEN page END)) AS count_disallow_account,
-  COUNT(DISTINCT(CASE WHEN REGEXP_CONTAINS(disallowed_endpoint, r'.*/account/.*') THEN page END)) / COUNT(DISTINCT(CASE WHEN has_robots_txt = "true" THEN page END)) AS pct_disallow_account
+  COUNT(DISTINCT(CASE WHEN REGEXP_CONTAINS(disallowed_endpoint, r'.*/account/.*') THEN page END)) / COUNT(DISTINCT(CASE WHEN has_robots_txt = 'true' THEN page END)) AS pct_disallow_account
 FROM
   (
     SELECT

--- a/sql/2021/security/security_headers_prevalence.sql
+++ b/sql/2021/security/security_headers_prevalence.sql
@@ -24,7 +24,7 @@ FROM (
   FROM
     `httparchive.almanac.requests`
   WHERE
-    (date = "2020-08-01" OR date = "2021-07-01") AND
+    (date = '2020-08-01' OR date = '2021-07-01') AND
     NET.HOST(urlShort) = NET.HOST(page)
 ),
 UNNEST(['Content-Security-Policy', 'Content-Security-Policy-Report-Only', 'Cross-Origin-Embedder-Policy', 'Cross-Origin-Opener-Policy',

--- a/sql/2021/security/server_header_value_prevalence.sql
+++ b/sql/2021/security/server_header_value_prevalence.sql
@@ -12,7 +12,7 @@ FROM
   (
     SELECT
       client,
-      "server" AS type,
+      'server' AS type,
       resp_server AS resp_value,
       SUM(COUNT(DISTINCT NET.HOST(page))) OVER (PARTITION BY client) AS total,
       COUNT(DISTINCT NET.HOST(page)) AS freq,
@@ -20,7 +20,7 @@ FROM
     FROM
       `httparchive.almanac.requests`
     WHERE
-      (date = "2020-08-01" OR date = "2021-07-01") AND
+      (date = '2020-08-01' OR date = '2021-07-01') AND
       resp_server IS NOT NULL AND
       resp_server != ''
     GROUP BY
@@ -35,7 +35,7 @@ UNION ALL
 (
   SELECT
     client,
-    "x-powered-by" AS type,
+    'x-powered-by' AS type,
     resp_x_powered_by AS resp_value,
     SUM(COUNT(DISTINCT NET.HOST(page))) OVER (PARTITION BY client) AS total,
     COUNT(DISTINCT NET.HOST(page)) AS freq,
@@ -43,7 +43,7 @@ UNION ALL
   FROM
     `httparchive.almanac.requests`
   WHERE
-    (date = "2020-08-01" OR date = "2021-07-01") AND
+    (date = '2020-08-01' OR date = '2021-07-01') AND
     resp_x_powered_by IS NOT NULL AND
     resp_x_powered_by != ''
   GROUP BY

--- a/sql/2021/security/server_information_header_prevalence.sql
+++ b/sql/2021/security/server_information_header_prevalence.sql
@@ -24,7 +24,7 @@ FROM (
   FROM
     `httparchive.almanac.requests`
   WHERE
-    (date = "2020-08-01" OR date = "2021-07-01")
+    (date = '2020-08-01' OR date = '2021-07-01')
 ),
 UNNEST(['Server', 'X-Server', 'X-Backend-Server', 'X-Powered-By', 'X-Aspnet-Version']) AS headername
 GROUP BY

--- a/sql/2021/security/sri_coverage_per_page.sql
+++ b/sql/2021/security/sri_coverage_per_page.sql
@@ -11,7 +11,7 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.sri-integrity") AS sris,
+    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.sri-integrity') AS sris,
     SAFE_CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._element_count'), '$.script') AS INT64) AS num_scripts
   FROM
     `httparchive.pages.2021_07_01_*`),

--- a/sql/2021/security/sri_hash_functions.sql
+++ b/sql/2021/security/sri_hash_functions.sql
@@ -6,7 +6,7 @@ WITH totals AS (
     COUNT(0) AS total_sri_elements
   FROM
     `httparchive.pages.2021_07_01_*`,
-    UNNEST( JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.sri-integrity")) AS sri
+    UNNEST( JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.sri-integrity')) AS sri
   GROUP BY
     client
 )
@@ -20,7 +20,7 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.sri-integrity") AS sris
+    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.sri-integrity') AS sris
   FROM
     `httparchive.pages.2021_07_01_*`),
   UNNEST(sris) AS sri,

--- a/sql/2021/security/sri_popular_hosts.sql
+++ b/sql/2021/security/sri_popular_hosts.sql
@@ -6,7 +6,7 @@ WITH totals AS (
     COUNT(0) AS total_sri_scripts
   FROM
     `httparchive.pages.2021_07_01_*`,
-    UNNEST( JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.sri-integrity")) AS sri
+    UNNEST( JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.sri-integrity')) AS sri
   WHERE
     sri IS NOT NULL AND
     JSON_EXTRACT_SCALAR(sri, '$.tagname') = 'script'
@@ -27,7 +27,7 @@ FROM (
   SELECT
     _TABLE_SUFFIX AS client,
     url,
-    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.sri-integrity") AS sris
+    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.sri-integrity') AS sris
   FROM
     `httparchive.pages.2021_07_01_*`),
   UNNEST(sris) AS sri

--- a/sql/2021/security/sri_usage.sql
+++ b/sql/2021/security/sri_usage.sql
@@ -18,7 +18,7 @@ FROM (
   SELECT
     _TABLE_SUFFIX AS client,
     url,
-    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), "$.sri-integrity") AS sris
+    JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._security'), '$.sri-integrity') AS sris
   FROM
     `httparchive.pages.2021_07_01_*`)
 LEFT JOIN UNNEST(sris) AS sri

--- a/sql/2021/security/well-known_security.sql
+++ b/sql/2021/security/well-known_security.sql
@@ -3,18 +3,18 @@
 SELECT
   client,
   COUNT(DISTINCT page) AS total_pages,
-  COUNTIF(has_security_txt = "true") AS count_security_txt,
-  COUNTIF(has_security_txt = "true") / COUNT(DISTINCT page) AS pct_security_txt,
-  COUNTIF(signed = "true") AS count_signed,
-  COUNTIF(signed = "true") / COUNTIF(has_security_txt = "true") AS pct_signed,
+  COUNTIF(has_security_txt = 'true') AS count_security_txt,
+  COUNTIF(has_security_txt = 'true') / COUNT(DISTINCT page) AS pct_security_txt,
+  COUNTIF(signed = 'true') AS count_signed,
+  COUNTIF(signed = 'true') / COUNTIF(has_security_txt = 'true') AS pct_signed,
   COUNTIF(canonical IS NOT NULL) AS canonical,
-  COUNTIF(canonical IS NOT NULL) / COUNTIF(has_security_txt = "true") AS pct_canonical,
+  COUNTIF(canonical IS NOT NULL) / COUNTIF(has_security_txt = 'true') AS pct_canonical,
   COUNTIF(encryption IS NOT NULL) AS encryption,
-  COUNTIF(encryption IS NOT NULL) / COUNTIF(has_security_txt = "true") AS pct_encryption,
+  COUNTIF(encryption IS NOT NULL) / COUNTIF(has_security_txt = 'true') AS pct_encryption,
   COUNTIF(expires IS NOT NULL) AS expires,
-  COUNTIF(expires IS NOT NULL) / COUNTIF(has_security_txt = "true") AS pct_expires,
+  COUNTIF(expires IS NOT NULL) / COUNTIF(has_security_txt = 'true') AS pct_expires,
   COUNTIF(policy IS NOT NULL) AS policy,
-  COUNTIF(policy IS NOT NULL) / COUNTIF(has_security_txt = "true") AS pct_policy
+  COUNTIF(policy IS NOT NULL) / COUNTIF(has_security_txt = 'true') AS pct_policy
 FROM (
     SELECT
       _TABLE_SUFFIX AS client,

--- a/sql/2021/seo/html-response-vary-header-used.sql
+++ b/sql/2021/seo/html-response-vary-header-used.sql
@@ -3,7 +3,7 @@
 
 SELECT
   _TABLE_SUFFIX AS client,
-  REGEXP_CONTAINS(LOWER(resp_vary), r"user-agent") AS resp_vary_user_agent,
+  REGEXP_CONTAINS(LOWER(resp_vary), r'user-agent') AS resp_vary_user_agent,
   COUNT(0) AS freq,
   SAFE_DIVIDE(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX)) AS pct
 FROM

--- a/sql/2021/seo/seo-stats.sql
+++ b/sql/2021/seo/seo-stats.sql
@@ -437,7 +437,7 @@ SELECT
   SAFE_DIVIDE(COUNTIF(wpt_bodies_info.rendering_changes_structured_data), COUNT(0)) AS pct_rendering_changes_structured_data,
 
   # http or https
-  SAFE_DIVIDE(COUNTIF(protocol = "https"), COUNT(0)) AS pct_https,
+  SAFE_DIVIDE(COUNTIF(protocol = 'https'), COUNT(0)) AS pct_https,
 
   # meta robots
   SAFE_DIVIDE(COUNTIF(wpt_bodies_info.rendered_otherbot_status_index), COUNT(0)) AS pct_rendered_otherbot_status_index,
@@ -477,7 +477,7 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    SPLIT(url, ":")[OFFSET(0)] AS protocol,
+    SPLIT(url, ':')[OFFSET(0)] AS protocol,
     getSeoStatsWptBodies(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
   FROM
     `httparchive.pages.2021_07_01_*`

--- a/sql/2021/third-parties/percent_of_third_party_with_security_headers.sql
+++ b/sql/2021/third-parties/percent_of_third_party_with_security_headers.sql
@@ -48,10 +48,10 @@ base AS (
     client,
     req_origin,
     req_category,
-    IF(STRPOS(respOtherHeaders, "strict-transport-security") > 0, 1, 0) AS hsts_header,
-    IF(STRPOS(respOtherHeaders, "x-content-type-options") > 0, 1, 0) AS x_content_type_options_header,
-    IF(STRPOS(respOtherHeaders, "x-frame-options") > 0, 1, 0) AS x_frame_options_header,
-    IF(STRPOS(respOtherHeaders, "x-xss-protection") > 0, 1, 0) AS x_xss_protection_header
+    IF(STRPOS(respOtherHeaders, 'strict-transport-security') > 0, 1, 0) AS hsts_header,
+    IF(STRPOS(respOtherHeaders, 'x-content-type-options') > 0, 1, 0) AS x_content_type_options_header,
+    IF(STRPOS(respOtherHeaders, 'x-frame-options') > 0, 1, 0) AS x_frame_options_header,
+    IF(STRPOS(respOtherHeaders, 'x-xss-protection') > 0, 1, 0) AS x_xss_protection_header
   FROM headers
 )
 

--- a/sql/2021/third-parties/tao_by_third_party.sql
+++ b/sql/2021/third-parties/tao_by_third_party.sql
@@ -74,8 +74,8 @@ base AS (
     client,
     IF(
       page_origin = req_origin OR
-      timing_allow_origin = "*, " OR
-      STRPOS(timing_allow_origin, CONCAT(page_origin, ", ")) > 0,
+      timing_allow_origin = '*, ' OR
+      STRPOS(timing_allow_origin, CONCAT(page_origin, ', ')) > 0,
       1, 0) AS timing_allowed
   FROM headers
 )

--- a/sql/2021/third-parties/third_parties_blocking_main_thread.sql
+++ b/sql/2021/third-parties/third_parties_blocking_main_thread.sql
@@ -19,12 +19,12 @@ SELECT
   APPROX_QUANTILES(blocking_time, 1000)[OFFSET(500)] AS p50_blocking_time
 FROM (
   SELECT
-    JSON_VALUE(third_party_items, "$.entity.url") AS domain,
+    JSON_VALUE(third_party_items, '$.entity.url') AS domain,
     page,
-    JSON_VALUE(third_party_items, "$.entity.text") AS category,
-    COUNTIF(SAFE_CAST(JSON_VALUE(report, "$.audits.third-party-summary.details.summary.wastedMs") AS FLOAT64) > 250) AS blocking,
-    SUM(SAFE_CAST(JSON_VALUE(third_party_items, "$.blockingTime") AS FLOAT64)) AS blocking_time,
-    SUM(SAFE_CAST(JSON_VALUE(third_party_items, "$.transferSize") AS FLOAT64) / 1024) AS transfer_size_kib
+    JSON_VALUE(third_party_items, '$.entity.text') AS category,
+    COUNTIF(SAFE_CAST(JSON_VALUE(report, '$.audits.third-party-summary.details.summary.wastedMs') AS FLOAT64) > 250) AS blocking,
+    SUM(SAFE_CAST(JSON_VALUE(third_party_items, '$.blockingTime') AS FLOAT64)) AS blocking_time,
+    SUM(SAFE_CAST(JSON_VALUE(third_party_items, '$.transferSize') AS FLOAT64) / 1024) AS transfer_size_kib
   FROM
     (
       SELECT

--- a/sql/2021/third-parties/third_parties_blocking_main_thread_percentiles.sql
+++ b/sql/2021/third-parties/third_parties_blocking_main_thread_percentiles.sql
@@ -17,12 +17,12 @@ SELECT
   APPROX_QUANTILES(blocking_time, 1000)[OFFSET(percentile * 10)] AS p50_blocking_time
 FROM (
   SELECT
-    JSON_VALUE(third_party_items, "$.entity.url") AS domain,
+    JSON_VALUE(third_party_items, '$.entity.url') AS domain,
     page,
-    JSON_VALUE(third_party_items, "$.entity.text") AS category,
-    COUNTIF(SAFE_CAST(JSON_VALUE(report, "$.audits.third-party-summary.details.summary.wastedMs") AS FLOAT64) > 250) AS blocking,
-    SUM(SAFE_CAST(JSON_VALUE(third_party_items, "$.blockingTime") AS FLOAT64)) AS blocking_time,
-    SUM(SAFE_CAST(JSON_VALUE(third_party_items, "$.transferSize") AS FLOAT64) / 1024) AS transfer_size_kib
+    JSON_VALUE(third_party_items, '$.entity.text') AS category,
+    COUNTIF(SAFE_CAST(JSON_VALUE(report, '$.audits.third-party-summary.details.summary.wastedMs') AS FLOAT64) > 250) AS blocking,
+    SUM(SAFE_CAST(JSON_VALUE(third_party_items, '$.blockingTime') AS FLOAT64)) AS blocking_time,
+    SUM(SAFE_CAST(JSON_VALUE(third_party_items, '$.transferSize') AS FLOAT64) / 1024) AS transfer_size_kib
   FROM
     (
       SELECT

--- a/sql/2021/third-parties/third_parties_blocking_rendering.sql
+++ b/sql/2021/third-parties/third_parties_blocking_rendering.sql
@@ -49,8 +49,8 @@ FROM (
     domain,
     page,
     category,
-    SUM(SAFE_CAST(JSON_VALUE(renderBlockingItems, "$.wastedMs") AS FLOAT64)) AS wasted_ms,
-    SUM(SAFE_CAST(JSON_VALUE(renderBlockingItems, "$.totalBytes") AS FLOAT64) / 1024) AS total_bytes_kib
+    SUM(SAFE_CAST(JSON_VALUE(renderBlockingItems, '$.wastedMs') AS FLOAT64)) AS wasted_ms,
+    SUM(SAFE_CAST(JSON_VALUE(renderBlockingItems, '$.totalBytes') AS FLOAT64) / 1024) AS total_bytes_kib
   FROM
     (
       SELECT
@@ -63,7 +63,7 @@ FROM (
   INNER JOIN
     `httparchive.almanac.third_parties`
   ON
-    NET.HOST(JSON_VALUE(renderBlockingItems, "$.url")) = domain
+    NET.HOST(JSON_VALUE(renderBlockingItems, '$.url')) = domain
   GROUP BY
     canonicalDomain,
     domain,

--- a/sql/2021/third-parties/third_parties_blocking_rendering_percentiles.sql
+++ b/sql/2021/third-parties/third_parties_blocking_rendering_percentiles.sql
@@ -46,8 +46,8 @@ FROM (
     canonicalDomain,
     page,
     category,
-    SUM(SAFE_CAST(JSON_VALUE(render_blocking_items, "$.wastedMs") AS FLOAT64)) AS wasted_ms,
-    SUM(SAFE_CAST(JSON_VALUE(render_blocking_items, "$.totalBytes") AS FLOAT64) / 1024) AS total_bytes_kib
+    SUM(SAFE_CAST(JSON_VALUE(render_blocking_items, '$.wastedMs') AS FLOAT64)) AS wasted_ms,
+    SUM(SAFE_CAST(JSON_VALUE(render_blocking_items, '$.totalBytes') AS FLOAT64) / 1024) AS total_bytes_kib
   FROM
     (
       SELECT
@@ -60,7 +60,7 @@ FROM (
   INNER JOIN
     `httparchive.almanac.third_parties`
   ON
-    NET.HOST(JSON_VALUE(render_blocking_items, "$.url")) = domain AND
+    NET.HOST(JSON_VALUE(render_blocking_items, '$.url')) = domain AND
     date = '2021-07-01'
   GROUP BY
     canonicalDomain,

--- a/sql/util/pwa_candidates.sql
+++ b/sql/util/pwa_candidates.sql
@@ -8,22 +8,22 @@ RETURNS STRING LANGUAGE js AS """
 SELECT DISTINCT
   date,
   client,
-  REGEXP_REPLACE(page, "^http:", "https:") AS pwa_url,
-  pathResolve(REGEXP_REPLACE(page, "^http:", "https:"),
-    REGEXP_EXTRACT(body, "navigator\\.serviceWorker\\.register\\s*\\(\\s*[\"']([^\\),\\s\"']+)")) AS sw_url,
-  pathResolve(REGEXP_REPLACE(page, "^http:", "https:"),
-    REGEXP_EXTRACT(REGEXP_EXTRACT(body, "(<link[^>]+rel=[\"']?manifest[\"']?[^>]+>)"), "href=[\"']?([^\\s\"'>]+)[\"']?")) AS manifest_url
+  REGEXP_REPLACE(page, '^http:', 'https:') AS pwa_url,
+  pathResolve(REGEXP_REPLACE(page, '^http:', 'https:'),
+    REGEXP_EXTRACT(body, 'navigator\\.serviceWorker\\.register\\s*\\(\\s*["\']([^\\),\\s"\']+)')) AS sw_url,
+  pathResolve(REGEXP_REPLACE(page, '^http:', 'https:'),
+    REGEXP_EXTRACT(REGEXP_EXTRACT(body, '(<link[^>]+rel=["\']?manifest["\']?[^>]+>)'), 'href=["\']?([^\\s"\'>]+)["\']?')) AS manifest_url
 FROM
   `httparchive.almanac.summary_response_bodies`
 WHERE
   date = '2020-08-01' AND
   (
     (
-      REGEXP_EXTRACT(body, "navigator\\.serviceWorker\\.register\\s*\\(\\s*[\"']([^\\),\\s\"']+)") IS NOT NULL AND
-      REGEXP_EXTRACT(body, "navigator\\.serviceWorker\\.register\\s*\\(\\s*[\"']([^\\),\\s\"']+)") != "/"
+      REGEXP_EXTRACT(body, 'navigator\\.serviceWorker\\.register\\s*\\(\\s*["\']([^\\),\\s"\']+)') IS NOT NULL AND
+      REGEXP_EXTRACT(body, 'navigator\\.serviceWorker\\.register\\s*\\(\\s*["\']([^\\),\\s"\']+)') != '/'
     ) OR
     (
-      REGEXP_EXTRACT(REGEXP_EXTRACT(body, "(<link[^>]+rel=[\"']?manifest[\"']?[^>]+>)"), "href=[\"']?([^\\s\"'>]+)[\"']?") IS NOT NULL AND
-      REGEXP_EXTRACT(REGEXP_EXTRACT(body, "(<link[^>]+rel=[\"']?manifest[\"']?[^>]+>)"), "href=[\"']?([^\\s\"'>]+)[\"']?") != "/"
+      REGEXP_EXTRACT(REGEXP_EXTRACT(body, '(<link[^>]+rel=["\']?manifest["\']?[^>]+>)'), 'href=["\']?([^\\s"\'>]+)["\']?') IS NOT NULL AND
+      REGEXP_EXTRACT(REGEXP_EXTRACT(body, '(<link[^>]+rel=["\']?manifest["\']?[^>]+>)'), 'href=["\']?([^\\s"\'>]+)["\']?') != '/'
     )
   )

--- a/sql/util/requests.sql
+++ b/sql/util/requests.sql
@@ -198,8 +198,8 @@ SELECT
   rank,
   url,
   getSummary(payload).*, -- noqa: L013
-  JSON_EXTRACT(payload, "$.request.headers") AS request_headers,
-  JSON_EXTRACT(payload, "$.response.headers") AS response_headers,
+  JSON_EXTRACT(payload, '$.request.headers') AS request_headers,
+  JSON_EXTRACT(payload, '$.response.headers') AS response_headers,
   payload
 FROM
   `httparchive.requests.2021_07_01_*`

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,4 +4,4 @@ gunicorn==20.1.0
 pytest==7.1.1
 pytest-watch==4.2.0
 pytest-cov==3.0.0
-sqlfluff==0.12.0
+sqlfluff==0.13.0


### PR DESCRIPTION
We mostly use single quotes for literals, but not always. This PR changes to be consistent to prevent a new SQLFluff rule flagging (the other alternative is to turn off that rule, but think we should have consistency).