### PR TITLE
Update SQLFluff config to latest

### DIFF
--- a/sql/.sqlfluff
+++ b/sql/.sqlfluff
@@ -1,16 +1,16 @@
 [sqlfluff]
-## verbose is an integer (0-2) indicating the level of log output
+# verbose is an integer (0-2) indicating the level of log output
 verbose = 0
-## Turn off color formatting of output
+# Turn off color formatting of output
 nocolor = False
-## Supported dialects https://docs.sqlfluff.com/en/stable/dialects.html
-## Or run 'sqlfluff dialects'
+# Supported dialects https://docs.sqlfluff.com/en/stable/dialects.html
+# Or run 'sqlfluff dialects'
 dialect = bigquery
-## One of [raw|jinja|python|placeholder]
+# One of [raw|jinja|python|placeholder]
 templater = jinja
-## Comma separated list of rules to check, or None for all
-rules = None
-## Comma separated list of rules to exclude, or None
+# Comma separated list of rules to check, default to all
+rules = all
+# Comma separated list of rules to exclude, or None
 exclude_rules = L011,L014,L016,L020,L022,L026,L027,L028,L029,L030,L031,L032,L034,L035,L036,L037,L042,L043,L051,L060
 # L011 - We don't always alias tables with AS ("FROM table1 AS tb1" instead of "FROM table1 tb1"). Do for columns but not for tables.
 # L014 - Unquoted identifiers (e.g. column names) will be mixed case so don't enforce case
@@ -38,7 +38,11 @@ recurse = 0
 output_line_length = 80
 # Number of passes to run before admitting defeat
 runaway_limit = 10
-# Ignore linting errors in templated sections
+# Ignore errors by category (one or more of the following, separated by commas: lexing,linting,parsing,templating)
+ignore = None
+# Ignore linting errors found within sections of code coming directly from
+# templated code (e.g. from within Jinja curly braces. Note that it does not
+# ignore errors from literal code found within template loops.
 ignore_templated_areas = True
 # can either be autodetect or a valid encoding e.g. utf-8, utf-8-sig
 encoding = autodetect
@@ -47,12 +51,26 @@ disable_noqa = False
 # Comma separated list of file extensions to lint
 # NB: This config will only apply in the root folder
 sql_file_exts = .sql,.sql.j2,.dml,.ddl
-
+# Allow fix to run on files, even if they contain parsing errors
+# Note altering this is NOT RECOMMENDED as can corrupt SQL
+fix_even_unparsable = False
+# Very large files can make the parser effectively hang.
+# This limit skips files over a certain character length
+# and warns the user what has happened.
+# Set this to 0 to disable.
+large_file_skip_char_limit = 40000
+# CPU processes to use while linting.
+# If positive, just implies number of processes.
+# If negative or zero, implies number_of_cpus - specifed_number.
+# e.g. -1 means use all processors but one. 0  means all cpus.
+processes = -1
 
 [sqlfluff:indentation]
-## See https://docs.sqlfluff.com/en/stable/indentation.html
+# See https://docs.sqlfluff.com/en/stable/indentation.html
 indented_joins = False
+indented_ctes = False
 indented_using_on = False
+indented_on_contents = True
 template_blocks_indent = True
 
 [sqlfluff:templater]
@@ -61,15 +79,7 @@ unwrap_wrapped_queries = True
 [sqlfluff:templater:jinja]
 apply_dbt_builtins = True
 
-[sqlfluff:templater:jinja:macros]
-# Macros provided as builtins for dbt projects
-dbt_ref = {% macro ref(model_ref) %}{{model_ref}}{% endmacro %}
-dbt_source = {% macro source(source_name, table) %}{{source_name}}_{{table}}{% endmacro %}
-dbt_config = {% macro config() %}{% for k in kwargs %}{% endfor %}{% endmacro %}
-dbt_var = {% macro var(variable) %}item{% endmacro %}
-dbt_is_incremental = {% macro is_incremental() %}True{% endmacro %}
-
-# Some rules can be configured directly from the config common to other rules.
+# Some rules can be configured directly from the config common to other rules
 [sqlfluff:rules]
 tab_space_size = 2
 max_line_length = 80
@@ -81,7 +91,7 @@ unquoted_identifiers_policy = all
 
 # Some rules have their own specific config.
 [sqlfluff:rules:L003]
