### PR TITLE
HTTP 2022 queries

### DIFF
--- a/sql/2022/http/connections_per_page_load_dist.sql
+++ b/sql/2022/http/connections_per_page_load_dist.sql
@@ -1,0 +1,44 @@
+#standardSQL
+
+# Measure the distribution of TCP Connections per site.
+
+SELECT
+  percentile,
+  client,
+  http_version_category,
+  COUNT(0) AS num_pages,
+  APPROX_QUANTILES(_connections, 1000)[OFFSET(percentile * 10)] AS connections
+FROM (
+  SELECT
+    client,
+    page,
+    CASE
+      WHEN LOWER(protocol) = 'quic' OR LOWER(protocol) LIKE 'h3%' THEN 'HTTP/2+'
+      WHEN LOWER(protocol) = 'http/2' OR LOWER(protocol) = 'http/3' THEN 'HTTP/2+'
+      WHEN protocol IS NULL THEN 'Unknown'
+      ELSE 'Non-HTTP/2'
+    END AS http_version_category
+  FROM
+    `httparchive.almanac.requests`
+  WHERE
+    date = '2022-06-01' AND
+    firstHtml)
+JOIN (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    url AS page,
+    _connections
+  FROM
+    `httparchive.summary_pages.2022_06_01_*`)
+USING
+  (client, page),
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
+GROUP BY
+  percentile,
+  client,
+  http_version_category
+ORDER BY
+  percentile,
+  client,
+  num_pages DESC,
+  http_version_category

--- a/sql/2022/http/early_hints_per_page.sql
+++ b/sql/2022/http/early_hints_per_page.sql
@@ -1,10 +1,11 @@
 #standardSQL
 
-# Distribution of requests being on HTTP/2 vs HTTP/1.1
+# Distribution of number of early hints resources
 
 SELECT
   client,
   percentile,
+  COUNT(DISTINCT page) as num_pages,
   APPROX_QUANTILES(num_reqs, 1000)[OFFSET(percentile * 10)] AS num_reqs,
   APPROX_QUANTILES(early_hints, 1000)[OFFSET(percentile * 10)] AS early_hints,
   APPROX_QUANTILES(pct_early_hints, 1000)[OFFSET(percentile * 10)] AS pct_early_hints

--- a/sql/2022/http/early_hints_per_page.sql
+++ b/sql/2022/http/early_hints_per_page.sql
@@ -1,0 +1,35 @@
+#standardSQL
+
+# Distribution of requests being on HTTP/2 vs HTTP/1.1
+
+SELECT
+  client,
+  percentile,
+  APPROX_QUANTILES(num_reqs, 1000)[OFFSET(percentile * 10)] AS num_reqs,
+  APPROX_QUANTILES(early_hints, 1000)[OFFSET(percentile * 10)] AS early_hints,
+  APPROX_QUANTILES(pct_early_hints, 1000)[OFFSET(percentile * 10)] AS pct_early_hints
+FROM
+  (
+    SELECT
+      client,
+      page,
+      COUNT(0) AS num_reqs,
+      COUNTIF(status = 103) AS early_hints,
+      COUNTIF(status = 103) / COUNT(0) AS pct_early_hints
+    FROM
+      `httparchive.almanac.requests`
+    WHERE
+      date = '2022-06-01'
+    GROUP BY
+      client,
+      page
+    ORDER BY
+      client ASC
+  ),
+  UNNEST(GENERATE_ARRAY(1, 100)) AS percentile
+GROUP BY
+  client,
+  percentile
+ORDER BY
+  client,
+  percentile

--- a/sql/2022/http/early_hints_per_page.sql
+++ b/sql/2022/http/early_hints_per_page.sql
@@ -5,7 +5,7 @@
 SELECT
   client,
   percentile,
-  COUNT(DISTINCT page) as num_pages,
+  COUNT(DISTINCT page) AS num_pages,
   APPROX_QUANTILES(num_reqs, 1000)[OFFSET(percentile * 10)] AS num_reqs,
   APPROX_QUANTILES(early_hints, 1000)[OFFSET(percentile * 10)] AS early_hints,
   APPROX_QUANTILES(pct_early_hints, 1000)[OFFSET(percentile * 10)] AS pct_early_hints

