### PR TITLE
Prevent Werkzeug 2.2.0 being used

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -5,3 +5,4 @@ pytest==7.1.2
 pytest-watch==4.2.0
 pytest-cov==3.0.0
 sqlfluff==1.2.1
+Werkzeug!=2.2.0


### PR DESCRIPTION
Added a line to requirements.txt to prevent use of Werkzeug 2.2.0 which has a bug causing our tests to fail: https://github.com/pallets/werkzeug/pull/2468