### PR TITLE
Linting fixes for already merged queries.

### DIFF
--- a/sql/2022/css/all_properties.sql
+++ b/sql/2022/css/all_properties.sql
@@ -35,7 +35,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )

--- a/sql/2022/css/box_sizing_border_box_selectors.sql
+++ b/sql/2022/css/box_sizing_border_box_selectors.sql
@@ -52,7 +52,7 @@ FROM (
       _TABLE_SUFFIX AS client,
       COUNT(0) AS total_pages
     FROM
-      `httparchive.summary_pages.2022_07_01_*`
+      `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
     GROUP BY
       client)
   USING

--- a/sql/2022/css/calc_operators.sql
+++ b/sql/2022/css/calc_operators.sql
@@ -69,7 +69,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )

--- a/sql/2022/css/calc_properties.sql
+++ b/sql/2022/css/calc_properties.sql
@@ -69,7 +69,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )

--- a/sql/2022/css/calc_units.sql
+++ b/sql/2022/css/calc_units.sql
@@ -69,7 +69,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )

--- a/sql/2022/css/color_alpha_functions.sql
+++ b/sql/2022/css/color_alpha_functions.sql
@@ -192,7 +192,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )

--- a/sql/2022/css/color_formats.sql
+++ b/sql/2022/css/color_formats.sql
@@ -180,7 +180,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )

--- a/sql/2022/css/color_p3.sql
+++ b/sql/2022/css/color_p3.sql
@@ -164,7 +164,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )

--- a/sql/2022/css/css_in_js.sql
+++ b/sql/2022/css/css_in_js.sql
@@ -44,14 +44,14 @@ FROM (
     url,
     cssInJs
   FROM
-    `httparchive.pages.2022_07_01_*`,
+    `httparchive.pages.2022_07_01_*`, -- noqa: L062
     UNNEST(getCssInJS(payload)) AS cssInJs)
 JOIN (
   SELECT
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client)
 USING (client)

--- a/sql/2022/css/custom_property_adoption.sql
+++ b/sql/2022/css/custom_property_adoption.sql
@@ -39,7 +39,7 @@ FROM (
     client,
     page)
 JOIN
-  (SELECT _TABLE_SUFFIX AS client, COUNT(0) AS total FROM `httparchive.summary_pages.2022_07_01_*` GROUP BY client)
+  (SELECT _TABLE_SUFFIX AS client, COUNT(0) AS total FROM `httparchive.summary_pages.2022_07_01_*` GROUP BY client) --noqa: L062
 USING
   (client)
 GROUP BY

--- a/sql/2022/css/custom_property_depth.sql
+++ b/sql/2022/css/custom_property_depth.sql
@@ -86,7 +86,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )
@@ -107,7 +107,7 @@ FROM (
     custom_properties.depth,
     custom_properties.freq
   FROM
-    `httparchive.pages.2022_07_01_*`,
+    `httparchive.pages.2022_07_01_*`, -- noqa: L062
     UNNEST(getCustomPropertyLengths(payload)) AS custom_properties)
 JOIN
   totals

--- a/sql/2022/css/custom_property_functions.sql
+++ b/sql/2022/css/custom_property_functions.sql
@@ -110,7 +110,7 @@ JOIN (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client)
 USING

--- a/sql/2022/css/custom_property_names.sql
+++ b/sql/2022/css/custom_property_names.sql
@@ -23,13 +23,13 @@ FROM (
     getCustomPropertyNames(payload) AS names,
     total
   FROM
-    `httparchive.pages.2022_07_01_*`
+    `httparchive.pages.2022_07_01_*` -- noqa: L062
   JOIN (
     SELECT
       _TABLE_SUFFIX,
       COUNT(DISTINCT url) AS total
     FROM
-      `httparchive.pages.2022_07_01_*`
+      `httparchive.pages.2022_07_01_*` -- noqa: L062
     GROUP BY
       _TABLE_SUFFIX)
   USING (_TABLE_SUFFIX)),

--- a/sql/2022/css/custom_property_properties.sql
+++ b/sql/2022/css/custom_property_properties.sql
@@ -110,7 +110,7 @@ JOIN (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client)
 USING

--- a/sql/2022/css/custom_property_value_types.sql
+++ b/sql/2022/css/custom_property_value_types.sql
@@ -154,7 +154,7 @@ FROM (
     value.type,
     value.freq
   FROM
-    `httparchive.pages.2022_07_01_*`
+    `httparchive.pages.2022_07_01_*` -- noqa: L062
   LEFT JOIN
     UNNEST(getCustomPropertyValueTypes(JSON_EXTRACT_SCALAR(payload, "$['_css-variables']"))) AS value)
 ORDER BY

--- a/sql/2022/css/effects_blend_mode_popularity.sql
+++ b/sql/2022/css/effects_blend_mode_popularity.sql
@@ -37,7 +37,7 @@ totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )

--- a/sql/2022/css/flexbox_grid.sql
+++ b/sql/2022/css/flexbox_grid.sql
@@ -6,7 +6,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
   UNION ALL

--- a/sql/2022/css/gradient_adoption.sql
+++ b/sql/2022/css/gradient_adoption.sql
@@ -165,7 +165,7 @@ JOIN (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client)
 USING

--- a/sql/2022/css/gradient_functions.sql
+++ b/sql/2022/css/gradient_functions.sql
@@ -166,7 +166,7 @@ JOIN (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client)
 USING

--- a/sql/2022/css/houdini_paint_worklets.sql
+++ b/sql/2022/css/houdini_paint_worklets.sql
@@ -31,7 +31,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )

--- a/sql/2022/css/i18n_dir_html_elements.sql
+++ b/sql/2022/css/i18n_dir_html_elements.sql
@@ -37,7 +37,7 @@ FROM (
     SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX, dir.element) AS total,
     COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX, dir.element) AS pct
   FROM
-    `httparchive.pages.2022_07_01_*`,
+    `httparchive.pages.2022_07_01_*`, -- noqa: L062
     UNNEST(getMarkupDirs(payload)) AS dir
   GROUP BY
     client,

--- a/sql/2022/css/i18n_logical_properties.sql
+++ b/sql/2022/css/i18n_logical_properties.sql
@@ -85,7 +85,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )

--- a/sql/2022/css/i18n_physical_properties.sql
+++ b/sql/2022/css/i18n_physical_properties.sql
@@ -85,7 +85,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )

--- a/sql/2022/css/keyword_totals.sql
+++ b/sql/2022/css/keyword_totals.sql
@@ -63,7 +63,7 @@ JOIN (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client)
 USING

--- a/sql/2022/css/layout_properties.sql
+++ b/sql/2022/css/layout_properties.sql
@@ -72,7 +72,7 @@ JOIN (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client)
 USING

--- a/sql/2022/css/media_query_features.sql
+++ b/sql/2022/css/media_query_features.sql
@@ -56,7 +56,7 @@ JOIN (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client)
 USING

--- a/sql/2022/css/media_query_properties.sql
+++ b/sql/2022/css/media_query_properties.sql
@@ -50,7 +50,7 @@ JOIN (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client)
 USING

--- a/sql/2022/css/media_query_responsive.sql
+++ b/sql/2022/css/media_query_responsive.sql
@@ -55,7 +55,7 @@ JOIN (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client)
 USING

--- a/sql/2022/css/media_query_values.sql
+++ b/sql/2022/css/media_query_values.sql
@@ -54,7 +54,7 @@ JOIN (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client)
 USING

--- a/sql/2022/css/meta_important_properties.sql
+++ b/sql/2022/css/meta_important_properties.sql
@@ -36,7 +36,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )

--- a/sql/2022/css/meta_shorthand_first_properties.sql
+++ b/sql/2022/css/meta_shorthand_first_properties.sql
@@ -450,7 +450,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )

--- a/sql/2022/css/multicol.sql
+++ b/sql/2022/css/multicol.sql
@@ -35,7 +35,7 @@ JOIN (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client)
 USING

--- a/sql/2022/css/print_page_properties.sql
+++ b/sql/2022/css/print_page_properties.sql
@@ -53,7 +53,7 @@ JOIN (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client)
 USING

--- a/sql/2022/css/print_page_pseudo_classes.sql
+++ b/sql/2022/css/print_page_pseudo_classes.sql
@@ -47,7 +47,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )

--- a/sql/2022/css/print_stylesheet_adoption.sql
+++ b/sql/2022/css/print_stylesheet_adoption.sql
@@ -15,7 +15,7 @@ WITH print AS (
     _TABLE_SUFFIX AS client,
     hasPrintStylesheet(payload) AS has_print_stylesheet
   FROM
-    `httparchive.pages.2022_07_01_*`
+    `httparchive.pages.2022_07_01_*` -- noqa: L062
 )
 
 

--- a/sql/2022/css/ruby_adoption.sql
+++ b/sql/2022/css/ruby_adoption.sql
@@ -47,7 +47,7 @@ JOIN (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client)
 USING

--- a/sql/2022/css/sass_animated_custom_properties.sql
+++ b/sql/2022/css/sass_animated_custom_properties.sql
@@ -70,7 +70,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )
@@ -96,7 +96,7 @@ JOIN (
     url AS page,
     prop
   FROM
-    `httparchive.pages.2022_07_01_*`,
+    `httparchive.pages.2022_07_01_*`, -- noqa: L062
     UNNEST(getCustomPropertiesWithComputedStyle(payload)) AS prop)
 USING
   (client, page, prop)

--- a/sql/2022/css/sass_combined_variable_names.sql
+++ b/sql/2022/css/sass_combined_variable_names.sql
@@ -24,7 +24,7 @@ FROM (
     SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS total,
     COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX) AS pct
   FROM
-    `httparchive.pages.2022_07_01_*`,
+    `httparchive.pages.2022_07_01_*`, -- noqa: L062
     UNNEST(getCombinedVariableNames(payload)) AS name
   GROUP BY
     client,

--- a/sql/2022/css/sass_combined_variables_distribution.sql
+++ b/sql/2022/css/sass_combined_variables_distribution.sql
@@ -25,7 +25,7 @@ FROM (
     var.usage,
     var.freq
   FROM
-    `httparchive.pages.2022_07_01_*`,
+    `httparchive.pages.2022_07_01_*`, -- noqa: L062
     UNNEST(countCombinedVariables(payload)) AS var),
   UNNEST([10, 25, 50, 75, 90, 100]) AS percentile
 GROUP BY

--- a/sql/2022/css/sass_combined_variables_pages.sql
+++ b/sql/2022/css/sass_combined_variables_pages.sql
@@ -29,14 +29,14 @@ FROM (
     var.usage,
     var.freq
   FROM
-    `httparchive.pages.2022_07_01_*`,
+    `httparchive.pages.2022_07_01_*`, -- noqa: L062
     UNNEST(countCombinedVariables(payload)) AS var)
 JOIN (
   SELECT
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client)
 USING

--- a/sql/2022/css/sass_control_flow_statements.sql
+++ b/sql/2022/css/sass_control_flow_statements.sql
@@ -33,7 +33,7 @@ WITH totals AS (
     COUNT(0) AS total_pages,
     COUNTIF(SAFE_CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._sass'), '$.scss.size') AS INT64) > 0) AS total_sass
   FROM
-    `httparchive.pages.2022_07_01_*`
+    `httparchive.pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )
@@ -56,7 +56,7 @@ FROM (
     statement.statement,
     SUM(statement.freq) AS freq
   FROM
-    `httparchive.pages.2022_07_01_*`,
+    `httparchive.pages.2022_07_01_*`, -- noqa: L062
     UNNEST(getStatements(payload)) AS statement
   GROUP BY
     client,

--- a/sql/2022/css/sass_custom_function_calls.sql
+++ b/sql/2022/css/sass_custom_function_calls.sql
@@ -31,7 +31,7 @@ FROM (
       fn.fn,
       fn.freq
     FROM
-      `httparchive.pages.2022_07_01_*`,
+      `httparchive.pages.2022_07_01_*`, -- noqa: L062
       UNNEST(getCustomFunctionCalls(payload)) AS fn)
   GROUP BY
     client,

--- a/sql/2022/css/sass_custom_function_names.sql
+++ b/sql/2022/css/sass_custom_function_names.sql
@@ -25,14 +25,14 @@ FROM (
     url,
     sass_custom_function
   FROM
-    `httparchive.pages.2022_07_01_*`,
+    `httparchive.pages.2022_07_01_*`, -- noqa: L062
     UNNEST(getCustomFunctionNames(payload)) AS sass_custom_function)
 JOIN (
   SELECT
     _TABLE_SUFFIX AS client,
     COUNTIF(SAFE_CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._sass'), '$.scss.size') AS INT64) > 0) AS total_sass
   FROM
-    `httparchive.pages.2022_07_01_*`
+    `httparchive.pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client)
 USING

--- a/sql/2022/css/sass_custom_functions.sql
+++ b/sql/2022/css/sass_custom_functions.sql
@@ -23,7 +23,7 @@ FROM (
     url AS page,
     SUM(getCustomFunctionCount(payload)) AS fn
   FROM
-    `httparchive.pages.2022_07_01_*`
+    `httparchive.pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client,
     page),

--- a/sql/2022/css/sass_function_calls.sql
+++ b/sql/2022/css/sass_function_calls.sql
@@ -31,7 +31,7 @@ FROM (
       fn.fn,
       fn.freq
     FROM
-      `httparchive.pages.2022_07_01_*`,
+      `httparchive.pages.2022_07_01_*`, -- noqa: L062
       UNNEST(getFunctionCalls(payload)) AS fn)
   GROUP BY
     client,

--- a/sql/2022/css/sass_mixin_calls.sql
+++ b/sql/2022/css/sass_mixin_calls.sql
@@ -31,7 +31,7 @@ FROM (
       mixin.mixin,
       mixin.freq
     FROM
-      `httparchive.pages.2022_07_01_*`,
+      `httparchive.pages.2022_07_01_*`, -- noqa: L062
       UNNEST(getMixinUsage(payload)) AS mixin)
   GROUP BY
     client,

--- a/sql/2022/css/sass_mixin_names.sql
+++ b/sql/2022/css/sass_mixin_names.sql
@@ -25,14 +25,14 @@ FROM (
     url,
     mixin
   FROM
-    `httparchive.pages.2022_07_01_*`,
+    `httparchive.pages.2022_07_01_*`, -- noqa: L062
     UNNEST(getMixinNames(payload)) AS mixin)
 JOIN (
   SELECT
     _TABLE_SUFFIX AS client,
     COUNTIF(SAFE_CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._sass'), '$.scss.size') AS INT64) > 0) AS total_sass
   FROM
-    `httparchive.pages.2022_07_01_*`
+    `httparchive.pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client)
 USING

--- a/sql/2022/css/sass_nesting.sql
+++ b/sql/2022/css/sass_nesting.sql
@@ -37,7 +37,7 @@ FROM (
     nested.nested,
     SUM(nested.freq) AS freq
   FROM
-    `httparchive.pages.2022_07_01_*`,
+    `httparchive.pages.2022_07_01_*`, -- noqa: L062
     UNNEST(getNestedUsage(payload)) AS nested
   GROUP BY
     client,
@@ -48,7 +48,7 @@ JOIN (
     _TABLE_SUFFIX AS client,
     COUNTIF(SAFE_CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._sass'), '$.scss.size') AS INT64) > 0) AS total_sass
   FROM
-    `httparchive.pages.2022_07_01_*`
+    `httparchive.pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client)
 USING

--- a/sql/2022/css/sass_variable_usage.sql
+++ b/sql/2022/css/sass_variable_usage.sql
@@ -32,14 +32,14 @@ FROM (
     variable.variable,
     variable.freq
   FROM
-    `httparchive.pages.2022_07_01_*`,
+    `httparchive.pages.2022_07_01_*`, -- noqa: L062
     UNNEST(getVariableUsage(payload)) AS variable)
 JOIN (
   SELECT
     _TABLE_SUFFIX AS client,
     COUNT(DISTINCT url) AS total_sass
   FROM
-    `httparchive.pages.2022_07_01_*`,
+    `httparchive.pages.2022_07_01_*`, -- noqa: L062
     UNNEST(getVariableUsage(payload))
   GROUP BY
     client)

--- a/sql/2022/css/supports_criteria.sql
+++ b/sql/2022/css/supports_criteria.sql
@@ -51,7 +51,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )

--- a/sql/2022/css/supports_properties.sql
+++ b/sql/2022/css/supports_properties.sql
@@ -53,7 +53,7 @@ JOIN (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client)
 USING

--- a/sql/2022/css/top_selector_classes_wp_fa_prefixes.sql
+++ b/sql/2022/css/top_selector_classes_wp_fa_prefixes.sql
@@ -62,7 +62,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )

--- a/sql/2022/css/top_selector_ids.sql
+++ b/sql/2022/css/top_selector_ids.sql
@@ -62,7 +62,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )

