### PR TITLE
Add 2022.json file

### DIFF
--- a/sql/2022/sustainability/README.md
+++ b/sql/2022/sustainability/README.md
@@ -1,0 +1,20 @@
+# 2022 Sustainability queries
+
+<!--
+  This directory contains all of the 2022 Sustainability chapter queries.
+
+  Each query should have a corresponding `metric_name.sql` file.
+  Note that readers are linked to this directory, so try to make the SQL file names descriptive for easy browsing.
+
+  Analysts: if helpful, you can use this README to give additional info about the queries.
+-->
+
+## Resources
+
+- [📄 Planning doc][~google-doc]
+- [📊 Results sheet][~google-sheets]
+- [📝 Markdown file][~chapter-markdown]
+
+[~google-doc]: https://docs.google.com/document/d/1g1ACWRTAzTlcaKKODNASLkXe4zquF-XR5oHh0GfayP8/edit?usp=sharing
+[~google-sheets]: https://docs.google.com/spreadsheets/d/1wU3SjB8XYkbaqxYt8CNtbmDbjCcYZ8m5kiYof7uyI5k/edit?usp=sharing
+[~chapter-markdown]: https://github.com/HTTPArchive/almanac.httparchive.org/tree/main/src/content/en/2022/sustainability.md

--- a/src/config/2022.json
+++ b/src/config/2022.json
@@ -1,0 +1,1559 @@
+{
+  "settings": [
+    {
+      "is_live": false,
+      "supported_languages": ["en","es","fr","hi","it","ja","nl","pt","ru","tr","uk","zh-CN","zh-TW"],
+      "ebook_languages": []
+    }
+  ],
+  "outline": [
+    {
+      "part": "I. Page Content",
+      "part_number": "1",
+      "chapters": [
+        {
+          "part": "I",
+          "chapter_number": "1",
+          "title": "CSS",
+          "slug": "css"
+        },
+        {
+          "part": "I",
+          "chapter_number": "2",
+          "title": "JavaScript",
+          "slug": "javascript"
+        },
+        {
+          "part": "I",
+          "chapter_number": "3",
+          "title": "Markup",
+          "slug": "markup"
+        },
+        {
+          "part": "I",
+          "chapter_number": "4",
+          "title": "Structured Data",
+          "slug": "structured-data",
+          "hero_dir": "2021"
+        },
+        {
+          "part": "I",
+          "chapter_number": "5",
+          "title": "Fonts",
+          "slug": "fonts"
+        },
+        {
+          "part": "I",
+          "chapter_number": "6",
+          "title": "Media",
+          "slug": "media"
+        },
+        {
+          "part": "I",
+          "chapter_number": "7",
+          "title": "WebAssembly",
+          "slug": "webassembly",
+          "hero_dir": "2021"
+        },
+        {
+          "part": "I",
+          "chapter_number": "8",
+          "title": "Third Parties",
+          "slug": "third-parties"
+        },
+        {
+          "part": "I",
+          "chapter_number": "9",
+          "title": "Interoperability",
+          "slug": "interop"
+        }
+      ]
+    },
+    {
+      "part": "II. User Experience",
+      "part_number": "2",
+      "chapters": [
+        {
+          "part": "II",
+          "chapter_number": "10",
+          "title": "SEO",
+          "slug": "seo"
+        },
+        {
+          "part": "II",
+          "chapter_number": "11",
+          "title": "Accessibility",
+          "slug": "accessibility"
+        },
+        {
+          "part": "II",
+          "chapter_number": "12",
+          "title": "Performance",
+          "slug": "performance"
+        },
+        {
+          "part": "II",
+          "chapter_number": "13",
+          "title": "Privacy",
+          "slug": "privacy",
+          "hero_dir": "2020"
+        },
+        {
+          "part": "II",
+          "chapter_number": "14",
+          "title": "Security",
+          "slug": "security"
+        },
+        {
+          "part": "II",
+          "chapter_number": "15",
+          "title": "Mobile Web",
+          "slug": "mobile-web"
+        },
+        {
+          "part": "II",
+          "chapter_number": "16",
+          "title": "Capabilities",
+          "slug": "capabilities",
+          "hero_dir": "2020"
+        },
+        {
+          "part": "II",
+          "chapter_number": "17",
+          "title": "PWA",
+          "slug": "pwa"
+        }
+      ]
+    },
+    {
+      "part": "III. Content Publishing",
+      "part_number": "3",
+      "chapters": [
+        {
+          "part": "III",
+          "chapter_number": "18",
+          "title": "CMS",
+          "slug": "cms"
+        },
+        {
+          "part": "III",
+          "chapter_number": "19",
+          "title": "Ecommerce",
+          "slug": "ecommerce"
+        },
+        {
+          "part": "III",
+          "chapter_number": "20",
+          "title": "Jamstack",
+          "slug": "jamstack",
+          "hero_dir": "2020"
+        },
+        {
+          "part": "III",
+          "chapter_number": "21",
+          "title": "Sustainability",
+          "slug": "sustainability",
+          "hero_dir": "2022"
+        }
+      ]
+    },
+    {
+      "part": "IV. Content Distribution",
+      "part_number": "4",
+      "chapters": [
+        {
+          "part": "IV",
+          "chapter_number": "22",
+          "title": "Page Weight",
+          "slug": "page-weight"
+        },
+        {
+          "part": "IV",
+          "chapter_number": "23",
+          "title": "CDN",
+          "slug": "cdn"
+        },
+        {
+          "part": "IV",
+          "chapter_number": "24",
+          "title": "Compression",
+          "slug": "compression"
+        },
+        {
+          "part": "IV",
+          "chapter_number": "25",
+          "title": "Caching",
+          "slug": "caching"
+        },
+        {
+          "part": "IV",
+          "chapter_number": "26",
+          "title": "HTTP",
+          "slug": "http"
+        }
+      ]
+    }
+  ],
+  "teams": {
+    "analysts": {
+      "name": "Analysts"
+    },
+    "authors": {
+      "name": "Authors"
+    },
+    "designers": {
+      "name": "Designers"
+    },
+    "developers": {
+      "name": "Developers"
+    },
+    "editors": {
+      "name": "Editors"
+    },
+    "leads": {
+      "name": "Leads"
+    },
+    "reviewers": {
+      "name": "Reviewers"
+    },
+    "translators": {
+      "name": "Translators"
+    }
+  },
+  "contributors": {
+    "aarongustafson": {
+      "name": "Aaron Gustafson",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "75736",
+      "github": "aarongustafson",
+      "website": "https://www.aaron-gustafson.com",
+      "twitter": "AaronGustafson"
+    },
+    "DesignrKnight": {
+      "name": "Abel Mathew",
+      "teams": [
+        "editors"
+      ],
+      "avatar_url": "27865704",
+      "github": "DesignrKnight",
+      "website": "http://designrknight.com/",
+      "twitter": "DesignrKnight"
+    },
+    "tropicadri": {
+      "name": "Adriana Jara",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "32825533",
+      "github": "tropicadri",
+      "twitter": "tropicadri"
+    },
+    "akshay-ranganath": {
+      "name": "Akshay Ranganath",
+      "teams": [
+        "analysts",
+        "authors"
+      ],
+      "avatar_url": "54864775",
+      "github": "akshay-ranganath",
+      "website": "https://www.cloudinary.com/"
+    },
+    "alankent": {
+      "name": "Alan Kent",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "5702163",
+      "website": "https://alankent.me",
+      "github": "alankent",
+      "twitter": "akent99"
+    },
+    "alexdenning": {
+      "name": "Alex Denning",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "3109255",
+      "github": "alexdenning",
+      "website": "getellipsis.com",
+      "twitter": "AlexDenning"
+    },
+    "AlexLakatos": {
+      "name": "Alex Lakatos",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "690132",
+      "github": "AlexLakatos",
+      "website": "http://alexlakatos.com",
+      "twitter": "avolakatos"
+    },
+    "alextait1": {
+      "name": "Alex Tait",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "24625637",
+      "website": "https://atfreshsolutions.com",
+      "github": "alextait1",
+      "twitter": "at_fresh_dev"
+    },
+    "DataBytzAI": {
+      "name": "Allen ONeill",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "422745",
+      "github": "DataBytzAI",
+      "website": "www.thedataworks.com",
+      "twitter": "DataBytzAI"
+    },
+    "alonkochba": {
+      "name": "Alon Kochba",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "7407047",
+      "github": "alonkochba",
+      "linkedin": "alonkochba",
+      "twitter": "alonkochba"
+    },
+    "amandeepsinghvirdi": {
+      "name": "Amandeep Singh",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "456173",
+      "github": "amandeepsinghvirdi",
+      "website": "https://byaman.com",
+      "twitter": "amanvirdi"
+    },
+    "cyberandy": {
+      "name": "Andrea Volpini",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "837037",
+      "github": "cyberandy",
+      "website": "https://wordlift.io/blog/en/entity/andrea-volpini",
+      "twitter": "cyberandy"
+    },
+    "abutail": {
+      "name": "Anuj",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "36935757",
+      "github": "abutail"
+    },
+    "4upz": {
+      "name": "Arik Smith",
+      "teams": [
+        "analysts"
+      ],
+      "avatar_url": "26828838",
+      "github": "4upz"
+    },
+    "tunetheweb": {
+      "name": "Barry Pollard",
+      "teams": [
+        "developers",
+        "editors",
+        "leads",
+        "reviewers"
+      ],
+      "avatar_url": "10931297",
+      "website": "https://www.tunetheweb.com",
+      "github": "tunetheweb",
+      "linkedin": "tunetheweb",
+      "twitter": "tunetheweb"
+    },
+    "binji": {
+      "name": "Ben Smith",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "1245315",
+      "github": "binji",
+      "website": "https://binji.github.io"
+    },
+    "beth-panx": {
+      "name": "Beth Pan",
+      "teams": [
+        "analysts",
+        "reviewers"
+      ],
+      "avatar_url": "7429891",
+      "github": "beth-panx",
+      "twitter": "beth_panx"
+    },
+    "bramstein": {
+      "name": "Bram Stein",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "114871",
+      "github": "bramstein",
+      "website": "http://www.bramstein.com/"
+    },
+    "clarkio": {
+      "name": "Brian Clark",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "6265396",
+      "github": "clarkio",
+      "website": "https://www.clarkio.com",
+      "twitter": "_clarkio"
+    },
+    "bkardell": {
+      "name": "Brian Kardell",
+      "teams": [
+        "authors",
+        "reviewers"
+      ],
+      "avatar_url": "870501",
+      "github": "bkardell",
+      "website": "https://bkardell.com",
+      "twitter": "briankardell"
+    },
+    "cqueern": {
+      "name": "Caleb Queern",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "1588185",
+      "github": "cqueern",
+      "twitter": "httpsecheaders"
+    },
+    "camcash17": {
+      "name": "Cameron Casher",
+      "teams": [
+        "analysts"
+      ],
+      "avatar_url": "32401001",
+      "github": "camcash17"
+    },
+    "mrchrisadams": {
+      "name": "Chris Adams",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "17906",
+      "github": "mrchrisadams",
+      "website": "chrisadams.me.uk"
+    },
+    "svgeesus": {
+      "name": "Chris Lilley",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "2506926",
+      "github": "svgeesus",
+      "website": "svgees.us",
+      "twitter": "svgeesus"
+    },
+    "christianliebel": {
+      "name": "Christian Liebel",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "6698344",
+      "github": "christianliebel",
+      "website": "https://christianliebel.com",
+      "twitter": "christianliebel"
+    },
+    "ColinEberhardt": {
+      "name": "Colin Eberhardt",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "1098110",
+      "github": "ColinEberhardt",
+      "website": "http://www.scottlogic.com"
+    },
+    "csliva": {
+      "name": "Colt Sliva",
+      "teams": [
+        "analysts"
+      ],
+      "avatar_url": "4701180",
+      "github": "csliva",
+      "twitter": "signorcolt"
+    },
+    "CSteele-gh": {
+      "name": "CSteele-gh",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "104934613",
+      "github": "CSteele-gh"
+    },
+    "dknauss": {
+      "name": "Dan Knauss",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "273554",
+      "github": "dknauss",
+      "website": "newlocalmedia.com"
+    },
+    "drohe": {
+      "name": "Danielle Rohe",
+      "teams": [
+        "analysts"
+      ],
+      "avatar_url": "62556996",
+      "github": "drohe",
+      "website": "https://www.digital-danielle.com",
+      "twitter": "d4ni_s"
+    },
+    "dwsmart": {
+      "name": "Dave Smart",
+      "teams": [
+        "authors",
+        "reviewers"
+      ],
+      "avatar_url": "11179452",
+      "github": "dwsmart",
+      "website": "https://tamethebots.com",
+      "twitter": "davewsmart"
+    },
+    "foxdavidj": {
+      "name": "David Fox",
+      "teams": [
+        "leads",
+        "reviewers"
+      ],
+      "avatar_url": "684747",
+      "website": "https://www.lookzook.com",
+      "github": "foxdavidj",
+      "twitter": "theobto"
+    },
+    "derekperkins": {
+      "name": "Derek Perkins",
+      "teams": [
+        "analysts"
+      ],
+      "avatar_url": "3588778",
+      "github": "derekperkins",
+      "website": "http://derekperkins.com"
+    },
+    "diekus": {
+      "name": "Diego Gonzalez",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "73939538",
+      "github": "diekus",
+      "website": "https://diek.us",
+      "twitter": "diekus"
+    },
+    "Djohn12": {
+      "name": "Edmond de Tournadre",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "38497742",
+      "github": "Djohn12"
+    },
+    "meyerweb": {
+      "name": "Eric A. Meyer",
+      "teams": [
+        "authors",
+        "reviewers"
+      ],
+      "avatar_url": "939727",
+      "github": "meyerweb",
+      "website": "http://meyerweb.com/"
+    },
+    "ericwbailey": {
+      "name": "Eric Bailey",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "634191",
+      "github": "ericwbailey",
+      "website": "https://ericwbailey.design/",
+      "twitter": "ericwbailey"
+    },
+    "eeeps": {
+      "name": "Eric Portis",
+      "teams": [
+        "analysts",
+        "authors"
+      ],
+      "avatar_url": "3441390",
+      "github": "eeeps",
+      "website": "https://ericportis.com"
+    },
+    "estelle": {
+      "name": "Estelle Weyl",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "69888",
+      "github": "estelle",
+      "website": "http://standardista.com"
+    },
+    "eustas": {
+      "name": "Eugene Kliuchnikov",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "203457",
+      "github": "eustas"
+    },
+    "feross": {
+      "name": "Feross Aboukhadijeh",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "121766",
+      "github": "feross",
+      "website": "https://feross.org",
+      "twitter": "feross"
+    },
+    "fershad": {
+      "name": "Fershad Irani",
+      "teams": [
+        "analysts"
+      ],
+      "avatar_url": "27988517",
+      "github": "fershad",
+      "website": "https://www.fershad.com",
+      "twitter": "fershad"
+    },
+    "beaufortfrancois": {
+      "name": "François Beaufort",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "634478",
+      "github": "beaufortfrancois"
+    },
+    "brassic-lint": {
+      "name": "Gareth Hughes",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "5341913",
+      "github": "brassic-lint"
+    },
+    "gerrymcgovernireland": {
+      "name": "Gerry McGovern",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "67965551",
+      "github": "gerrymcgovernireland"
+    },
+    "GJFR": {
+      "name": "Gertjan Franken",
+      "teams": [
+        "analysts"
+      ],
+      "avatar_url": "5749508",
+      "github": "GJFR"
+    },
+    "GregBrimble": {
+      "name": "Greg Brimble",
+      "teams": [
+        "analysts",
+        "reviewers"
+      ],
+      "avatar_url": "8484333",
+      "github": "GregBrimble",
+      "website": "https://gregbrimble.com/",
+      "twitter": "GregBrimble"
+    },
+    "hanopcan": {
+      "name": "Hannah Smith",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "11687898",
+      "github": "hanopcan",
+      "website": "https://opcan.co.uk",
+      "twitter": "hanopcan"
+    },
+    "harendra": {
+      "name": "Haren",
+      "teams": [
+        "analysts"
+      ],
+      "avatar_url": "1376275",
+      "github": "harendra"
+    },
+    "Nutlope": {
+      "name": "Hassan El Mghari",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "63742054",
+      "github": "Nutlope",
+      "website": "https://www.elmghari.com/",
+      "twitter": "nutlope"
+    },
+    "hemanth": {
+      "name": "hemanth.hm",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "18315",
+      "github": "hemanth",
+      "website": "http://h3manth.com",
+      "twitter": "gnumanth"
+    },
+    "himani-kankaria": {
+      "name": "Himani Kankaria",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "103807756",
+      "github": "himani-kankaria"
+    },
+    "housseindjirdeh": {
+      "name": "Houssein Djirdeh",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "12476932",
+      "github": "housseindjirdeh",
+      "website": "https://houssein.me"
+    },
+    "RReverser": {
+      "name": "Ingvar Stepanyan",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "557590",
+      "github": "RReverser",
+      "website": "https://rreverser.com/",
+      "twitter": "RReverser"
+    },
+    "iskander-sanchez-rola": {
+      "name": "Iskander Sanchez-Rola",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "26458054",
+      "github": "iskander-sanchez-rola",
+      "website": "https://iskander-sanchez-rola.com/"
+    },
+    "itamarblauer": {
+      "name": "Itamar Blauer",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "104349412",
+      "github": "itamarblauer"
+    },
+    "jrstanley": {
+      "name": "James Stanley",
+      "teams": [
+        "analysts"
+      ],
+      "avatar_url": "291675",
+      "github": "jrstanley"
+    },
+    "fellowhuman1101": {
+      "name": "Jamie Indigo",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "52051775",
+      "github": "fellowhuman1101",
+      "website": "https://not-a-robot.com",
+      "twitter": "Jammer_Volts"
+    },
+    "JamieWhitMac": {
+      "name": "Jamie Macdonald",
+      "teams": [
+        "analysts"
+      ],
+      "avatar_url": "27693707",
+      "github": "JamieWhitMac"
+    },
+    "honzasladek": {
+      "name": "Jan Sládek",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "176694",
+      "github": "honzasladek",
+      "website": "http://cz.linkedin.com/in/honzasladek/",
+      "twitter": "honzasladek"
+    },
+    "JasmineDW": {
+      "name": "Jasmine Drudge-Willson",
+      "teams": [
+        "editors"
+      ],
+      "avatar_url": "29200198",
+      "github": "JasmineDW"
+    },
+    "jrharalson": {
+      "name": "Jason Haralson",
+      "teams": [
+        "analysts"
+      ],
+      "avatar_url": "7421844",
+      "github": "jrharalson"
+    },
+    "CodeMartian": {
+      "name": "Jeff Martin",
+      "teams": [
+        "analysts"
+      ],
+      "avatar_url": "49497114",
+      "github": "CodeMartian"
+    },
+    "j9t": {
+      "name": "Jens Oliver Meiert",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "1700772",
+      "github": "j9t",
+      "website": "https://meiert.com/en/",
+      "twitter": "j9t"
+    },
+    "malchata": {
+      "name": "Jeremy Wagner",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "1635238",
+      "github": "malchata",
+      "website": "https://jlwagner.net/",
+      "twitter": "malchata"
+    },
+    "imeugenia": {
+      "name": "Jevgenija Zigisova",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "17236402",
+      "github": "imeugenia"
+    },
+    "joeviggiano": {
+      "name": "Joe Viggiano",
+      "teams": [
+        "analysts"
+      ],
+      "avatar_url": "17817811",
+      "github": "joeviggiano",
+      "twitter": "JosephVigg"
+    },
+    "johnmurch": {
+      "name": "John Murch",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "692521",
+      "github": "johnmurch",
+      "website": "http://www.johnmurch.com",
+      "twitter": "johnmurch"
+    },
+    "sirjonathan": {
+      "name": "Jonathan Wold",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "104149",
+      "github": "sirjonathan",
+      "website": "https://jonathanwold.com",
+      "twitter": "sirjonathan"
+    },
+    "jonoalderson": {
+      "name": "Jono Alderson",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "11629607",
+      "github": "jonoalderson",
+      "website": "https://www.jonoalderson.com",
+      "twitter": "jonoalderson"
+    },
+    "jmsole": {
+      "name": "José Solé",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "1424556",
+      "github": "jmsole",
+      "website": "www.jmsole.cl",
+      "twitter": "jmsoleb"
+    },
+    "jroakes": {
+      "name": "JR Oakes",
+      "teams": [
+        "analysts"
+      ],
+      "avatar_url": "10191545",
+      "github": "jroakes",
+      "website": "codeseo.io",
+      "twitter": "jroakes"
+    },
+    "jyrkialakuijala": {
+      "name": "Jyrki Alakuijala",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "9086028",
+      "github": "jyrkialakuijala",
+      "twitter": "jyzg"
+    },
+    "Schweinepriester": {
+      "name": "Kai Hollberg",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "2644614",
+      "github": "Schweinepriester",
+      "twitter": "schweinepriestr"
+    },
+    "konfirmed": {
+      "name": "Kanmi Obasa",
+      "teams": [
+        "analysts",
+        "reviewers"
+      ],
+      "avatar_url": "9829274",
+      "github": "konfirmed",
+      "website": "https://www.knfrmd.com",
+      "twitter": "kanmiobasa"
+    },
+    "somecloudguy": {
+      "name": "Karan",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "44303527",
+      "github": "somecloudguy"
+    },
+    "karlcow": {
+      "name": "Karl Dubost",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "505230",
+      "github": "karlcow",
+      "website": "http://www.la-grange.net/karl/",
+      "twitter": "karlcow"
+    },
+    "kevinfarrugia": {
+      "name": "Kevin Farrugia",
+      "teams": [
+        "analysts",
+        "reviewers"
+      ],
+      "avatar_url": "8075326",
+      "github": "kevinfarrugia",
+      "website": "https://imkev.dev",
+      "twitter": "imkevdev"
+    },
+    "dereknahman": {
+      "name": "Kirsty Simmonds",
+      "teams": [
+        "editors"
+      ],
+      "avatar_url": "44810431",
+      "github": "dereknahman",
+      "website": "https://kirsty.codes",
+      "twitter": "keinegurke_"
+    },
+    "kushaldas": {
+      "name": "Kushal Das",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "272303",
+      "github": "kushaldas",
+      "website": "https://kushaldas.in",
+      "twitter": "kushaldas"
+    },
+    "ldevernay": {
+      "name": "Laurent Devernay",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "23695083",
+      "github": "ldevernay",
+      "website": "https://ldevernay.github.io/",
+      "twitter": "ldevernay"
+    },
+    "seldo": {
+      "name": "Laurie Voss",
+      "teams": [
+        "analysts",
+        "authors",
+        "reviewers"
+      ],
+      "avatar_url": "185893",
+      "github": "seldo",
+      "website": "http://seldo.com"
+    },
+    "lirantal": {
+      "name": "Liran Tal",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "316371",
+      "github": "lirantal",
+      "website": "https://twitter.com/liran_tal",
+      "twitter": "liran_tal"
+    },
+    "LPardue": {
+      "name": "Lucas Pardue",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "6571445",
+      "github": "LPardue",
+      "website": "https://lucaspardue.com",
+      "twitter": "SimmerVigor"
+    },
+    "max-ostapenko": {
+      "name": "Max Ostapenko",
+      "teams": [
+        "analysts"
+      ],
+      "avatar_url": "1611259",
+      "github": "max-ostapenko",
+      "website": "https://maxostapenko.com",
+      "twitter": "themax_o"
+    },
+    "webmaxru": {
+      "name": "Maxim Salnikov",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "1560278",
+      "github": "webmaxru",
+      "website": "https://medium.com/@webmaxru",
+      "twitter": "webmaxru"
+    },
+    "mel-ada": {
+      "name": "Melissa Ada",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "5370850",
+      "github": "mel-ada",
+      "website": "https://www.linkedin.com/in/morelmelissa",
+      "twitter": "mel_melificent"
+    },
+    "MichaelLewittes": {
+      "name": "Michael Lewittes",
+      "teams": [
+        "editors"
+      ],
+      "avatar_url": "96250205",
+      "github": "MichaelLewittes"
+    },
+    "MichaelSolati": {
+      "name": "Michael Solati",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "11811422",
+      "github": "MichaelSolati",
+      "website": "https://michaelsolati.com",
+      "twitter": "MichaelSolati"
+    },
+    "miketaylr": {
+      "name": "Mike Taylor",
+      "teams": [
+        "editors",
+        "reviewers"
+      ],
+      "avatar_url": "67283",
+      "github": "miketaylr",
+      "website": "https://miketaylr.com",
+      "twitter": "miketaylr"
+    },
+    "mgechev": {
+      "name": "Minko Gechev",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "455023",
+      "github": "mgechev",
+      "website": "https://blog.mgechev.com/",
+      "twitter": "mgechev"
+    },
+    "mobeenali97": {
+      "name": "Mobeen Ali",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "20677785",
+      "github": "mobeenali97",
+      "website": "https://siffar.com",
+      "twitter": "mobeenali97"
+    },
+    "m-shafiul": {
+      "name": "Mohammad Shafiullah",
+      "teams": [
+        "analysts"
+      ],
+      "avatar_url": "106201180",
+      "github": "m-shafiul",
+      "website": "https://www.linkedin.com/in/mshafiullah/"
+    },
+    "mordy-oberstein": {
+      "name": "Mordy Oberstein",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "104999516",
+      "github": "mordy-oberstein"
+    },
+    "mo271": {
+      "name": "Moritz Firsching",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "3491627",
+      "github": "mo271",
+      "website": "https://mo271.github.io/",
+      "twitter": "MoritzFirsching"
+    },
+    "msolercanals": {
+      "name": "msolercanals",
+      "teams": [
+        "analysts"
+      ],
+      "avatar_url": "76776586",
+      "github": "msolercanals"
+    },
+    "Navaneeth-Akamai": {
+      "name": "Navaneeth",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "99408355",
+      "github": "Navaneeth-Akamai"
+    },
+    "nhoizey": {
+      "name": "Nicolas Hoizey",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "78213",
+      "github": "nhoizey",
+      "website": "https://nicolas-hoizey.com/",
+      "twitter": "nhoizey"
+    },
+    "NishuGoel": {
+      "name": "Nishu Goel",
+      "teams": [
+        "analysts",
+        "reviewers"
+      ],
+      "avatar_url": "26349046",
+      "github": "NishuGoel",
+      "website": "unravelweb.dev",
+      "twitter": "TheNishuGoel"
+    },
+    "nrllh": {
+      "name": "Nurullah Demir",
+      "teams": [
+        "authors",
+        "reviewers"
+      ],
+      "avatar_url": "13475745",
+      "github": "nrllh",
+      "website": "internet-sicherheit.de",
+      "twitter": "nrllah"
+    },
+    "pankajparkar": {
+      "name": "Pankaj Parkar",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "5320044",
+      "github": "pankajparkar",
+      "website": "https://medium.com/@pankajparkar",
+      "twitter": "pankajparkar"
+    },
+    "patrickstox": {
+      "name": "Patrick Stox",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "32576994",
+      "github": "patrickstox",
+      "website": "https://patrickstox.com",
+      "twitter": "patrickstox"
+    },
+    "paulcalvano": {
+      "name": "Paul Calvano",
+      "teams": [
+        "analysts",
+        "leads"
+      ],
+      "avatar_url": "7459458",
+      "github": "paulcalvano",
+      "twitter": "paulcalvano",
+      "website": "https://paulcalvano.com"
+    },
+    "foolip": {
+      "name": "Philip Jägenstedt",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "498917",
+      "github": "foolip",
+      "website": "https://foolip.org/"
+    },
+    "polyglotyeoja": {
+      "name": "polyglotyeoja",
+      "teams": [
+        "analysts"
+      ],
+      "avatar_url": "9722690",
+      "github": "polyglotyeoja"
+    },
+    "25prathamesh": {
+      "name": "Prathamesh Rasam",
+      "teams": [
+        "analysts",
+        "reviewers"
+      ],
+      "avatar_url": "10120153",
+      "github": "25prathamesh",
+      "website": "https://www.linkedin.com/in/prathameshrasam"
+    },
+    "rachelandrew": {
+      "name": "Rachel Andrew",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "2764898",
+      "github": "rachelandrew",
+      "website": "https://rachelandrew.co.uk",
+      "twitter": "rachelandrew"
+    },
+    "rrajiv": {
+      "name": "Rajiv Ramnath",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "1437727",
+      "github": "rrajiv",
+      "linkedin": "rajivramnath"
+    },
+    "rviscomi": {
+      "name": "Rick Viscomi",
+      "teams": [
+        "analysts",
+        "editors",
+        "leads",
+        "reviewers"
+      ],
+      "avatar_url": "1120896",
+      "github": "rviscomi",
+      "twitter": "rick_viscomi"
+    },
+    "SeoRobt": {
+      "name": "Rob Teitelman",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "83400777",
+      "github": "SeoRobt",
+      "twitter": "teitelmanrob"
+    },
+    "rmarx": {
+      "name": "Robin Marx",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "2240689",
+      "github": "rmarx",
+      "website": "http://internetonmars.org",
+      "twitter": "programmingart"
+    },
+    "rockeynebhwani": {
+      "name": "Rockey Nebhwani",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "1718757",
+      "github": "rockeynebhwani",
+      "twitter": "rnebhwani",
+      "linkedin": "rockeynebhwani"
+    },
+    "RoelN": {
+      "name": "Roel Nieskens",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "4570664",
+      "github": "RoelN",
+      "website": "http://pixelambacht.nl"
+    },
+    "roryhewitt": {
+      "name": "Rory Hewitt",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "11558891",
+      "github": "roryhewitt",
+      "website": "https://romche.com/",
+      "linkedin": "roryhewitt",
+      "twitter": "roryhewitt3"
+    },
+    "sagrao": {
+      "name": "sagrao",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "40746707",
+      "github": "sagrao"
+    },
+    "whitep4nth3r": {
+      "name": "Salma",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "52798353",
+      "github": "whitep4nth3r",
+      "website": "https://whitep4nth3r.com/",
+      "twitter": "whitep4nth3r"
+    },
+    "SaptakS": {
+      "name": "Saptak Sengupta",
+      "teams": [
+        "authors",
+        "reviewers"
+      ],
+      "avatar_url": "9530293",
+      "github": "SaptakS",
+      "website": "https://saptaks.website",
+      "twitter": "Saptak013"
+    },
+    "ibnesayeed": {
+      "name": "Sawood Alam",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "65147",
+      "github": "ibnesayeed",
+      "website": "http://www.cs.odu.edu/~salam/",
+      "twitter": "ibnesayeed"
+    },
+    "scottdavis99": {
+      "name": "Scott Davis",
+      "teams": [
+        "analysts",
+        "authors"
+      ],
+      "avatar_url": "15577",
+      "github": "scottdavis99",
+      "website": "http://thirstyhead.com",
+      "twitter": "scottdavis99"
+    },
+    "shantsis": {
+      "name": "Shaina Hantsis",
+      "teams": [
+        "designers",
+        "editors",
+        "reviewers"
+      ],
+      "avatar_url": "22671477",
+      "github": "shantsis"
+    },
+    "spanicker": {
+      "name": "Shubhie Panicker",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "4945616",
+      "github": "spanicker",
+      "twitter": "shubhie"
+    },
+    "siakaramalegos": {
+      "name": "Sia Karamalegos",
+      "teams": [
+        "leads"
+      ],
+      "avatar_url": "4777393",
+      "website": "https://sia.codes",
+      "github": "siakaramalegos",
+      "linkedin": "karamalegos",
+      "twitter": "TheGreenGreek"
+    },
+    "siwinlo": {
+      "name": "Siwin Lo",
+      "teams": [
+        "editors"
+      ],
+      "avatar_url": "41877484",
+      "github": "siwinlo"
+    },
+    "SophieBrannon": {
+      "name": "Sophie Brannon",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "103587838",
+      "github": "SophieBrannon",
+      "twitter": "SophieBrannon"
+    },
+    "Suzzicks": {
+      "name": "Cindy Krum",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "72282209",
+      "github": "Suzzicks"
+    },
+    "thibaudcolas": {
+      "name": "Thibaud Colas",
+      "teams": [
+        "analysts"
+      ],
+      "avatar_url": "877585",
+      "github": "thibaudcolas",
+      "website": "https://thib.me/",
+      "twitter": "thibaud_colas"
+    },
+    "daKmoR": {
+      "name": "Thomas Allmer",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "24378",
+      "github": "daKmoR",
+      "website": "https://open-wc.org",
+      "twitter": "daKmoR"
+    },
+    "tomayac": {
+      "name": "Thomas Steiner",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "145676",
+      "github": "tomayac",
+      "website": "https://blog.tomayac.com/",
+      "twitter": "tomayac"
+    },
+    "timfrick": {
+      "name": "Tim Frick",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "103747873",
+      "github": "timfrick",
+      "website": "https://www.mightybytes.com/",
+      "twitter": "timfrick"
+    },
+    "tpgreenwood": {
+      "name": "Tom Greenwood",
+      "teams": [
+        "authors"
+      ],
+      "avatar_url": "3329982",
+      "github": "tpgreenwood"
+    },
+    "bobbyshaw": {
+      "name": "Tom Robertshaw",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "553566",
+      "website": "https://www.space48.com",
+      "github": "bobbyshaw",
+      "linkedin": "tomrobertshaw",
+      "twitter": "bobbyshaw"
+    },
+    "tomvangoethem": {
+      "name": "Tom Van Goethem",
+      "teams": [
+        "authors",
+        "reviewers"
+      ],
+      "avatar_url": "4355579",
+      "github": "tomvangoethem"
+    },
+    "TusharPol": {
+      "name": "Tushar Pol",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "104352788",
+      "github": "TusharPol"
+    },
+    "pepelsbey": {
+      "name": "Vadim Makeev",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "105274",
+      "github": "pepelsbey",
+      "website": "https://pepelsbey.net/",
+      "twitter": "pepelsbey"
+    },
+    "paivaspol": {
+      "name": "Vaspol Ruamviboonsuk",
+      "teams": [
+        "analysts",
+        "authors"
+      ],
+      "avatar_url": "1900571",
+      "github": "paivaspol",
+      "twitter": "paivaspol"
+    },
+    "vgotluru": {
+      "name": "vgotluru",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "43121485",
+      "github": "vgotluru"
+    },
+    "VictorLeP": {
+      "name": "Victor Le Pochat",
+      "teams": [
+        "analysts"
+      ],
+      "avatar_url": "6874341",
+      "github": "VictorLeP",
+      "linkedin": "victor-le-pochat",
+      "twitter": "VictorLePochat",
+      "website": "https://lepoch.at"
+    },
+    "vikvanderlinden": {
+      "name": "Vik Vanderlinden",
+      "teams": [
+        "analysts"
+      ],
+      "avatar_url": "10332876",
+      "github": "vikvanderlinden"
+    },
+    "ydimova": {
+      "name": "Yana Dimova",
+      "teams": [
+        "analysts"
+      ],
+      "avatar_url": "9135107",
+      "github": "ydimova"
+    },
+    "yoavweiss": {
+      "name": "Yoav Weiss",
+      "teams": [
+        "reviewers"
+      ],
+      "avatar_url": "786187",
+      "website": "https://blog.yoav.ws",
+      "github": "yoavweiss",
+      "twitter": "yoavweiss"
+    }
+  }
+}

