### PR TITLE
Display chapter dates

### DIFF
--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -846,11 +846,9 @@ figure .fig-desktop {
 
 /* Mobile View */
 @media (max-width: 37.5em) {
-
   .article-dates {
     display: block;
   }
-
 }
 
 /* Code highlighting */

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -172,6 +172,10 @@
   margin-bottom: 2rem;
 }
 
+.title {
+  margin: 10px 0;
+}
+
 .content ul li {
   list-style: none;
 }
@@ -206,14 +210,12 @@
   font-weight: normal;
 }
 
-.chapter-info {
+.article-dates {
   display: flex;
   justify-content: space-between;
   column-gap: 20px;
-}
-
-.article-dates {
   font-style: italic;
+  margin-bottom: 10px;
 }
 
 .article-dates time {
@@ -775,9 +777,7 @@ figure .fig-desktop {
   table {
     font-size: 0.8em;
   }
-}
 
-@media (max-width: 56.25em) {
   figure {
     margin: 0 15px;
     margin: 0 0.9375rem;
@@ -842,14 +842,15 @@ figure .fig-desktop {
   .content ul li {
     padding: 5px 0;
   }
+}
 
-  .chapter-info {
+/* Mobile View */
+@media (max-width: 37.5em) {
+
+  .article-dates {
     display: block;
   }
 
-  .article-dates {
-    margin-top: 20px;
-  }
 }
 
 /* Code highlighting */

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -209,10 +209,15 @@
 .chapter-info {
   display: flex;
   justify-content: space-between;
+  column-gap: 20px;
 }
 
 .article-dates {
   font-style: italic;
+}
+
+.article-dates time {
+  white-space: nowrap;
 }
 
 .btn.chapter-cta > svg {

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -187,7 +187,7 @@
 }
 
 .content-banner {
-  max-width: 100%;
+  width: 100%;
   height: auto;
   border-radius: 8px;
   border-radius: 0.5rem;
@@ -204,6 +204,15 @@
 .byline.analysts,
 .byline.editors {
   font-weight: normal;
+}
+
+.chapter-info {
+  display: flex;
+  justify-content: space-between;
+}
+
+.article-dates {
+  font-style: italic;
 }
 
 .btn.chapter-cta > svg {
@@ -827,6 +836,14 @@ figure .fig-desktop {
 
   .content ul li {
     padding: 5px 0;
+  }
+
+  .chapter-info {
+    display: block;
+  }
+
+  .article-dates {
+    margin-top: 20px;
   }
 }
 

--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -104,7 +104,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
 {% endmacro %}
 
 
-{% macro render_bylines() %}
+{% macro render_byline() %}
 <div class="bylines">
   <div class="byline">{{ self.written_by_before() }}
   {% for author in metadata.get('authors') %}
@@ -396,6 +396,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
                 <span class="chapter-unedited">{{ self.unedited() }}</span>
                 {% endif %}
             </h1>
+            {{ render_publish_dates() }}
             <!-- Show large image for large screens and high density screens and use avif and webp when supported -->
             <picture>
               <source media="(min-width: 866px)" type="image/avif" srcset="{{ chapter_hero_dir }}hero_lg.avif" />
@@ -406,10 +407,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
               <source type="image/jpeg" srcset="{{ chapter_hero_dir }}hero_sm.jpg 1x, {{ chapter_hero_dir }}hero_lg.jpg 2x" />
               <img src="{{ chapter_hero_dir }}hero_lg.jpg" class="content-banner" alt="" width="866" height="433" fetchpriority="high" />
             </picture>
-            <div class="chapter-info">
-              {{ render_bylines() }}
-              {{ render_publish_dates() }}
-            </div>
+            {{ render_byline() }}
             {{ self.main_content() }}
         </article>
         <div class="chapter-links">

--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -104,7 +104,8 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
 {% endmacro %}
 
 
-{% macro render_byline() %}
+{% macro render_bylines() %}
+<div class="bylines">
   <div class="byline">{{ self.written_by_before() }}
   {% for author in metadata.get('authors') %}
   <a class="author" href="{{ url_for('contributors', year=year, lang=lang, _anchor=author) }}">{{ config.contributors[author].name if author in config.contributors else author }}</a>{% if loop.length > 2 %}{{ self.comma() if loop.index < loop.length - 1 }}{{ self.oxford_comma() if loop.index == loop.length - 1 }}{% endif %}
@@ -147,20 +148,22 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
   {% endfor %}{{ self.translated_by_after() }}
   </div>
   {% endif %}
+</div>
 {% endmacro %}
 
 {% macro render_publish_dates() %}
 <div class="article-dates">
-  <div>
+  <div class="article-date">
   {{ self.date_published() }}<time id="published-date" datetime="{{ date_published }}">{{ date_published[0:4] }}/{{ date_published[5:7] }}/{{ date_published[8:10] }}</time>
   </div>
   {% if date_published != date_modified %}
-  <div>
+  <div class="article-date">
     {{ self.date_updated() }}<time id="modified-date" datetime="{{ date_modified }}">{{ date_modified[0:4] }}/{{ date_modified[5:7] }}/{{ date_modified[8:10] }}</time>
   </div>
   {% endif %}
   <script nonce="{{ csp_nonce() }}">
-    // Display chapter dates immeadiately to avoid annoying shift as much as possible
+    // Update chapter dates to locale/language-specific format immeadiately with inline
+    // script to avoid annoying shift as much as possible since this is in initial viewport.
     function formatDates(selector) {
       if (window.Intl && window.Intl.DateTimeFormat) {
         var publishedDateElement=document.querySelector(selector);
@@ -404,9 +407,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
               <img src="{{ chapter_hero_dir }}hero_lg.jpg" class="content-banner" alt="" width="866" height="433" fetchpriority="high" />
             </picture>
             <div class="chapter-info">
-              <div>
-                {{ render_byline() }}
-              </div>
+              {{ render_bylines() }}
               {{ render_publish_dates() }}
             </div>
             {{ self.main_content() }}

--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -172,7 +172,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
         // Set up the date format - initially using the users default locale
         // This allows different locales in same language to be respected
         // (e.g. en-GB or en-US).
-        var options = { dateStyle: "medium" };
+        var options = { day: "numeric", month: "short", year: "numeric" };
         var dateFormat = new Intl.DateTimeFormat([], options)
         const usedOptions = dateFormat.resolvedOptions();
         if (!usedOptions.locale.startsWith("{{ lang }}")) {

--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -149,6 +149,47 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
   {% endif %}
 {% endmacro %}
 
+{% macro render_publish_dates() %}
+<div class="article-dates">
+  <div>
+  {{ self.date_published() }}<time id="published-date" datetime="{{ date_published }}">{{ date_published[0:4] }}/{{ date_published[5:7] }}/{{ date_published[8:10] }}</time>
+  </div>
+  {% if date_published != date_modified %}
+  <div>
+    {{ self.date_updated() }}<time id="modified-date" datetime="{{ date_modified }}">{{ date_modified[0:4] }}/{{ date_modified[5:7] }}/{{ date_modified[8:10] }}</time>
+  </div>
+  {% endif %}
+  <script nonce="{{ csp_nonce() }}">
+    // Display chapter dates immeadiately to avoid annoying shift as much as possible
+    function formatDates(selector) {
+      if (window.Intl && window.Intl.DateTimeFormat) {
+        var publishedDateElement=document.querySelector(selector);
+        var publishedDate = new Date(publishedDateElement.getAttribute("datetime"));
+
+        // Set up the date format - initially using the users default locale
+        // This allows different locales in same language to be respected
+        // (e.g. en-GB or en-US).
+        var options = { dateStyle: "medium" };
+        var dateFormat = new Intl.DateTimeFormat([], options)
+        const usedOptions = dateFormat.resolvedOptions();
+        if (!usedOptions.locale.startsWith("{{ lang }}")) {
+          // Reader is looking at a page in a language that is not their default locale
+          // Set date format to page's language locale to avoid incorrect date translation.
+          dateFormat = new Intl.DateTimeFormat("{{ lang }}", options)
+        }
+        publishedDateElement.innerHTML = dateFormat.format(publishedDate);
+
+      } else {
+        console.log("Could not format date");
+      }
+    }
+
+    formatDates("#published-date");
+    formatDates("#modified-date");
+  </script>
+</div>
+{% endmacro %}
+
 {% macro render_webmentions() %}
   <h2 id="reactions">
     <a href="#reactions" class="anchor-link">{{ self.reactions() }}</a>
@@ -362,7 +403,12 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
               <source type="image/jpeg" srcset="{{ chapter_hero_dir }}hero_sm.jpg 1x, {{ chapter_hero_dir }}hero_lg.jpg 2x" />
               <img src="{{ chapter_hero_dir }}hero_lg.jpg" class="content-banner" alt="" width="866" height="433" fetchpriority="high" />
             </picture>
-            {{ render_byline() }}
+            <div class="chapter-info">
+              <div>
+                {{ render_byline() }}
+              </div>
+              {{ render_publish_dates() }}
+            </div>
             {{ self.main_content() }}
         </article>
         <div class="chapter-links">

--- a/src/templates/en/base.html
+++ b/src/templates/en/base.html
@@ -83,6 +83,9 @@ Our mission is to combine the raw stats and trends of the HTTP Archive with the 
 {% block reviewed_and_analyzed_by_after %}{% endblock %}
 {% block analysis_and_editing_by_after %}{% endblock %}
 
+{% block date_published %}Date published: {% endblock %}
+{% block date_updated %}Last updated: {% endblock %}
+
 {% block unedited %}[Unedited]{% endblock %}
 
 {% block author %}Author{% endblock %}

--- a/src/templates/es/base.html
+++ b/src/templates/es/base.html
@@ -83,6 +83,9 @@
 {% block reviewed_and_analyzed_by_after %}{% endblock %}
 {% block analysis_and_editing_by_after %}{% endblock %}
 
+{% block date_published %}Fecha de publicación: {% endblock %}
+{% block date_updated %}Fecha de actualización: {% endblock %}
+
 {% block unedited %}[no corregido]{% endblock %}
 
 {% block author %}Autor(a){% endblock %}

--- a/src/templates/fr/base.html
+++ b/src/templates/fr/base.html
@@ -83,6 +83,9 @@ Notre mission est de combiner les statistiques brutes et les tendances de HTTP A
 {% block reviewed_and_analyzed_by_after %}{% endblock %}
 {% block analysis_and_editing_by_after %}{% endblock %}
 
+{% block date_published %}Date de publication : {% endblock %}
+{% block date_updated %}Date de mise à jour : {% endblock %}
+
 {% block unedited %}[non corrigé]{% endblock %}
 
 {% block author %}Auteur·ice{% endblock %}

--- a/src/templates/hi/base.html
+++ b/src/templates/hi/base.html
@@ -83,6 +83,9 @@
 {% block reviewed_and_analyzed_by_after %}{% endblock %}
 {% block analysis_and_editing_by_after %}{% endblock %}
 
+{% block date_published %}प्रकाशित होने की तिथि: {% endblock %}
+{% block date_updated %}अद्यतन तिथि: {% endblock %}
+
 {% block unedited %}[अप्रकाशित]{% endblock %}
 
 {% block author %}लेखक{% endblock %}

--- a/src/templates/it/base.html
+++ b/src/templates/it/base.html
@@ -83,6 +83,9 @@ La nostra missione è combinare le statistiche grezze e le tendenze del HTTP Arc
 {% block reviewed_and_analyzed_by_after %}{% endblock %}
 {% block analysis_and_editing_by_after %}{% endblock %}
 
+{% block date_published %}Data di pubblicazione: {% endblock %}
+{% block date_updated %}Data di aggiornamento: {% endblock %}
+
 {% block unedited %}[Inedito]{% endblock %}
 
 {% block author %}Autore{% endblock %}

--- a/src/templates/ja/base.html
+++ b/src/templates/ja/base.html
@@ -83,6 +83,9 @@
 {% block reviewed_and_analyzed_by_after %}によってレビュ と による分析。{% endblock %}
 {% block analysis_and_editing_by_after %}による分析 と 編集。{% endblock %}
 
+{% block date_published %}公開日：{% endblock %}
+{% block date_updated %}更新日：{% endblock %}
+
 {% block unedited %}[未編集]{% endblock %}
 
 {% block author %}著者{% endblock %}

--- a/src/templates/nl/base.html
+++ b/src/templates/nl/base.html
@@ -83,6 +83,9 @@
 {% block reviewed_and_analyzed_by_after %}{% endblock %}
 {% block analysis_and_editing_by_after %}{% endblock %}
 
+{% block date_published %}Publicatiedatum: {% endblock %}
+{% block date_updated %}Datum bijgewerkt: {% endblock %}
+
 {% block unedited %}[Onuitgegeven]{% endblock %}
 
 {% block author %}Auteur{% endblock %}

--- a/src/templates/pt/base.html
+++ b/src/templates/pt/base.html
@@ -83,6 +83,9 @@ Nossa missão é combinar as estatísticas brutas e as tendências do HTTP Archi
 {% block reviewed_and_analyzed_by_after %}{% endblock %}
 {% block analysis_and_editing_by_after %}{% endblock %}
 
+{% block date_published %}Data de publicação:: {% endblock %}
+{% block date_updated %}Data atualizada: {% endblock %}
+
 {% block unedited %}[Não editado]{% endblock %}
 
 {% block author %}Autor(a){% endblock %}

--- a/src/templates/ru/base.html
+++ b/src/templates/ru/base.html
@@ -83,6 +83,9 @@
 {% block reviewed_and_analyzed_by_after %}{% endblock %}
 {% block analysis_and_editing_by_after %}{% endblock %}
 
+{% block date_published %}Дата публикации: {% endblock %}
+{% block date_updated %}Дата обновления: {% endblock %}
+
 {% block unedited %}[Неотредактированная версия]{% endblock %}
 
 {% block author %}Автор{% endblock %}

--- a/src/templates/tr/base.html
+++ b/src/templates/tr/base.html
@@ -83,6 +83,9 @@ Misyonumuz, HTTP Archive&#8217;ın ham istatistiklerini ve eğilimlerini web top
 {% block reviewed_and_analyzed_by_after %}{% endblock %}
 {% block analysis_and_editing_by_after %}{% endblock %}
 
+{% block date_published %}Yayınlanma tarihi: {% endblock %}
+{% block date_updated %}Güncellenme tarihi: {% endblock %}
+
 {% block unedited %}[Düzenlenmiş olan]{% endblock %}
 
 {% block author %}Yazar{% endblock %}

--- a/src/templates/uk/base.html
+++ b/src/templates/uk/base.html
@@ -83,6 +83,9 @@
 {% block reviewed_and_analyzed_by_after %}{% endblock %}
 {% block analysis_and_editing_by_after %}{% endblock %}
 
+{% block date_published %}Дата публікації: {% endblock %}
+{% block date_updated %}Дата оновлення: {% endblock %}
+
 {% block unedited %}[Очікує корегування]{% endblock %}
 
 {% block author %}Автор{% endblock %}

--- a/src/templates/zh-CN/base.html
+++ b/src/templates/zh-CN/base.html
@@ -83,6 +83,9 @@
 {% block reviewed_and_analyzed_by_after %}{% endblock %}
 {% block analysis_and_editing_by_after %}{% endblock %}
 
+{% block date_published %}发布日期：{% endblock %}
+{% block date_updated %}更新日期：{% endblock %}
+
 {% block unedited %}[未编辑]{% endblock %}
 
 {% block author %}作者{% endblock %}

--- a/src/templates/zh-TW/base.html
+++ b/src/templates/zh-TW/base.html
@@ -83,6 +83,9 @@
 {% block reviewed_and_analyzed_by_after %}{% endblock %}
 {% block analysis_and_editing_by_after %}{% endblock %}
 
+{% block date_published %}發布日期：{% endblock %}
+{% block date_updated %}更新日期：{% endblock %}
+
 {% block unedited %}[尚未編輯]{% endblock %}
 
 {% block author %}作者{% endblock %}


### PR DESCRIPTION
Fixes #3001

Did some funky stuff with locals to display the date nicely depending on user locale and chapter language. Let if you think that's overkill.

Staged it so can see examples here:
- English - https://20220713t163920-dot-webalmanac.uk.r.appspot.com/en/2021/seo (should be in US/GB English depending how your machine is set up)
- Japanese - https://20220713t163920-dot-webalmanac.uk.r.appspot.com/ja/2021/seo
- Russian - https://20220713t163920-dot-webalmanac.uk.r.appspot.com/ru/2021/seo

2020 SEO chapter is a longer example with a lot of authors:
- English - https://20220713t163920-dot-webalmanac.uk.r.appspot.com/en/2020/seo
- Spanish - https://20220713t163920-dot-webalmanac.uk.r.appspot.com/es/2020/seo

Also move the dates down, beneath the contributors, in mobile view.

Let me know your thoughts.

Screenshots of desktop, tablet and mobile view:

<img width="960" alt="desktop view" src="https://user-images.githubusercontent.com/10931297/178781466-1a6d144b-9c1f-4f87-8ce8-b4577b4604de.png">

<img width="668" alt="tablet view" src="https://user-images.githubusercontent.com/10931297/178781534-cdab92ed-87d9-4cf0-928f-274f60fd7dd5.png">

<img width="409" alt="mobile view" src="https://user-images.githubusercontent.com/10931297/178781623-2cdb2a1b-e956-4650-b3b9-367c90945e83.png">