-lint_templated_tokens = True
+hanging_indents = True
 
 [sqlfluff:rules:L007]
 operator_new_lines = before
@@ -89,22 +99,91 @@ operator_new_lines = before
 [sqlfluff:rules:L010]
 # Keywords
 capitalisation_policy = upper
+# Comma separated list of words to ignore for this rule
+ignore_words = None
+ignore_words_regex = None
+
+[sqlfluff:rules:L011]
+# Aliasing preference for tables
+aliasing = explicit
 
 [sqlfluff:rules:L012]
 # Aliasing preference for columns
 aliasing = explicit
 
+[sqlfluff:rules:L014]
+# Unquoted identifiers
+extended_capitalisation_policy = consistent
+# Comma separated list of words to ignore for this rule
+ignore_words = None
+ignore_words_regex = None
+
+[sqlfluff:rules:L016]
+# Line length
+ignore_comment_lines = False
+ignore_comment_clauses = False
+
+[sqlfluff:rules:L027]
+# Comma separated list of words to ignore for this rule
+ignore_words = None
+ignore_words_regex = None
+
+[sqlfluff:rules:L026]
+# References must be in FROM clause
+# Disabled for some dialects (e.g. bigquery)
+force_enable = False
+
+[sqlfluff:rules:L028]
+# References must be consistently used
+# Disabled for some dialects (e.g. bigquery)
+force_enable = False
+
+[sqlfluff:rules:L029]
+# Keywords should not be used as identifiers.
+unquoted_identifiers_policy = aliases
+quoted_identifiers_policy = none
+# Comma separated list of words to ignore for this rule
+ignore_words = None
+ignore_words_regex = None
+
+[sqlfluff:rules:L030]
+# Function names
+extended_capitalisation_policy = consistent
+# Comma separated list of words to ignore for this rule
+ignore_words = None
+ignore_words_regex = None
+
+[sqlfluff:rules:L031]
+# Avoid table aliases in from clauses and join conditions.
+# Disabled for some dialects (e.g. bigquery)
+force_enable = False
+
+[sqlfluff:rules:L036]
+wildcard_policy = single
+
 [sqlfluff:rules:L038]
+# Trailing commas
 select_clause_trailing_comma = forbid
 
 [sqlfluff:rules:L040]
 # Null & Boolean Literals
 capitalisation_policy = consistent
+# Comma separated list of words to ignore for this rule
+ignore_words = None
+ignore_words_regex = None
+
+[sqlfluff:rules:L042]
+# By default, allow subqueries in from clauses, but not join clauses
+forbid_subquery_in = join
 
 [sqlfluff:rules:L047]
 # Consistent syntax to count all rows
 prefer_count_1 = False
 prefer_count_0 = True
+
+[sqlfluff:rules:L051]
+# Fully qualify JOIN clause
+fully_qualify_join_types = inner
 
 [sqlfluff:rules:L052]
 # Semi-colon formatting approach
@@ -121,6 +200,15 @@ unquoted_identifiers_policy = all
 quoted_identifiers_policy = all
 allow_space_in_identifier = False
 additional_allowed_characters = "-."
+ignore_words = None
+ignore_words_regex = None
+
+[sqlfluff:rules:L059]
+# Policy on quoted and unquoted identifiers
+prefer_quoted_identifiers = False
+ignore_words = None
+ignore_words_regex = None
+force_enable = False
 
 [sqlfluff:rules:L062]
 # Comma separated list of blocked words that should not be used
@@ -138,9 +226,14 @@ blocked_regex = (2022_?05_?12|2022_?06_?09|2022_?07_?01|2021_?06_?01)
 extended_capitalisation_policy = upper
 # Comma separated list of words to ignore for this rule
 ignore_words = None
+ignore_words_regex = None
 
 [sqlfluff:rules:L064]
 # Consistent usage of preferred quotes for quoted literals
 preferred_quoted_literal_style = single_quotes
 # Disabled for dialects that do not support single and double quotes for quoted literals (e.g. Postgres)
 force_enable = False
+
+[sqlfluff:rules:L066]
+min_alias_length = None
+max_alias_length = None


### PR DESCRIPTION
This updates the SQLFluff config to the latest config, and also changes one default setting (`large_file_skip_char_limit`) needed to allow our SQL to validate. This will be needed when SQLFluff 1.2.2 is release.