### PR TITLE
Accessibility 2022 queries

### DIFF
--- a/sql/2022/accessibility/README.md
+++ b/sql/2022/accessibility/README.md
@@ -1,13 +1,15 @@
 # 2022 Accessibility queries
 
-<!--
-  This directory contains all of the 2022 Accessibility chapter queries.
+The majority of 2022 accessibility queries here copies from the [2021 accessibility queries](https://github.com/HTTPArchive/almanac.httparchive.org/tree/main/sql/2021/accessibility), with a few exceptions copied from other chapters:
 
-  Each query should have a corresponding `metric_name.sql` file.
-  Note that readers are linked to this directory, so try to make the SQL file names descriptive for easy browsing.
+- From CSS 2022: `units_properties.sql`
+- From CSS 2022: `media_query_features.sql`
+- From CSS 2021: `focus_visible.sql` (with minor perf-related change)
+- From CSS 2021: `focus_outline_0.sql` (note this doesn’t include the 2021 variant `focus_outline_0_or_none.sql`, which didn’t make it to the published report)
+- From Mobile Web 2022: `viewport_zoom_scale.sql` (already copied in 2021 queries)
+- From Mobile Web 2022: `viewport_zoom_scale_by_domain_rank.sql`
 
-  Analysts: if helpful, you can use this README to give additional info about the queries.
--->
+Note out of the 44 2021 accessibility queries, we only copied the two thirds that were used in the published report.
 
 ## Resources
 

--- a/sql/2022/accessibility/a11y_overall_tech_usage_by_domain_rank.sql
+++ b/sql/2022/accessibility/a11y_overall_tech_usage_by_domain_rank.sql
@@ -1,0 +1,50 @@
+#standardSQL
+# Overall A11Y technology usage by domain rank
+SELECT
+  client,
+  rank_grouping,
+  total_in_rank,
+
+  COUNT(DISTINCT url) AS sites_with_a11y_tech,
+  COUNT(DISTINCT url) / total_in_rank AS pct_sites_with_a11y_tech
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    url
+  FROM
+    `httparchive.technologies.2021_07_01_*`
+  WHERE
+    category = 'Accessibility'
+)
+LEFT OUTER JOIN (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    url,
+    rank_grouping
+  FROM
+    `httparchive.summary_pages.2021_07_01_*`,
+    UNNEST([1000, 10000, 100000, 1000000, 10000000]) AS rank_grouping
+  WHERE
+    rank <= rank_grouping
+) USING (client, url)
+JOIN (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    rank_grouping,
+    COUNT(0) AS total_in_rank
+  FROM
+    `httparchive.summary_pages.2021_07_01_*`,
+    UNNEST([1000, 10000, 100000, 1000000, 10000000]) AS rank_grouping
+  WHERE
+    rank <= rank_grouping
+  GROUP BY
+    client,
+    rank_grouping
+) USING (client, rank_grouping)
+GROUP BY
+  rank_grouping,
+  total_in_rank,
+  client
+ORDER BY
+  client,
+  rank_grouping

--- a/sql/2022/accessibility/a11y_overall_tech_usage_by_domain_rank.sql
+++ b/sql/2022/accessibility/a11y_overall_tech_usage_by_domain_rank.sql
@@ -12,7 +12,7 @@ FROM (
     _TABLE_SUFFIX AS client,
     url
   FROM
-    `httparchive.technologies.2021_07_01_*`
+    `httparchive.technologies.2022_06_01_*`
   WHERE
     category = 'Accessibility'
 )