--- a/src/config/2022.json
+++ b/src/config/2022.json
@@ -15,57 +15,67 @@
           "part": "I",
           "chapter_number": "1",
           "title": "CSS",
-          "slug": "css"
+          "slug": "css",
+          "todo": true
         },
         {
           "part": "I",
           "chapter_number": "2",
           "title": "JavaScript",
-          "slug": "javascript"
+          "slug": "javascript",
+          "todo": true
         },
         {
           "part": "I",
           "chapter_number": "3",
           "title": "Markup",
-          "slug": "markup"
+          "slug": "markup",
+          "todo": true
         },
         {
           "part": "I",
           "chapter_number": "4",
           "title": "Structured Data",
           "slug": "structured-data",
-          "hero_dir": "2021"
+          "hero_dir": "2021",
+          "todo": true
         },
         {
           "part": "I",
           "chapter_number": "5",
           "title": "Fonts",
-          "slug": "fonts"
+          "slug": "fonts",
+          "todo": true
         },
         {
           "part": "I",
           "chapter_number": "6",
           "title": "Media",
-          "slug": "media"
+          "slug": "media",
+          "todo": true
         },
         {
           "part": "I",
           "chapter_number": "7",
           "title": "WebAssembly",
           "slug": "webassembly",
-          "hero_dir": "2021"
+          "hero_dir": "2021",
+          "todo": true
         },
         {
           "part": "I",
           "chapter_number": "8",
           "title": "Third Parties",
-          "slug": "third-parties"
+          "slug": "third-parties",
+          "todo": true
         },
         {
           "part": "I",
           "chapter_number": "9",
           "title": "Interoperability",
-          "slug": "interop"
+          "slug": "interop",
+          "hero_dir": "2022",
+          "todo": true
         }
       ]
     },
