### PR TITLE
Add client to PWA Lighthouse audit report

### DIFF
--- a/sql/2022/pwa/lighthouse_pwa_audits.sql
+++ b/sql/2022/pwa/lighthouse_pwa_audits.sql
@@ -20,6 +20,7 @@ return results;
 ''';
 
 SELECT
+  _TABLE_SUFFIX AS client,
   'PWA Sites' AS type,
   audits.id AS id,
   COUNTIF(audits.score > 0) AS num_pages,
@@ -30,23 +31,26 @@ SELECT
   MAX(audits.audit_group) AS audit_group,
   MAX(audits.description) AS description
 FROM
-  `httparchive.lighthouse.2022_06_01_mobile`,
+  `httparchive.lighthouse.2022_06_01_*`,
   UNNEST(getAudits(JSON_EXTRACT(report, '$.categories.pwa.auditRefs'), JSON_EXTRACT(report, '$.audits'))) AS audits
 JOIN
   (
     SELECT
+      _TABLE_SUFFIX,
       url
     FROM
-      `httparchive.pages.2022_06_01_mobile`
+      `httparchive.pages.2022_06_01_*`
     WHERE
       JSON_EXTRACT(payload, '$._pwa.serviceWorkerHeuristic') = 'true' AND
       JSON_EXTRACT(payload, '$._pwa.manifests') != '[]' AND JSON_EXTRACT(payload, '$._pwa.manifests') != '{}'
   )
-USING (url)
+USING (_TABLE_SUFFIX, url)
 GROUP BY
+  client,
   audits.id
 UNION ALL
 SELECT
+  _TABLE_SUFFIX AS client,
   'ALL Sites' AS type,
   audits.id AS id,
   COUNTIF(audits.score > 0) AS num_pages,
@@ -57,11 +61,13 @@ SELECT
   MAX(audits.audit_group) AS audit_group,
   MAX(audits.description) AS description
 FROM
-  `httparchive.lighthouse.2022_06_01_mobile`,
+  `httparchive.lighthouse.2022_06_01_*`,
   UNNEST(getAudits(JSON_EXTRACT(report, '$.categories.pwa.auditRefs'), JSON_EXTRACT(report, '$.audits'))) AS audits
 GROUP BY
+  client,
   audits.id
 ORDER BY
+  client,
   type DESC,
   median_weight DESC,
   id

--- a/sql/2022/pwa/lighthouse_pwa_score.sql
+++ b/sql/2022/pwa/lighthouse_pwa_score.sql
@@ -49,6 +49,7 @@ GROUP BY
   date,
   percentile
 ORDER BY
+  client,
   date,
-  type DESC,
+  type,
   percentile


### PR DESCRIPTION
Makes progress on #2895 

A follow on from the fix I did in [a recent linter upgrade](https://github.com/HTTPArchive/almanac.httparchive.org/pull/3035/files#diff-e1837ce5af87b04fed2cae9ea542561edef9f056b4db0d451b6d6e6b96b0358b) where I noticed the wrong date had been used, and also added the desktop data. This PR adds the desktop data to the other Lighthouse report that I missed at that time.

Data has been updated in the Sheet already:
- Audits - https://docs.google.com/spreadsheets/d/1PbzjhN--jU9MGuWobw5L9EsmlVzI9tlbCe3_NKA7giU/edit#gid=2095859911
- Score - https://docs.google.com/spreadsheets/d/1PbzjhN--jU9MGuWobw5L9EsmlVzI9tlbCe3_NKA7giU/edit#gid=674035010