--- a/sql/2022/http/h2_adoption_by_cdn_pct.sql
+++ b/sql/2022/http/h2_adoption_by_cdn_pct.sql
@@ -1,0 +1,31 @@
+#standardSQL
+
+# Percentage of requests using HTTP/2+ vs HTTP/1.1 broken down by whether the
+# request was served from CDN.
+
+SELECT
+  client,
+  CASE
+    WHEN LENGTH(_cdn_provider) > 0 THEN 'from-cdn'
+    ELSE 'non-cdn'
+  END AS cdn,
+  CASE
+    WHEN LOWER(protocol) = 'quic' OR LOWER(protocol) LIKE 'h3%' THEN 'HTTP/2+'
+    WHEN LOWER(protocol) = 'http/2' OR LOWER(protocol) = 'http/3' THEN 'HTTP/2+'
+    WHEN protocol IS NULL THEN 'Unknown'
+    ELSE UPPER(protocol)
+  END AS http_version_category,
+  COUNT(0) AS num_reqs,
+  SUM(COUNT(0)) OVER (PARTITION BY client) AS total_reqs,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct_reqs
+FROM
+  `httparchive.almanac.requests`
+WHERE
+  date = '2022-06-01'
+GROUP BY
+  client,
+  cdn,
+  http_version_category
+ORDER BY
+  client ASC,
+  num_reqs DESC

--- a/sql/2022/http/h2_adoption_pages_reqs.sql
+++ b/sql/2022/http/h2_adoption_pages_reqs.sql
@@ -4,29 +4,32 @@
 # page.
 
 SELECT
-    client,
-    protocol,
-    CASE
-        WHEN
-            LOWER(protocol) LIKE 'h3%' OR LOWER(protocol) = 'quic' THEN 'HTTP/3'
-        WHEN protocol IS NULL THEN 'Unknown'
-        ELSE UPPER(protocol)
-    END AS http_version,
-    COUNT(*) AS num_reqs,
-    SUM(COUNT(*)) OVER (PARTITION BY client) AS total_reqs,
-    COUNT(*) / SUM(COUNT(*)) OVER (PARTITION BY client) AS pct_reqs,
-    COUNTIF(firsthtml) AS num_pages,
-    SUM(COUNTIF(firsthtml)) OVER (PARTITION BY client) AS total_pages,
-    COUNTIF(
-        firsthtml
-    ) / SUM(COUNTIF(firsthtml)) OVER (PARTITION BY client) AS pct_pages
+  client,
+  protocol,
+  CASE
+    WHEN LOWER(protocol) = 'quic' OR LOWER(protocol) LIKE 'h3%' THEN 'HTTP/2+'
+    WHEN LOWER(protocol) = 'http/2' OR LOWER(protocol) = 'http/3' THEN 'HTTP/2+'
+    WHEN protocol IS NULL THEN 'Unknown'
+    ELSE UPPER(protocol)
+  END AS http_version_category,
+  CASE
+    WHEN LOWER(protocol) LIKE 'h3%' OR LOWER(protocol) = 'quic' THEN 'HTTP/3'
+    WHEN protocol IS NULL THEN 'Unknown'
+    ELSE UPPER(protocol)
+  END AS http_version,
+  COUNT(0) AS num_reqs,
+  SUM(COUNT(0)) OVER (PARTITION BY client) AS total_reqs,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct_reqs,
+  COUNTIF(firsthtml) AS num_pages,
+  SUM(COUNTIF(firsthtml)) OVER (PARTITION BY client) AS total_pages,
+  COUNTIF(firsthtml) / SUM(COUNTIF(firsthtml)) OVER (PARTITION BY client) AS pct_pages
 FROM
-    `httparchive.almanac.requests` TABLESAMPLE SYSTEM (0.001 PERCENT)
+  `httparchive.almanac.requests`
 WHERE
-    date = '2022-06-01'
+  date = '2022-06-01'
 GROUP BY
-    client,
-    protocol
+  client,
+  protocol
 ORDER BY
-    client ASC,
-    num_reqs DESC
+  client ASC,
+  num_reqs DESC

