### PR TITLE
Add noqa for SEO 2022 queries

### DIFF
--- a/sql/2022/seo/anchor-rel-attribute-usage.sql
+++ b/sql/2022/seo/anchor-rel-attribute-usage.sql
@@ -41,13 +41,13 @@ FROM
       total,
       getRelStatsWptBodies(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
     FROM
-      `httparchive.pages.2022_07_01_*`
+      `httparchive.pages.2022_07_01_*` -- noqa: L062
     JOIN
       (
 
         SELECT _TABLE_SUFFIX, COUNT(0) AS total
         FROM
-          `httparchive.pages.2022_07_01_*`
+          `httparchive.pages.2022_07_01_*` -- noqa: L062
         GROUP BY _TABLE_SUFFIX
       )
     USING (_TABLE_SUFFIX)

--- a/sql/2022/seo/anchor-same-site-occurance-stats.sql
+++ b/sql/2022/seo/anchor-same-site-occurance-stats.sql
@@ -52,14 +52,14 @@ FROM (
     total,
     getLinkDesciptionsWptBodies(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
   FROM
-    `httparchive.pages.2022_07_01_*`
+    `httparchive.pages.2022_07_01_*` -- noqa: L062
   JOIN (
 
     SELECT
       _TABLE_SUFFIX,
       COUNT(0) AS total
     FROM
-      `httparchive.pages.2022_07_01_*`
+      `httparchive.pages.2022_07_01_*` -- noqa: L062
     GROUP BY
       _TABLE_SUFFIX
   )

--- a/sql/2022/seo/content-language-usage.sql
+++ b/sql/2022/seo/content-language-usage.sql
@@ -36,13 +36,13 @@ FROM
       total,
       getContentLanguagesAlmanac(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS content_languages
     FROM
-      `httparchive.pages.2022_07_01_*`
+      `httparchive.pages.2022_07_01_*` -- noqa: L062
     JOIN
       (
 
         SELECT _TABLE_SUFFIX, COUNT(0) AS total
         FROM
-          `httparchive.pages.2022_07_01_*`
+          `httparchive.pages.2022_07_01_*` -- noqa: L062
 
         GROUP BY _TABLE_SUFFIX
       )

--- a/sql/2022/seo/hreflang-header-usage.sql
+++ b/sql/2022/seo/hreflang-header-usage.sql
@@ -37,13 +37,13 @@ FROM
       total,
       getHreflangWptBodies(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS hreflang_wpt_bodies_info
     FROM
-      `httparchive.pages.2022_07_01_*`
+      `httparchive.pages.2022_07_01_*` -- noqa: L062
     JOIN
       (
         SELECT
           _TABLE_SUFFIX, COUNT(0) AS total
         FROM
-          `httparchive.pages.2022_07_01_*`
+          `httparchive.pages.2022_07_01_*` -- noqa: L062
         GROUP BY
           _TABLE_SUFFIX
       )

--- a/sql/2022/seo/hreflang-link-tag-usage.sql
+++ b/sql/2022/seo/hreflang-link-tag-usage.sql
@@ -36,13 +36,13 @@ FROM (
     getHreflangWptBodies(JSON_EXTRACT_SCALAR(payload,
         '$._wpt_bodies')) AS hreflang_wpt_bodies_info
   FROM
-    `httparchive.pages.2022_07_01_*`
+    `httparchive.pages.2022_07_01_*` -- noqa: L062
   JOIN (
     SELECT
       _TABLE_SUFFIX,
       COUNT(0) AS total
     FROM
-      `httparchive.pages.2022_07_01_*`
+      `httparchive.pages.2022_07_01_*` -- noqa: L062
     GROUP BY
       _TABLE_SUFFIX)
   USING

--- a/sql/2022/seo/html-response-content-language.sql
+++ b/sql/2022/seo/html-response-content-language.sql
@@ -7,7 +7,7 @@ SELECT
   COUNT(0) AS freq,
   SAFE_DIVIDE(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX)) AS pct
 FROM
-  `httparchive.summary_requests.2022_07_01_*`
+  `httparchive.summary_requests.2022_07_01_*` -- noqa: L062
 WHERE
   firstHtml
 GROUP BY

--- a/sql/2022/seo/html-response-vary-header-used.sql
+++ b/sql/2022/seo/html-response-vary-header-used.sql
@@ -7,7 +7,7 @@ SELECT
   COUNT(0) AS freq,
   SAFE_DIVIDE(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY _TABLE_SUFFIX)) AS pct
 FROM
-  `httparchive.summary_requests.2022_07_01_*`
+  `httparchive.summary_requests.2022_07_01_*` -- noqa: L062
 WHERE
   firstHtml
 GROUP BY

--- a/sql/2022/seo/iframe-loading-property-usage.sql
+++ b/sql/2022/seo/iframe-loading-property-usage.sql
@@ -46,13 +46,13 @@ FROM (
     total,
     getIframeMarkupInfo(JSON_EXTRACT_SCALAR(payload, '$._markup')) AS iframe_markup_info
   FROM
-    `httparchive.pages.2022_07_01_*`
+    `httparchive.pages.2022_07_01_*` -- noqa: L062
   JOIN (
       SELECT
         _TABLE_SUFFIX,
         COUNT(0) AS total
       FROM
-        `httparchive.pages.2022_07_01_*`
+        `httparchive.pages.2022_07_01_*` -- noqa: L062
       GROUP BY
         _TABLE_SUFFIX)
   USING

--- a/sql/2022/seo/image-alt-stats.sql
+++ b/sql/2022/seo/image-alt-stats.sql
@@ -70,7 +70,7 @@ FROM (
     url,
     get_markup_info(JSON_EXTRACT_SCALAR(payload, '$._markup')) AS markup_info
   FROM
-    `httparchive.pages.2022_07_01_*`,
+    `httparchive.pages.2022_07_01_*`, -- noqa: L062
     UNNEST([10, 25, 50, 75, 90]) AS percentile
 )
 GROUP BY

--- a/sql/2022/seo/image-loading-property-usage.sql
+++ b/sql/2022/seo/image-loading-property-usage.sql
@@ -46,12 +46,12 @@ FROM
       total,
       getLoadingPropertyMarkupInfo(JSON_EXTRACT_SCALAR(payload, '$._markup')) AS loading_property_markup_info
     FROM
-      `httparchive.pages.2022_07_01_*`
+      `httparchive.pages.2022_07_01_*` -- noqa: L062
     JOIN
       (
         SELECT _TABLE_SUFFIX, COUNT(0) AS total
         FROM
-          `httparchive.pages.2022_07_01_*`
+          `httparchive.pages.2022_07_01_*` -- noqa: L062
         GROUP BY _TABLE_SUFFIX
       )
     USING (_TABLE_SUFFIX)

--- a/sql/2022/seo/lighthouse-seo-stats.sql
+++ b/sql/2022/seo/lighthouse-seo-stats.sql
@@ -87,5 +87,5 @@ FROM (
     JSON_EXTRACT_SCALAR(report, '$.audits.heading-order.score') = '1' AS heading_order_valid,
     isCrawlableDetails(report) AS is_crawlable_details
   FROM
-    `httparchive.lighthouse.2022_07_01_*`
+    `httparchive.lighthouse.2022_07_01_*` -- noqa: L062
 )

--- a/sql/2022/seo/lighthouse_unused_css_js_by_rank.sql
+++ b/sql/2022/seo/lighthouse_unused_css_js_by_rank.sql
@@ -14,7 +14,7 @@ FROM (
     url AS page,
     rank
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   WHERE _TABLE_SUFFIX = 'mobile')
 
 LEFT JOIN (
@@ -24,7 +24,7 @@ LEFT JOIN (
     SAFE_DIVIDE(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.unused-javascript.details.overallSavingsBytes') AS INT64), 1024) AS unused_javascript,
     SAFE_DIVIDE(CAST(JSON_EXTRACT_SCALAR(report, '$.audits.unused-css-rules.details.overallSavingsBytes') AS INT64), 1024) AS unused_css_rules
   FROM
-    `httparchive.lighthouse.2022_07_01_*`)
+    `httparchive.lighthouse.2022_07_01_*`) -- noqa: L062
 
 USING
   (client, page),

--- a/sql/2022/seo/markup-stats.sql
+++ b/sql/2022/seo/markup-stats.sql
@@ -84,7 +84,7 @@ FROM
       _TABLE_SUFFIX AS client,
       getMarkupStatsInfo(JSON_EXTRACT_SCALAR(payload, '$._markup')) AS markup_info
     FROM
-      `httparchive.pages.2022_07_01_*`
+      `httparchive.pages.2022_07_01_*` -- noqa: L062
   )
 GROUP BY
   client

--- a/sql/2022/seo/media-property-usage-link-tags-rel-alternate.sql
+++ b/sql/2022/seo/media-property-usage-link-tags-rel-alternate.sql
@@ -35,13 +35,13 @@ FROM
       total,
       getMediaPropertyAlmanacInfo(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS media_property_almanac_info
     FROM
-      `httparchive.pages.2022_07_01_*`
+      `httparchive.pages.2022_07_01_*` -- noqa: L062
     JOIN
       (
 
         SELECT _TABLE_SUFFIX, COUNT(0) AS total
         FROM
-          `httparchive.pages.2022_07_01_*`
+          `httparchive.pages.2022_07_01_*` -- noqa: L062
         GROUP BY _TABLE_SUFFIX
       )
     USING (_TABLE_SUFFIX)

--- a/sql/2022/seo/meta-tag-usage-by-name.sql
+++ b/sql/2022/seo/meta-tag-usage-by-name.sql
@@ -35,13 +35,13 @@ FROM
       total,
       getMetaTagAlmanacInfo(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS meta_tag_almanac_info
     FROM
-      `httparchive.pages.2022_07_01_*`
+      `httparchive.pages.2022_07_01_*` -- noqa: L062
     JOIN
       (
 
         SELECT _TABLE_SUFFIX, COUNT(0) AS total
         FROM
-          `httparchive.pages.2022_07_01_*`
+          `httparchive.pages.2022_07_01_*` -- noqa: L062
         GROUP BY _TABLE_SUFFIX
       )
     USING (_TABLE_SUFFIX)

--- a/sql/2022/seo/meta-tag-usage-by-property.sql
+++ b/sql/2022/seo/meta-tag-usage-by-property.sql
@@ -35,13 +35,13 @@ FROM
       total,
       getMetaTagAlmanacInfo(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS meta_tag_almanac_info
     FROM
-      `httparchive.pages.2022_07_01_*`
+      `httparchive.pages.2022_07_01_*` -- noqa: L062
     JOIN
       (
 
         SELECT _TABLE_SUFFIX, COUNT(0) AS total
         FROM
-          `httparchive.pages.2022_07_01_*`
+          `httparchive.pages.2022_07_01_*` -- noqa: L062
         GROUP BY _TABLE_SUFFIX
       )
     USING (_TABLE_SUFFIX)

--- a/sql/2022/seo/outgoing_links_by_rank.sql
+++ b/sql/2022/seo/outgoing_links_by_rank.sql
@@ -46,7 +46,7 @@ FROM (
     url AS page,
     getOutgoingLinkMetrics(payload) AS outgoing_link_metrics
   FROM
-    `httparchive.pages.2022_07_01_*`
+    `httparchive.pages.2022_07_01_*` -- noqa: L062
 ),
 UNNEST([10, 25, 50, 75, 90, 100]) AS percentile
 LEFT JOIN (
@@ -55,7 +55,7 @@ LEFT JOIN (
     url AS page,
     rank
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
 )
 USING
   (client, page),

--- a/sql/2022/seo/pages-canonical-stats.sql
+++ b/sql/2022/seo/pages-canonical-stats.sql
@@ -164,7 +164,7 @@ FROM (
     _TABLE_SUFFIX AS client,
     getCanonicalMetrics(payload) AS canonical_metrics
   FROM
-    `httparchive.pages.2022_07_01_*`)
+    `httparchive.pages.2022_07_01_*`) -- noqa: L062
 
 -- Only reporting where wpt_bodies sucessfully extracted. ~20/100,000 pages missing wpt_bodies.
 WHERE

--- a/sql/2022/seo/pages-containing-a-video-element.sql
+++ b/sql/2022/seo/pages-containing-a-video-element.sql
@@ -36,7 +36,7 @@ FROM
       _TABLE_SUFFIX AS client,
       getVideosAlmanacInfo(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS videos_almanac_info
     FROM
-      `httparchive.pages.2022_07_01_*`
+      `httparchive.pages.2022_07_01_*` -- noqa: L062
   )
 GROUP BY
   client

--- a/sql/2022/seo/robots-meta-usage.sql
+++ b/sql/2022/seo/robots-meta-usage.sql
@@ -58,12 +58,12 @@ FROM
       total,
       JSON_EXTRACT(payload, '$._robots_meta') AS robots_meta_json
     FROM
-      `httparchive.pages.2022_07_01_*`
+      `httparchive.pages.2022_07_01_*` -- noqa: L062
     JOIN
       (
         SELECT _TABLE_SUFFIX, COUNT(0) AS total
         FROM
-          `httparchive.pages.2022_07_01_*`
+          `httparchive.pages.2022_07_01_*` -- noqa: L062
         GROUP BY _TABLE_SUFFIX
       )
     USING (_TABLE_SUFFIX)

--- a/sql/2022/seo/robots-text-size.sql
+++ b/sql/2022/seo/robots-text-size.sql
@@ -37,7 +37,7 @@ FROM (
     url AS site,
     getRobotsSize(payload) AS robots_size
   FROM
-    `httparchive.pages.2022_07_01_*`)
+    `httparchive.pages.2022_07_01_*`) -- noqa: L062
 GROUP BY
   client
 ORDER BY

--- a/sql/2022/seo/robots-txt-status-codes.sql
+++ b/sql/2022/seo/robots-txt-status-codes.sql
@@ -32,7 +32,7 @@ FROM
       _TABLE_SUFFIX AS client,
       getRobotsStatusInfo(JSON_EXTRACT_SCALAR(payload, '$._robots_txt')) AS robots_txt_status_info
     FROM
-      `httparchive.pages.2022_07_01_*`
+      `httparchive.pages.2022_07_01_*` -- noqa: L062
   )
 GROUP BY
   client,

--- a/sql/2022/seo/robots-txt-user-agent-usage-by-rank.sql
+++ b/sql/2022/seo/robots-txt-user-agent-usage-by-rank.sql
@@ -24,7 +24,7 @@ WITH totals AS (
     rank_grouping,
     COUNT(0) AS rank_page_count
   FROM
-    `httparchive.summary_pages.2022_07_01_*`,
+    `httparchive.summary_pages.2022_07_01_*`, -- noqa: L062
     UNNEST([1000, 10000, 100000, 1000000, 10000000]) AS rank_grouping
   WHERE
     rank <= rank_grouping
@@ -39,7 +39,7 @@ robots AS (
     url,
     getRobotsTxtUserAgents(JSON_EXTRACT_SCALAR(payload, '$._robots_txt')) AS robots_txt_user_agent_info
   FROM
-    `httparchive.pages.2022_07_01_*`
+    `httparchive.pages.2022_07_01_*` -- noqa: L062
 ),
 
 base AS (
@@ -52,7 +52,7 @@ base AS (
     robots,
     UNNEST(robots_txt_user_agent_info.user_agents) AS user_agent
   JOIN
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` -- noqa: L062
   USING (_TABLE_SUFFIX, url)
 )
 

--- a/sql/2022/seo/robots-txt-user-agent-usage.sql
+++ b/sql/2022/seo/robots-txt-user-agent-usage.sql
@@ -31,13 +31,13 @@ FROM
       total,
       getRobotsTextUserAgents(JSON_EXTRACT_SCALAR(payload, '$._robots_txt')) AS robots_txt_user_agent_info
     FROM
-      `httparchive.pages.2022_07_01_*`
+      `httparchive.pages.2022_07_01_*` -- noqa: L062
     JOIN
       (
 
         SELECT _TABLE_SUFFIX, COUNT(0) AS total
         FROM
-          `httparchive.pages.2022_07_01_*`
+          `httparchive.pages.2022_07_01_*` -- noqa: L062
         GROUP BY _TABLE_SUFFIX
       )
     USING (_TABLE_SUFFIX)

--- a/sql/2022/seo/seo-stats-by-percentile.sql
+++ b/sql/2022/seo/seo-stats-by-percentile.sql
@@ -138,7 +138,7 @@ FROM (
     url,
     get_wpt_bodies_info(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
   FROM
-    `httparchive.pages.2022_07_01_*`,
+    `httparchive.pages.2022_07_01_*`, -- noqa: L062
     UNNEST([10, 25, 50, 75, 90]) AS percentile
 )
 WHERE

--- a/sql/2022/seo/seo-stats.sql
+++ b/sql/2022/seo/seo-stats.sql
@@ -480,7 +480,7 @@ FROM (
     SPLIT(url, ':')[OFFSET(0)] AS protocol,
     getSeoStatsWptBodies(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS wpt_bodies_info
   FROM
-    `httparchive.pages.2022_07_01_*`
+    `httparchive.pages.2022_07_01_*` -- noqa: L062
 )
 GROUP BY
   client

--- a/sql/2022/seo/structured-data-formats.sql
+++ b/sql/2022/seo/structured-data-formats.sql
@@ -49,14 +49,14 @@ FROM
       total,
       getStructuredDataWptBodies(JSON_EXTRACT_SCALAR(payload, '$._wpt_bodies')) AS structured_data_wpt_bodies_info
     FROM
-      `httparchive.pages.2022_07_01_*`
+      `httparchive.pages.2022_07_01_*` -- noqa: L062
     JOIN
       (
         SELECT
           _TABLE_SUFFIX,
           COUNT(0) AS total
         FROM
-          `httparchive.pages.2022_07_01_*`
+          `httparchive.pages.2022_07_01_*` -- noqa: L062
         GROUP BY
           _TABLE_SUFFIX
       )

--- a/sql/2022/seo/structured-data-schema-types.sql
+++ b/sql/2022/seo/structured-data-schema-types.sql
@@ -37,13 +37,13 @@ FROM (
     getStructuredSchemaWptBodies(JSON_EXTRACT_SCALAR(payload,
         '$._wpt_bodies')) AS structured_schema_wpt_bodies_info
   FROM
-    `httparchive.pages.2022_07_01_*`
+    `httparchive.pages.2022_07_01_*` -- noqa: L062
   JOIN (
     SELECT
       _TABLE_SUFFIX,
       COUNT(0) AS total
     FROM
-      `httparchive.pages.2022_07_01_*`
+      `httparchive.pages.2022_07_01_*` -- noqa: L062
     GROUP BY
       _TABLE_SUFFIX)
   USING

--- a/sql/2022/seo/valid-head-elements.sql
+++ b/sql/2022/seo/valid-head-elements.sql
@@ -8,7 +8,7 @@ WITH pages AS (SELECT
   JSON_QUERY(payload, '$._valid-head.invalidHead') AS invalidHead,
   JSON_EXTRACT_ARRAY(payload, '$._valid-head.invalidElements') AS invalidElements,
   ARRAY_LENGTH(JSON_EXTRACT_ARRAY(payload, '$._valid-head.invalidElements')) AS invalidCount
-  FROM `httparchive.pages.2022_07_01_*`
+  FROM `httparchive.pages.2022_07_01_*` -- noqa: L062
 )
 
 SELECT element, COUNT(element) AS elementCount FROM pages

--- a/sql/2022/seo/videos-per-page.sql
+++ b/sql/2022/seo/videos-per-page.sql
@@ -36,7 +36,7 @@ FROM (
     url,
     getVideosAlmanacInfo(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS video_almanac_info
   FROM
-    `httparchive.pages.2022_07_01_*`,
+    `httparchive.pages.2022_07_01_*`, -- noqa: L062
     UNNEST([10, 25, 50, 75, 90]) AS percentile
 )
 WHERE


### PR DESCRIPTION
We [decided to merge with the non-standard July for SEO chapter](https://github.com/HTTPArchive/almanac.httparchive.org/pull/2987#pullrequestreview-1072182786) so this PR adds `noqa` comments to prevent the linter flagging them.