@@ -77,51 +87,59 @@
           "part": "II",
           "chapter_number": "10",
           "title": "SEO",
-          "slug": "seo"
+          "slug": "seo",
+          "todo": true
         },
         {
           "part": "II",
           "chapter_number": "11",
           "title": "Accessibility",
-          "slug": "accessibility"
+          "slug": "accessibility",
+          "todo": true
         },
         {
           "part": "II",
           "chapter_number": "12",
           "title": "Performance",
-          "slug": "performance"
+          "slug": "performance",
+          "todo": true
         },
         {
           "part": "II",
           "chapter_number": "13",
           "title": "Privacy",
           "slug": "privacy",
-          "hero_dir": "2020"
+          "hero_dir": "2020",
+          "todo": true
         },
         {
           "part": "II",
           "chapter_number": "14",
           "title": "Security",
-          "slug": "security"
+          "slug": "security",
+          "todo": true
         },
         {
           "part": "II",
           "chapter_number": "15",
           "title": "Mobile Web",
-          "slug": "mobile-web"
+          "slug": "mobile-web",
+          "todo": true
         },
         {
           "part": "II",
           "chapter_number": "16",
           "title": "Capabilities",
           "slug": "capabilities",
-          "hero_dir": "2020"
+          "hero_dir": "2020",
+          "todo": true
         },
         {
           "part": "II",
           "chapter_number": "17",
           "title": "PWA",
-          "slug": "pwa"
+          "slug": "pwa",
+          "todo": true
         }
       ]
     },