--- a/sql/2022/http/h2_adoption_pages_reqs.sql
+++ b/sql/2022/http/h2_adoption_pages_reqs.sql
@@ -1,0 +1,32 @@
+#standardSQL
+
+# Percentage of websites using HTTP/2+ vs HTTP/1.1; this is based on the home
+# page.
+
+SELECT
+    client,
+    protocol,
+    CASE
+        WHEN
+            LOWER(protocol) LIKE 'h3%' OR LOWER(protocol) = 'quic' THEN 'HTTP/3'
+        WHEN protocol IS NULL THEN 'Unknown'
+        ELSE UPPER(protocol)
+    END AS http_version,
+    COUNT(*) AS num_reqs,
+    SUM(COUNT(*)) OVER (PARTITION BY client) AS total_reqs,
+    COUNT(*) / SUM(COUNT(*)) OVER (PARTITION BY client) AS pct_reqs,
+    COUNTIF(firsthtml) AS num_pages,
+    SUM(COUNTIF(firsthtml)) OVER (PARTITION BY client) AS total_pages,
+    COUNTIF(
+        firsthtml
+    ) / SUM(COUNTIF(firsthtml)) OVER (PARTITION BY client) AS pct_pages
+FROM
+    `httparchive.almanac.requests` TABLESAMPLE SYSTEM (0.001 PERCENT)
+WHERE
+    date = '2022-06-01'
+GROUP BY
+    client,
+    protocol
+ORDER BY
+    client ASC,
+    num_reqs DESC

--- a/sql/2022/http/h2_adoption_reqs_dist.sql
+++ b/sql/2022/http/h2_adoption_reqs_dist.sql
@@ -1,0 +1,45 @@
+#standardSQL
+
+# Distribution of requests being on HTTP/2 vs HTTP/1.1
+
+SELECT
+  client,
+  http_version_category,
+  percentile,
+  APPROX_QUANTILES(num_reqs, 1000)[OFFSET(percentile * 10)] AS num_reqs,
+  APPROX_QUANTILES(total_reqs, 1000)[OFFSET(percentile * 10)] AS total_reqs,
+  APPROX_QUANTILES(pct_reqs, 1000)[OFFSET(percentile * 10)] AS pct_reqs
+FROM
+  (
+    SELECT
+      client,
+      page,
+      CASE
+        WHEN LOWER(protocol) = 'quic' OR LOWER(protocol) LIKE 'h3%' THEN 'HTTP/2+'
+        WHEN LOWER(protocol) = 'http/2' OR LOWER(protocol) = 'http/3' THEN 'HTTP/2+'
+        WHEN protocol IS NULL THEN 'Unknown'
+        ELSE UPPER(protocol)
+      END AS http_version_category,
+      COUNT(0) AS num_reqs,
+      SUM(COUNT(0)) OVER (PARTITION BY client, page) AS total_reqs,
+      COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client, page) AS pct_reqs
+    FROM
+      `httparchive.almanac.requests`
+    WHERE
+      date = '2022-06-01'
+    GROUP BY
+      client,
+      page,
+      http_version_category
+    ORDER BY
+      client ASC,
+      num_reqs
+   ),
+  UNNEST(GENERATE_ARRAY(1,100)) AS percentile
+GROUP BY
+  client,
+  http_version_category,
+  percentile
+ORDER BY
+  client,
+  percentile

--- a/sql/2022/http/h2_adoption_reqs_dist.sql
+++ b/sql/2022/http/h2_adoption_reqs_dist.sql
@@ -34,8 +34,8 @@ FROM
     ORDER BY
       client ASC,
       num_reqs
-   ),
-  UNNEST(GENERATE_ARRAY(1,100)) AS percentile
+  ),
+  UNNEST(GENERATE_ARRAY(1, 100)) AS percentile
 GROUP BY
   client,
   http_version_category,

--- a/sql/2022/http/h2_adoption_reqs_dist.sql
+++ b/sql/2022/http/h2_adoption_reqs_dist.sql
@@ -17,8 +17,7 @@ FROM
       CASE
         WHEN LOWER(protocol) = 'quic' OR LOWER(protocol) LIKE 'h3%' THEN 'HTTP/2+'
         WHEN LOWER(protocol) = 'http/2' OR LOWER(protocol) = 'http/3' THEN 'HTTP/2+'
-        WHEN protocol IS NULL THEN 'Unknown'
-        ELSE UPPER(protocol)
+        ELSE 'non-HTTP/2'
       END AS http_version_category,
       COUNT(0) AS num_reqs,
       SUM(COUNT(0)) OVER (PARTITION BY client, page) AS total_reqs,

