### PR TITLE
Add missing SQL file link for 2021 accessibility Heading hierarchy score

### DIFF
--- a/src/content/en/2021/accessibility.md
+++ b/src/content/en/2021/accessibility.md
@@ -301,7 +301,7 @@ Headings make it easier for screen readers to properly navigate a page by supply
   content="58%",
   classes="big-number",
   sheets_gid="461215072",
-  sql_file="???"
+  sql_file="lighthouse_a11y_audits.sql"
 )
 }}
 

--- a/src/content/ja/2021/accessibility.md
+++ b/src/content/ja/2021/accessibility.md
@@ -301,7 +301,7 @@ HTML5導入以前は、これを実現するためにARIAのランドマーク�
   content="58%",
   classes="big-number",
   sheets_gid="461215072",
-  sql_file="???"
+  sql_file="lighthouse_a11y_audits.sql"
 )
 }}
 


### PR DESCRIPTION
The query does exist, I was able to find it based on the naming of the file and columns.

- Sheet (with link to the exact cell in use): https://docs.google.com/spreadsheets/d/1WjAM5ZnHjMQt-rKyHvj2eVhU_WdzzFTjpoYWMr_I0Cw/edit#gid=461215072&range=E22
- SQL file: https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2021/accessibility/lighthouse_a11y_audits.sql