@@ -133,27 +151,31 @@
           "part": "III",
           "chapter_number": "18",
           "title": "CMS",
-          "slug": "cms"
+          "slug": "cms",
+          "todo": true
         },
         {
           "part": "III",
           "chapter_number": "19",
           "title": "Ecommerce",
-          "slug": "ecommerce"
+          "slug": "ecommerce",
+          "todo": true
         },
         {
           "part": "III",
           "chapter_number": "20",
           "title": "Jamstack",
           "slug": "jamstack",
-          "hero_dir": "2020"
+          "hero_dir": "2020",
+          "todo": true
         },
         {
           "part": "III",
           "chapter_number": "21",
           "title": "Sustainability",
           "slug": "sustainability",
-          "hero_dir": "2022"
+          "hero_dir": "2022",
+          "todo": true
         }
       ]
     },
@@ -165,31 +187,36 @@
           "part": "IV",
           "chapter_number": "22",
           "title": "Page Weight",
-          "slug": "page-weight"
+          "slug": "page-weight",
+          "todo": true
         },
         {
           "part": "IV",
           "chapter_number": "23",
           "title": "CDN",
-          "slug": "cdn"
+          "slug": "cdn",
+          "todo": true
         },
         {
           "part": "IV",
           "chapter_number": "24",
           "title": "Compression",
-          "slug": "compression"
+          "slug": "compression",
+          "todo": true
         },
         {
           "part": "IV",
           "chapter_number": "25",
           "title": "Caching",
-          "slug": "caching"
+          "slug": "caching",
+          "todo": true
         },
         {
           "part": "IV",
           "chapter_number": "26",
           "title": "HTTP",
-          "slug": "http"
+          "slug": "http",
+          "todo": true
         }
       ]
     }

