### PR TITLE
Fix search button hamburger menu spacing on zoom

### DIFF
--- a/src/static/css/almanac.css
+++ b/src/static/css/almanac.css
@@ -1075,6 +1075,7 @@ p.copyright a {
 
   .search-nav input {
     min-width: 200px;
+    margin-bottom: 10px;
   }
 
   header nav > ul > li:last-child {


### PR DESCRIPTION
I'm old and have had to up my zoom on my phone 😔

The search button moves to a new line and is too close up:

<img src="https://user-images.githubusercontent.com/10931297/179856873-7bf62cdd-f7a8-4abe-8e2d-38878042b457.png" alt="no breathing space" width="192" height="144">

This PR adds a little more breathing space for this scenario:

<img src="https://user-images.githubusercontent.com/10931297/179857044-ce7becff-e23c-4b3a-970f-8d1d0edef108.png" alt="no breathing space" width="192" height="144">

Testing

