### PR TITLE
Fix SQL query link for 2021 accessibility "Language identification"

### DIFF
--- a/src/content/en/2021/accessibility.md
+++ b/src/content/en/2021/accessibility.md
@@ -108,7 +108,7 @@ When we consider the most popular sites in particular, the numbers for mobile ar
   content="80.5%",
   classes="big-number",
   sheets_gid="2009310389",
-  sql_file="common_html_lang_attrib.sql"
+  sql_file="valid_html_lang.sql"
 )
 }}
 

--- a/src/content/ja/2021/accessibility.md
+++ b/src/content/ja/2021/accessibility.md
@@ -108,7 +108,7 @@ Webアクセシビリティの重要な要素として、コンテンツを可�
   content="80.5%",
   classes="big-number",
   sheets_gid="2009310389",
-  sql_file="common_html_lang_attrib.sql"
+  sql_file="valid_html_lang.sql"
 )
 }}
 


### PR DESCRIPTION
Similar to #3039 / #3040. This time the sheet link is correct, but the SQL query isn’t.

- Section: https://almanac.httparchive.org/en/2021/accessibility#language-identification
- Sheet: https://docs.google.com/spreadsheets/d/1WjAM5ZnHjMQt-rKyHvj2eVhU_WdzzFTjpoYWMr_I0Cw/edit#gid=2009310389
- SQL file: https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2021/accessibility/valid_html_lang.sql