--- a/sql/2022/http/h2_h3_pushed.sql
+++ b/sql/2022/http/h2_h3_pushed.sql
@@ -1,0 +1,41 @@
+#standardSQL
+
+# Distribution of requests being on HTTP/2 vs HTTP/1.1
+
+SELECT
+  client,
+  percentile,
+  COUNT(DISTINCT page) AS num_pages,
+  APPROX_QUANTILES(num_pushed, 1000)[OFFSET(percentile * 10)] AS pct_num_pushed,
+  APPROX_QUANTILES(transfered_KiB, 1000)[OFFSET(percentile * 10)] AS pct_transfered_KiB
+FROM
+  (
+    SELECT
+      client,
+      page,
+      SUM(respSize / 1024) AS transfered_KiB,
+      COUNT(0) AS num_pushed
+    FROM
+      `httparchive.almanac.requests`
+    WHERE
+      date = '2022-06-01' AND
+      pushed = '1' AND
+      (
+        LOWER(protocol) = 'http/2' OR
+        LOWER(protocol) LIKE '%quic%' OR
+        LOWER(protocol) LIKE 'h3%' OR
+        LOWER(protocol) = 'http/3'
+      )
+    GROUP BY
+      client,
+      page
+    ORDER BY
+      client ASC
+  ),
+  UNNEST(GENERATE_ARRAY(1, 100)) AS percentile
+GROUP BY
+  client,
+  percentile
+ORDER BY
+  client,
+  percentile

--- a/sql/2022/http/priority_hints_per_page.sql
+++ b/sql/2022/http/priority_hints_per_page.sql
@@ -1,0 +1,34 @@
+#standardSQL
+
+# Number of resources with priority hints.
+
+CREATE TEMPORARY FUNCTION getNumPriorityHints(payload STRING)
+RETURNS INT LANGUAGE js AS """
+try {
+  const $ = JSON.parse(payload)
+  const almanac = JSON.parse($._almanac);
+  return almanac['priority-hints']['total'];
+} catch (e) {
+  return -1;
+}
+""";
+
+SELECT
+  client,
+  percentile,
+  APPROX_QUANTILES(num_priority_hints, 1000)[OFFSET(percentile * 10)] AS num_percentiles
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    url AS page,
+    getNumPriorityHints(payload) AS num_priority_hints
+  FROM
+    `httparchive.pages.2022_06_01_*`
+),
+UNNEST([10, 25, 50, 75, 90, 95, 100]) AS percentile
+GROUP BY
+  client,
+  percentile
+ORDER BY
+  client,
+  percentile


### PR DESCRIPTION
This PR tracks the query progress for #2903 . All metrics will be computed in both absolute and relative (i.e., percentage) terms. They should also include breakdown by desktop and mobile.

# Adoption
Compare between 2021 and 2022:
- [x] (2022) % of websites using HTTP/2+ vs HTTP/1.1
- [x] (2022) Distribution of number and % of resources on HTTP/2 vs HTTP/1.1 broken down by whether the resource was requested via CDN.
- [x] (2022) Distribution of number and % of resources on HTTP/2 vs HTTP/1.1
- [x] (2021) % of websites using HTTP/2+ vs HTTP/1.1
- [ ] (2021) Distribution of number and % of resources on HTTP/2 vs HTTP/1.1
- [ ] (2021) Distribution of number and % of resources on HTTP/2 vs HTTP/1.1 broken down by whether the resource was requested via CDN.

# Benefits from HTTP/2

## Connections
- [x] Median number of connections per page load.
- [ ] Average number of connections per page load.
- [x] Distribution of connections across websites.

## Prioritization
- [x] Number of sites using priority hints. Custom metrics already [implemented](https://github.com/HTTPArchive/custom-metrics/blob/4c6bc0493b1b51dc021d6dcf7471b80224dc9228/dist/almanac.js#L215-L219).
- [x] Distribution of number of resources with priority hints.
- [x] _Not querying as most websites have not adopted priority hints._ Breakdown of priority hint levels per page. For example, CDF across websites of the number of resources with priority hints broken down in two lines: `high` and `low`. We should only execute this only if there is enough data for this analysis to make sense.-

## Push
- [x] Number of pushed resources
- [ ] Number of Link rel="preload" in HTTP response headers--signal for push for CDNs and proxies.
- [x] Number of sites using Early Hints. Sites with 103 responses.

# HTTP/3
- [ ] Breakdown of server side supported versions of protocols. Distribution and median value.
