### PR TITLE
Markup 2022 queries

### DIFF
--- a/sql/.sqlfluff
+++ b/sql/.sqlfluff
@@ -11,11 +11,12 @@ templater = jinja
 ## Comma separated list of rules to check, or None for all
 rules = None
 ## Comma separated list of rules to exclude, or None
-exclude_rules = L011,L014,L016,L020,L026,L027,L028,L029,L030,L031,L032,L034,L035,L036,L037,L042,L043,L051,L060
+exclude_rules = L011,L014,L016,L020,L022,L026,L027,L028,L029,L030,L031,L032,L034,L035,L036,L037,L042,L043,L051,L060
 # L011 - We don't always alias tables with AS ("FROM table1 AS tb1" instead of "FROM table1 tb1"). Do for columns but not for tables.
 # L014 - Unquoted identifiers (e.g. column names) will be mixed case so don't enforce case
 # L016 - We allow longer lines as some of our queries are complex. Maybe should limit in future?
 # L020 - Asks for unique table aliases meaning it complains if selecting from two 2021_07_01 tables as implicit alias is table name (not fully qualified) so same.
+# L022 - CTEs may be chained and do not require a blank line separator, only the last one.
 # L026 - BigQuery uses STRUCTS which can look like incorrect table references
 # L027 - Asks for qualified columns for ambiguous ones, but we not qualify our columns, and they are not really ambiguous (or BigQuery would complain)
 # L028 - Insists on references in column names even if not ambiguous. Bit OTT.

--- a/sql/2022/markup/README.md
+++ b/sql/2022/markup/README.md
@@ -1,14 +1,5 @@
 # 2022 Markup queries
 
-<!--
-  This directory contains all of the 2022 Markup chapter queries.
-
-  Each query should have a corresponding `metric_name.sql` file.
-  Note that readers are linked to this directory, so try to make the SQL file names descriptive for easy browsing.
-
-  Analysts: if helpful, you can use this README to give additional info about the queries.
--->
-
 ## Resources
 
 - [📄 Planning doc][~google-doc]

