### PR TITLE
Bump Node version used in GitHub Actions from v15 to v16

### DIFF
--- a/.github/workflows/predeploy.yml
+++ b/.github/workflows/predeploy.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Setup Node.js for use with actions
       uses: actions/setup-node@v3
       with:
-        node-version: '15'
+        node-version: '16'
     - name: Set up Python 3.8
       uses: actions/setup-python@v4.0.0
       with:

--- a/.github/workflows/test-template-changes.yml
+++ b/.github/workflows/test-template-changes.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Setup Node.js for use with actions
       uses: actions/setup-node@v3
       with:
-        node-version: '15'
+        node-version: '16'
     - name: Test Template Changes
       run: ./src/tools/scripts/test_template_changes.sh
     - name: 'Comment PR'

--- a/.github/workflows/test_website.yml
+++ b/.github/workflows/test_website.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup Node.js for use with actions
       uses: actions/setup-node@v3
       with:
-        node-version: '15'
+        node-version: '16'
     - name: Set up Python 3.8
       uses: actions/setup-python@v4.0.0
       with:


### PR DESCRIPTION
v15 wasn't a stable version but we bumped it in #2086 to solve an NPM annoyance.
Now v16 is in LTS we should use that for our GitHub Actions.

Note that locally you can still use older versions (at least v14, but also possible v12)... at least for now :-)