### PR TITLE
Add fetch priority to hero images

### DIFF
--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -361,7 +361,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
               <source type="image/avif" srcset="{{ chapter_hero_dir }}hero_sm.avif 1x, {{ chapter_hero_dir }}hero_lg.avif 2x" />
               <source type="image/webp" srcset="{{ chapter_hero_dir }}hero_sm.webp 1x, {{ chapter_hero_dir }}hero_lg.webp 2x" />
               <source type="image/jpeg" srcset="{{ chapter_hero_dir }}hero_sm.jpg 1x, {{ chapter_hero_dir }}hero_lg.jpg 2x" />
-              <img src="{{ chapter_hero_dir }}hero_lg.jpg" class="content-banner" alt="" width="866" height="433" loading="eager" fetchpriority="high" />
+              <img src="{{ chapter_hero_dir }}hero_lg.jpg" class="content-banner" alt="" width="866" height="433" fetchpriority="high" />
             </picture>
             {{ render_byline() }}
             {{ self.main_content() }}

--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -361,7 +361,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
               <source type="image/avif" srcset="{{ chapter_hero_dir }}hero_sm.avif 1x, {{ chapter_hero_dir }}hero_lg.avif 2x" />
               <source type="image/webp" srcset="{{ chapter_hero_dir }}hero_sm.webp 1x, {{ chapter_hero_dir }}hero_lg.webp 2x" />
               <source type="image/jpeg" srcset="{{ chapter_hero_dir }}hero_sm.jpg 1x, {{ chapter_hero_dir }}hero_lg.jpg 2x" />
-              <img src="{{ chapter_hero_dir }}hero_lg.jpg" class="content-banner" alt="" width="866" height="433" loading="eager" />
+              <img src="{{ chapter_hero_dir }}hero_lg.jpg" class="content-banner" alt="" width="866" height="433" loading="eager" fetchpriority="high" />
             </picture>
             {{ render_byline() }}
             {{ self.main_content() }}

--- a/src/templates/base/index.html
+++ b/src/templates/base/index.html
@@ -77,7 +77,7 @@
         <text x="8" y="15">{{ year }}</text>
       </svg>
       {% endif %}
-      <img src="/static/images/home-hero.png" alt="" width="820" height="562">
+      <img src="/static/images/home-hero.png" alt="" width="820" height="562" fetchpriority="high">
     </div>
   </section>
   {% block featured_chapter_section %}

--- a/src/templates/en/2019/methodology.html
+++ b/src/templates/en/2019/methodology.html
@@ -46,7 +46,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">Overview</a></h2>
 

--- a/src/templates/en/2019/methodology.html
+++ b/src/templates/en/2019/methodology.html
@@ -46,7 +46,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">Overview</a></h2>
 

--- a/src/templates/en/2020/methodology.html
+++ b/src/templates/en/2020/methodology.html
@@ -51,7 +51,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">Overview</a></h2>
 

--- a/src/templates/en/2020/methodology.html
+++ b/src/templates/en/2020/methodology.html
@@ -51,7 +51,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">Overview</a></h2>
 

--- a/src/templates/en/2021/methodology.html
+++ b/src/templates/en/2021/methodology.html
@@ -52,7 +52,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">Overview</a></h2>
 

--- a/src/templates/en/2021/methodology.html
+++ b/src/templates/en/2021/methodology.html
@@ -52,7 +52,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">Overview</a></h2>
 

--- a/src/templates/fr/2019/methodology.html
+++ b/src/templates/fr/2019/methodology.html
@@ -46,7 +46,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">Vue d’ensemble</a></h2>
 

--- a/src/templates/fr/2019/methodology.html
+++ b/src/templates/fr/2019/methodology.html
@@ -46,7 +46,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">Vue d’ensemble</a></h2>
 

--- a/src/templates/fr/2020/methodology.html
+++ b/src/templates/fr/2020/methodology.html
@@ -51,7 +51,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">Vue d’ensemble</a></h2>
 

--- a/src/templates/fr/2020/methodology.html
+++ b/src/templates/fr/2020/methodology.html
@@ -51,7 +51,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">Vue d’ensemble</a></h2>
 

--- a/src/templates/hi/2019/methodology.html
+++ b/src/templates/hi/2019/methodology.html
@@ -46,7 +46,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">अवलोकन</a></h2>
 

--- a/src/templates/hi/2019/methodology.html
+++ b/src/templates/hi/2019/methodology.html
@@ -46,7 +46,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">अवलोकन</a></h2>
 

--- a/src/templates/hi/2020/methodology.html
+++ b/src/templates/hi/2020/methodology.html
@@ -51,7 +51,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">अवलोकन</a></h2>
 

