### PR TITLE
Hide methodology from ebook if not translated

### DIFF
--- a/src/templates/base/base_ebook.html
+++ b/src/templates/base/base_ebook.html
@@ -308,9 +308,11 @@
       <div class="part">
         <h2 class="part-name">{{ self.appendices() }}</h2>
         <div class="toc-chapters">
+          {% if get_ebook_methodology(lang,year) %}
           <div class="toc-chapter">
             <a href="#methodology">{{ self.methodology_title() }}</a>
           </div>
+          {% endif %}
           <div class="toc-chapter">
             <a href="#contributors">{{ self.contributors_title() }}</a>
           </div>
@@ -328,10 +330,12 @@
 
   {{ self.chapters() }}
 
+  {% if get_ebook_methodology(lang,year) %}
   <section class="chapter" id="methodology">
     <div class="subtitle">{{ self.appendix() }} A</div>
     {{ get_ebook_methodology(lang,year) | safe }}
   </section>
+  {% endif %}
 
   <section class="chapter" id="contributors">
     <div class="subtitle">{{ self.appendix() }} B</div>


### PR DESCRIPTION
The 2021 Japanese Ebook has been switched on, but the methodology does not exist yet leaving a weird `False` line in it:

<img width="615" alt="image" src="https://user-images.githubusercontent.com/10931297/183387136-ab07fdd0-9396-4a8e-8ece-553fb73ed9d9.png">

This PR hides this Appendix from the ebook until it is translated.