--- a/sql/2022/css/top_selector_pseudo_classes.sql
+++ b/sql/2022/css/top_selector_pseudo_classes.sql
@@ -62,7 +62,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )

--- a/sql/2022/css/transition_animation_names.sql
+++ b/sql/2022/css/transition_animation_names.sql
@@ -100,7 +100,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )

--- a/sql/2022/css/transition_properties.sql
+++ b/sql/2022/css/transition_properties.sql
@@ -119,7 +119,7 @@ JOIN (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client)
 USING

--- a/sql/2022/css/transition_timing_functions.sql
+++ b/sql/2022/css/transition_timing_functions.sql
@@ -102,7 +102,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )

--- a/sql/2022/css/units_frequency.sql
+++ b/sql/2022/css/units_frequency.sql
@@ -100,7 +100,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   GROUP BY
     client
 )

--- a/sql/2022/ecommerce/pct_ecommsites_bydevice_compare20212022.sql
+++ b/sql/2022/ecommerce/pct_ecommsites_bydevice_compare20212022.sql
@@ -37,13 +37,13 @@ SELECT
   total,
   COUNT(DISTINCT url) / total AS pct
 FROM
-  `httparchive.technologies.2021_06_01_*`
+  `httparchive.technologies.2021_07_01_*`
 JOIN (
   SELECT
     _TABLE_SUFFIX,
     COUNT(DISTINCT url) AS total
   FROM
-    `httparchive.summary_pages.2021_06_01_*`
+    `httparchive.summary_pages.2021_07_01_*`
   GROUP BY
     _TABLE_SUFFIX)
 USING

