### PR TITLE
Clean up HEAD

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -7,14 +7,13 @@
     {% block head %}
       <title>{% block title %}The Web Almanac{% endblock %}</title>
       <link rel="stylesheet" href="{{ get_versioned_filename('/static/css/normalize.css') }}">
-      <link rel="preload" href="{{ get_versioned_filename('/static/css/normalize.css') }}" as="style">
       {% block styles %}{% endblock %}
       <link rel="preload" href="/static/fonts/Lato-Regular.woff2" as="font" type="font/woff2" crossorigin>
       <link rel="preload" href="/static/fonts/Poppins-Bold.woff2" as="font" type="font/woff2" crossorigin>
       <link rel="preload" href="/static/fonts/Lato-Black.woff2" as="font" type="font/woff2" crossorigin>
       <link rel="preload" href="/static/fonts/Lato-Bold.woff2" as="font" type="font/woff2" crossorigin>
 
-      <script nonce="{{ csp_nonce() }}">
+      <script async nonce="{{ csp_nonce() }}">
         window.dataLayer = window.dataLayer || [];
         function gtag() {
             dataLayer.push(arguments);

--- a/src/templates/base/accessibility_statement.html
+++ b/src/templates/base/accessibility_statement.html
@@ -36,7 +36,6 @@
 {% block styles %}
 {{ super() }}
 <link rel="stylesheet" href="{{ get_versioned_filename('/static/css/page.css') }}">
-<link rel="preload" href="{{ get_versioned_filename('/static/css/page.css') }}" as="style">
 {% endblock %}
 
 {# Don't need year switcher for this template so blank it out #}

--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -2,7 +2,6 @@
 
 {% block styles %}
   <link rel="stylesheet" href="{{ get_versioned_filename('/static/css/almanac.css') }}">
-  <link rel="preload" href="{{ get_versioned_filename('/static/css/almanac.css') }}" as="style" />
 {% endblock %}
 
 {% block page_url %}https://almanac.httparchive.org{{ url_for(request.endpoint, **get_view_args(lang=language.lang_code, year=year)) }}{% endblock %}

--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -48,7 +48,6 @@
 {% block styles %}
 {{ super() }}
 <link rel="stylesheet" href="{{ get_versioned_filename('/static/css/page.css') }}">
-<link rel="preload" href="{{ get_versioned_filename('/static/css/page.css') }}" as="style" />
 {% endblock %}
 
 {% block scripts %}

--- a/src/templates/base/error.html
+++ b/src/templates/base/error.html
@@ -55,7 +55,7 @@
     </div>
     <img class="methodology-characters" src="/static/images/methodology-characters.png" alt="" />
   </main>
-  <script nonce="{{ csp_nonce() }}">
+  <script defer nonce="{{ csp_nonce() }}">
     gtag('event', '{{ HTTP_STATUS_CODES[error.code] }}', { 'event_category': 'error', 'event_label': '{{ request.path }}', 'value': 1 });
   </script>
 {% endblock %}

--- a/src/templates/base/index.html
+++ b/src/templates/base/index.html
@@ -41,7 +41,6 @@
 {% block styles %}
   {{ super() }}
   <link rel="stylesheet" href="{{ get_versioned_filename('/static/css/index.css') }}">
-  <link rel="preload" href="{{ get_versioned_filename('/static/css/index.css') }}" as="style" />
   <link rel="preload" href="/static/fonts/Poppins-Light.woff2" as="font" type="font/woff2" crossorigin>
 {% endblock %}
 

--- a/src/templates/base/methodology.html
+++ b/src/templates/base/methodology.html
@@ -7,7 +7,6 @@
 {% block styles %}
 {{ super() }}
 <link rel="stylesheet" href="{{ get_versioned_filename('/static/css/page.css') }}">
-<link rel="preload" href="{{ get_versioned_filename('/static/css/page.css') }}" as="style" />
 {% endblock %}
 
 {% block main %}

--- a/src/templates/base/search.html
+++ b/src/templates/base/search.html
@@ -63,7 +63,7 @@
   {% endif %}
 </main>
 
-<script nonce="{{ csp_nonce() }}">
+<script defer nonce="{{ csp_nonce() }}">
   if (window.URLSearchParams) {
     var searchParams = new URLSearchParams(window.location.search);
     q = searchParams.get("q");


### PR DESCRIPTION
We used to preload stylesheets due to a bug in chrome that over prioritised our preloaded fonts.

That big was fixed a few releases ago so can remove the workaround

Also added `async` or `defer` to scripts that were missing them.

No real difference in WPT: https://www.webpagetest.org/video/compare.php?tests=220701_AiDcA4_FVM,220701_AiDc2C_FVK