--- a/src/templates/hi/2020/methodology.html
+++ b/src/templates/hi/2020/methodology.html
@@ -51,7 +51,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">अवलोकन</a></h2>
 

--- a/src/templates/ja/2019/methodology.html
+++ b/src/templates/ja/2019/methodology.html
@@ -46,7 +46,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">概要</a></h2>
 

--- a/src/templates/ja/2019/methodology.html
+++ b/src/templates/ja/2019/methodology.html
@@ -46,7 +46,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">概要</a></h2>
 

--- a/src/templates/ja/2020/methodology.html
+++ b/src/templates/ja/2020/methodology.html
@@ -51,7 +51,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">概要</a></h2>
 

--- a/src/templates/ja/2020/methodology.html
+++ b/src/templates/ja/2020/methodology.html
@@ -51,7 +51,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">概要</a></h2>
 

--- a/src/templates/nl/2019/methodology.html
+++ b/src/templates/nl/2019/methodology.html
@@ -46,7 +46,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">Overzicht</a></h2>
 

--- a/src/templates/nl/2019/methodology.html
+++ b/src/templates/nl/2019/methodology.html
@@ -46,7 +46,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">Overzicht</a></h2>
 

--- a/src/templates/nl/2020/methodology.html
+++ b/src/templates/nl/2020/methodology.html
@@ -51,7 +51,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">Overzicht</a></h2>
 

--- a/src/templates/nl/2020/methodology.html
+++ b/src/templates/nl/2020/methodology.html
@@ -51,7 +51,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">Overzicht</a></h2>
 

--- a/src/templates/ru/2019/methodology.html
+++ b/src/templates/ru/2019/methodology.html
@@ -46,7 +46,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">Краткий обзор</a></h2>
 

--- a/src/templates/ru/2019/methodology.html
+++ b/src/templates/ru/2019/methodology.html
@@ -46,7 +46,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">Краткий обзор</a></h2>
 

--- a/src/templates/ru/2020/methodology.html
+++ b/src/templates/ru/2020/methodology.html
@@ -51,7 +51,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">Краткий обзор</a></h2>
 

--- a/src/templates/ru/2020/methodology.html
+++ b/src/templates/ru/2020/methodology.html
@@ -51,7 +51,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">Краткий обзор</a></h2>
 

--- a/src/templates/zh-CN/2019/methodology.html
+++ b/src/templates/zh-CN/2019/methodology.html
@@ -46,7 +46,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">概览</a></h2>
 

--- a/src/templates/zh-CN/2019/methodology.html
+++ b/src/templates/zh-CN/2019/methodology.html
@@ -46,7 +46,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">概览</a></h2>
 

--- a/src/templates/zh-CN/2020/methodology.html
+++ b/src/templates/zh-CN/2020/methodology.html
@@ -51,7 +51,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">概述</a></h2>
 

--- a/src/templates/zh-CN/2020/methodology.html
+++ b/src/templates/zh-CN/2020/methodology.html
@@ -51,7 +51,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">概述</a></h2>
 

--- a/src/templates/zh-TW/2020/methodology.html
+++ b/src/templates/zh-TW/2020/methodology.html
@@ -51,7 +51,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">總覽</a></h2>
 

--- a/src/templates/zh-TW/2020/methodology.html
+++ b/src/templates/zh-TW/2020/methodology.html
@@ -51,7 +51,7 @@
           <source type="image/jpeg" srcset="/static/images/methodology-banner.png 2x" />
           <source type="image/webp" srcset="/static/images/methodology-banner-sm.webp" />
           <source type="image/jpeg" srcset="/static/images/methodology-banner-sm.png" />
-          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" loading="eager" fetchpriority="high" />
+          <img src="/static/images/methodology-banner.png" class="content-banner" alt="" width="1200" height="984" fetchpriority="high" />
         </picture>
         <h2 id="overview"><a href="#overview" class="anchor-link">總覽</a></h2>
 


### PR DESCRIPTION
Doesn't make a huge difference to be honest, but I still like to use the Web Almanac to demo best practices (and to act as a reminder for me on how to do things 😁).

WebPageTest Comparison: https://www.webpagetest.org/video/compare.php?tests=220610_AiDcT1_BT4%2C220610_BiDcKC_BTE&thumbSize=200&ival=100&end=visual

Without this change:
<img width="1074" alt="hero image request is delayed" src="https://user-images.githubusercontent.com/10931297/173129106-371a3dc0-f225-4b17-b92a-f0b603b9f471.png">

With this change:
<img width="1040" alt="hero image is requested earlier" src="https://user-images.githubusercontent.com/10931297/173129155-fd263cd5-e3c9-4a10-b073-d6adbd6d4571.png">

Note the hero image is requested a lot earlier (even though it finishes arriving at pretty much the same time).