--- a/sql/2022/ecommerce/pct_ecommsites_bydevice_compare20212022.sql
+++ b/sql/2022/ecommerce/pct_ecommsites_bydevice_compare20212022.sql
@@ -4,7 +4,7 @@
 ## This query is built using 2019 query from https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2019/13_Ecommerce/13_02b.sql but this commit fixes a flaw in 2019 query. See - https://github.com/HTTPArchive/almanac.httparchive.org/issues/1810
 SELECT
   _TABLE_SUFFIX AS client,
-  2021 AS year,
+  2022 AS year,
   COUNT(DISTINCT url) AS freq,
   total,
   COUNT(DISTINCT url) / total AS pct
@@ -32,7 +32,7 @@ GROUP BY
 UNION ALL
 SELECT
   _TABLE_SUFFIX AS client,
-  2020 AS year,
+  2021 AS year,
   COUNT(DISTINCT url) AS freq,
   total,
   COUNT(DISTINCT url) / total AS pct


### PR DESCRIPTION
Includes following changes
- Correction to ecommerce queries checked in, in #2958 - only noticed after merging as lastest linting only ran then.
- Correction to CSS queries to noqa July datasets as using non-standard month

The dataset check was only recently released in SQLFluff and many branches were started before that update. Might see a few more of these.