### PR TITLE
Fix inversion of mobile and desktop numbers for anchors_with_role_button in Accessibility 2021 chapter

### DIFF
--- a/src/content/en/2021/accessibility.md
+++ b/src/content/en/2021/accessibility.md
@@ -626,14 +626,14 @@ When a button role is applied to an `<a>` element, it overrides the implicit lin
 
 {{ figure_markup(
   caption="Desktop websites have at least one link with a button role",
-  content="17.5%",
+  content="18.6%",
   classes="big-number",
   sheets_gid="1014817325",
   sql_file="anchors_with_role_button.sql"
 )
 }}
 
-We found that 18% of desktop pages (up from 16% in 2020) and 19% (up from 15% in 2020) of mobile pages contained at least one anchor element with `role="button"`. A native `<button>` element would be a better choice, <a hreflang="en" href="https://www.w3.org/TR/using-aria/#rule1">per the first rule of ARIA</a>.
+We found that 19% of desktop pages (up from 16% in 2020) and 18% (up from 15% in 2020) of mobile pages contained at least one anchor element with `role="button"`. A native `<button>` element would be a better choice, <a hreflang="en" href="https://www.w3.org/TR/using-aria/#rule1">per the first rule of ARIA</a>.
 
 This act of adding ARIA roles, or a <a hreflang="en" href="https://adrianroselli.com/2020/02/role-up.html">"role-up"</a>, is usually less ideal than using the correct native HTML element. Again, in the vast majority of these cases a better pattern than explicitly defining `role="button"` on the element in question would be to leverage the native HTML `<button>` element, as it comes with the expected semantics and behavior.
 

--- a/src/content/ja/2021/accessibility.md
+++ b/src/content/ja/2021/accessibility.md
@@ -626,14 +626,14 @@ ARIAロールのもっとも一般的な誤用の1つは、 `<div>`や `<span>`�
 
 {{ figure_markup(
   caption="デスクトップのWebサイトには、少なくとも1つのボタンの役割を持つリンクがあります。",
-  content="17.5%",
+  content="18.6%",
   classes="big-number",
   sheets_gid="1014817325",
   sql_file="anchors_with_role_button.sql"
 )
 }}
 
-デスクトップページの18％（2020年の16％から増加）、モバイルページの19％（2020年の15％から増加）に `role="button"` のアンカー要素が少なくとも1つ含まれていることがわかりました。ネイティブの `<button>` 要素の方が、<a hreflang="en" href="https://www.w3.org/TR/using-aria/#rule1">ARIAの最初の規則</a>にしたがって、より良い選択でしょう。
+デスクトップページの19％（2020年の16％から増加）、モバイルページの18％（2020年の15％から増加）に `role="button"` のアンカー要素が少なくとも1つ含まれていることがわかりました。ネイティブの `<button>` 要素の方が、<a hreflang="en" href="https://www.w3.org/TR/using-aria/#rule1">ARIAの最初の規則</a>にしたがって、より良い選択でしょう。
 
 このARIAロールを追加する行為、つまり<a hreflang="en" href="https://adrianroselli.com/2020/02/role-up.html">"role-up"</a>は、通常、正しいネイティブHTML要素を使用するより理想的ではありません。繰り返しますが、これらのケースの大部分では、問題の要素に明示的に `role="button"` を定義するよりも、ネイティブのHTML`<button>` 要素を活用する方が良いパターンでしょう。
 


### PR DESCRIPTION
In the [Just use a button!](https://almanac.httparchive.org/en/2021/accessibility#just-use-a-button) section, one set of numbers has the mobile and desktop figures interverted.

- On the figure: _17.5% Desktop websites have at least one link with a button role_  – on the corresponding sheet, the Desktop figure is [18.6%](https://docs.google.com/spreadsheets/d/1WjAM5ZnHjMQt-rKyHvj2eVhU_WdzzFTjpoYWMr_I0Cw/edit#gid=1014817325&range=D3). It’s the mobile figure that’s 17.5%.
- In the text, _We found that [18% of desktop pages (up from 16% in 2020) and 19% (up from 15% in 2020) of mobile pages](https://almanac.httparchive.org/en/2021/accessibility#just-use-a-button:~:text=18%25%20of%20desktop%20pages%20(up%20from%2016%25%20in%202020)%20and%2019%25%20(up%20from%2015%25%20in%202020)%20of%20mobile%20pages)_ - the 2021 numbers are also inverted (they’re rounding ups of the same figures).

I chose to swap the numbers rather than the labels, as I assume the choice of which type of site to showcase was intentional. Also makes it easier to update the Japanese translation!

---

- [2021 sheet](https://docs.google.com/spreadsheets/d/1WjAM5ZnHjMQt-rKyHvj2eVhU_WdzzFTjpoYWMr_I0Cw/edit#gid=1014817325)
- [2020 sheet](https://docs.google.com/spreadsheets/d/1UjEBhq0TfYxUpdpq5IuxjeHB4yqhJq4NOKEd6Dwwrdk/edit#gid=2037683008) for reference (the numbers are correct [in the 2020 chapter](https://almanac.httparchive.org/en/2020/accessibility#just-use-a-button:~:text=15.50%25%20of%20desktop%20pages%20and%2014.62%25%20of%20mobile%20pages), and also as they’re referenced in 2021’s.