--- a/sql/2022/markup/anchors_javascript_void.sql
+++ b/sql/2022/markup/anchors_javascript_void.sql
@@ -11,7 +11,7 @@ WITH totals AS (
 SELECT
   _TABLE_SUFFIX AS client,
   COUNT(DISTINCT url) AS pages,
-  ANY_VALUE(total) AS toal,
+  ANY_VALUE(total) AS total,
   COUNT(DISTINCT url) / ANY_VALUE(total) AS pct_pages
 FROM
   `httparchive.pages.2022_06_01_*`,

--- a/sql/2022/markup/anchors_javascript_void.sql
+++ b/sql/2022/markup/anchors_javascript_void.sql
@@ -1,0 +1,30 @@
+WITH totals AS (
+  SELECT
+    _TABLE_SUFFIX,
+    COUNT(0) AS total
+  FROM
+    `httparchive.summary_pages.2022_06_01_*`
+  GROUP BY
+    _TABLE_SUFFIX
+)
+
+SELECT
+  _TABLE_SUFFIX AS client,
+  COUNT(DISTINCT url) AS pages,
+  ANY_VALUE(total) AS toal,
+  COUNT(DISTINCT url) / ANY_VALUE(total) AS pct_pages
+FROM
+  `httparchive.pages.2022_06_01_*`,
+  UNNEST(JSON_VALUE_ARRAY(JSON_VALUE(payload, '$._markup'), '$.anchors.hrefs_without_special_scheme')) AS href
+JOIN
+  totals
+USING
+  (_TABLE_SUFFIX)
+WHERE
+  REGEXP_CONTAINS(href, r'^[\'"]?javascript:\s*void\(0\);?[\'"]?$')
+GROUP BY
+  client
+HAVING
+  pages > 1000
+ORDER BY
+  pct_pages DESC

--- a/sql/2022/markup/anchors_schemes.sql
+++ b/sql/2022/markup/anchors_schemes.sql
@@ -12,7 +12,7 @@ SELECT
   _TABLE_SUFFIX AS client,
   REGEXP_EXTRACT(href, r'^[\'"]?(\w+):') AS scheme,
   COUNT(DISTINCT url) AS pages,
-  ANY_VALUE(total) AS toal,
+  ANY_VALUE(total) AS total,
   COUNT(DISTINCT url) / ANY_VALUE(total) AS pct_pages
 FROM
   `httparchive.pages.2022_06_01_*`,

--- a/sql/2022/markup/anchors_schemes.sql
+++ b/sql/2022/markup/anchors_schemes.sql
@@ -1,0 +1,30 @@
+WITH totals AS (
+  SELECT
+    _TABLE_SUFFIX,
+    COUNT(0) AS total
+  FROM
+    `httparchive.summary_pages.2022_06_01_*`
+  GROUP BY
+    _TABLE_SUFFIX
+)
+
+SELECT
+  _TABLE_SUFFIX AS client,
+  REGEXP_EXTRACT(href, r'^[\'"]?(\w+):') AS scheme,
+  COUNT(DISTINCT url) AS pages,
+  ANY_VALUE(total) AS toal,
+  COUNT(DISTINCT url) / ANY_VALUE(total) AS pct_pages
+FROM
+  `httparchive.pages.2022_06_01_*`,
+  UNNEST(JSON_VALUE_ARRAY(JSON_VALUE(payload, '$._markup'), '$.anchors.hrefs_without_special_scheme')) AS href
+JOIN
+  totals
+USING
+  (_TABLE_SUFFIX)
+GROUP BY
+  client,
+  scheme
+HAVING
+  pages > 1000
+ORDER BY
+  pct_pages DESC

--- a/sql/2022/markup/anchors_unspecial_scheme.sql
+++ b/sql/2022/markup/anchors_unspecial_scheme.sql
@@ -1,0 +1,30 @@
+WITH totals AS (
+  SELECT
+    _TABLE_SUFFIX,
+    COUNT(0) AS total
+  FROM
+    `httparchive.summary_pages.2022_06_01_*`
+  GROUP BY
+    _TABLE_SUFFIX
+)
+
+SELECT
+  _TABLE_SUFFIX AS client,
+  href,
+  COUNT(DISTINCT url) AS pages,
+  ANY_VALUE(total) AS total,
+  COUNT(DISTINCT url) / ANY_VALUE(total) AS pct_pages
+FROM
+  `httparchive.pages.2022_06_01_*`,
+  UNNEST(JSON_VALUE_ARRAY(JSON_VALUE(payload, '$._markup'), '$.anchors.hrefs_without_special_scheme')) AS href
+JOIN
+  totals
+USING
+  (_TABLE_SUFFIX)
+GROUP BY
+  client,
+  href
+HAVING
+  pages > 1000
+ORDER BY
+  pct_pages DESC

--- a/sql/2022/markup/attributes.sql
+++ b/sql/2022/markup/attributes.sql
@@ -1,0 +1,58 @@
+#standardSQL
+# pages almanac metrics grouped by device and element attribute use (frequency)
+
+CREATE TEMPORARY FUNCTION get_almanac_attribute_info(almanac_string STRING)
+RETURNS ARRAY<STRUCT<name STRING, freq INT64>> LANGUAGE js AS '''
+try {
+    var almanac = JSON.parse(almanac_string);
+
+    if (Array.isArray(almanac) || typeof almanac != 'object') return [];
+
+    if (almanac.attributes_used_on_elements) {
+      return Object.entries(almanac.attributes_used_on_elements).map(([name, freq]) => ({name, freq}));
+    }
+
+} catch (e) {
+
+}
+return [];
+''';
+
+WITH totals AS (
+  SELECT
+    _TABLE_SUFFIX,
+    COUNT(0) AS total
+  FROM
+    `httparchive.pages.2022_06_01_*`
+  GROUP BY
+    _TABLE_SUFFIX
+), attributes AS (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    almanac_attribute_info.name,
+    COUNT(DISTINCT url) AS pages,
+    ANY_VALUE(total) AS total_pages,
+    COUNT(DISTINCT url) / ANY_VALUE(total) AS pct_pages,
+    SUM(almanac_attribute_info.freq) AS freq,
+    SUM(SUM(almanac_attribute_info.freq)) OVER (PARTITION BY _TABLE_SUFFIX) AS total,
+    SUM(almanac_attribute_info.freq) / SUM(SUM(almanac_attribute_info.freq)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct_ratio
+  FROM
+    `httparchive.pages.2022_06_01_*`,
+    UNNEST(get_almanac_attribute_info(JSON_EXTRACT_SCALAR(payload, '$._almanac'))) AS almanac_attribute_info
+  JOIN
+    totals
+  USING
+    (_TABLE_SUFFIX)
+  GROUP BY
+    client,
+    almanac_attribute_info.name
+)
+
+SELECT
+  *
+FROM
+  attributes
+ORDER BY
+  pct_ratio DESC
+LIMIT
+  1000

--- a/sql/2022/markup/buttons.sql
+++ b/sql/2022/markup/buttons.sql
@@ -1,0 +1,45 @@
+CREATE TEMPORARY FUNCTION get_markup_buttons_info(markup_string STRING)
+RETURNS ARRAY<STRING> LANGUAGE js AS '''
+try {
+    var markup = JSON.parse(markup_string);
+    var type_total = Object.values(markup.buttons.types).reduce((total, i) => total + i, 0);
+    var types = [];
+    if (markup.buttons.total > type_total) {
+      types = ['NO_TYPE'];
+    }
+    return Object.keys(markup.buttons.types).concat(types);
+} catch (e) {
+  return [];
+}
+''';
+
+WITH totals AS (
+  SELECT
+    _TABLE_SUFFIX,
+    COUNT(0) AS total
+  FROM
+    `httparchive.summary_pages.2022_06_01_*`
+  GROUP BY
+    _TABLE_SUFFIX
+)
+
+SELECT
+  _TABLE_SUFFIX AS client,
+  LOWER(TRIM(button_type)) AS button_type,
+  COUNT(DISTINCT url) AS page,
+  ANY_VALUE(total) AS total,
+  COUNT(DISTINCT url) / ANY_VALUE(total) AS pct_pages 
+FROM
+  `httparchive.pages.2022_06_01_*`
+JOIN
+  totals
+USING
+  (_TABLE_SUFFIX),
+  UNNEST(get_markup_buttons_info(JSON_EXTRACT_SCALAR(payload, '$._markup'))) AS button_type
+GROUP BY
+  client,
+  button_type
+ORDER BY
+  pct_pages DESC
+LIMIT
+  1000

--- a/sql/2022/markup/buttons.sql
+++ b/sql/2022/markup/buttons.sql
@@ -28,7 +28,7 @@ SELECT
   LOWER(TRIM(button_type)) AS button_type,
   COUNT(DISTINCT url) AS page,
   ANY_VALUE(total) AS total,
-  COUNT(DISTINCT url) / ANY_VALUE(total) AS pct_pages 
+  COUNT(DISTINCT url) / ANY_VALUE(total) AS pct_pages
 FROM
   `httparchive.pages.2022_06_01_*`
 JOIN

--- a/sql/2022/markup/comments.sql
+++ b/sql/2022/markup/comments.sql
@@ -1,0 +1,20 @@
+WITH comments AS (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    CAST(JSON_VALUE(JSON_VALUE(payload, '$._wpt_bodies'), '$.raw_html.comment_count') AS INT64) AS num_comments,
+    CAST(JSON_VALUE(JSON_VALUE(payload, '$._wpt_bodies'), '$.raw_html.conditional_comment_count') AS INT64) AS num_conditional_comments
+  FROM
+    `httparchive.pages.2022_06_01_*`
+)
+
+SELECT
+  client,
+  COUNTIF(num_comments > 0) AS num_comments,
+  COUNTIF(num_conditional_comments > 0) AS num_conditional_comments,
+  COUNT(0) AS total,
+  COUNTIF(num_comments > 0) / COUNT(0) AS pct_comments,
+  COUNTIF(num_conditional_comments > 0) / COUNT(0) AS pct_conditional_comments
+FROM
+  comments
+GROUP BY
+  client

--- a/sql/2022/markup/content_encoding.sql
+++ b/sql/2022/markup/content_encoding.sql
@@ -1,0 +1,16 @@
+SELECT
+  client,
+  resp_content_encoding AS content_encoding,
+  COUNT(0) AS freq,
+  SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct
+FROM
+  `httparchive.almanac.requests`
+WHERE
+  date = '2022-06-01' AND
+  firstHtml
+GROUP BY
+  client,
+  content_encoding
+ORDER BY
+  pct DESC

--- a/sql/2022/markup/custom_elements_js_bytes_distribution.sql
+++ b/sql/2022/markup/custom_elements_js_bytes_distribution.sql
@@ -1,0 +1,37 @@
+WITH js_bytes AS (
+  SELECT
+    _TABLE_SUFFIX,
+    url,
+    bytesJs / 1024 AS kbytes_js
+  FROM
+    `httparchive.summary_pages.2022_06_01_*`
+), custom_elements AS (
+  SELECT
+    _TABLE_SUFFIX,
+    url,
+    COALESCE(ARRAY_LENGTH(JSON_VALUE_ARRAY(JSON_VALUE(payload, '$._wpt_bodies'), '$.web_components.rendered.customElements.names')) > 0, FALSE) AS has_custom_elements
+  FROM
+    `httparchive.pages.2022_06_01_*`
+)
+
+SELECT
+  percentile,
+  _TABLE_SUFFIX AS client,
+  has_custom_elements,
+  APPROX_QUANTILES(kbytes_js, 1000)[OFFSET(percentile * 10)] AS kbytes_js,
+  COUNT(DISTINCT url) AS pages
+FROM
+  custom_elements
+JOIN
+  js_bytes
+USING
+  (_TABLE_SUFFIX, url),
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
+GROUP BY
+  percentile,
+  client,
+  has_custom_elements
+ORDER BY
+  percentile,
+  client,
+  has_custom_elements

--- a/sql/2022/markup/custom_elements_slot_distribution.sql
+++ b/sql/2022/markup/custom_elements_slot_distribution.sql
@@ -1,0 +1,32 @@
+WITH totals AS (
+  SELECT
+    _TABLE_SUFFIX,
+    COUNT(0) AS total
+  FROM
+    `httparchive.summary_pages.2022_06_01_*`
+  GROUP BY
+    _TABLE_SUFFIX
+)
+
+SELECT
+  _TABLE_SUFFIX AS client,
+  CAST(num_slots AS INT64) AS num_slots,
+  COUNT(0) AS freq,
+  SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct,
+  COUNT(DISTINCT url) AS pages,
+  ANY_VALUE(total) AS total_pages,
+  COUNT(DISTINCT url) / ANY_VALUE(total) AS pct_pages
+FROM
+  `httparchive.pages.2022_06_01_*`,
+  UNNEST(JSON_VALUE_ARRAY(JSON_VALUE(payload, '$._wpt_bodies'), '$.web_components.raw.hyphenatedElements.slots')) AS num_slots
+JOIN
+  totals
+USING
+  (_TABLE_SUFFIX)
+GROUP BY
+  client,
+  num_slots
+ORDER BY
+  num_slots,
+  client

--- a/sql/2022/markup/custom_elements_template_shadowroot.sql
+++ b/sql/2022/markup/custom_elements_template_shadowroot.sql
@@ -1,0 +1,29 @@
+CREATE TEMP FUNCTION GET_SHADOWROOT_ATTR(templates STRING) RETURNS ARRAY<STRING> LANGUAGE js AS r'''
+try {
+  templates = JSON.parse(templates);
+  return templates.filter(t => {
+    return 'shadowroot' in t;
+  }).map(t => {
+    return t.shadowroot;
+  });
+} catch {
+  return [];
+}
+''';
+
+WITH templates AS (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    url,
+    JSON_EXTRACT(JSON_VALUE(payload, '$._wpt_bodies'), '$.web_components.raw.hyphenatedElements.templates') AS template
+  FROM
+    `httparchive.pages.2022_06_01_*`
+)
+
+SELECT
+  client,
+  url,
+  attr
+FROM
+  templates,
+  UNNEST(GET_SHADOWROOT_ATTR(template)) AS attr

--- a/sql/2022/markup/data_attributes.sql
+++ b/sql/2022/markup/data_attributes.sql
@@ -1,0 +1,53 @@
+CREATE TEMPORARY FUNCTION get_almanac_attribute_info(almanac_string STRING)
+RETURNS ARRAY<STRUCT<name STRING, freq INT64>> LANGUAGE js AS '''
+try {
+    var almanac = JSON.parse(almanac_string);
+
+    if (Array.isArray(almanac) || typeof almanac != 'object') return [];
+
+    if (almanac.attributes_used_on_elements) {
+      return Object.entries(almanac.attributes_used_on_elements).filter(([name, freq]) => name.startsWith('data-')).map(([name, freq]) => ({name, freq}));
+    }
+
+} catch (e) {}
+return [];
+''';
+
+WITH totals AS (
+  SELECT
+    _TABLE_SUFFIX,
+    COUNT(0) AS total_pages
+  FROM
+    `httparchive.pages.2022_06_01_*`
+  GROUP BY
+    _TABLE_SUFFIX
+), data_attrs AS (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    almanac_attribute_info.name,
+    COUNT(DISTINCT url) AS pages,
+    ANY_VALUE(total_pages) AS total_pages,
+    COUNT(DISTINCT url) / ANY_VALUE(total_pages) AS pct_pages,
+    SUM(almanac_attribute_info.freq) AS freq, # total count from all pages
+    SUM(SUM(almanac_attribute_info.freq)) OVER (PARTITION BY _TABLE_SUFFIX) AS total,
+    SUM(almanac_attribute_info.freq) / SUM(SUM(almanac_attribute_info.freq)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct_ratio
+  FROM
+    `httparchive.pages.2022_06_01_*`
+  JOIN
+    totals
+  USING
+    (_TABLE_SUFFIX),
+    UNNEST(get_almanac_attribute_info(JSON_EXTRACT_SCALAR(payload, '$._almanac'))) AS almanac_attribute_info
+  GROUP BY
+    client,
+    almanac_attribute_info.name
+)
+
+SELECT
+  *
+FROM
+  data_attrs
+ORDER BY
+  pct_ratio DESC
+LIMIT
+  1000

--- a/sql/2022/markup/doctype.sql
+++ b/sql/2022/markup/doctype.sql
@@ -1,0 +1,15 @@
+SELECT
+  _TABLE_SUFFIX AS client,
+  LOWER(REGEXP_REPLACE(TRIM(doctype), r' +', ' ')) AS doctype, # remove extra spaces and make lower case
+  COUNT(0) AS pages,
+  SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct_pages
+FROM
+  `httparchive.summary_pages.2022_06_01_*`
+GROUP BY
+  client,
+  doctype
+ORDER BY
+  pct DESC
+LIMIT
+  100

--- a/sql/2022/markup/document_trends.sql
+++ b/sql/2022/markup/document_trends.sql
@@ -1,0 +1,46 @@
+#standardSQL
+# summary_pages trends grouped by device
+
+WITH summary_requests AS (
+  SELECT
+    '2019' AS year,
+    _TABLE_SUFFIX AS client,
+    *
+  FROM
+    `httparchive.summary_pages.2019_07_01_*`
+  UNION ALL
+  SELECT
+    '2020' AS year,
+    _TABLE_SUFFIX AS client,
+    *
+  FROM
+    `httparchive.summary_pages.2020_08_01_*`
+  UNION ALL
+  SELECT
+    '2021' AS year,
+    _TABLE_SUFFIX AS client,
+    *
+  FROM
+    `httparchive.summary_pages.2021_07_01_*`
+  UNION ALL
+  SELECT
+    '2022' AS year,
+    _TABLE_SUFFIX AS client,
+    * EXCEPT (metadata)
+  FROM
+    `httparchive.summary_pages.2022_06_01_*`
+)
+
+SELECT
+  year,
+  client,
+  APPROX_QUANTILES(bytesHtml / 1024, 1000)[OFFSET(500)] AS median_kbytes_html,
+  COUNT(0) AS total
+FROM
+  summary_requests
+GROUP BY
+  year,
+  client
+ORDER BY
+  year,
+  client

--- a/sql/2022/markup/element_count_distribution.sql
+++ b/sql/2022/markup/element_count_distribution.sql
@@ -1,0 +1,45 @@
+CREATE TEMPORARY FUNCTION get_element_count_info(element_count_string STRING)
+RETURNS STRUCT<elements_count INT64, types_count INT64> LANGUAGE js AS '''
+var result = {};
+try {
+    if (!element_count_string) return result;
+
+    var element_count = JSON.parse(element_count_string);
+
+    if (Array.isArray(element_count) || typeof element_count != 'object') return result;
+
+    result.elements_count = Object.values(element_count).reduce((total, freq) => total + (parseInt(freq, 10) || 0), 0);
+
+    result.types_count = Object.keys(element_count).length;
+
+} catch (e) {}
+return result;
+''';
+
+SELECT
+  client,
+  percentile,
+  COUNT(DISTINCT url) AS total,
+
+  # total number of elements on a page
+  APPROX_QUANTILES(element_count_info.elements_count, 1000)[OFFSET(percentile * 10)] AS elements_count,
+
+  # number of types of elements on a page
+  APPROX_QUANTILES(element_count_info.types_count, 1000)[OFFSET(percentile * 10)] AS types_count
+
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    percentile,
+    url,
+    get_element_count_info(JSON_EXTRACT_SCALAR(payload, '$._element_count')) AS element_count_info
+  FROM
+    `httparchive.pages.2022_06_01_*`,
+    UNNEST([10, 25, 50, 75, 90]) AS percentile
+)
+GROUP BY
+  percentile,
+  client
+ORDER BY
+  percentile,
+  client

--- a/sql/2022/markup/element_frequency.sql
+++ b/sql/2022/markup/element_frequency.sql
@@ -1,0 +1,49 @@
+CREATE TEMPORARY FUNCTION get_element_types_info(element_count_string STRING)
+RETURNS ARRAY<STRUCT<name STRING, freq INT64>> LANGUAGE js AS '''
+try {
+    if (!element_count_string) return []; // 2019 had a few cases
+
+    var element_count = JSON.parse(element_count_string); // should be an object with element type properties with values of how often they are present
+
+    if (Array.isArray(element_count) || typeof element_count != 'object') return [];
+
+    return Object.entries(element_count).map(([name, freq]) => ({name, freq}));
+
+} catch (e) {
+    return [];
+}
+''';
+
+WITH totals AS (
+  SELECT
+    _TABLE_SUFFIX,
+    COUNT(0) AS total
+  FROM
+    `httparchive.summary_pages.2022_06_01_*`
+  GROUP BY
+    _TABLE_SUFFIX
+)
+
+SELECT
+  _TABLE_SUFFIX AS client,
+  element_type_info.name,
+  COUNT(DISTINCT url) AS pages,
+  ANY_VALUE(total) AS total_pages,
+  COUNT(DISTINCT url) / ANY_VALUE(total) AS pct_pages,
+  SUM(element_type_info.freq) AS freq, # total count from all pages
+  SUM(SUM(element_type_info.freq)) OVER (PARTITION BY _TABLE_SUFFIX) AS total_freq,
+  SUM(element_type_info.freq) / SUM(SUM(element_type_info.freq)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct
+FROM
+  `httparchive.pages.2022_06_01_*`,
+  UNNEST(get_element_types_info(JSON_EXTRACT_SCALAR(payload, '$._element_count'))) AS element_type_info
+JOIN
+  totals
+USING
+  (_TABLE_SUFFIX)
+GROUP BY
+  client,
+  element_type_info.name
+ORDER BY
+  pct DESC
+LIMIT
+  1000

--- a/sql/2022/markup/element_popularity.sql
+++ b/sql/2022/markup/element_popularity.sql
@@ -1,0 +1,48 @@
+CREATE TEMPORARY FUNCTION get_element_types(element_count_string STRING)
+RETURNS ARRAY<STRING> LANGUAGE js AS '''
+try {
+    if (!element_count_string) return []; // 2019 had a few cases
+
+    var element_count = JSON.parse(element_count_string); // should be an object with element type properties with values of how often they are present
+
+    if (Array.isArray(element_count)) return [];
+    if (typeof element_count != 'object') return [];
+
+    return Object.keys(element_count);
+} catch (e) {
+    return [];
+}
+''';
+
+WITH totals AS (
+  SELECT
+    _TABLE_SUFFIX,
+    COUNT(0) AS total
+  FROM
+    `httparchive.pages.2022_06_01_*`
+  GROUP BY
+    _TABLE_SUFFIX
+)
+
+SELECT
+  _TABLE_SUFFIX AS client,
+  element_type,
+  COUNT(DISTINCT url) AS pages,
+  total,
+  COUNT(DISTINCT url) / total AS pct
+FROM
+  `httparchive.pages.2022_06_01_*`
+JOIN
+  totals
+USING
+  (_TABLE_SUFFIX),
+  UNNEST(get_element_types(JSON_EXTRACT_SCALAR(payload, '$._element_count'))) AS element_type
+GROUP BY
+  client,
+  total,
+  element_type
+ORDER BY
+  pct DESC,
+  client,
+  pages DESC
+LIMIT 1000

--- a/sql/2022/markup/favicons.sql
+++ b/sql/2022/markup/favicons.sql
@@ -1,0 +1,65 @@
+CREATE TEMPORARY FUNCTION getFaviconImage(almanac_string STRING)
+RETURNS STRING LANGUAGE js AS '''
+var result = 'NO_DATA';
+try {
+    var almanac = JSON.parse(almanac_string);
+
+    if (Array.isArray(almanac) || typeof almanac != 'object') return result;
+
+    if (almanac["link-nodes"] && almanac["link-nodes"].nodes && almanac["link-nodes"].nodes.find) {
+      var faviconNode = almanac["link-nodes"].nodes.find(n => n.rel && n.rel.split(' ').find(r => r.trim().toLowerCase() == 'icon'));
+
+      if (faviconNode) {
+        if (faviconNode.href) {
+          var temp = faviconNode.href;
+
+          if (temp.includes('?')) {
+            temp = temp.substring(0, temp.indexOf('?'));
+          }
+
+          if (temp.includes('.')) {
+            temp = temp.substring(temp.lastIndexOf('.')+1);
+
+            result = temp.toLowerCase().trim();
+          }
+          else {
+            result = "NO_EXTENSION";
+          }
+
+        } else {
+          result = "NO_HREF";
+        }
+      } else {
+        result = "NO_ICON";
+      }
+    }
+    else {
+      result = "NO_DATA";
+    }
+
+} catch {}
+return result;
+''';
+
+WITH favicons AS (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    getFaviconImage(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS image_type_extension,
+    COUNT(0) AS freq,
+    SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS total,
+    COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct
+  FROM
+    `httparchive.pages.2022_06_01_*`
+  GROUP BY
+    client,
+    image_type_extension
+)
+
+SELECT
+  *
+FROM
+  favicons
+ORDER BY
+  pct DESC
+LIMIT
+  1000

--- a/sql/2022/markup/forms.sql
+++ b/sql/2022/markup/forms.sql
@@ -1,10 +1,10 @@
 WITH forms AS (
   SELECT
-  _TABLE_SUFFIX,
-  url,
-  CAST(IFNULL(JSON_VALUE(JSON_EXTRACT_SCALAR(payload, '$._element_count'), '$.form'), '0') AS INT64) AS forms_count
-FROM
-  `httparchive.pages.2022_06_01_*`
+    _TABLE_SUFFIX,
+    url,
+    CAST(IFNULL(JSON_VALUE(JSON_EXTRACT_SCALAR(payload, '$._element_count'), '$.form'), '0') AS INT64) AS forms_count
+  FROM
+    `httparchive.pages.2022_06_01_*`
 )
 
 SELECT

--- a/sql/2022/markup/forms.sql
+++ b/sql/2022/markup/forms.sql
@@ -1,0 +1,22 @@
+WITH forms AS (
+  SELECT
+  _TABLE_SUFFIX,
+  url,
+  CAST(IFNULL(JSON_VALUE(JSON_EXTRACT_SCALAR(payload, '$._element_count'), '$.form'), '0') AS INT64) AS forms_count
+FROM
+  `httparchive.pages.2022_06_01_*`
+)
+
+SELECT
+  _TABLE_SUFFIX AS client,
+  forms_count,
+  COUNT(0) AS pages,
+  SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct_pages
+FROM
+  forms
+GROUP BY
+  client,
+  forms_count
+ORDER BY
+  forms_count DESC

--- a/sql/2022/markup/inputs.sql
+++ b/sql/2022/markup/inputs.sql
@@ -1,0 +1,52 @@
+CREATE TEMPORARY FUNCTION get_markup_inputs_info(markup_string STRING)
+RETURNS ARRAY<STRUCT<name STRING, freq INT64>> LANGUAGE js AS '''
+var result = [];
+try {
+    var markup = JSON.parse(markup_string);
+
+    if (Array.isArray(markup) || typeof markup != 'object') return result;
+
+    if (markup.inputs && markup.inputs.types) {
+      var total = markup.inputs.total;
+      var withType = 0;
+      result = Object.entries(markup.inputs.types).map(([name, freq]) => { withType+=freq; return  {name: name.toLowerCase().trim(), freq};});
+
+      result.push({name:"NO_TYPE", freq: total - withType})
+
+      return result;
+    }
+
+} catch (e) {}
+return result;
+''';
+
+WITH totals AS (
+  SELECT
+    _TABLE_SUFFIX,
+    COUNT(0) AS total
+  FROM
+    `httparchive.pages.2022_06_01_*`
+  GROUP BY
+    _TABLE_SUFFIX
+)
+
+SELECT
+  _TABLE_SUFFIX AS client,
+  markup_input_info.name AS input_type,
+  COUNTIF(markup_input_info.freq > 0) AS freq_page_with_input,
+  COUNTIF(markup_input_info.freq > 0) / ANY_VALUE(total) AS pct_page_with_input,
+  SUM(markup_input_info.freq) AS freq_input,
+  SUM(markup_input_info.freq) / SUM(SUM(markup_input_info.freq)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct_input
+FROM
+  `httparchive.pages.2022_06_01_*`
+JOIN
+  totals
+USING (_TABLE_SUFFIX),
+  UNNEST(get_markup_inputs_info(JSON_EXTRACT_SCALAR(payload, '$._markup'))) AS markup_input_info
+GROUP BY
+  client,
+  input_type
+ORDER BY
+  freq_page_with_input DESC
+LIMIT
+  1000

--- a/sql/2022/markup/inputs_per_form.sql
+++ b/sql/2022/markup/inputs_per_form.sql
@@ -1,0 +1,31 @@
+CREATE TEMP FUNCTION getInputsPerForm(markup STRING) RETURNS ARRAY<INT64> LANGUAGE js AS r'''
+try {
+  markup = JSON.parse(markup);
+  return markup.form.elements.map(i => i.total);
+} catch {
+  return [];
+}
+''';
+
+WITH inputs AS (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    inputs_per_form
+  FROM
+    `httparchive.pages.2022_06_01_*`,
+    UNNEST(getInputsPerForm(JSON_VALUE(payload, '$._markup'))) AS inputs_per_form
+)
+
+SELECT
+  percentile,
+  client,
+  APPROX_QUANTILES(inputs_per_form, 1000)[OFFSET(percentile * 10)] AS inputs_per_form
+FROM
+  inputs,
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
+GROUP BY
+  percentile,
+  client
+ORDER BY
+  percentile,
+  client

--- a/sql/2022/markup/lang.sql
+++ b/sql/2022/markup/lang.sql
@@ -1,0 +1,24 @@
+WITH langs AS (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    TRIM(LOWER(JSON_VALUE(JSON_VALUE(payload, '$._almanac'), '$.html_node.lang'))) AS lang
+  FROM
+    `httparchive.pages.2022_06_01_*`
+)
+
+SELECT
+  client,
+  IFNULL(lang, '(not set)') AS html_lang_region,
+  IFNULL(REGEXP_EXTRACT(lang, r'^([^\-]+)'), '(not set)') AS html_lang,
+  COUNT(0) AS pages,
+  SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct_pages
+FROM
+  langs
+GROUP BY
+  client,
+  lang
+HAVING
+  freq > 100
+ORDER BY
+  pct DESC

--- a/sql/2022/markup/link_targets.sql
+++ b/sql/2022/markup/link_targets.sql
@@ -1,0 +1,37 @@
+WITH bodies AS (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies') AS wpt_bodies
+  FROM
+    `httparchive.pages.2022_06_01_*`
+), links AS (
+  SELECT
+    client,
+    SAFE_CAST(JSON_VALUE(wpt_bodies, '$.anchors.rendered.target_blank.total') AS INT64) AS target_blank_total,
+    SAFE_CAST(JSON_VALUE(wpt_bodies, '$.anchors.rendered.target_blank.noopener_noreferrer') AS INT64) AS target_blank_noopener_noreferrer_total,
+    SAFE_CAST(JSON_VALUE(wpt_bodies, '$.anchors.rendered.target_blank.noopener') AS INT64) AS target_blank_noopener_total,
+    SAFE_CAST(JSON_VALUE(wpt_bodies, '$.anchors.rendered.target_blank.noreferrer') AS INT64) AS target_blank_noreferrer_total,
+    SAFE_CAST(JSON_VALUE(wpt_bodies, '$.anchors.rendered.target_blank.neither') AS INT64) AS target_blank_neither_total
+  FROM
+    bodies
+)
+
+SELECT
+  client,
+  COUNT(0) AS total,
+
+  # pages with all target _banks including rel="noopener noreferrer"
+  COUNTIF(target_blank_total IS NULL OR target_blank_total = target_blank_noopener_noreferrer_total) / COUNT(0) AS pct_always_target_blank_noopener_noreferrer,
+
+  # pages with some target _banks not using rel="noopener noreferrer"
+  COUNTIF(target_blank_total > target_blank_noopener_noreferrer_total) / COUNT(0) AS pct_some_target_blank_without_noopener_noreferrer,
+
+  COUNTIF(target_blank_total > 0) / COUNT(0) AS pct_has_target_blank,
+  COUNTIF(target_blank_noopener_noreferrer_total > 0) / COUNT(0) AS pct_has_target_blank_noopener_noreferrer,
+  COUNTIF(target_blank_noopener_total > 0) / COUNT(0) AS pct_has_target_blank_noopener,
+  COUNTIF(target_blank_noreferrer_total > 0) / COUNT(0) AS pct_has_target_blank_noreferrer,
+  COUNTIF(target_blank_neither_total > 0) / COUNT(0) AS pct_has_target_blank_neither
+FROM
+  links
+GROUP BY
+  client

--- a/sql/2022/markup/meta_node_names.sql
+++ b/sql/2022/markup/meta_node_names.sql
@@ -1,0 +1,50 @@
+CREATE TEMPORARY FUNCTION getMetaNodes(payload STRING)
+RETURNS ARRAY<STRING>
+LANGUAGE js AS '''
+try {
+  var almanac = JSON.parse(payload);
+  return almanac['meta-nodes'].nodes.map(n => n.name || n.property);
+} catch (e) {
+  return [];
+}
+''';
+
+WITH totals AS (
+  SELECT
+    _TABLE_SUFFIX,
+    COUNT(0) AS total_pages
+  FROM
+    `httparchive.pages.2022_06_01_*`
+  GROUP BY
+    _TABLE_SUFFIX
+), meta AS (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    IF(IFNULL(TRIM(name), '') = '', '(not set)', name) AS name,
+    COUNT(0) AS freq,
+    COUNT(0) / SUM(COUNT(0)) OVER () AS pct_nodes,
+    COUNT(DISTINCT url) AS num_urls,
+    COUNT(DISTINCT url) / total_pages AS pct_pages
+  FROM
+    `httparchive.pages.2022_06_01_*`,
+    UNNEST(getMetaNodes(JSON_VALUE(payload, '$._almanac'))) AS name
+  JOIN
+    totals
+  USING
+    (_TABLE_SUFFIX)
+  GROUP BY
+    client,
+    total_pages,
+    name
+)
+
+SELECT
+  *
+FROM
+  meta
+WHERE
+  freq > 1
+ORDER BY
+  pct_nodes DESC
+LIMIT
+  200

--- a/sql/2022/markup/meta_viewports.sql
+++ b/sql/2022/markup/meta_viewports.sql
@@ -1,0 +1,36 @@
+CREATE TEMPORARY FUNCTION normalise(content STRING) RETURNS STRING LANGUAGE js AS '''
+try {
+  // split by ,
+  // trim
+  // lower case
+  // alphabetize
+  // re join by comma
+
+  return content.split(",").map(c1 => c1.trim().toLowerCase().replace(/ +/g, "").replace(/\\.0*/,"")).sort().join(",");
+} catch (e) {
+  return '';
+}
+''';
+
+WITH viewports AS (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    normalise(meta_viewport) AS meta_viewport,
+    COUNT(0) AS freq,
+    SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS total,
+    COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct
+  FROM
+    `httparchive.summary_pages.2022_06_01_*`
+  GROUP BY
+    client,
+    meta_viewport
+)
+
+SELECT
+  *
+FROM
+  viewports
+ORDER BY
+  pct DESC
+LIMIT
+  100

--- a/sql/2022/markup/obsolete_elements.sql
+++ b/sql/2022/markup/obsolete_elements.sql
@@ -1,0 +1,50 @@
+CREATE TEMPORARY FUNCTION get_element_types(element_count_string STRING)
+RETURNS ARRAY<STRING> LANGUAGE js AS '''
+try {
+    if (!element_count_string) return []; // 2019 had a few cases
+
+    var element_count = JSON.parse(element_count_string); // should be an object with element type properties with values of how often they are present
+
+    if (Array.isArray(element_count)) return [];
+    if (typeof element_count != 'object') return [];
+
+    return Object.keys(element_count);
+} catch (e) {
+    return [];
+}
+''';
+
+CREATE TEMPORARY FUNCTION is_obsolete(element STRING) AS (
+  element IN ('applet', 'acronym', 'bgsound', 'dir', 'frame', 'frameset', 'noframes', 'isindex', 'keygen', 'listing', 'menuitem', 'nextid', 'noembed', 'plaintext', 'rb', 'rtc', 'strike', 'xmp', 'basefont', 'big', 'blink', 'center', 'font', 'marquee', 'multicol', 'nobr', 'spacer', 'tt')
+);
+
+WITH totals AS (
+  SELECT
+    _TABLE_SUFFIX,
+    COUNT(0) AS total
+  FROM
+    `httparchive.pages.2022_06_01_*`
+  GROUP BY _TABLE_SUFFIX
+)
+
+SELECT
+  _TABLE_SUFFIX AS client,
+  element_type AS obsolete_element_type,
+  COUNT(DISTINCT url) AS pages,
+  total AS total_pages,
+  COUNT(DISTINCT url) / total AS pct_pages_with_obsolete_elements
+FROM
+  `httparchive.pages.2022_06_01_*`
+JOIN
+  totals
+USING
+  (_TABLE_SUFFIX),
+  UNNEST(get_element_types(JSON_EXTRACT_SCALAR(payload, '$._element_count'))) AS element_type
+WHERE
+  is_obsolete(element_type)
+GROUP BY
+  client,
+  total,
+  obsolete_element_type
+ORDER BY
+  pct_pages_with_obsolete_elements DESC

--- a/sql/2022/markup/svg.sql
+++ b/sql/2022/markup/svg.sql
@@ -1,0 +1,29 @@
+WITH totals AS (
+  SELECT
+    _TABLE_SUFFIX,
+    COUNT(0) AS total
+  FROM
+    `httparchive.summary_pages.2022_06_01_*`
+  GROUP BY
+    _TABLE_SUFFIX
+), svgs AS (
+  SELECT
+    _TABLE_SUFFIX,
+    CAST(JSON_VALUE(JSON_VALUE(payload, '$._markup'), '$.svgs.svg_total') AS INT64) AS svg
+  FROM
+    `httparchive.pages.2022_06_01_*`
+)
+
+SELECT
+  _TABLE_SUFFIX AS client,
+  COUNTIF(svg > 0) AS pages,
+  ANY_VALUE(total) AS total,
+  COUNTIF(svg > 0) / ANY_VALUE(total) AS pct_pages
+FROM
+  svgs
+JOIN
+  totals
+USING
+  (_TABLE_SUFFIX)
+GROUP BY
+  client

--- a/sql/2022/markup/web_components_distribution.sql
+++ b/sql/2022/markup/web_components_distribution.sql
@@ -1,0 +1,24 @@
+WITH web_components AS (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    url,
+    ARRAY_LENGTH(JSON_VALUE_ARRAY(JSON_VALUE(payload, '$._wpt_bodies'), '$.web_components.rendered.customElements.names')) AS num_web_components
+  FROM
+    `httparchive.pages.2022_06_01_*`
+)
+
+SELECT
+  client,
+  num_web_components,
+  COUNT(0) AS freq,
+  SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct
+FROM
+  web_components
+WHERE
+  num_web_components > 0
+GROUP BY
+  client,
+  num_web_components
+ORDER BY
+  num_web_components

--- a/sql/2022/markup/web_components_top1k.sql
+++ b/sql/2022/markup/web_components_top1k.sql
@@ -1,0 +1,21 @@
+WITH web_components AS (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    url,
+    CAST(JSON_VALUE(payload, '$._metadata.rank') AS INT64) AS rank,
+    ARRAY_LENGTH(JSON_VALUE_ARRAY(JSON_VALUE(payload, '$._wpt_bodies'), '$.web_components.rendered.customElements.names')) AS num_web_components
+  FROM
+    `httparchive.pages.2022_06_01_*`
+)
+
+SELECT
+  client,
+  url,
+  num_web_components
+FROM
+  web_components
+WHERE
+  rank = 1000 AND
+  num_web_components >= 2
+ORDER BY
+  num_web_components DESC


### PR DESCRIPTION
Progress on #2881 
[Results sheet](https://docs.google.com/spreadsheets/d/1grkd2_1xSV3jvNK6ucRQ0OL1HmGTsScHuwA8GZuRLHU/edit?usp=sharing)

## General

- [x] Doctype popularity
- [x] Distribution of document size (compressed and uncompressed)
- [x] Adoption of compression
- [x] `lang` popularity
- [x] Adoption of HTML comments
- [x] Adoption of SVG

## Elements

- [x] "Hixie" stats on element diversity and elements per page
- [x] Element popularity
- [x] Obsolete element popularity
- [x] Embedding elements popularity (img, frame, source, picture, video, object)

## Custom elements

- [x] Top pages built with custom elements (2+ custom elements, rank 1000)
- [x] Distribution of custom elements per page (among pages with 1+)
- [x] Most used custom element libraries (among pages with 1+)
- [x] Adoption of shadow DOM
  - [x] Adoption of declarative shadow DOM (`template[shadowroot]`)
  - ~Distribution of the number of children of the shadow root~ (no data)
- [x] Adoption of `slot`
  - [x] Distribution of slots per component
- [x] Distributions of JS bytes on pages that do/don't use custom elements

## Forms

- [x] Adoption of forms
- [x] Input type popularity (input type text, number, date, etc, textarea, select, etc)
- [x] Distribution of input elements per form

## Attributes

- [x] Attribute popularity
- [x] Meta name/property popularity (includes social markup)
- [x] `data-` attribute popularity

## Miscellaneous

- [x] `viewport` popularity
- [x] favicon format popularity
- [x] Adoption of buttons
  - [x] Button `type` popularity
- [x] Links
  - [x] Attribute combo popularity (target, noopener, noreferrer)
  - [x] Popularity of non-URL `href` values (`javascript:`, `#`?)

cc @AlexLakatos 