### PR TITLE
Fix figure numbering in Resource Hints chapter

### DIFF
--- a/src/content/en/2021/resource-hints.md
+++ b/src/content/en/2021/resource-hints.md
@@ -167,7 +167,7 @@ To counter this decrease, the top 1,000 pages have an increased adoption for the
 
 Resource hints can be very effective if used correctly. By shifting the responsibility from the browser to the developer, it allows you to prioritize resources required for the critical rendering path and improve the load times & user experience.
 
-<figure markdown>
+<figure>
 <table>
   <thead>
     <tr>

--- a/src/tools/generate/generate_figure_ids.js
+++ b/src/tools/generate/generate_figure_ids.js
@@ -10,7 +10,7 @@ const generate_figure_ids = (html) => {
   // Need to add id in <figure> element at top of table
   // and also in figure_link call from <figcaption> element
   // at bottom of table.
-  re = /(<figure>|<figure markdown>|<figure data-markdown="1">)\s*\n*\s*<table/gi;
+  re = /(<figure>|<figure markdown>(<p>)*|<figure data-markdown="1">(<p>)*)\s*\n*\s*<table/gi;
   html = html.replace(re, () => '<figure id="fig-_figid_"><table');
   re = /figure_link\s*\(/g;
   html = html.replace(re, () => 'figure_link(metadata=metadata, chapter_config=chapter_config, id=_figidn_, ');


### PR DESCRIPTION
We have two figure 5s in 2021 resource-hint chapter. This fixes that.