### PR TITLE
Point to correct SQL files for overlay figures in 2021 accessibility chapter

### DIFF
--- a/src/content/en/2021/accessibility.md
+++ b/src/content/en/2021/accessibility.md
@@ -760,7 +760,7 @@ We found that 0.96% of desktop websites—or well over 60,000—use one of these
   description="A bar chart showing usage of the most popular accessibility apps by domain rank on desktop sites. AccessiBe is not used on the top 1,000 sites but is used by 0.15% of the top 10,000 sites, by 0.39% of the top 100,000 sites, by 0.37% of the top million sites and by 0.27% of all sites. AudioEye is used by 0.13%, 0.20%, 0.13%, 0.16%, and 0.24% respectively. EqualWeb is not used on the top 1,000 or top 10,000 site but is used by 0.02% of the top 100,000, 0.03% of the top million, and 0.02% of all sites. Texthelp similarly is not used on the top 1,000 or top 10,000 sites but is used by 0.02% of the top 100,000, 0.04% of the top million, and 0.02% of all sites. Finally, UserWay is not used on the top 1,000 sites but is used by 0.04% of the top 10,000 sites, by 0.09% of the top 100,000 sites, by 0.24% of the top million and by 0.39% of all sites. Only AudioEye is used by the top 1,000 sites.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vQf4cxIC7ywDV-K2RpfaTeCYI4URyJE1air8BCAxoOw7VW9MjGRQfwHuILvhw-6UmcWnsrAJ0-1TTD_/pubchart?oid=473077851&format=interactive",
   sheets_gid="2077755325",
-  sql_file="a11y_overall_tech_usage_by_domain_rank.sql"
+  sql_file="a11y_technology_usage_by_domain_rank.sql"
 ) }}
 
 When considering domain rank, the top 1,000 websites have a lower percentage —0.1%— of overlay usage. However, considering the reach of these top-ranking sites, the potential impact of even one website with this much traffic using an overlay is very substantial.
@@ -771,7 +771,7 @@ When considering domain rank, the top 1,000 websites have a lower percentage —
   description="A bar chart showing that for the top 1,000 sites, 0.1% on desktop and 0.1% on mobile use and accessibility app, for the top 10,000 it's 0.6% and 0.5% respectively, for the top 100,000 it's 0.8% and 0.7%, for the top million it's 0.9% and 0.8%, and finally for all sites 1.0% it's 0.8%.",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vQf4cxIC7ywDV-K2RpfaTeCYI4URyJE1air8BCAxoOw7VW9MjGRQfwHuILvhw-6UmcWnsrAJ0-1TTD_/pubchart?oid=851935325&format=interactive",
   sheets_gid="827309922",
-  sql_file="a11y_technology_usage_by_domain_rank.sql"
+  sql_file="a11y_overall_tech_usage_by_domain_rank.sql"
 ) }}
 
 ### The consequences of overlays

--- a/src/content/ja/2021/accessibility.md
+++ b/src/content/ja/2021/accessibility.md
@@ -760,7 +760,7 @@ _ARIAライブリージョン_は、DOMの変更を監視し、スクリーン�
   description="デスクトップサイトでもっとも人気のあるアクセシビリティ・アプリのドメインランク別の利用状況を示す棒グラフです。AccessiBeは上位1,000サイトでは利用されていないが、上位10,000サイトでは0.15%、上位100,000サイトが0.39%、上位100万サイトは0.37%、全サイトで0.27%利用されていることがわかる。AudioEyeは、それぞれ0.13%、0.20%、0.13%、0.16%、0.24%で使用されています。EqualWebは、上位1,000サイトや上位10,000サイトでは使用されていませんが、上位10万サイトの0.02％、上位100万サイトの0.03％、全サイトの0.02％で使用されています。 テキストヘルプも同様に、上位1,000サイトや上位10,000サイトでは使用されていませんが、上位10万サイトの0.02％、上位100万サイトの0.04％、全サイトの0.02％で使用されています。最後に、UserWayは上位1,000サイトでは使用されていないが、上位1万サイトの0.04%、上位10万サイトの0.09%、上位100万サイトの0.24%、全サイトの0.39%で使用されている。AudioEyeのみ、上位1,000サイトで使用されています。",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vQf4cxIC7ywDV-K2RpfaTeCYI4URyJE1air8BCAxoOw7VW9MjGRQfwHuILvhw-6UmcWnsrAJ0-1TTD_/pubchart?oid=473077851&format=interactive",
   sheets_gid="2077755325",
-  sql_file="a11y_overall_tech_usage_by_domain_rank.sql"
+  sql_file="a11y_technology_usage_by_domain_rank.sql"
 ) }}
 
 ドメインランクを考慮すると、上位1,000サイトのオーバーレイ使用率は0.1%と低くなっています。しかし、これらの上位サイトのリーチを考慮すると、これだけのトラフィックを持つ1つのWebサイトがオーバーレイを使用した場合の潜在的な影響は非常に大きなものです。
@@ -771,7 +771,7 @@ _ARIAライブリージョン_は、DOMの変更を監視し、スクリーン�
   description="上位1,000サイトではデスクトップで0.1%、モバイル利用とアクセシビリティアプリで0.1%、上位1万サイトではそれぞれ0.6%、0.5%、上位10万サイトは0.8%、0.7%、上位100万サイトで0.9%、0.8%、最後にすべてのサイトで1%、0.8%となっており、棒グラフが示されています。",
   chart_url="https://docs.google.com/spreadsheets/d/e/2PACX-1vQf4cxIC7ywDV-K2RpfaTeCYI4URyJE1air8BCAxoOw7VW9MjGRQfwHuILvhw-6UmcWnsrAJ0-1TTD_/pubchart?oid=851935325&format=interactive",
   sheets_gid="827309922",
-  sql_file="a11y_technology_usage_by_domain_rank.sql"
+  sql_file="a11y_overall_tech_usage_by_domain_rank.sql"
 ) }}
 
 ### オーバーレイのもたらすもの


### PR DESCRIPTION
In [Accessibility overlays](https://almanac.httparchive.org/en/2021/accessibility#accessibility-overlays), two successive charts point to the correct sheets, but not to the correct query for their data. You can tell based on the column names.

1. Accessibility app usage by rank: [sheet](https://docs.google.com/spreadsheets/d/1WjAM5ZnHjMQt-rKyHvj2eVhU_WdzzFTjpoYWMr_I0Cw/edit#gid=2077755325), [correct query: `a11y_technology_usage_by_domain_rank.sql`](https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2021/accessibility/a11y_technology_usage_by_domain_rank.sql). Note the `pct_sites_with_app` column.
2. Pages using accessibility apps by rank: [sheet](https://docs.google.com/spreadsheets/d/1WjAM5ZnHjMQt-rKyHvj2eVhU_WdzzFTjpoYWMr_I0Cw/edit#gid=827309922), [correct query: `a11y_technology_usage_by_domain_rank.sql`](https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2021/accessibility/a11y_overall_tech_usage_by_domain_rank.sql). Note the `pct_sites_with_a11y_tech` column.

This is all pretty confusing due to the naming of the charts, sheets, queries.

1. The first query counts how much usage each of the accessibility overlays gets by domain rank (and the chart only shows 5 pre-selected tools)
2. The second query counts total usage of accessibility overlays by domain rank