--- a/src/content/en/2022/accessibility.md
+++ b/src/content/en/2022/accessibility.md
@@ -1,11 +1,12 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: Accessibility
-description: TODO
-authors: []
-reviewers: []
-analysts: []
-editors: []
+#TODO - Review and update chapter description
+description: Accessibility chapter of the 2022 Web Almanac covering ease of reading, media, ease of navigation, and compatibility with assistive technologies.
+authors: [scottdavis99, SaptakS]
+reviewers: [shantsis, alextait1, ericwbailey]
+analysts: [scottdavis99, thibaudcolas]
+editors: [dereknahman]
 translators: []
 results: https://docs.google.com/spreadsheets/d/1ladaKh6RbtMKQwkccwxDJGQf85KyhfLrtlM_9e9sLH8/
 featured_quote: TODO

--- a/src/content/en/2022/accessibility.md
+++ b/src/content/en/2022/accessibility.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/caching.md
+++ b/src/content/en/2022/caching.md
@@ -1,10 +1,11 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: Caching
-description: TODO
-authors: []
-reviewers: []
-analysts: []
+#TODO - Review and update chapter description
+description: Caching chapter of the 2022 Web Almanac covering cache-control, expires, TTLs, validity, vary, set-cookies, service workers and opportunities.
+authors: [roryhewitt]
+reviewers: [rrajiv]
+analysts: [kevinfarrugia]
 editors: []
 translators: []
 results: https://docs.google.com/spreadsheets/d/16wQoA9ZciYkdW65RfR6CuW9H8TdMTQjhLuTSvVlN_rs/

