### PR TITLE
Fix default python date format

### DIFF
--- a/src/server/helpers.py
+++ b/src/server/helpers.py
@@ -279,7 +279,7 @@ def accentless_sort(value):
 def get_file_date_info(file, type):
     timestamps_config = get_timestamps_config()
     # Default Published and Last Updated to today
-    today = datetime.datetime.utcnow().isoformat()
+    today = datetime.datetime.utcnow().isoformat(timespec='milliseconds')
     if type == "date_published" or type == "date_modified":
         return timestamps_config.get(file, {}).get(type, today)
     else:


### PR DESCRIPTION
When a chapter doesn't have a data in our config (shouldn't happen for releases) we default the date. We currently default to a date format that currently fails HTML validation. This fixes that.

Doesn't really impact anything as correct date is created in JavaScript as part of release process but noticed it when reviewing a new translation