@@ -22,7 +22,7 @@ LEFT OUTER JOIN (
     url,
     rank_grouping
   FROM
-    `httparchive.summary_pages.2021_07_01_*`,
+    `httparchive.summary_pages.2022_06_01_*`,
     UNNEST([1000, 10000, 100000, 1000000, 10000000]) AS rank_grouping
   WHERE
     rank <= rank_grouping
@@ -33,7 +33,7 @@ JOIN (
     rank_grouping,
     COUNT(0) AS total_in_rank
   FROM
-    `httparchive.summary_pages.2021_07_01_*`,
+    `httparchive.summary_pages.2022_06_01_*`,
     UNNEST([1000, 10000, 100000, 1000000, 10000000]) AS rank_grouping
   WHERE
     rank <= rank_grouping

--- a/sql/2022/accessibility/a11y_technology_usage.sql
+++ b/sql/2022/accessibility/a11y_technology_usage.sql
@@ -1,0 +1,28 @@
+#standardSQL
+# A11Y technology usage
+SELECT
+  client,
+  total_sites,
+  sites_with_a11y_tech,
+  sites_with_a11y_tech / total_sites AS perc_sites_with_a11y_tech
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    COUNT(DISTINCT url) AS sites_with_a11y_tech
+  FROM
+    `httparchive.technologies.2021_07_01_*`
+  WHERE
+    category = 'Accessibility'
+  GROUP BY
+    client
+)
+JOIN (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    COUNT(0) AS total_sites
+  FROM
+    `httparchive.summary_pages.2021_07_01_*`
+  GROUP BY
+    client
+)
+USING (client)

--- a/sql/2022/accessibility/a11y_technology_usage.sql
+++ b/sql/2022/accessibility/a11y_technology_usage.sql
@@ -10,7 +10,7 @@ FROM (
     _TABLE_SUFFIX AS client,
     COUNT(DISTINCT url) AS sites_with_a11y_tech
   FROM
-    `httparchive.technologies.2021_07_01_*`
+    `httparchive.technologies.2022_06_01_*`
   WHERE
     category = 'Accessibility'
   GROUP BY
@@ -21,7 +21,7 @@ JOIN (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_sites
   FROM
-    `httparchive.summary_pages.2021_07_01_*`
+    `httparchive.summary_pages.2022_06_01_*`
   GROUP BY
     client
 )

--- a/sql/2022/accessibility/a11y_technology_usage_by_domain_rank.sql
+++ b/sql/2022/accessibility/a11y_technology_usage_by_domain_rank.sql
@@ -1,0 +1,54 @@
+#standardSQL
+# A11Y technology usage by domain rank
+SELECT
+  client,
+  rank_grouping,
+  total_in_rank,
+
+  app,
+  COUNT(0) AS sites_with_app,
+  COUNT(0) / total_in_rank AS pct_sites_with_app
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    app,
+    url
+  FROM
+    `httparchive.technologies.2021_07_01_*`
+  WHERE
+    category = 'Accessibility'
+)
+LEFT OUTER JOIN (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    url,
+    rank_grouping
+  FROM
+    `httparchive.summary_pages.2021_07_01_*`,
+    UNNEST([1000, 10000, 100000, 1000000, 10000000]) AS rank_grouping
+  WHERE
+    rank <= rank_grouping
+) USING (client, url)
+JOIN (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    rank_grouping,
+    COUNT(0) AS total_in_rank
+  FROM
+    `httparchive.summary_pages.2021_07_01_*`,
+    UNNEST([1000, 10000, 100000, 1000000, 10000000]) AS rank_grouping
+  WHERE
+    rank <= rank_grouping
+  GROUP BY
+    client,
+    rank_grouping
+) USING (client, rank_grouping)
+GROUP BY
+  rank_grouping,
+  total_in_rank,
+  client,
+  app
+ORDER BY
+  app,
+  rank_grouping,
+  client

--- a/sql/2022/accessibility/a11y_technology_usage_by_domain_rank.sql
+++ b/sql/2022/accessibility/a11y_technology_usage_by_domain_rank.sql
@@ -14,7 +14,7 @@ FROM (
     app,
     url
   FROM
-    `httparchive.technologies.2021_07_01_*`
+    `httparchive.technologies.2022_06_01_*`
   WHERE
     category = 'Accessibility'
 )
@@ -24,7 +24,7 @@ LEFT OUTER JOIN (
     url,
     rank_grouping
   FROM
-    `httparchive.summary_pages.2021_07_01_*`,
+    `httparchive.summary_pages.2022_06_01_*`,
     UNNEST([1000, 10000, 100000, 1000000, 10000000]) AS rank_grouping
   WHERE
     rank <= rank_grouping
@@ -35,7 +35,7 @@ JOIN (
     rank_grouping,
     COUNT(0) AS total_in_rank
   FROM
-    `httparchive.summary_pages.2021_07_01_*`,
+    `httparchive.summary_pages.2022_06_01_*`,
     UNNEST([1000, 10000, 100000, 1000000, 10000000]) AS rank_grouping
   WHERE
     rank <= rank_grouping

--- a/sql/2022/accessibility/alt_ending_in_image_extension.sql
+++ b/sql/2022/accessibility/alt_ending_in_image_extension.sql
@@ -1,0 +1,67 @@
+#standardSQL
+# Alt text ending in an image extension
+CREATE TEMPORARY FUNCTION getUsedExtensions(payload STRING)
+RETURNS ARRAY<STRUCT<extension STRING, total INT64>> LANGUAGE js AS '''
+try {
+  const a11y = JSON.parse(payload);
+
+  return Object.entries(a11y.file_extension_alts.file_extensions).map(([extension, total]) => {
+    return {extension, total};
+  });
+} catch (e) {
+  return [];
+}
+''';
+SELECT
+  client,
+  sites_with_non_empty_alt,
+  sites_with_file_extension_alt,
+  total_alts_with_file_extensions,
+
+  # Of sites with a non-empty alt, what % have an alt with a file extension
+  sites_with_file_extension_alt / sites_with_non_empty_alt AS pct_sites_with_file_extension_alt,
+  # Given a random alt, how often will it end in a file extension
+  total_alts_with_file_extensions / total_non_empty_alts AS pct_alts_with_file_extension,
+
+  extension_stat.extension AS extension,
+  COUNT(0) AS total_sites_using,
+  # Of sites with a non-empty alt, what % have an alt with this file extension
+  COUNT(0) / sites_with_non_empty_alt AS pct_applicable_sites_using,
+
+  # Of sites with a non-empty alt, what % have an alt with this file extension
+  SUM(extension_stat.total) AS total_occurances,
+  # Given a random alt ending in a file extension, how often will it end in this file extension
+  SUM(extension_stat.total) / total_alts_with_file_extensions AS pct_total_occurances
+FROM
+  `httparchive.pages.2021_07_01_*`,
+  UNNEST(getUsedExtensions(JSON_EXTRACT_SCALAR(payload, '$._a11y'))) AS extension_stat
+LEFT JOIN (
+  SELECT
+    client,
+    COUNTIF(total_non_empty_alt > 0) AS sites_with_non_empty_alt,
+    COUNTIF(total_with_file_extension > 0) AS sites_with_file_extension_alt,
+
+    SUM(total_non_empty_alt) AS total_non_empty_alts,
+    SUM(total_with_file_extension) AS total_alts_with_file_extensions
+  FROM (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._markup'), '$.images.img.alt.present') AS INT64) AS total_non_empty_alt,
+      CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._a11y'), '$.file_extension_alts.total_with_file_extension') AS INT64) AS total_with_file_extension
+    FROM
+      `httparchive.pages.2021_07_01_*`
+  )
+  GROUP BY
+    client
+)
+ON (_TABLE_SUFFIX = client)
+GROUP BY
+  client,
+  sites_with_non_empty_alt,
+  sites_with_file_extension_alt,
+  total_non_empty_alts,
+  total_alts_with_file_extensions,
+  extension
+ORDER BY
+  client,
+  total_occurances DESC

--- a/sql/2022/accessibility/alt_ending_in_image_extension.sql
+++ b/sql/2022/accessibility/alt_ending_in_image_extension.sql
@@ -33,7 +33,7 @@ SELECT
   # Given a random alt ending in a file extension, how often will it end in this file extension
   SUM(extension_stat.total) / total_alts_with_file_extensions AS pct_total_occurances
 FROM
-  `httparchive.pages.2021_07_01_*`,
+  `httparchive.pages.2022_06_01_*`,
   UNNEST(getUsedExtensions(JSON_EXTRACT_SCALAR(payload, '$._a11y'))) AS extension_stat
 LEFT JOIN (
   SELECT
@@ -49,7 +49,7 @@ LEFT JOIN (
       CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._markup'), '$.images.img.alt.present') AS INT64) AS total_non_empty_alt,
       CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._a11y'), '$.file_extension_alts.total_with_file_extension') AS INT64) AS total_with_file_extension
     FROM
-      `httparchive.pages.2021_07_01_*`
+      `httparchive.pages.2022_06_01_*`
   )
   GROUP BY
     client

--- a/sql/2022/accessibility/anchors_with_role_button.sql
+++ b/sql/2022/accessibility/anchors_with_role_button.sql
@@ -1,0 +1,19 @@
+#standardSQL
+# Anchors with role='button'
+SELECT
+  client,
+  COUNTIF(total_anchors > 0) AS sites_with_anchors,
+  COUNTIF(total_anchors_with_role_button > 0) AS sites_with_anchor_role_button,
+
+  # Of sites that have anchors... how many have an anchor with a role='button'
+  COUNTIF(total_anchors_with_role_button > 0) / COUNTIF(total_anchors > 0) AS pct_sites_with_anchor_role_button
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._a11y'), '$.total_anchors_with_role_button') AS INT64) AS total_anchors_with_role_button,
+    IFNULL(CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._element_count'), '$.a') AS INT64), 0) AS total_anchors
+  FROM
+    `httparchive.pages.2021_07_01_*`
+)
+GROUP BY
+  client

--- a/sql/2022/accessibility/anchors_with_role_button.sql
+++ b/sql/2022/accessibility/anchors_with_role_button.sql
@@ -13,7 +13,7 @@ FROM (
     CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._a11y'), '$.total_anchors_with_role_button') AS INT64) AS total_anchors_with_role_button,
     IFNULL(CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._element_count'), '$.a') AS INT64), 0) AS total_anchors
   FROM
-    `httparchive.pages.2021_07_01_*`
+    `httparchive.pages.2022_06_01_*`
 )
 GROUP BY
   client

--- a/sql/2022/accessibility/audio_track_usage.sql
+++ b/sql/2022/accessibility/audio_track_usage.sql
@@ -1,0 +1,21 @@
+#standardSQL
+# Audio elements track usage
+SELECT
+  client,
+  COUNT(0) AS total_sites,
+  COUNTIF(total_audios > 0) AS total_with_audio,
+  COUNTIF(total_with_track > 0) AS total_with_tracks,
+
+  SUM(total_with_track) / SUM(total_audios) AS pct_audios_with_tracks,
+  COUNTIF(total_audios > 0) / COUNT(0) AS pct_sites_with_audios,
+  COUNTIF(total_with_track > 0) / COUNTIF(total_audios > 0) AS pct_audio_sites_with_tracks
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._almanac'), '$.audios.total') AS INT64) AS total_audios,
+    CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._almanac'), '$.audios.total_with_track') AS INT64) AS total_with_track
+  FROM
+    `httparchive.pages.2021_07_01_*`
+)
+GROUP BY
+  client

--- a/sql/2022/accessibility/audio_track_usage.sql
+++ b/sql/2022/accessibility/audio_track_usage.sql
@@ -15,7 +15,7 @@ FROM (
     CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._almanac'), '$.audios.total') AS INT64) AS total_audios,
     CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._almanac'), '$.audios.total_with_track') AS INT64) AS total_with_track
   FROM
-    `httparchive.pages.2021_07_01_*`
+    `httparchive.pages.2022_06_01_*`
 )
 GROUP BY
   client

--- a/sql/2022/accessibility/button_name_sources.sql
+++ b/sql/2022/accessibility/button_name_sources.sql
@@ -1,0 +1,68 @@
+#standardSQL
+# Where button elements get their A11Y names from
+CREATE TEMPORARY FUNCTION a11yButtonNameSources(payload STRING)
+RETURNS ARRAY<STRING> LANGUAGE js AS '''
+  try {
+    const a11y = JSON.parse(payload);
+
+    const accessible_name_sources = [];
+    for (const tree_node of a11y.form_control_a11y_tree) {
+      const is_button_type = tree_node.type === "button";
+      const is_submit_input = tree_node.type === "input" && tree_node.attributes.type === "submit";
+      if (!is_button_type && !is_submit_input) {
+        continue;
+      }
+
+      if (tree_node.accessible_name.length === 0) {
+        // No A11Y name given
+        accessible_name_sources.push("No accessible name");
+        continue;
+      }
+
+      if (tree_node.accessible_name_sources.length <= 0) {
+        continue;
+      }
+
+      const name_source = tree_node.accessible_name_sources[0];
+      let pretty_name_source = name_source.type;
+      if (name_source.type === "attribute") {
+        pretty_name_source = `${name_source.type}: ${name_source.attribute}`;
+      } else if (name_source.type === "relatedElement") {
+        if (name_source.attribute) {
+          pretty_name_source = `${name_source.type}: ${name_source.attribute}`;
+        } else {
+          pretty_name_source = `${name_source.type}: label`;
+        }
+      }
+
+      accessible_name_sources.push(pretty_name_source);
+    }
+
+    return accessible_name_sources;
+  } catch (e) {
+    return [];
+  }
+''';
+
+SELECT
+  client,
+  SUM(COUNT(0)) OVER (PARTITION BY client) AS total_buttons,
+
+  button_name_source,
+  COUNT(0) AS total_with_this_source,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS perc_of_all_buttons
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    button_name_source
+  FROM
+    `httparchive.pages.2021_07_01_*`,
+    UNNEST(
+      a11yButtonNameSources(JSON_EXTRACT_SCALAR(payload, '$._a11y'))
+    ) AS button_name_source
+)
+GROUP BY
+  client,
+  button_name_source
+ORDER BY
+  perc_of_all_buttons DESC

--- a/sql/2022/accessibility/button_name_sources.sql
+++ b/sql/2022/accessibility/button_name_sources.sql
@@ -56,7 +56,7 @@ FROM (
     _TABLE_SUFFIX AS client,
     button_name_source
   FROM
-    `httparchive.pages.2021_07_01_*`,
+    `httparchive.pages.2022_06_01_*`,
     UNNEST(
       a11yButtonNameSources(JSON_EXTRACT_SCALAR(payload, '$._a11y'))
     ) AS button_name_source

--- a/sql/2022/accessibility/captcha_usage.sql
+++ b/sql/2022/accessibility/captcha_usage.sql
@@ -1,0 +1,28 @@
+#standardSQL
+# Captcha usage
+SELECT
+  client,
+  total_sites,
+  sites_with_captcha,
+  sites_with_captcha / total_sites AS perc_sites_with_captcha
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    COUNT(DISTINCT url) AS sites_with_captcha
+  FROM
+    `httparchive.technologies.2021_07_01_*`
+  WHERE
+    app = 'reCAPTCHA' OR app = 'hCaptcha'
+  GROUP BY
+    client
+)
+JOIN (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    COUNT(0) AS total_sites
+  FROM
+    `httparchive.summary_pages.2021_07_01_*`
+  GROUP BY
+    client
+)
+USING (client)

--- a/sql/2022/accessibility/captcha_usage.sql
+++ b/sql/2022/accessibility/captcha_usage.sql
@@ -10,7 +10,7 @@ FROM (
     _TABLE_SUFFIX AS client,
     COUNT(DISTINCT url) AS sites_with_captcha
   FROM
-    `httparchive.technologies.2021_07_01_*`
+    `httparchive.technologies.2022_06_01_*`
   WHERE
     app = 'reCAPTCHA' OR app = 'hCaptcha'
   GROUP BY
@@ -21,7 +21,7 @@ JOIN (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_sites
   FROM
-    `httparchive.summary_pages.2021_07_01_*`
+    `httparchive.summary_pages.2022_06_01_*`
   GROUP BY
     client
 )

--- a/sql/2022/accessibility/color_contrast.sql
+++ b/sql/2022/accessibility/color_contrast.sql
@@ -1,0 +1,12 @@
+#standardSQL
+# % mobile sites with sufficient text color contrast with its background
+SELECT
+  COUNTIF(color_contrast_score IS NOT NULL) AS total_applicable,
+  COUNTIF(CAST(color_contrast_score AS NUMERIC) = 1) AS total_good_contrast,
+  COUNTIF(CAST(color_contrast_score AS NUMERIC) = 1) / COUNTIF(color_contrast_score IS NOT NULL) AS perc_good_contrast
+FROM (
+  SELECT
+    JSON_EXTRACT_SCALAR(report, '$.audits.color-contrast.score') AS color_contrast_score
+  FROM
+    `httparchive.lighthouse.2021_07_01_mobile`
+)

--- a/sql/2022/accessibility/color_contrast.sql
+++ b/sql/2022/accessibility/color_contrast.sql
@@ -1,12 +1,18 @@
 #standardSQL
-# % mobile sites with sufficient text color contrast with its background
+# % of pages with sufficient text color contrast with its background
 SELECT
+  client,
   COUNTIF(color_contrast_score IS NOT NULL) AS total_applicable,
   COUNTIF(CAST(color_contrast_score AS NUMERIC) = 1) AS total_good_contrast,
   COUNTIF(CAST(color_contrast_score AS NUMERIC) = 1) / COUNTIF(color_contrast_score IS NOT NULL) AS perc_good_contrast
 FROM (
   SELECT
+    _TABLE_SUFFIX AS client,
     JSON_EXTRACT_SCALAR(report, '$.audits.color-contrast.score') AS color_contrast_score
   FROM
-    `httparchive.lighthouse.2022_06_01_mobile`
+    `httparchive.lighthouse.2022_06_01_*`
 )
+GROUP BY
+  client
+ORDER BY
+  client

--- a/sql/2022/accessibility/color_contrast.sql
+++ b/sql/2022/accessibility/color_contrast.sql
@@ -8,5 +8,5 @@ FROM (
   SELECT
     JSON_EXTRACT_SCALAR(report, '$.audits.color-contrast.score') AS color_contrast_score
   FROM
-    `httparchive.lighthouse.2021_07_01_mobile`
+    `httparchive.lighthouse.2022_06_01_mobile`
 )

--- a/sql/2022/accessibility/common_alt_text_length.sql
+++ b/sql/2022/accessibility/common_alt_text_length.sql
@@ -1,0 +1,34 @@
+#standardSQL
+# Most common lengths of alt text
+# Note: A value of -1 means there is no alt tag. 0 means it is empty
+# Note: Lengths of 2000+ characters are grouped together
+SELECT
+  client,
+  SUM(COUNT(0)) OVER (PARTITION BY client) AS total_images,
+  SUM(COUNTIF(alt_length_clipped >= 0)) OVER (PARTITION BY client) AS total_alt_tags,
+
+  alt_length_clipped AS alt_length,
+  COUNT(0) AS occurrences,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct_all_occurrences
+FROM (
+  SELECT
+    client,
+    LEAST(alt_length, 2000) AS alt_length_clipped
+  FROM (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      SAFE_CAST(alt_length_string AS INT64) AS alt_length
+    FROM
+      `httparchive.pages.2021_07_01_*`,
+      UNNEST(
+        JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._almanac'), '$.images.alt_lengths')
+      ) AS alt_length_string
+  )
+  WHERE
+    alt_length IS NOT NULL
+)
+GROUP BY
+  client,
+  alt_length
+ORDER BY
+  alt_length ASC

--- a/sql/2022/accessibility/common_alt_text_length.sql
+++ b/sql/2022/accessibility/common_alt_text_length.sql
@@ -19,7 +19,7 @@ FROM (
       _TABLE_SUFFIX AS client,
       SAFE_CAST(alt_length_string AS INT64) AS alt_length
     FROM
-      `httparchive.pages.2021_07_01_*`,
+      `httparchive.pages.2022_06_01_*`,
       UNNEST(
         JSON_EXTRACT_ARRAY(JSON_EXTRACT_SCALAR(payload, '$._almanac'), '$.images.alt_lengths')
       ) AS alt_length_string

--- a/sql/2022/accessibility/common_aria_role.sql
+++ b/sql/2022/accessibility/common_aria_role.sql
@@ -1,0 +1,37 @@
+#standardSQL
+# % of sites using each type of aria role
+CREATE TEMPORARY FUNCTION getUsedRoles(payload STRING)
+RETURNS ARRAY<STRING> LANGUAGE js AS '''
+try {
+  const almanac = JSON.parse(payload);
+  return Object.keys(almanac.nodes_using_role.usage_and_count);
+} catch (e) {
+  return [];
+}
+''';
+SELECT
+  _TABLE_SUFFIX AS client,
+  total_sites,
+  role,
+  COUNT(0) AS total_sites_using,
+  COUNT(0) / total_sites AS pct_sites_using
+FROM
+  `httparchive.pages.2021_07_01_*`,
+  UNNEST(getUsedRoles(JSON_EXTRACT_SCALAR(payload, '$._almanac'))) AS role
+LEFT JOIN (
+  SELECT
+    _TABLE_SUFFIX,
+    COUNT(0) AS total_sites
+  FROM
+    `httparchive.pages.2021_07_01_*`
+  GROUP BY _TABLE_SUFFIX
+)
+USING (_TABLE_SUFFIX)
+GROUP BY
+  client,
+  role,
+  total_sites
+HAVING
+  total_sites_using >= 100
+ORDER BY
+  pct_sites_using DESC

--- a/sql/2022/accessibility/common_aria_role.sql
+++ b/sql/2022/accessibility/common_aria_role.sql
@@ -16,14 +16,14 @@ SELECT
   COUNT(0) AS total_sites_using,
   COUNT(0) / total_sites AS pct_sites_using
 FROM
-  `httparchive.pages.2021_07_01_*`,
+  `httparchive.pages.2022_06_01_*`,
   UNNEST(getUsedRoles(JSON_EXTRACT_SCALAR(payload, '$._almanac'))) AS role
 LEFT JOIN (
   SELECT
     _TABLE_SUFFIX,
     COUNT(0) AS total_sites
   FROM
-    `httparchive.pages.2021_07_01_*`
+    `httparchive.pages.2022_06_01_*`
   GROUP BY _TABLE_SUFFIX
 )
 USING (_TABLE_SUFFIX)

--- a/sql/2022/accessibility/common_element_attributes.sql
+++ b/sql/2022/accessibility/common_element_attributes.sql
@@ -1,0 +1,38 @@
+#standardSQL
+# How often pages contain an element with a given attribute
+CREATE TEMPORARY FUNCTION getUsedAttributes(payload STRING)
+RETURNS ARRAY<STRING> LANGUAGE js AS '''
+try {
+  const almanac = JSON.parse(payload);
+  return Object.keys(almanac.attributes_used_on_elements);
+} catch (e) {
+  return [];
+}
+''';
+SELECT
+  _TABLE_SUFFIX AS client,
+  total_sites,
+  attribute,
+  COUNT(0) AS total_sites_using,
+  COUNT(0) / total_sites AS pct_sites_using
+FROM
+  `httparchive.pages.2021_07_01_*`,
+  UNNEST(getUsedAttributes(JSON_EXTRACT_SCALAR(payload, '$._almanac'))) AS attribute
+LEFT JOIN (
+  SELECT
+    _TABLE_SUFFIX,
+    COUNT(0) AS total_sites
+  FROM
+    `httparchive.pages.2021_07_01_*`
+  GROUP BY _TABLE_SUFFIX
+)
+USING (_TABLE_SUFFIX)
+GROUP BY
+  client,
+  attribute,
+  total_sites
+HAVING
+  STARTS_WITH(attribute, 'aria-') OR
+  pct_sites_using >= 0.01
+ORDER BY
+  pct_sites_using DESC

--- a/sql/2022/accessibility/common_element_attributes.sql
+++ b/sql/2022/accessibility/common_element_attributes.sql
@@ -16,14 +16,14 @@ SELECT
   COUNT(0) AS total_sites_using,
   COUNT(0) / total_sites AS pct_sites_using
 FROM
-  `httparchive.pages.2021_07_01_*`,
+  `httparchive.pages.2022_06_01_*`,
   UNNEST(getUsedAttributes(JSON_EXTRACT_SCALAR(payload, '$._almanac'))) AS attribute
 LEFT JOIN (
   SELECT
     _TABLE_SUFFIX,
     COUNT(0) AS total_sites
   FROM
-    `httparchive.pages.2021_07_01_*`
+    `httparchive.pages.2022_06_01_*`
   GROUP BY _TABLE_SUFFIX
 )
 USING (_TABLE_SUFFIX)

--- a/sql/2022/accessibility/focus_outline_0.sql
+++ b/sql/2022/accessibility/focus_outline_0.sql
@@ -1,0 +1,75 @@
+#standardSQL
+# Adoption of :focus pseudoclass and outline: 0 style
+CREATE TEMPORARY FUNCTION getFocusStylesOutline0(css STRING) RETURNS ARRAY<BOOL> LANGUAGE js
+OPTIONS (library = "gs://httparchive/lib/css-utils.js") AS '''
+try {
+  var reduceValues = (values, rule) => {
+    if ('rules' in rule) {
+      return rule.rules.reduce(reduceValues, values);
+    }
+    if (!('declarations' in rule)) {
+      return values;
+    }
+
+    // Oversimplified but fast regex check.
+    var focusRegEx = /:focus/;
+    var fastFocusCheck = rule.selectors.find(selector => {
+      return focusRegEx.test(selector);
+    });
+    if (!fastFocusCheck) {
+      return values;
+    }
+
+    var hasFocusPseudoClass = rule.selectors.find(selector => {
+      var tokens = parsel.tokenize(selector);
+      return tokens.find(token => {
+        return token.type == 'pseudo-class' && token.name == 'focus';
+      });
+    });
+
+    if (!hasFocusPseudoClass) {
+      return values;
+    }
+
+    var setsOutline0 = !!rule.declarations.find(d => d.property.toLowerCase() == 'outline' && d.value == '0');
+    return values.concat(setsOutline0);
+  };
+  var $ = JSON.parse(css);
+  return $.stylesheet.rules.reduce(reduceValues, []);
+} catch (e) {
+  return [e];
+}
+''';
+
+SELECT
+  client,
+  COUNTIF(sets_focus_style) AS pages_focus,
+  COUNTIF(sets_focus_outline_0) AS pages_focus_outline_0,
+  ANY_VALUE(total_pages) AS total_pages,
+  COUNTIF(sets_focus_style) / ANY_VALUE(total_pages) AS pct_pages_focus,
+  COUNTIF(sets_focus_outline_0) / ANY_VALUE(total_pages) AS pct_pages_focus_outline_0
+FROM (
+  SELECT
+    client,
+    page,
+    COUNT(0) > 0 AS sets_focus_style,
+    COUNTIF(sets_outline_0) > 0 AS sets_focus_outline_0
+  FROM
+    `httparchive.almanac.parsed_css`,
+    UNNEST(getFocusStylesOutline0(css)) AS sets_outline_0
+  WHERE
+    date = '2021-07-01'
+  GROUP BY
+    client,
+    page)
+JOIN (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    COUNT(0) AS total_pages
+  FROM
+    `httparchive.summary_pages.2021_07_01_*`
+  GROUP BY
+    _TABLE_SUFFIX)
+USING (client)
+GROUP BY
+  client

--- a/sql/2022/accessibility/focus_outline_0.sql
+++ b/sql/2022/accessibility/focus_outline_0.sql
@@ -1,5 +1,6 @@
 #standardSQL
 # Adoption of :focus pseudoclass and outline: 0 style
+# Copy of sql/2021/css/focus_outline_0.sql
 CREATE TEMPORARY FUNCTION getFocusStylesOutline0(css STRING) RETURNS ARRAY<BOOL> LANGUAGE js
 OPTIONS (library = "gs://httparchive/lib/css-utils.js") AS '''
 try {
@@ -58,7 +59,7 @@ FROM (
     `httparchive.almanac.parsed_css`,
     UNNEST(getFocusStylesOutline0(css)) AS sets_outline_0
   WHERE
-    date = '2021-07-01'
+    date = '2022-07-01'
   GROUP BY
     client,
     page)
@@ -67,7 +68,7 @@ JOIN (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2021_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     _TABLE_SUFFIX)
 USING (client)

--- a/sql/2022/accessibility/focus_visible.sql
+++ b/sql/2022/accessibility/focus_visible.sql
@@ -1,0 +1,80 @@
+#standardSQL
+CREATE TEMPORARY FUNCTION getSelectorParts(css STRING)
+RETURNS STRUCT<
+  class ARRAY<STRING>,
+  id ARRAY<STRING>,
+  attribute ARRAY<STRING>,
+  pseudo_class ARRAY<STRING>,
+  pseudo_element ARRAY<STRING>
+>
+LANGUAGE js
+OPTIONS (library = "gs://httparchive/lib/css-utils.js")
+AS '''
+try {
+  function compute(ast) {
+    let ret = {
+      class: {},
+      id: {},
+      attribute: {},
+      "pseudo-class": {},
+      "pseudo-element": {}
+    };
+
+    walkSelectors(ast, selector => {
+      let sast = parsel.parse(selector, {list: false});
+
+      parsel.walk(sast, node => {
+        if (node.type in ret) {
+          incrementByKey(ret[node.type], node.name);
+        }
+      }, {subtree: true});
+    });
+
+    for (let type in ret) {
+      ret[type] = sortObject(ret[type]);
+    }
+
+    return ret;
+  }
+
+  function unzip(obj) {
+    return Object.entries(obj).filter(([name, value]) => {
+      return !isNaN(value);
+    }).map(([name, value]) => name);
+  }
+
+  const ast = JSON.parse(css);
+  let parts = compute(ast);
+  return {
+    class: unzip(parts.class),
+    id: unzip(parts.id),
+    attribute: unzip(parts.attribute),
+    pseudo_class: unzip(parts['pseudo-class']),
+    pseudo_element: unzip(parts['pseudo-element'])
+  }
+} catch (e) {
+  return null;
+}
+''';
+
+SELECT
+  client,
+  COUNTIF(num_focus_visible > 0) AS has_focus_visible,
+  COUNT(0) AS total,
+  COUNTIF(num_focus_visible > 0) / COUNT(0) AS pct_pages_focus_visible
+FROM (
+  SELECT
+    client,
+    page,
+    COUNTIF(pseudo_class = 'focus-visible') AS num_focus_visible
+  FROM
+    `httparchive.almanac.parsed_css`
+  LEFT JOIN
+    UNNEST(getSelectorParts(css).pseudo_class) AS pseudo_class
+  WHERE
+    date = '2021-07-01'
+  GROUP BY
+    client,
+    page)
+GROUP BY
+  client

--- a/sql/2022/accessibility/focus_visible.sql
+++ b/sql/2022/accessibility/focus_visible.sql
@@ -1,4 +1,5 @@
 #standardSQL
+# Copy of sql/2021/css/focus_visible.sql
 CREATE TEMPORARY FUNCTION getSelectorParts(css STRING)
 RETURNS STRUCT<
   class ARRAY<STRING>,
@@ -72,7 +73,9 @@ FROM (
   LEFT JOIN
     UNNEST(getSelectorParts(css).pseudo_class) AS pseudo_class
   WHERE
-    date = '2021-07-01'
+    date = '2022-07-01' AND
+    # Limit the size of the CSS to avoid OOM crashes.
+    LENGTH(css) < 0.1 * 1024 * 1024
   GROUP BY
     client,
     page)

--- a/sql/2022/accessibility/form_input_name_sources.sql
+++ b/sql/2022/accessibility/form_input_name_sources.sql
@@ -1,0 +1,67 @@
+#standardSQL
+# Where input elements get their A11Y names from
+CREATE TEMPORARY FUNCTION a11yInputNameSources(payload STRING)
+RETURNS ARRAY<STRING> LANGUAGE js AS '''
+  try {
+    const a11y = JSON.parse(payload);
+
+    const accessible_name_sources = [];
+    for (const tree_node of a11y.form_control_a11y_tree) {
+      if (tree_node.type === "button") {
+        continue;
+      }
+      if (tree_node.type === "input" && tree_node.attributes.type === "submit") {
+        continue;
+      }
+
+      if (tree_node.accessible_name.length === 0) {
+        // No A11Y name given
+        accessible_name_sources.push("No accessible name");
+        continue;
+      }
+
+      if (tree_node.accessible_name_sources.length <= 0) {
+        continue;
+      }
+
+      const name_source = tree_node.accessible_name_sources[0];
+      let pretty_name_source = name_source.type;
+      if (name_source.type === "attribute") {
+        pretty_name_source = `${name_source.type}: ${name_source.attribute}`;
+      } else if (name_source.type === "relatedElement") {
+        if (name_source.attribute) {
+          pretty_name_source = `${name_source.type}: ${name_source.attribute}`;
+        } else {
+          pretty_name_source = `${name_source.type}: label`;
+        }
+      }
+
+      accessible_name_sources.push(pretty_name_source);
+    }
+
+    return accessible_name_sources;
+  } catch (e) {
+    return [];
+  }
+''';
+
+SELECT
+  client,
+  SUM(COUNT(0)) OVER (PARTITION BY client) AS total_inputs,
+
+  input_name_source,
+  COUNT(0) AS total_with_this_source,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS perc_of_all_inputs
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    input_name_source
+  FROM
+    `httparchive.pages.2021_07_01_*`,
+    UNNEST(
+      a11yInputNameSources(JSON_EXTRACT_SCALAR(payload, '$._a11y'))
+    ) AS input_name_source
+)
+GROUP BY
+  client,
+  input_name_source

--- a/sql/2022/accessibility/form_input_name_sources.sql
+++ b/sql/2022/accessibility/form_input_name_sources.sql
@@ -57,7 +57,7 @@ FROM (
     _TABLE_SUFFIX AS client,
     input_name_source
   FROM
-    `httparchive.pages.2021_07_01_*`,
+    `httparchive.pages.2022_06_01_*`,
     UNNEST(
       a11yInputNameSources(JSON_EXTRACT_SCALAR(payload, '$._a11y'))
     ) AS input_name_source

--- a/sql/2022/accessibility/form_required_controls.sql
+++ b/sql/2022/accessibility/form_required_controls.sql
@@ -1,0 +1,108 @@
+#standardSQL
+# Various stats for required form controls (form controls being: input, select, textarea)
+CREATE TEMPORARY FUNCTION requiredControls(payload STRING)
+RETURNS STRUCT<total INT64, asterisk INT64, required_attribute INT64, aria_required INT64, all_three INT64, asterisk_required INT64, asterisk_aria INT64, required_with_aria INT64> LANGUAGE js AS '''
+  try {
+    const a11y = JSON.parse(payload);
+    const required_form_controls = a11y.required_form_controls
+
+    const total = required_form_controls.length;
+    let asterisk = 0;
+    let required_attribute = 0;
+    let aria_required = 0;
+
+    let all_three = 0;
+    let asterisk_required = 0;
+    let asterisk_aria = 0;
+    let required_with_aria = 0;
+    for (const form_control of required_form_controls) {
+      if (form_control.has_visible_required_asterisk) {
+        asterisk++;
+      }
+      if (form_control.has_visible_required_asterisk && form_control.has_required) {
+        asterisk_required++;
+      }
+      if (form_control.has_visible_required_asterisk && form_control.has_aria_required) {
+        asterisk_aria++;
+      }
+
+      if (form_control.has_required) {
+        required_attribute++;
+      }
+      if (form_control.has_required && form_control.has_aria_required) {
+        required_with_aria++;
+      }
+
+      if (form_control.has_aria_required) {
+        aria_required++;
+      }
+
+
+      if (form_control.has_visible_required_asterisk &&
+          form_control.has_required &&
+          form_control.has_aria_required) {
+        all_three++;
+      }
+    }
+
+    return {
+      total,
+      asterisk,
+      required_attribute,
+      aria_required,
+
+      all_three,
+      asterisk_required,
+      asterisk_aria,
+      required_with_aria,
+    };
+  } catch (e) {
+    return {
+      total: 0,
+      asterisk: 0,
+      required_attribute: 0,
+      aria_required: 0,
+
+      all_three: 0,
+      asterisk_required: 0,
+      asterisk_aria: 0,
+      required_with_aria: 0,
+    };
+  }
+''';
+
+SELECT
+  client,
+  COUNT(0) AS total_sites,
+  COUNTIF(stats.total > 0) AS total_sites_with_required_controls,
+  SUM(stats.total) AS total_required_controls,
+
+  SUM(stats.asterisk) AS total_asterisk,
+  SUM(stats.asterisk) / SUM(stats.total) AS perc_asterisk,
+
+  SUM(stats.required_attribute) AS total_required_attribute,
+  SUM(stats.required_attribute) / SUM(stats.total) AS perc_required_attribute,
+
+  SUM(stats.aria_required) AS total_aria_required,
+  SUM(stats.aria_required) / SUM(stats.total) AS perc_aria_required,
+
+  SUM(stats.all_three) AS total_all_three,
+  SUM(stats.all_three) / SUM(stats.total) AS perc_all_three,
+
+  SUM(stats.asterisk_required) AS total_asterisk_required,
+  SUM(stats.asterisk_required) / SUM(stats.total) AS perc_asterisk_required,
+
+  SUM(stats.asterisk_aria) AS total_asterisk_aria,
+  SUM(stats.asterisk_aria) / SUM(stats.total) AS perc_asterisk_aria,
+
+  SUM(stats.required_with_aria) AS total_required_with_aria,
+  SUM(stats.required_with_aria) / SUM(stats.total) AS perc_required_with_aria
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    requiredControls(JSON_EXTRACT_SCALAR(payload, '$._a11y')) AS stats
+  FROM
+    `httparchive.pages.2021_07_01_*`
+)
+GROUP BY
+  client

--- a/sql/2022/accessibility/form_required_controls.sql
+++ b/sql/2022/accessibility/form_required_controls.sql
@@ -102,7 +102,7 @@ FROM (
     _TABLE_SUFFIX AS client,
     requiredControls(JSON_EXTRACT_SCALAR(payload, '$._a11y')) AS stats
   FROM
-    `httparchive.pages.2021_07_01_*`
+    `httparchive.pages.2022_06_01_*`
 )
 GROUP BY
   client

--- a/sql/2022/accessibility/landmark_elements_and_roles.sql
+++ b/sql/2022/accessibility/landmark_elements_and_roles.sql
@@ -1,0 +1,114 @@
+#standardSQL
+# percentage/count of pages that contain common elements and roles
+
+CREATE TEMPORARY FUNCTION getUsedRoles(payload STRING)
+RETURNS ARRAY<STRING> LANGUAGE js AS '''
+try {
+  const almanac = JSON.parse(payload);
+  return Object.keys(almanac.nodes_using_role.usage_and_count);
+} catch (e) {
+  return [];
+}
+''';
+
+CREATE TEMPORARY FUNCTION get_element_types(element_count_string STRING)
+RETURNS ARRAY<STRING> LANGUAGE js AS '''
+try {
+    if (!element_count_string) return []; // 2019 had a few cases
+
+    var element_count = JSON.parse(element_count_string); // should be an object with element type properties with values of how often they are present
+
+    if (Array.isArray(element_count)) return [];
+    if (typeof element_count != 'object') return [];
+
+    return Object.keys(element_count);
+} catch (e) {
+    return [];
+}
+''';
+
+WITH mappings AS (
+  SELECT 1 AS mapping_id, 'main' AS element_type, 'main' AS role_type
+  UNION ALL
+  SELECT 2 AS mapping_id, 'header' AS element_type, 'banner' AS role_type
+  UNION ALL
+  SELECT 3 AS mapping_id, 'nav' AS element_type, 'navigation' AS role_type
+  UNION ALL
+  SELECT 4 AS mapping_id, 'footer' AS element_type, 'contentinfo' AS role_type
+),
+
+elements AS (
+  SELECT
+    _TABLE_SUFFIX,
+    url,
+    element_type
+  FROM
+    `httparchive.pages.2021_07_01_*`,
+    UNNEST(get_element_types(JSON_EXTRACT_SCALAR(payload, '$._element_count'))) AS element_type
+  JOIN
+    mappings
+  USING (element_type)
+),
+
+roles AS (
+  SELECT
+    _TABLE_SUFFIX,
+    url,
+    role_type
+  FROM
+    `httparchive.pages.2021_07_01_*`,
+    UNNEST(getUsedRoles(JSON_EXTRACT_SCALAR(payload, '$._almanac'))) AS role_type
+  JOIN
+    mappings
+  USING (role_type)
+),
+
+base AS (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    url,
+    mapping_id,
+    element_type,
+    role_type,
+    COUNTIF(e.element_type IS NOT NULL) AS element_usage,
+    COUNTIF(r.role_type IS NOT NULL) AS role_usage
+  FROM
+    `httparchive.pages.2021_07_01_*`
+  INNER JOIN mappings ON (TRUE)
+  LEFT OUTER JOIN
+    elements e
+  USING (_TABLE_SUFFIX, url, element_type)
+  LEFT OUTER JOIN
+    roles r
+  USING (_TABLE_SUFFIX, url, role_type)
+  GROUP BY
+    client,
+    url,
+    mapping_id,
+    element_type,
+    role_type
+)
+
+SELECT
+  client,
+  mapping_id,
+  element_type,
+  role_type,
+  COUNT(DISTINCT url) AS total_pages,
+  COUNTIF(element_usage > 0) AS element_usage,
+  COUNTIF(role_usage > 0) AS role_usage,
+  COUNTIF(element_usage > 0 OR role_usage > 0) AS both_usage,
+  COUNTIF(element_usage > 0) / COUNT(DISTINCT url) AS element_pct,
+  COUNTIF(role_usage > 0) / COUNT(DISTINCT url) AS role_pct,
+  COUNTIF(element_usage > 0 OR role_usage > 0) / COUNT(DISTINCT url) AS both_pct
+FROM
+  base
+GROUP BY
+  client,
+  mapping_id,
+  element_type,
+  role_type
+ORDER BY
+  client,
+  mapping_id,
+  element_type

--- a/sql/2022/accessibility/landmark_elements_and_roles.sql
+++ b/sql/2022/accessibility/landmark_elements_and_roles.sql
@@ -43,7 +43,7 @@ elements AS (
     url,
     element_type
   FROM
-    `httparchive.pages.2021_07_01_*`,
+    `httparchive.pages.2022_06_01_*`,
     UNNEST(get_element_types(JSON_EXTRACT_SCALAR(payload, '$._element_count'))) AS element_type
   JOIN
     mappings
@@ -56,7 +56,7 @@ roles AS (
     url,
     role_type
   FROM
-    `httparchive.pages.2021_07_01_*`,
+    `httparchive.pages.2022_06_01_*`,
     UNNEST(getUsedRoles(JSON_EXTRACT_SCALAR(payload, '$._almanac'))) AS role_type
   JOIN
     mappings
@@ -73,7 +73,7 @@ base AS (
     COUNTIF(e.element_type IS NOT NULL) AS element_usage,
     COUNTIF(r.role_type IS NOT NULL) AS role_usage
   FROM
-    `httparchive.pages.2021_07_01_*`
+    `httparchive.pages.2022_06_01_*`
   INNER JOIN mappings ON (TRUE)
   LEFT OUTER JOIN
     elements e

--- a/sql/2022/accessibility/lighthouse_a11y_audits.sql
+++ b/sql/2022/accessibility/lighthouse_a11y_audits.sql
@@ -1,0 +1,42 @@
+#standardSQL
+# Get summary of all lighthouse scores for a category
+# Note scores, weightings, groups and descriptions may be off in mixed months when new versions of Lighthouse roles out
+
+CREATE TEMPORARY FUNCTION getAudits(report STRING, category STRING)
+RETURNS ARRAY<STRUCT<id STRING, weight INT64, audit_group STRING, title STRING, description STRING, score INT64>> LANGUAGE js AS '''
+var $ = JSON.parse(report);
+var auditrefs = $.categories[category].auditRefs;
+var audits = $.audits;
+$ = null;
+var results = [];
+for (auditref of auditrefs) {
+  results.push({
+    id: auditref.id,
+    weight: auditref.weight,
+    audit_group: auditref.group,
+    description: audits[auditref.id].description,
+    score: audits[auditref.id].score
+  });
+}
+return results;
+''';
+
+SELECT
+  audits.id AS id,
+  COUNTIF(audits.score > 0) AS num_pages,
+  COUNT(0) AS total,
+  COUNTIF(audits.score IS NOT NULL) AS total_applicable,
+  SAFE_DIVIDE(COUNTIF(audits.score > 0), COUNTIF(audits.score IS NOT NULL)) AS pct,
+  APPROX_QUANTILES(audits.weight, 100)[OFFSET(50)] AS median_weight,
+  MAX(audits.audit_group) AS audit_group,
+  MAX(audits.description) AS description
+FROM
+  `httparchive.lighthouse.2021_07_01_mobile`,
+  UNNEST(getAudits(report, 'accessibility')) AS audits
+WHERE
+  LENGTH(report) < 20000000  # necessary to avoid out of memory issues. Excludes very large results
+GROUP BY
+  audits.id
+ORDER BY
+  median_weight DESC,
+  id

--- a/sql/2022/accessibility/lighthouse_a11y_audits.sql
+++ b/sql/2022/accessibility/lighthouse_a11y_audits.sql
@@ -31,7 +31,7 @@ SELECT
   MAX(audits.audit_group) AS audit_group,
   MAX(audits.description) AS description
 FROM
-  `httparchive.lighthouse.2021_07_01_mobile`,
+  `httparchive.lighthouse.2022_06_01_mobile`,
   UNNEST(getAudits(report, 'accessibility')) AS audits
 WHERE
   LENGTH(report) < 20000000  # necessary to avoid out of memory issues. Excludes very large results

--- a/sql/2022/accessibility/lighthouse_a11y_audits.sql
+++ b/sql/2022/accessibility/lighthouse_a11y_audits.sql
@@ -22,6 +22,7 @@ return results;
 ''';
 
 SELECT
+  _TABLE_SUFFIX AS client,
   audits.id AS id,
   COUNTIF(audits.score > 0) AS num_pages,
   COUNT(0) AS total,
@@ -31,12 +32,14 @@ SELECT
   MAX(audits.audit_group) AS audit_group,
   MAX(audits.description) AS description
 FROM
-  `httparchive.lighthouse.2022_06_01_mobile`,
+  `httparchive.lighthouse.2022_06_01_*`,
   UNNEST(getAudits(report, 'accessibility')) AS audits
 WHERE
   LENGTH(report) < 20000000  # necessary to avoid out of memory issues. Excludes very large results
 GROUP BY
+  client,
   audits.id
 ORDER BY
+  client,
   median_weight DESC,
   id

--- a/sql/2022/accessibility/lighthouse_a11y_score.sql
+++ b/sql/2022/accessibility/lighthouse_a11y_score.sql
@@ -1,0 +1,51 @@
+#standardSQL
+# Percentiles of lighthouse a11y score from 2019 - 2021
+SELECT
+  '2019_07_01' AS date,
+  percentile,
+  APPROX_QUANTILES(score, 1000)[OFFSET(percentile * 10)] AS score
+FROM (
+  SELECT
+    CAST(JSON_EXTRACT(report, '$.categories.accessibility.score') AS NUMERIC) AS score
+  FROM
+    `httparchive.lighthouse.2019_07_01_mobile`),
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
+GROUP BY
+  date,
+  percentile
+
+UNION ALL
+
+SELECT
+  '2020_08_01' AS date,
+  percentile,
+  APPROX_QUANTILES(score, 1000)[OFFSET(percentile * 10)] AS score
+FROM (
+  SELECT
+    CAST(JSON_EXTRACT(report, '$.categories.accessibility.score') AS NUMERIC) AS score
+  FROM
+    `httparchive.lighthouse.2020_08_01_mobile`),
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
+GROUP BY
+  date,
+  percentile
+
+UNION ALL
+
+SELECT
+  '2021_07_01' AS date,
+  percentile,
+  APPROX_QUANTILES(score, 1000)[OFFSET(percentile * 10)] AS score
+FROM (
+  SELECT
+    CAST(JSON_EXTRACT(report, '$.categories.accessibility.score') AS NUMERIC) AS score
+  FROM
+    `httparchive.lighthouse.2021_07_01_mobile`),
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
+GROUP BY
+  date,
+  percentile
+
+ORDER BY
+  date,
+  percentile

--- a/sql/2022/accessibility/lighthouse_a11y_score.sql
+++ b/sql/2022/accessibility/lighthouse_a11y_score.sql
@@ -1,5 +1,5 @@
 #standardSQL
-# Percentiles of lighthouse a11y score from 2019 - 2021
+# Percentiles of lighthouse a11y score from 2019 - 2022
 SELECT
   '2019_07_01' AS date,
   percentile,
@@ -41,6 +41,22 @@ FROM (
     CAST(JSON_EXTRACT(report, '$.categories.accessibility.score') AS NUMERIC) AS score
   FROM
     `httparchive.lighthouse.2021_07_01_mobile`),
+  UNNEST([10, 25, 50, 75, 90]) AS percentile
+GROUP BY
+  date,
+  percentile
+
+UNION ALL
+
+SELECT
+  '2022_06_01' AS date,
+  percentile,
+  APPROX_QUANTILES(score, 1000)[OFFSET(percentile * 10)] AS score
+FROM (
+  SELECT
+    CAST(JSON_EXTRACT(report, '$.categories.accessibility.score') AS NUMERIC) AS score
+  FROM
+    `httparchive.lighthouse.2022_06_01_mobile`),
   UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
   date,

--- a/sql/2022/accessibility/lighthouse_a11y_score.sql
+++ b/sql/2022/accessibility/lighthouse_a11y_score.sql
@@ -56,7 +56,7 @@ SELECT
   client,
   '2022_06_01' AS date,
   percentile,
-  APPROX_QUANTILES(score, 1000)[OFFSET(percentile * 10)] AS score,
+  APPROX_QUANTILES(score, 1000)[OFFSET(percentile * 10)] AS score
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,

--- a/sql/2022/accessibility/lighthouse_a11y_score.sql
+++ b/sql/2022/accessibility/lighthouse_a11y_score.sql
@@ -1,6 +1,8 @@
 #standardSQL
 # Percentiles of lighthouse a11y score from 2019 - 2022
+# Starts fetching desktop scores when they became available in 2022.
 SELECT
+  'mobile' AS client,
   '2019_07_01' AS date,
   percentile,
   APPROX_QUANTILES(score, 1000)[OFFSET(percentile * 10)] AS score
@@ -17,6 +19,7 @@ GROUP BY
 UNION ALL
 
 SELECT
+  'mobile' AS client,
   '2020_08_01' AS date,
   percentile,
   APPROX_QUANTILES(score, 1000)[OFFSET(percentile * 10)] AS score
@@ -33,6 +36,7 @@ GROUP BY
 UNION ALL
 
 SELECT
+  'mobile' AS client,
   '2021_07_01' AS date,
   percentile,
   APPROX_QUANTILES(score, 1000)[OFFSET(percentile * 10)] AS score
@@ -49,16 +53,19 @@ GROUP BY
 UNION ALL
 
 SELECT
+  client,
   '2022_06_01' AS date,
   percentile,
-  APPROX_QUANTILES(score, 1000)[OFFSET(percentile * 10)] AS score
+  APPROX_QUANTILES(score, 1000)[OFFSET(percentile * 10)] AS score,
 FROM (
   SELECT
+    _TABLE_SUFFIX AS client,
     CAST(JSON_EXTRACT(report, '$.categories.accessibility.score') AS NUMERIC) AS score
   FROM
-    `httparchive.lighthouse.2022_06_01_mobile`),
+    `httparchive.lighthouse.2022_06_01_*`),
   UNNEST([10, 25, 50, 75, 90]) AS percentile
 GROUP BY
+  client,
   date,
   percentile
 

--- a/sql/2022/accessibility/media_query_features.sql
+++ b/sql/2022/accessibility/media_query_features.sql
@@ -1,0 +1,71 @@
+#standardSQL
+CREATE TEMPORARY FUNCTION getMediaQueryFeatures(css STRING)
+RETURNS ARRAY<STRING>
+LANGUAGE js
+OPTIONS (library = "gs://httparchive/lib/css-utils.js")
+AS '''
+try {
+  function compute(ast) {
+    let ret = {};
+
+    walkRules(ast, rule => {
+      let features = rule.media
+                .replace(/\\s+/g, "")
+                .match(/\\([\\w-]+(?=[:\\)])/g);
+
+      if (features) {
+        features = features.map(s => s.slice(1));
+
+        for (let feature of features) {
+          incrementByKey(ret, feature);
+        }
+      }
+    }, {type: "media"});
+
+    return ret;
+  }
+
+  const ast = JSON.parse(css);
+  let features = compute(ast);
+  return Object.keys(features);
+} catch (e) {
+  return [];
+}
+''';
+
+SELECT
+  client,
+  feature,
+  COUNT(DISTINCT page) AS pages,
+  total,
+  COUNT(DISTINCT page) / total AS pct
+FROM (
+  SELECT DISTINCT
+    client,
+    page,
+    LOWER(feature) AS feature
+  FROM
+    `httparchive.almanac.parsed_css`
+  LEFT JOIN
+    UNNEST(getMediaQueryFeatures(css)) AS feature
+  WHERE
+    date = '2021-07-01' AND
+    feature IS NOT NULL)
+JOIN (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    COUNT(0) AS total
+  FROM
+    `httparchive.summary_pages.2021_07_01_*`
+  GROUP BY
+    client)
+USING
+  (client)
+GROUP BY
+  client,
+  total,
+  feature
+HAVING
+  pages >= 100
+ORDER BY
+  pct DESC

--- a/sql/2022/accessibility/media_query_features.sql
+++ b/sql/2022/accessibility/media_query_features.sql
@@ -1,4 +1,5 @@
 #standardSQL
+# Copy of sql/2022/css/media_query_features.sql
 CREATE TEMPORARY FUNCTION getMediaQueryFeatures(css STRING)
 RETURNS ARRAY<STRING>
 LANGUAGE js
@@ -49,14 +50,14 @@ FROM (
   LEFT JOIN
     UNNEST(getMediaQueryFeatures(css)) AS feature
   WHERE
-    date = '2021-07-01' AND
+    date = '2022-07-01' AND
     feature IS NOT NULL)
 JOIN (
   SELECT
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total
   FROM
-    `httparchive.summary_pages.2021_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client)
 USING

--- a/sql/2022/accessibility/page_title.sql
+++ b/sql/2022/accessibility/page_title.sql
@@ -1,0 +1,22 @@
+#standardSQL
+# Page title stats (usage, descriptive, changed on render)
+SELECT
+  client,
+  COUNT(0) AS total_sites,
+  COUNTIF(total_title_words > 0) AS total_has_title,
+  COUNTIF(total_title_words > 3) AS total_title_with_four_or_more_words,
+  COUNTIF(title_changed_on_render) AS total_title_changed,
+
+  COUNTIF(total_title_words > 0) / COUNT(0) AS pct_with_title,
+  COUNTIF(total_title_words > 3) / COUNTIF(total_title_words > 0) AS pct_titles_four_or_more_words,
+  COUNTIF(title_changed_on_render) / COUNTIF(total_title_words > 0) AS pct_titles_changed_on_render
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies'), '$.title.title_changed_on_render') AS BOOL) AS title_changed_on_render,
+    CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies'), '$.title.rendered.primary.words') AS INT64) AS total_title_words
+  FROM
+    `httparchive.pages.2021_07_01_*`
+)
+GROUP BY
+  client

--- a/sql/2022/accessibility/page_title.sql
+++ b/sql/2022/accessibility/page_title.sql
@@ -16,7 +16,7 @@ FROM (
     CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies'), '$.title.title_changed_on_render') AS BOOL) AS title_changed_on_render,
     CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies'), '$.title.rendered.primary.words') AS INT64) AS total_title_words
   FROM
-    `httparchive.pages.2021_07_01_*`
+    `httparchive.pages.2022_06_01_*`
 )
 GROUP BY
   client

--- a/sql/2022/accessibility/pages_with_search_input.sql
+++ b/sql/2022/accessibility/pages_with_search_input.sql
@@ -1,0 +1,46 @@
+#standardSQL
+# Pages with search input
+CREATE TEMPORARY FUNCTION hasSearchInput(payload STRING)
+RETURNS BOOLEAN LANGUAGE js AS '''
+  try {
+    const almanac = JSON.parse(payload);
+    return almanac.input_elements.nodes.some((node) => {
+      if (node.type.toLowerCase() === "search") {
+        return true;
+      }
+
+      // Detect regular inputs of type text and the first word being "search"
+      if (node.type.toLowerCase() === "text" &&
+          /^\\s*search(\\s|$)/i.test(node.placeholder || '')) {
+        return true;
+      }
+
+      return false;
+    });
+
+  } catch (e) {
+    return false;
+  }
+''';
+
+SELECT
+  client,
+  COUNT(0) AS total_sites,
+  COUNTIF(has_inputs) AS total_with_inputs,
+  COUNTIF(has_search_input) AS total_with_search_input,
+
+  # Perc of all sites which have a search input
+  COUNTIF(has_search_input) / COUNT(0) AS perc_sites_with_search_input,
+  # Of sites that have at least 1 input element, how many have a search input
+  COUNTIF(has_search_input) / COUNTIF(has_inputs) AS perc_input_sites_with_search_input
+FROM
+  (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      SAFE_CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._almanac'), '$.input_elements.total') AS INT64) > 0 AS has_inputs,
+      hasSearchInput(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS has_search_input
+    FROM
+      `httparchive.pages.2021_07_01_*`
+  )
+GROUP BY
+  client

--- a/sql/2022/accessibility/pages_with_search_input.sql
+++ b/sql/2022/accessibility/pages_with_search_input.sql
@@ -40,7 +40,7 @@ FROM
       SAFE_CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._almanac'), '$.input_elements.total') AS INT64) > 0 AS has_inputs,
       hasSearchInput(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS has_search_input
     FROM
-      `httparchive.pages.2021_07_01_*`
+      `httparchive.pages.2022_06_01_*`
   )
 GROUP BY
   client

--- a/sql/2022/accessibility/placeholder_but_no_label.sql
+++ b/sql/2022/accessibility/placeholder_but_no_label.sql
@@ -1,0 +1,25 @@
+#standardSQL
+# Form controls with placeholder but no label
+SELECT
+  client,
+  COUNT(0) AS total_sites,
+  COUNTIF(total_placeholder > 0) AS sites_with_placeholder,
+  COUNTIF(total_no_label > 0) AS sites_with_no_label, # Has placeholder but no label
+
+  COUNTIF(total_placeholder > 0) / COUNT(0) AS pct_sites_with_placeholder,
+  # Sites with placeholders that dont always use labels alongside them
+  COUNTIF(total_no_label > 0) / COUNTIF(total_placeholder > 0) AS pct_placeholder_sites_with_no_label,
+
+  SUM(total_placeholder) AS total_placeholders,
+  SUM(total_no_label) AS total_placeholder_with_no_label,
+  SUM(total_no_label) / SUM(total_placeholder) AS pct_placeholders_with_no_label
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._a11y'), '$.placeholder_but_no_label.total_placeholder') AS INT64) AS total_placeholder,
+    CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._a11y'), '$.placeholder_but_no_label.total_no_label') AS INT64) AS total_no_label
+  FROM
+    `httparchive.pages.2021_07_01_*`
+)
+GROUP BY
+  client

--- a/sql/2022/accessibility/placeholder_but_no_label.sql
+++ b/sql/2022/accessibility/placeholder_but_no_label.sql
@@ -19,7 +19,7 @@ FROM (
     CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._a11y'), '$.placeholder_but_no_label.total_placeholder') AS INT64) AS total_placeholder,
     CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._a11y'), '$.placeholder_but_no_label.total_no_label') AS INT64) AS total_no_label
   FROM
-    `httparchive.pages.2021_07_01_*`
+    `httparchive.pages.2022_06_01_*`
 )
 GROUP BY
   client

--- a/sql/2022/accessibility/sites_using_role.sql
+++ b/sql/2022/accessibility/sites_using_role.sql
@@ -1,0 +1,24 @@
+#standardSQL
+# Sites using the role attribute
+SELECT
+  client,
+  SUM(COUNT(0)) OVER (PARTITION BY client) AS total_sites,
+  SUM(COUNTIF(total_role_attributes > 0)) OVER (PARTITION BY client) AS total_using_role,
+  SUM(COUNTIF(total_role_attributes > 0)) OVER (PARTITION BY client) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct_using_role,
+
+  percentile,
+  APPROX_QUANTILES(total_role_attributes, 1000)[OFFSET(percentile * 10)] AS total_role_usages
+FROM (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._almanac'), '$.nodes_using_role.total') AS INT64) AS total_role_attributes
+    FROM
+      `httparchive.pages.2021_07_01_*`
+  ),
+  UNNEST([10, 25, 50, 75, 90, 100]) AS percentile
+GROUP BY
+  percentile,
+  client
+ORDER BY
+  percentile,
+  client

--- a/sql/2022/accessibility/sites_using_role.sql
+++ b/sql/2022/accessibility/sites_using_role.sql
@@ -13,7 +13,7 @@ FROM (
       _TABLE_SUFFIX AS client,
       CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._almanac'), '$.nodes_using_role.total') AS INT64) AS total_role_attributes
     FROM
-      `httparchive.pages.2021_07_01_*`
+      `httparchive.pages.2022_06_01_*`
   ),
   UNNEST([10, 25, 50, 75, 90, 100]) AS percentile
 GROUP BY

--- a/sql/2022/accessibility/skip_links.sql
+++ b/sql/2022/accessibility/skip_links.sql
@@ -1,0 +1,21 @@
+#standardSQL
+# % of pages having skip links
+CREATE TEMPORARY FUNCTION getEarlyHash(payload STRING)
+RETURNS INT64 LANGUAGE js AS '''
+try {
+  const almanac = JSON.parse(payload);
+  return almanac['seo-anchor-elements'].earlyHash;
+} catch (e) {
+  return 0;
+}
+''';
+
+SELECT
+  _TABLE_SUFFIX AS client,
+  COUNTIF(getEarlyHash(JSON_EXTRACT_SCALAR(payload, '$._almanac')) > 0) AS pages,
+  COUNT(0) AS total,
+  COUNTIF(getEarlyHash(JSON_EXTRACT_SCALAR(payload, '$._almanac')) > 0) / COUNT(0) AS pct
+FROM
+  `httparchive.pages.2021_07_01_*`
+GROUP BY
+  client

--- a/sql/2022/accessibility/skip_links.sql
+++ b/sql/2022/accessibility/skip_links.sql
@@ -16,6 +16,6 @@ SELECT
   COUNT(0) AS total,
   COUNTIF(getEarlyHash(JSON_EXTRACT_SCALAR(payload, '$._almanac')) > 0) / COUNT(0) AS pct
 FROM
-  `httparchive.pages.2021_07_01_*`
+  `httparchive.pages.2022_06_01_*`
 GROUP BY
   client

--- a/sql/2022/accessibility/sr_only_classes.sql
+++ b/sql/2022/accessibility/sr_only_classes.sql
@@ -1,0 +1,16 @@
+#standardSQL
+# Sites using sr-only or visually-hidden classes
+SELECT
+  client,
+  COUNT(0) AS total_sites,
+  COUNTIF(uses_sr_only) AS sites_with_sr_only,
+  COUNTIF(uses_sr_only) / COUNT(0) AS pct_sites_with_sr_only
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._a11y'), '$.screen_reader_classes') AS BOOL) AS uses_sr_only
+  FROM
+    `httparchive.pages.2021_07_01_*`
+)
+GROUP BY
+  client

--- a/sql/2022/accessibility/sr_only_classes.sql
+++ b/sql/2022/accessibility/sr_only_classes.sql
@@ -10,7 +10,7 @@ FROM (
     _TABLE_SUFFIX AS client,
     CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._a11y'), '$.screen_reader_classes') AS BOOL) AS uses_sr_only
   FROM
-    `httparchive.pages.2021_07_01_*`
+    `httparchive.pages.2022_06_01_*`
 )
 GROUP BY
   client

--- a/sql/2022/accessibility/tabindex_usage_and_values.sql
+++ b/sql/2022/accessibility/tabindex_usage_and_values.sql
@@ -1,0 +1,50 @@
+#standardSQL
+# Positive tabindex value occurrences
+CREATE TEMPORARY FUNCTION getTotalPositiveTabIndexes(payload STRING)
+RETURNS STRUCT<total INT64, total_positive INT64, total_negative INT64, total_zero INT64> LANGUAGE js AS '''
+try {
+  const almanac = JSON.parse(payload);
+
+  let total = 0;
+  let total_positive = 0;
+  let total_negative = 0;
+  let total_zero = 0;
+  for (const node of almanac['09.27'].nodes) {
+    total++;
+    const int = parseInt(node.tabindex, 10);
+    if (int > 0) {
+      total_positive++;
+    } else if (int < 0) {
+      total_negative++;
+    } else if (int === 0) {
+      total_zero++;
+    }
+  }
+
+  return {total, total_positive, total_negative, total_zero};
+} catch (e) {
+  return {total: 0, total_positive: 0, total_negative: 0, total_zero: 0};
+}
+''';
+
+SELECT
+  client,
+  COUNT(0) AS total_sites,
+  COUNTIF(tab_index_stats.total > 0) AS total_with_tab_indexes,
+  COUNTIF(tab_index_stats.total_positive > 0) AS total_with_positive_tab_indexes,
+  COUNTIF(tab_index_stats.total_negative > 0) AS total_with_negative_tab_indexes,
+  COUNTIF(tab_index_stats.total_zero > 0) AS total_with_zero_tab_indexes,
+  COUNTIF(tab_index_stats.total_negative > 0 OR tab_index_stats.total_zero > 0) AS total_with_negative_or_zero,
+
+  COUNTIF(tab_index_stats.total > 0) / COUNT(0) AS pct_with_tab_indexes,
+  COUNTIF(tab_index_stats.total_positive > 0) / COUNT(0) AS pct_with_positive_tab_indexes,
+  COUNTIF(tab_index_stats.total_positive > 0) / COUNTIF(tab_index_stats.total > 0) AS pct_positive_in_sites_with_tab_indexes
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    getTotalPositiveTabIndexes(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS tab_index_stats
+  FROM
+    `httparchive.pages.2021_07_01_*`
+)
+GROUP BY
+  client

--- a/sql/2022/accessibility/tabindex_usage_and_values.sql
+++ b/sql/2022/accessibility/tabindex_usage_and_values.sql
@@ -44,7 +44,7 @@ FROM (
     _TABLE_SUFFIX AS client,
     getTotalPositiveTabIndexes(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS tab_index_stats
   FROM
-    `httparchive.pages.2021_07_01_*`
+    `httparchive.pages.2022_06_01_*`
 )
 GROUP BY
   client

--- a/sql/2022/accessibility/table_stats.sql
+++ b/sql/2022/accessibility/table_stats.sql
@@ -1,0 +1,31 @@
+#standardSQL
+# Table stats. Total all, captioned and presentational
+SELECT
+  client,
+  COUNT(0) AS total_sites,
+
+  COUNTIF(total_tables > 0) AS sites_with_table,
+  COUNTIF(total_captioned > 0) AS sites_with_captions,
+  COUNTIF(total_presentational > 0) AS sites_with_presentational,
+
+  COUNTIF(total_tables > 0) / COUNT(0) AS pct_sites_with_table,
+  COUNTIF(total_captioned > 0) / COUNTIF(total_tables > 0) AS pct_table_sites_with_captioned,
+  COUNTIF(total_presentational > 0) / COUNTIF(total_tables > 0) AS pct_table_sites_with_presentational,
+
+  SUM(total_tables) AS total_tables,
+  SUM(total_captioned) AS total_captioned,
+  SUM(total_presentational) AS total_presentational,
+
+  SUM(total_captioned) / SUM(total_tables) AS pct_captioned,
+  SUM(total_presentational) / SUM(total_tables) AS pct_presentational
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._a11y'), '$.tables.total') AS INT64) AS total_tables,
+    CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._a11y'), '$.tables.total_with_caption') AS INT64) AS total_captioned,
+    CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._a11y'), '$.tables.total_with_presentational') AS INT64) AS total_presentational
+  FROM
+    `httparchive.pages.2021_07_01_*`
+)
+GROUP BY
+  client

--- a/sql/2022/accessibility/table_stats.sql
+++ b/sql/2022/accessibility/table_stats.sql
@@ -25,7 +25,7 @@ FROM (
     CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._a11y'), '$.tables.total_with_caption') AS INT64) AS total_captioned,
     CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._a11y'), '$.tables.total_with_presentational') AS INT64) AS total_presentational
   FROM
-    `httparchive.pages.2021_07_01_*`
+    `httparchive.pages.2022_06_01_*`
 )
 GROUP BY
   client

--- a/sql/2022/accessibility/units_properties.sql
+++ b/sql/2022/accessibility/units_properties.sql
@@ -1,0 +1,131 @@
+#standardSQL
+CREATE TEMPORARY FUNCTION getPropertyUnits(css STRING)
+RETURNS ARRAY<STRUCT<property STRING, unit STRING, freq INT64>>
+LANGUAGE js
+OPTIONS (library = "gs://httparchive/lib/css-utils.js")
+AS '''
+try {
+  function compute(ast) {
+    let ret = {
+      zeroes: {},
+      by_property: {}
+    };
+
+    const lengths = /(?<![-#\\w])\\b(?<number>-?\\d*\\.?\\d+)(?<unit>%|[a-z]{1,4}\\b|(?=\\s|$|,|\\*|\\/)\\b)/gi;
+
+    walkDeclarations(ast, ({property, value}) => {
+      // Remove color functions to avoid mucking results
+      value = removeFunctionCalls(value, {names: ["rgb", "rgba", "hsl", "hsla"]});
+
+      for (let length of value.matchAll(lengths)) {
+        let {number, unit} = length.groups;
+        ret.by_property[property] = ret.by_property[property] || {};
+
+        if (number === "0") {
+          incrementByKey(ret.zeroes, unit || "<number>");
+        }
+
+        if (unit) {
+          incrementByKey(ret, unit);
+          incrementByKey(ret.by_property[property], unit);
+        }
+        else {
+          incrementByKey(ret, "<number>");
+          incrementByKey(ret.by_property[property], "<number>");
+        }
+
+        incrementByKey(ret, "total"); // for calculating %
+        incrementByKey(ret.by_property[property], "total"); // for calculating %
+      }
+    }, {
+      // Properties that take one or more lengths
+      // We avoid shorthands because they're a mess to parse
+      // This helped: https://codepen.io/leaverou/pen/rNergbW?editors=0010
+      properties: [
+        "baseline-shift",
+        "box-shadow",
+        "vertical-align",
+        "clip-path",
+        /^column[s-]|^inset\b/g,
+        "contain-intrinsic-size",
+        "cx",
+        "cy",
+        "flex-basis",
+        "letter-spacing",
+        "perspective",
+        "perspective-origin",
+        "r",
+        "row-gap",
+        "rx",
+        "ry",
+        "tab-size",
+        "text-indent",
+        "text-shadow",
+        "translate",
+        "vertical-align",
+        "word-spacing",
+        "x",
+        "y",
+        /\\b(?:width|height|thickness|offset|origin|padding|border|margin|outline|top|right|bottom|left|(inline|block)-(start|end)|gap|size|position)\\b/g
+      ],
+      not: {
+        // Drop prefixed properties and custom properties
+        properties: /^-|-color$/
+      }
+    });
+
+    ret = sortObject(ret);
+
+    for (let property in ret.by_property) {
+      ret.by_property[property] = sortObject(ret.by_property[property]);
+    }
+
+    return ret;
+  }
+  var ast = JSON.parse(css);
+  var units = compute(ast);
+  return Object.entries(units.by_property).flatMap(([property, units]) => {
+    return Object.entries(units).filter(([unit]) => {
+      return unit != 'total';
+    }).map(([unit, freq]) => {
+      return {property, unit, freq};
+    });
+  });
+} catch (e) {
+  return [];
+}
+''';
+
+SELECT
+  *
+FROM (
+  SELECT
+    client,
+    property,
+    unit,
+    SUM(freq) AS freq,
+    SUM(SUM(freq)) OVER (PARTITION BY client, property) AS total,
+    SUM(freq) / SUM(SUM(freq)) OVER (PARTITION BY client, property) AS pct
+  FROM (
+    SELECT
+      client,
+      unit.property,
+      unit.unit,
+      unit.freq
+    FROM
+      `httparchive.almanac.parsed_css`,
+      UNNEST(getPropertyUnits(css)) AS unit
+    WHERE
+      date = '2021-07-01' AND
+      # Limit the size of the CSS to avoid OOM crashes.
+      LENGTH(css) < 0.1 * 1024 * 1024)
+  GROUP BY
+    client,
+    unit,
+    property)
+WHERE
+  total >= 1000 AND
+  pct >= 0.01
+ORDER BY
+  total DESC,
+  pct DESC

--- a/sql/2022/accessibility/units_properties.sql
+++ b/sql/2022/accessibility/units_properties.sql
@@ -1,4 +1,5 @@
 #standardSQL
+# Copy of sql/2022/css/units_properties.sql
 CREATE TEMPORARY FUNCTION getPropertyUnits(css STRING)
 RETURNS ARRAY<STRUCT<property STRING, unit STRING, freq INT64>>
 LANGUAGE js
@@ -116,7 +117,7 @@ FROM (
       `httparchive.almanac.parsed_css`,
       UNNEST(getPropertyUnits(css)) AS unit
     WHERE
-      date = '2021-07-01' AND
+      date = '2022-07-01' AND
       # Limit the size of the CSS to avoid OOM crashes.
       LENGTH(css) < 0.1 * 1024 * 1024)
   GROUP BY

--- a/sql/2022/accessibility/valid_html_lang.sql
+++ b/sql/2022/accessibility/valid_html_lang.sql
@@ -1,0 +1,14 @@
+#standardSQL
+# % of mobile sites with a valid html lang attribute
+SELECT
+  COUNT(0) AS total,
+  COUNTIF(valid_lang) AS valid_lang,
+  COUNTIF(has_lang) AS has_lang,
+  COUNTIF(has_lang) / COUNT(0) AS pct_has_of_total,
+  COUNTIF(valid_lang) / COUNT(0) AS pct_valid_of_total
+FROM (
+  SELECT
+    JSON_EXTRACT_SCALAR(report, "$.audits['html-has-lang'].score") = '1' AS has_lang,
+    JSON_EXTRACT_SCALAR(report, "$.audits['html-lang-valid'].score") = '1' AS valid_lang
+  FROM
+    `httparchive.lighthouse.2021_07_01_mobile`)

--- a/sql/2022/accessibility/valid_html_lang.sql
+++ b/sql/2022/accessibility/valid_html_lang.sql
@@ -11,4 +11,4 @@ FROM (
     JSON_EXTRACT_SCALAR(report, "$.audits['html-has-lang'].score") = '1' AS has_lang,
     JSON_EXTRACT_SCALAR(report, "$.audits['html-lang-valid'].score") = '1' AS valid_lang
   FROM
-    `httparchive.lighthouse.2021_07_01_mobile`)
+    `httparchive.lighthouse.2022_06_01_mobile`)

--- a/sql/2022/accessibility/valid_html_lang.sql
+++ b/sql/2022/accessibility/valid_html_lang.sql
@@ -1,6 +1,7 @@
 #standardSQL
-# % of mobile sites with a valid html lang attribute
+# % of pages with a valid html lang attribute
 SELECT
+  client,
   COUNT(0) AS total,
   COUNTIF(valid_lang) AS valid_lang,
   COUNTIF(has_lang) AS has_lang,
@@ -8,7 +9,12 @@ SELECT
   COUNTIF(valid_lang) / COUNT(0) AS pct_valid_of_total
 FROM (
   SELECT
+    _TABLE_SUFFIX AS client,
     JSON_EXTRACT_SCALAR(report, "$.audits['html-has-lang'].score") = '1' AS has_lang,
     JSON_EXTRACT_SCALAR(report, "$.audits['html-lang-valid'].score") = '1' AS valid_lang
   FROM
-    `httparchive.lighthouse.2022_06_01_mobile`)
+    `httparchive.lighthouse.2022_06_01_*`)
+GROUP BY
+  client
+ORDER BY
+  client

--- a/sql/2022/accessibility/video_track_usage.sql
+++ b/sql/2022/accessibility/video_track_usage.sql
@@ -1,0 +1,21 @@
+#standardSQL
+# Video elements track usage
+SELECT
+  client,
+  COUNT(0) AS total_sites,
+  COUNTIF(total_videos > 0) AS total_with_video,
+  COUNTIF(total_with_track > 0) AS total_with_tracks,
+
+  SUM(total_with_track) / SUM(total_videos) AS pct_videos_with_tracks,
+  COUNTIF(total_videos > 0) / COUNT(0) AS pct_sites_with_videos,
+  COUNTIF(total_with_track > 0) / COUNTIF(total_videos > 0) AS pct_video_sites_with_tracks
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._almanac'), '$.videos.total') AS INT64) AS total_videos,
+    CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._almanac'), '$.videos.total_with_track') AS INT64) AS total_with_track
+  FROM
+    `httparchive.pages.2021_07_01_*`
+)
+GROUP BY
+  client

--- a/sql/2022/accessibility/video_track_usage.sql
+++ b/sql/2022/accessibility/video_track_usage.sql
@@ -15,7 +15,7 @@ FROM (
     CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._almanac'), '$.videos.total') AS INT64) AS total_videos,
     CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._almanac'), '$.videos.total_with_track') AS INT64) AS total_with_track
   FROM
-    `httparchive.pages.2021_07_01_*`
+    `httparchive.pages.2022_06_01_*`
 )
 GROUP BY
   client

--- a/sql/2022/accessibility/viewport_zoom_scale.sql
+++ b/sql/2022/accessibility/viewport_zoom_scale.sql
@@ -1,0 +1,28 @@
+#standardSQL
+# Disabled zooming and scaling via the viewport tag
+SELECT
+  client,
+  COUNT(0) AS total_sites,
+  COUNTIF(has_meta_viewport) AS total_viewports,
+  COUNTIF(not_scalable) AS total_no_scale,
+  COUNTIF(max_scale_1_or_less) AS total_locked_max_scale,
+  COUNTIF(not_scalable OR max_scale_1_or_less) AS total_either,
+
+  COUNTIF(not_scalable) / COUNT(0) AS perc_sites_no_scale,
+  COUNTIF(max_scale_1_or_less) / COUNT(0) AS perc_sites_locked_max_scale,
+  COUNTIF(not_scalable OR max_scale_1_or_less) / COUNT(0) AS perc_sites_either
+FROM (
+  SELECT
+    client,
+    meta_viewport IS NOT NULL AS has_meta_viewport,
+    REGEXP_EXTRACT(meta_viewport, r'(?i)user-scalable\s*=\s*(no|0)') IS NOT NULL AS not_scalable,
+    SAFE_CAST(REGEXP_EXTRACT(meta_viewport, r'(?i)maximum-scale\s*=\s*([0-9]*\.[0-9]+|[0-9]+)') AS FLOAT64) <= 1 AS max_scale_1_or_less
+  FROM (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      JSON_EXTRACT_SCALAR(payload, '$._meta_viewport') AS meta_viewport
+    FROM
+      `httparchive.pages.2021_07_01_*`
+  )
+)
+GROUP BY client

--- a/sql/2022/accessibility/viewport_zoom_scale.sql
+++ b/sql/2022/accessibility/viewport_zoom_scale.sql
@@ -1,16 +1,17 @@
 #standardSQL
 # Disabled zooming and scaling via the viewport tag
+# Copy of sql/2022/mobile-web/viewport_zoom_scale.sql
 SELECT
   client,
-  COUNT(0) AS total_sites,
+  COUNT(0) AS total_pages,
   COUNTIF(has_meta_viewport) AS total_viewports,
   COUNTIF(not_scalable) AS total_no_scale,
   COUNTIF(max_scale_1_or_less) AS total_locked_max_scale,
   COUNTIF(not_scalable OR max_scale_1_or_less) AS total_either,
 
-  COUNTIF(not_scalable) / COUNT(0) AS perc_sites_no_scale,
-  COUNTIF(max_scale_1_or_less) / COUNT(0) AS perc_sites_locked_max_scale,
-  COUNTIF(not_scalable OR max_scale_1_or_less) / COUNT(0) AS perc_sites_either
+  COUNTIF(not_scalable) / COUNT(0) AS pct_pages_no_scale,
+  COUNTIF(max_scale_1_or_less) / COUNT(0) AS pct_pages_locked_max_scale,
+  COUNTIF(not_scalable OR max_scale_1_or_less) / COUNT(0) AS pct_pages_either
 FROM (
   SELECT
     client,
@@ -22,7 +23,7 @@ FROM (
       _TABLE_SUFFIX AS client,
       JSON_EXTRACT_SCALAR(payload, '$._meta_viewport') AS meta_viewport
     FROM
-      `httparchive.pages.2021_07_01_*`
+      `httparchive.pages.2022_06_01_*`
   )
 )
 GROUP BY client

--- a/sql/2022/accessibility/viewport_zoom_scale_by_domain_rank.sql
+++ b/sql/2022/accessibility/viewport_zoom_scale_by_domain_rank.sql
@@ -1,0 +1,45 @@
+#standardSQL
+# Disabled zooming and scaling via the viewport tag by domain rank
+SELECT
+  client,
+  rank_grouping,
+
+  COUNT(0) AS total_pages,
+  COUNTIF(has_meta_viewport) AS total_viewports,
+  COUNTIF(not_scalable) AS total_no_scale,
+  COUNTIF(max_scale_1_or_less) AS total_locked_max_scale,
+  COUNTIF(not_scalable OR max_scale_1_or_less) AS total_either,
+
+  COUNTIF(not_scalable) / COUNT(0) AS pct_pages_no_scale,
+  COUNTIF(max_scale_1_or_less) / COUNT(0) AS pct_pages_locked_max_scale,
+  COUNTIF(not_scalable OR max_scale_1_or_less) / COUNT(0) AS pct_pages_either
+FROM (
+  SELECT
+    client,
+    url,
+    meta_viewport IS NOT NULL AS has_meta_viewport,
+    REGEXP_EXTRACT(meta_viewport, r'(?i)user-scalable\s*=\s*(no|0)') IS NOT NULL AS not_scalable,
+    SAFE_CAST(REGEXP_EXTRACT(meta_viewport, r'(?i)maximum-scale\s*=\s*([0-9]*\.[0-9]+|[0-9]+)') AS FLOAT64) <= 1 AS max_scale_1_or_less
+  FROM (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      url,
+      JSON_EXTRACT_SCALAR(payload, '$._meta_viewport') AS meta_viewport
+    FROM
+      `httparchive.pages.2021_07_01_*`
+  )
+)
+LEFT JOIN (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    url,
+    rank_grouping
+  FROM
+    `httparchive.summary_pages.2021_07_01_*`,
+    UNNEST([1000, 10000, 100000, 1000000, 10000000]) AS rank_grouping
+  WHERE
+    rank <= rank_grouping
+) USING (client, url)
+GROUP BY
+  rank_grouping,
+  client

--- a/sql/2022/accessibility/viewport_zoom_scale_by_domain_rank.sql
+++ b/sql/2022/accessibility/viewport_zoom_scale_by_domain_rank.sql
@@ -1,5 +1,6 @@
 #standardSQL
 # Disabled zooming and scaling via the viewport tag by domain rank
+# Copy of sql/2022/mobile-web/viewport_zoom_scale_by_domain_rank.sql
 SELECT
   client,
   rank_grouping,
@@ -26,7 +27,7 @@ FROM (
       url,
       JSON_EXTRACT_SCALAR(payload, '$._meta_viewport') AS meta_viewport
     FROM
-      `httparchive.pages.2021_07_01_*`
+      `httparchive.pages.2022_06_01_*`
   )
 )
 LEFT JOIN (
@@ -35,7 +36,7 @@ LEFT JOIN (
     url,
     rank_grouping
   FROM
-    `httparchive.summary_pages.2021_07_01_*`,
+    `httparchive.summary_pages.2022_06_01_*`,
     UNNEST([1000, 10000, 100000, 1000000, 10000000]) AS rank_grouping
   WHERE
     rank <= rank_grouping


### PR DESCRIPTION
Progress on #2889.

For the accessibility chapter, we’re choosing to reuse the 2021 queries as-is so we can catch up on the milestones. This PR has two commits – one that copies the needed 2021 queries and won’t be that interesting to review. And [one that updates the queries for 2022](https://github.com/HTTPArchive/almanac.httparchive.org/pull/3057/commits/de2d76d5b4523ca83572498070a0dedbcc02e4e2), which is what will be the most relevant to review. For the majority of queries I updated only the dates, For a few other, I made further changes.

For each query listed below, I’ve added the _2021_ sheet’s title, and a link to a copy I made of the 2021 results, with tentative 2022 results within the same sheet. This is only to help validating the queries / results are in line with expectations, and to help me making sure I generate pivot tables and figures correctly. There are a few queries listed multiple times – that’s just to indicate their results are reused multiple times.

---

## Introduction

- [x] `lighthouse_a11y_score` [Percentiles of lighthouse a11y score YoY](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=1224854971)

## Ease of reading

No queries.

### Color contrast

- [x] `color_contrast` [% mobile sites with sufficient text color contrast with its background](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=51084807)

### Zooming and scaling

- [x] `viewport_zoom_scale` [Viewport zoom scale](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=744885125)
- [x] `viewport_zoom_scale_by_domain_rank` [Disabled zooming and scaling via the viewport tag by domain rank](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=645664156)

### Language identification

- [x] `valid_html_lang` [% of mobile sites with a valid html lang attribute](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=2009310389)

### Font size and line height

- [x] `units_properties` [Length units top properties - From CSS Chapter](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=1740727138)

### Focus Styles

- [x] `focus_outline_0` [focus and outline 0 - From CSS chapter](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=1517955087)
- [x] `focus_visible` [focus and outline 0 - From CSS chapter](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=1517955087) (this query’s results are combined with `focus_outline_0` into a single chart)

### User preference media queries and high contrast support

- [x] `media_query_features` [Prefers data - From CSS chapter](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=1027210289)

## Ease of page navigation

No queries.

### Landmarks and page structure

- [x] `landmark_elements_and_roles` [sites using landmark elements or roles](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=1736231238)

### Document titles

- [x] `page_title` [Page title stats](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=1437437016)

### Secondary Navigation

- [x] `pages_with_search_input` [Pages with search input](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=95974815)

### Tabindex

- [x] `tabindex_usage_and_values` [Tabindex usage data](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=1330777562)

### Skip links

- [x] `skip_links` [% of pages having skip links](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=1767801208)

### Heading hierarchy

- [x] `lighthouse_a11y_audits` [Summary of all lighthouse scores for a category](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=461215072)

### Tables

- [x] `table_stats` [Table stats](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=1802381033)

### Table captions

No queries.

### Tables for layout

- [x] `table_stats` [Table stats](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=1802381033)

### Tabs

- [x] `common_aria_role` [% of sites using each type of aria role](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=2046624948)

### Captchas

- [x] `captcha_usage` [Captcha usage](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=1059643233)

## Forms

No queries.

### The `<label>` element

- [x] `form_input_name_sources` [Where input elements get their A11Y names from](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=1517205301)

### The improper use of the `placeholder` attribute for labeling inputs

- [x] `placeholder_but_no_label` [Form controls with placeholder but no label](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=743455437)

### Requiring information

- [x] `form_required_controls` [Various stats for required form controls](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=2064792791)

## Media on the web

No queries.

### Overview of text alternatives

No queries.

#### Images

- [x] `alt_ending_in_image_extension` [Alt text ending in an image extension](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=747755748)
- [x] `alt_ending_in_image_extension` [Alt text ending in an image extension](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=747755748)
- [x] `common_alt_text_length` [Most common lengths of alt text](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=384780873)
- [x] `lighthouse_a11y_audits` [Summary of all lighthouse scores for a category](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=461215072)

#### Audio

- [x] `audio_track_usage` [Audio elements track usage](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=1198212185)

#### Video

- [x] `video_track_usage` [Video elements track usage](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=1261793459)

## Supporting assistive technology with ARIA

No queries.

### ARIA roles

- [x] `sites_using_role` [Sites using the role attribute](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=1612528407)
- [x] `common_aria_role` [% of sites using each type of aria role](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=2046624948)

### Just use a button!

- [x] `anchors_with_role_button` [Anchors with role='button'](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=1014817325)
- [x] `common_aria_role` [% of sites using each type of aria role](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=2046624948)

### Using presentation role

- [x] `common_aria_role` [% of sites using each type of aria role](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=2046624948)

### Labelling and describing elements with ARIA

- [x] `common_element_attributes` [How often pages contain an element with a given attribute](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=1763660541)

#### Where do buttons get their accessible names from?

- [x] `button_name_sources` [Where button elements get their A11Y names from](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=1467280228)

### Hiding content

- [x] `common_element_attributes` [How often pages contain an element with a given attribute](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=1763660541)
- [x] `common_element_attributes` [How often pages contain an element with a given attribute](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=1763660541)

### Screen reader-only text

- [x] `sr_only_classes` [Sites using sr-only or visually-hidden classes](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=960991314)

### Dynamically-rendered content

- [x] `common_element_attributes` [How often pages contain an element with a given attribute](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=1763660541)

## Accessibility overlays

- [x] `a11y_technology_usage` [A11Y technology usage](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=150155313)
- [x] `a11y_technology_usage_by_domain_rank` [A11Y technology usage by domain rank](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=2077755325)
- [x] `a11y_overall_tech_usage_by_domain_rank` [A11Y technology usage by rank](https://docs.google.com/spreadsheets/d/1eJtp09ja2FLoY4OTcDR3LdunGDsE62Gm3ZCcRF_7r8c/edit#gid=827309922)

### The consequences of overlays

No queries.

### Privacy concerns

No queries.

### Overlays and lawsuits

No queries.

### Why do some companies use overlays?

No queries.

### Additional resources about overlays

No queries.

## Conclusion

No queries.