--- a/src/content/en/2022/caching.md
+++ b/src/content/en/2022/caching.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/capabilities.md
+++ b/src/content/en/2022/capabilities.md
@@ -1,10 +1,11 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: Capabilities
-description: TODO
-authors: []
-reviewers: []
-analysts: []
+#TODO - Review and update chapter description
+description: Capabilities chapter of the 2022 Web Almanac covering brand-new, powerful web platform APIs that give web apps access to hardware interfaces, enhance web-based productivity apps, and more.
+authors: [MichaelSolati]
+reviewers: [webmaxru, hemanth, beaufortfrancois, tomayac, christianliebel]
+analysts: [jrstanley]
 editors: []
 translators: []
 results: https://docs.google.com/spreadsheets/d/13S9FRj8OPRtoMPb94jFh6pPNz3lNS9yztIaorZYe288/

--- a/src/content/en/2022/capabilities.md
+++ b/src/content/en/2022/capabilities.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/cdn.md
+++ b/src/content/en/2022/cdn.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/cdn.md
+++ b/src/content/en/2022/cdn.md
@@ -1,10 +1,11 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: CDN
-description: TODO
-authors: []
-reviewers: []
-analysts: []
+#TODO - Review and update chapter description
+description: CDN chapter of the 2022 Web Almanac covering adoption of CDNs, top CDN players, the impact of CDNs on TLS, HTTP/2+, and Brotli adoption
+authors: [Navaneeth-Akamai, sagrao, abutail, somecloudguy]
+reviewers: [brassic-lint, vgotluru]
+analysts: [joeviggiano, m-shafiul, harendra]
 editors: []
 translators: []
 results: https://docs.google.com/spreadsheets/d/1ySETT2IZ9ae5_VUphxUol2ZU3P1RJvcSVjDU5BgnK5A/

--- a/src/content/en/2022/cms.md
+++ b/src/content/en/2022/cms.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/cms.md
+++ b/src/content/en/2022/cms.md
@@ -1,10 +1,11 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: CMS
-description: TODO
-authors: []
-reviewers: []
-analysts: []
+#TODO - Review and update chapter description
+description: CMS chapter of the 2022 Web Almanac covering CMS adoption, user experience of websites running on CMS platforms, and CMS resource weights.
+authors: [sirjonathan]
+reviewers: [alexdenning, dknauss, alonkochba, honzasladek]
+analysts: [csliva]
 editors: []
 translators: []
 results: https://docs.google.com/spreadsheets/d/1HvTcCEw9LeMNX-fI_yOy0HemKFYKaQAHBxtB0etakqY/

--- a/src/content/en/2022/compression.md
+++ b/src/content/en/2022/compression.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/compression.md
+++ b/src/content/en/2022/compression.md
@@ -1,10 +1,11 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: Compression
-description: TODO
-authors: []
-reviewers: []
-analysts: []
+#TODO - Review and update chapter description
+description: Compression chapter of the 2022 Web Almanac covering HTTP compression, algorithms, compression levels, content types, 1st party and 3rd party compression and opportunities.
+authors: [eustas, jyrkialakuijala]
+reviewers: [mo271]
+analysts: [paulcalvano]
 editors: []
 translators: []
 results: https://docs.google.com/spreadsheets/d/1PKedBijfkrV1Y6gbzi71Ozw5ylBnq2EZLlAt2lfAEUk/

--- a/src/content/en/2022/css.md
+++ b/src/content/en/2022/css.md
@@ -1,11 +1,12 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: CSS
-description: TODO
-authors: []
-reviewers: []
-analysts: []
-editors: []
+#TODO - Review and update chapter description
+description: CSS chapter of the 2022 Web Almanac covering trends, changes, and patterns in CSS use across the web.
+authors: [rachelandrew]
+reviewers: [j9t, meyerweb, svgeesus]
+analysts: [rviscomi]
+editors: [dereknahman]
 translators: []
 results: https://docs.google.com/spreadsheets/d/1OU8ahxC5oYU8VRryQs9BzHToaXcOntVlh6KUHjm15G4/
 featured_quote: TODO

--- a/src/content/en/2022/css.md
+++ b/src/content/en/2022/css.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/ecommerce.md
+++ b/src/content/en/2022/ecommerce.md
@@ -1,11 +1,12 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: Ecommerce
-description: TODO
-authors: []
-reviewers: []
-analysts: []
-editors: []
+#TODO - Review and update chapter description
+description: Ecommerce chapter of the 2022 Web Almanac covering ecommerce platforms, page weight, images, third-parties, core web vitals and lighthouse performance metrics, SEO, and PWAs.
+authors: [amandeepsinghvirdi, himani-kankaria]
+reviewers: [alankent, bobbyshaw, rockeynebhwani]
+analysts: [jrharalson]
+editors: [shantsis]
 translators: []
 results: https://docs.google.com/spreadsheets/d/1UXCD_A748UF79McCg1cdLdCKPKE8JNFAdd1l-t-glrI/
 featured_quote: TODO

--- a/src/content/en/2022/ecommerce.md
+++ b/src/content/en/2022/ecommerce.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/fonts.md
+++ b/src/content/en/2022/fonts.md
@@ -1,10 +1,11 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: Fonts
-description: TODO
-authors: []
-reviewers: []
-analysts: []
+#TODO - Review and update chapter description
+description: Fonts chapter of the 2022 Web Almanac covering where fonts are loaded from, font formats, font loading performance, variable fonts and color fonts.
+authors: [bramstein]
+reviewers: [RoelN, svgeesus, jmsole]
+analysts: [konfirmed]
 editors: []
 translators: []
 results: https://docs.google.com/spreadsheets/d/1A1XwuGa1DkqNLaF-lSXz4ndxO9G6SfACHwUvvywHgbQ/

--- a/src/content/en/2022/fonts.md
+++ b/src/content/en/2022/fonts.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/http.md
+++ b/src/content/en/2022/http.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/http.md
+++ b/src/content/en/2022/http.md
@@ -1,10 +1,11 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: HTTP
-description: TODO
-authors: []
-reviewers: []
-analysts: []
+#TODO - Review and update chapter description
+description: The HTTP chapter of the 2022 Web Almanac covers data on historical versions of HTTP used across the web, as well as the uptick in new versions including HTTP/2 and HTTP/3, while also inspecting key metrics a part of the HTTP lifecycle.
+authors: [paivaspol]
+reviewers: [tunetheweb, rmarx, LPardue]
+analysts: [paivaspol]
 editors: []
 translators: []
 results: https://docs.google.com/spreadsheets/d/1NJrPOjBoJSDsHV0rAHpcZ9qBUgy6RVG3QtvbTqrj5_o/

--- a/src/content/en/2022/interop.md
+++ b/src/content/en/2022/interop.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/interop.md
+++ b/src/content/en/2022/interop.md
@@ -1,10 +1,11 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: Interoperability
-description: TODO
-authors: []
-reviewers: []
-analysts: []
+#TODO - Review and update chapter description
+description: Interoperability chapter of the 2022 Web Almanac covering ...
+authors: [bkardell, meyerweb]
+reviewers: [karlcow, foolip, miketaylr]
+analysts: [rviscomi, kevinfarrugia]
 editors: []
 translators: []
 results: https://docs.google.com/spreadsheets/d/1w3GzzTNeKxafFODmjDs6OC2dseNEDDKwUV8KeSgRI1Y/

--- a/src/content/en/2022/jamstack.md
+++ b/src/content/en/2022/jamstack.md
@@ -1,10 +1,11 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: Jamstack
-description: TODO
-authors: []
-reviewers: []
-analysts: []
+#TODO - Review and update chapter description
+description: Jamstack chapter of the 2022 Web Almanac covers adoption of technology, performance of websites built with Jamstack and weights for various resources.
+authors: [seldo, whitep4nth3r]
+reviewers: [GregBrimble, Nutlope]
+analysts: [seldo, GregBrimble]
 editors: []
 translators: []
 results: https://docs.google.com/spreadsheets/d/1yfNaj25ToezMwQLKdYP6Qh7AUoX9zMdKMSRVC8JlZMY/

--- a/src/content/en/2022/jamstack.md
+++ b/src/content/en/2022/jamstack.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/javascript.md
+++ b/src/content/en/2022/javascript.md
@@ -1,11 +1,12 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: JavaScript
-description: TODO
-authors: []
-reviewers: []
-analysts: []
-editors: []
+#TODO - Review and update chapter description
+description: JavaScript chapter of the 2022 Web Almanac covering the usage of JavaScript on the web, libraries and frameworks, compression, web components, and source maps.
+authors: [malchata, ibnesayeed]
+reviewers: [mgechev, pankajparkar, NishuGoel, seldo, housseindjirdeh, kevinfarrugia]
+analysts: [NishuGoel, kevinfarrugia]
+editors: [DesignrKnight]
 translators: []
 results: https://docs.google.com/spreadsheets/d/1vOeFUyfEtWRen3Xj57ZsWav40n5tlcJoV0HmAxmNE_I/
 featured_quote: TODO

--- a/src/content/en/2022/javascript.md
+++ b/src/content/en/2022/javascript.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/markup.md
+++ b/src/content/en/2022/markup.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/media.md
+++ b/src/content/en/2022/media.md
@@ -1,11 +1,12 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: Media
-description: TODO
-authors: []
-reviewers: []
-analysts: []
-editors: []
+#TODO - Review and update chapter description
+description: Media chapter of the 2022 Web Almanac covering how images and videos are currently being encoded, embedded, styled, and delivered on the web
+authors: [eeeps, akshay-ranganath]
+reviewers: [nhoizey, yoavweiss]
+analysts: [eeeps, akshay-ranganath]
+editors: [MichaelLewittes]
 translators: []
 results: https://docs.google.com/spreadsheets/d/1T5oVAVmcH3sM6R-WwH4ksr2jFtPhuLXs3-iXXoABb3E/
 featured_quote: TODO

--- a/src/content/en/2022/media.md
+++ b/src/content/en/2022/media.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/mobile-web.md
+++ b/src/content/en/2022/mobile-web.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/mobile-web.md
+++ b/src/content/en/2022/mobile-web.md
@@ -1,10 +1,11 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: Mobile Web
-description: TODO
-authors: []
-reviewers: []
-analysts: []
+#TODO - Review and update chapter description
+description: Mobile Web chapter of the 2022 Web Almanac covering page web vitals, images, technology adoption, accessibility and more.
+authors: [Suzzicks]
+reviewers: [dwsmart, hemanth, foxdavidj]
+analysts: [polyglotyeoja, CodeMartian]
 editors: []
 translators: []
 results: https://docs.google.com/spreadsheets/d/1GB39gbyOilTSvgJHVdY8zwxwaFdsUB5iaD29cMwkdDY/

--- a/src/content/en/2022/page-weight.md
+++ b/src/content/en/2022/page-weight.md
@@ -1,10 +1,11 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: Page Weight
-description: TODO
-authors: []
-reviewers: []
-analysts: []
+#TODO - Review and update chapter description
+description: Page Weight chapter of the 2022 Web Almanac covering why page weight matters, bandwidth, complex pages, page weight over time, page requests, and file formats.
+authors: [fellowhuman1101, dwsmart]
+reviewers: [CSteele-gh, mordy-oberstein]
+analysts: [drohe]
 editors: []
 translators: []
 results: https://docs.google.com/spreadsheets/d/1JvJMiRsL6T9m_NEBHFh-rrQmU5a-ufdOKriSJbrEN8M/

--- a/src/content/en/2022/page-weight.md
+++ b/src/content/en/2022/page-weight.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/performance.md
+++ b/src/content/en/2022/performance.md
@@ -1,10 +1,11 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: Performance
-description: TODO
-authors: []
-reviewers: []
-analysts: []
+#TODO - Review and update chapter description
+description: Performance chapter of the 2022 Web Almanac covering Core Web Vitals (Largest Contentful Paint, Cumulative Layout Shift, First Input Delay) as well as First Contentful Paint and Time to First Byte
+authors: [mel-ada]
+reviewers: [konfirmed, rviscomi, 25prathamesh, estelle]
+analysts: [konfirmed, 25prathamesh]
 editors: []
 translators: []
 results: https://docs.google.com/spreadsheets/d/1TPA_4xRTBB2fQZaBPZHVFvD0ikrR-4sNkfJfUEpjibs/

--- a/src/content/en/2022/performance.md
+++ b/src/content/en/2022/performance.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/privacy.md
+++ b/src/content/en/2022/privacy.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/privacy.md
+++ b/src/content/en/2022/privacy.md
@@ -1,11 +1,12 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: Privacy
-description: TODO
-authors: []
-reviewers: []
-analysts: []
-editors: []
+#TODO - Review and update chapter description
+description: Privacy chapter of the 2022 Web Almanac covering adoption and impact of online tracking, privacy preference signals and browser initiatives for a privacy-friendlier web.
+authors: [tomvangoethem, spanicker, nrllh]
+reviewers: [miketaylr, iskander-sanchez-rola, SaptakS]
+analysts: [max-ostapenko, ydimova]
+editors: [miketaylr]
 translators: []
 results: https://docs.google.com/spreadsheets/d/1iJqj3g0VEjpmjzvtX6VLeRehE7LDQGcw6lOadxGxkjk/
 featured_quote: TODO

--- a/src/content/en/2022/pwa.md
+++ b/src/content/en/2022/pwa.md
@@ -1,11 +1,12 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: PWA
-description: TODO
-authors: []
-reviewers: []
-analysts: []
-editors: []
+#TODO - Review and update chapter description
+description: PWA chapter of the 2022 Web Almanac covering service workers (usage and features), Web App Manifests, Lighthouse insights, service worker libraries (including Workbox), Web Push notifications and distribution.
+authors: [diekus, Suzzicks]
+reviewers: [aarongustafson, webmaxru, Schweinepriester, tropicadri, beth-panx, tropicadri]
+analysts: [beth-panx]
+editors: [siwinlo]
 translators: []
 results: https://docs.google.com/spreadsheets/d/1PbzjhN--jU9MGuWobw5L9EsmlVzI9tlbCe3_NKA7giU/
 featured_quote: TODO

--- a/src/content/en/2022/pwa.md
+++ b/src/content/en/2022/pwa.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/security.md
+++ b/src/content/en/2022/security.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/security.md
+++ b/src/content/en/2022/security.md
@@ -1,10 +1,11 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: Security
-description: TODO
-authors: []
-reviewers: []
-analysts: []
+#TODO - Review and update chapter description
+description: Security chapter of the 2022 Web Almanac covering Transport Layer Security, content inclusion (CSP, Feature Policy, SRI), web defense mechanisms (tackling XSS, XS-Leaks), and drivers of security mechanism adoptions.
+authors: [SaptakS, feross, lirantal]
+reviewers: [kushaldas, tomvangoethem, nrllh, clarkio]
+analysts: [VictorLeP, vikvanderlinden, GJFR]
 editors: []
 translators: []
 results: https://docs.google.com/spreadsheets/d/1cwJ43NL2IN2PxJa5oiOoJCRkSh566XE_k9uHnGJdWeg/

--- a/src/content/en/2022/seo.md
+++ b/src/content/en/2022/seo.md
@@ -1,11 +1,12 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: SEO
-description: TODO
-authors: []
-reviewers: []
-analysts: []
-editors: []
+#TODO - Review and update chapter description
+description: SEO chapter of the 2022 Web Almanac covering crawlability, indexability, page experience, on-page SEO, links, AMP, internationalization, and more.
+authors: [SophieBrannon, itamarblauer]
+reviewers: [mobeenali97, dwsmart, patrickstox, johnmurch, TusharPol]
+analysts: [derekperkins, csliva, jroakes]
+editors: [MichaelLewittes]
 translators: []
 results: https://docs.google.com/spreadsheets/d/1qBQWxNKIAVJNOFwGlslT7AW0VAoK85Mf3nFvtw0QjVU/
 featured_quote: TODO

--- a/src/content/en/2022/seo.md
+++ b/src/content/en/2022/seo.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/structured-data.md
+++ b/src/content/en/2022/structured-data.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/structured-data.md
+++ b/src/content/en/2022/structured-data.md
@@ -1,11 +1,12 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: Structured Data
-description: TODO
-authors: []
-reviewers: []
-analysts: []
-editors: []
+#TODO - Review and update chapter description
+description: Structured Data chapter of the 2022 Web Almanac covering adoption and impact of schema.org, RDFa, Microdata and more.
+authors: [cyberandy, DataBytzAI]
+reviewers: [SeoRobt, jonoalderson]
+analysts: [rviscomi]
+editors: [JasmineDW]
 translators: []
 results: https://docs.google.com/spreadsheets/d/1iRsyYq4TDMpsgeo_uLq-yqBisHviypeKVUMF1pM1fiM/
 featured_quote: TODO

--- a/src/content/en/2022/sustainability.md
+++ b/src/content/en/2022/sustainability.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/sustainability.md
+++ b/src/content/en/2022/sustainability.md
@@ -1,14 +1,14 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
-title: Markup
+title: Sustainability
 #TODO - Review and update chapter description
-description: Markup chapter of the 2022 Web Almanac covering the use of elements, attributes, document trends, as well as adoption rates of new standards.
-authors: [AlexLakatos, ibnesayeed, daKmoR]
-reviewers: [j9t, bkardell]
-analysts: [rviscomi]
+description: Sustainability chapter of the 2022 Web Almanac covering ...
+authors: [ldevernay, gerrymcgovernireland, tpgreenwood, timfrick]
+reviewers: [mrchrisadams, cqueern, Djohn12, hanopcan]
+analysts: [fershad, camcash17, 4upz]
 editors: []
 translators: []
-results: https://docs.google.com/spreadsheets/d/1grkd2_1xSV3jvNK6ucRQ0OL1HmGTsScHuwA8GZuRLHU/
+results: https://docs.google.com/spreadsheets/d/1wU3SjB8XYkbaqxYt8CNtbmDbjCcYZ8m5kiYof7uyI5k/
 featured_quote: TODO
 featured_stat_1: TODO
 featured_stat_label_1: TODO

--- a/src/content/en/2022/third-parties.md
+++ b/src/content/en/2022/third-parties.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/content/en/2022/third-parties.md
+++ b/src/content/en/2022/third-parties.md
@@ -1,10 +1,11 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: Third Parties
-description: TODO
-authors: []
-reviewers: []
-analysts: []
+#TODO - Review and update chapter description
+description: Third Parties chapter of the 2022 Web Almanac covering data of what third parties are used, what they are used for, a deep dive into performance impacts and a discussion on security and privacy impacts.
+authors: [imeugenia]
+reviewers: [tunetheweb, housseindjirdeh, pepelsbey, kevinfarrugia]
+analysts: [kevinfarrugia, msolercanals]
 editors: []
 translators: []
 results: https://docs.google.com/spreadsheets/d/1YqoRRsyiNsrEabVLu2nRU98JIG_0zLLuoQhC2nX8xbM/

--- a/src/content/en/2022/webassembly.md
+++ b/src/content/en/2022/webassembly.md
@@ -1,10 +1,11 @@
 ---
 #See https://github.com/HTTPArchive/almanac.httparchive.org/wiki/Authors'-Guide#metadata-to-add-at-the-top-of-your-chapters
 title: WebAssembly
-description: TODO
-authors: []
-reviewers: []
-analysts: []
+#TODO - Review and update chapter description
+description: WebAssembly chapter of the 2022 Web Almanac covering Wasm compression, section sizes, most popular instructions, and post-MVP proposals
+authors: [ColinEberhardt]
+reviewers: [binji, RReverser]
+analysts: [JamieWhitMac]
 editors: []
 translators: []
 results: https://docs.google.com/spreadsheets/d/11jyABro0fKtuN6INnYP9pJlv5QWwp0jfJyTsGfKgScg/

--- a/src/content/en/2022/webassembly.md
+++ b/src/content/en/2022/webassembly.md
@@ -16,6 +16,7 @@ featured_stat_2: TODO
 featured_stat_label_2: TODO
 featured_stat_3: TODO
 featured_stat_label_3: TODO
+unedited: true
 ---
 
 ## TODO

--- a/src/tools/generate/generate_chapters.js
+++ b/src/tools/generate/generate_chapters.js
@@ -48,7 +48,9 @@ const generate_chapters = async (chapter_match) => {
       "analysts": new Set(),
       "editors": new Set()
     };
-    sitemap_languages[year] = configs[year].settings[0].supported_languages;
+    if (configs[year].settings[0].is_live) {
+      sitemap_languages[year] = configs[year].settings[0].supported_languages;
+    }
     for (const part in configs[year].outline) {
       for (const chapter in configs[year].outline[part].chapters) {
         const theconfig = configs[year].outline[part].chapters[chapter];
@@ -105,7 +107,7 @@ const generate_chapters = async (chapter_match) => {
           }
           featured_quotes[language][year][chapter] = chapter_featured_quote;
         }
-        if ( sitemap_languages[year].includes(language) ) {
+        if ( sitemap_languages[year] && sitemap_languages[year].includes(language) ) {
           sitemap.push({ language, year, chapter });
           const {description, title, authors} = metadata;
           rss.push({ language, year, chapter, title, description, authors });

--- a/src/tools/scripts/set_lighthouse_urls.sh
+++ b/src/tools/scripts/set_lighthouse_urls.sh
@@ -48,6 +48,8 @@ http://127.0.0.1:8080/en/2021/third-parties
 END
 )
 
+# TODO - when 2022 chapters are ready, remove the last check on line 72
+
 if [ "${production}" == "1" ]; then
 
     # Get the production URLs from the production sitemap (except PDFs and Stories)
@@ -67,7 +69,7 @@ elif [ "${RUN_TYPE}" == "pull_request" ] && [ "${COMMIT_SHA}" != "" ]; then
     git pull --quiet
     git checkout main
     # Then get the changes
-    CHANGED_FILES=$(git diff --name-only "main...${COMMIT_SHA}" --diff-filter=d content templates | grep -v base.html | grep -v ejs | grep -v base_ | grep -v sitemap | grep -v error.html | grep -v stories)
+    CHANGED_FILES=$(git diff --name-only "main...${COMMIT_SHA}" --diff-filter=d content templates | grep -v base.html | grep -v ejs | grep -v base_ | grep -v sitemap | grep -v error.html | grep -v stories | grep -v "2022/")
     # Then back to the pull request changes
     git checkout --progress --force "${COMMIT_SHA}"
 

--- a/src/tools/scripts/set_lighthouse_urls.sh
+++ b/src/tools/scripts/set_lighthouse_urls.sh
@@ -48,7 +48,9 @@ http://127.0.0.1:8080/en/2021/third-parties
 END
 )
 
-# TODO - when 2022 chapters are ready, remove the last check on line 72
+# TODO - when the 2022 base pages are ready, remove the last check on line 74.
+# when home page exists, chapters will 301 to that. Until then, they 404 as invalid year.
+# Lighthouse handles a 301 fine, but not a 404 (where it bombs out - hence need to strip out for now).
 
 if [ "${production}" == "1" ]; then
 

--- a/src/tools/test/test_status_codes.js
+++ b/src/tools/test/test_status_codes.js
@@ -21,8 +21,10 @@ const get_config = async () => {
 
   configs = await get_yearly_configs();
   for (const year in configs) {
-    languages[year] = configs[year].settings[0].supported_languages;
-    ebooks[year] = configs[year].settings[0].ebook_languages;
+    if (configs[year].settings[0].is_live) {
+      languages[year] = configs[year].settings[0].supported_languages;
+      ebooks[year] = configs[year].settings[0].ebook_languages;
+    }
   }
 };
 


### PR DESCRIPTION
Adds the 2022.json file with all the current contributors to try to avoid the merge conflict hell we got last year.

I've also added the contributors to the chapter Markdowns to allow the team checks to pass.

This will also allow us to launch the "Coming soon" landing page (for a future PR).