### PR TITLE
More 2022 Fonts queries

### DIFF
--- a/sql/2022/fonts/font_feature_settings_tags_usage.sql
+++ b/sql/2022/fonts/font_feature_settings_tags_usage.sql
@@ -1,0 +1,70 @@
+CREATE TEMPORARY FUNCTION getFontFeatureTags(json STRING)
+RETURNS ARRAY < STRING >
+LANGUAGE js
+OPTIONS(library = "gs://httparchive/lib/css-utils.js")
+AS '''
+
+function parseFontFeatureSettings(value) {
+  const features = (value || '').split(/\\s*,\\s*/);
+  const result = []
+
+  for (let i = 0; i < features.length; i++) {
+    const match = /^"([\u0020-\u007e]{1,4})"(?:\\s+(\\d+|on|off))?$/i.exec(features[i]);
+
+    if (match) {
+      result.push(match[1]);
+    }
+  }
+  return result;
+}
+
+try {
+  const ast = JSON.parse(json);
+  const result = [];
+  walkDeclarations(ast, decl => {
+    const tags = parseFontFeatureSettings(decl.value);
+    if (tags && tags.length) {
+      tags.forEach(t => result.push(t));
+    }
+  }, {
+    properties: 'font-feature-settings',
+    rules: r => r.type !== 'font-face'
+  });
+
+  return result;
+} catch (e) {
+  return [];
+}
+''';
+
+SELECT
+  client,
+  font_feature,
+  pages,
+  total,
+  pages / total AS pct
+FROM (
+  SELECT
+    client,
+    font_feature,
+    COUNT(DISTINCT page) AS pages
+  FROM
+    `httparchive.almanac.parsed_css` ,
+    UNNEST(getFontFeatureTags(css)) AS font_feature
+  WHERE
+    date = '2022-07-01'
+  GROUP BY
+    client,
+    font_feature)
+JOIN (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    COUNT(0) AS total
+  FROM
+    `httparchive.summary_pages.2022_07_01_*`
+  GROUP BY
+    client)
+USING
+  (client)
+ORDER BY
+  pct DESC

--- a/sql/2022/fonts/font_feature_settings_tags_usage.sql
+++ b/sql/2022/fonts/font_feature_settings_tags_usage.sql
@@ -61,7 +61,7 @@ JOIN (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` --noqa: L062
   GROUP BY
     client)
 USING

--- a/sql/2022/fonts/font_feature_settings_vs_font_variant.sql
+++ b/sql/2022/fonts/font_feature_settings_vs_font_variant.sql
@@ -9,11 +9,9 @@ try {
     walkDeclarations(ast, ({property, value}) => {
       const propName = property.toLowerCase();
 
-      if (propName === 'font-variant' && property.value === 'small-caps') {
+      if (propName.startsWith('font-variant-') && property.value !== 'none' && property.value !== 'normal') {
         incrementByKey(ret, 'font-variant');
-      } else if (propName.startsWith('font-variant-')) {
-        incrementByKey(ret, 'font-variant');
-      } else if (propName === 'font-feature-settings') {
+      } else if (propName === 'font-feature-settings' && property.value !== 'normal') {
         incrementByKey(ret, 'font-feature-settings');
       }
     });

--- a/sql/2022/fonts/font_feature_settings_vs_font_variant.sql
+++ b/sql/2022/fonts/font_feature_settings_vs_font_variant.sql
@@ -33,7 +33,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` --noqa: L062 
   GROUP BY
     client
 )

--- a/sql/2022/fonts/font_feature_settings_vs_font_variant.sql
+++ b/sql/2022/fonts/font_feature_settings_vs_font_variant.sql
@@ -9,7 +9,9 @@ try {
     walkDeclarations(ast, ({property, value}) => {
       const propName = property.toLowerCase();
 
-      if (propName.startsWith('font-variant')) {
+      if (propName === 'font-variant' && property.value === 'small-caps') {
+        incrementByKey(ret, 'font-variant');
+      } else if (propName.startsWith('font-variant-')) {
         incrementByKey(ret, 'font-variant');
       } else if (propName === 'font-feature-settings') {
         incrementByKey(ret, 'font-feature-settings');

--- a/sql/2022/fonts/font_feature_settings_vs_font_variant.sql
+++ b/sql/2022/fonts/font_feature_settings_vs_font_variant.sql
@@ -33,7 +33,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*` --noqa: L062 
+    `httparchive.summary_pages.2022_07_01_*` --noqa: L062
   GROUP BY
     client
 )

--- a/sql/2022/fonts/font_variant_values.sql
+++ b/sql/2022/fonts/font_variant_values.sql
@@ -1,0 +1,64 @@
+CREATE TEMPORARY FUNCTION getProperties(css STRING)
+RETURNS ARRAY<STRING>
+LANGUAGE js
+OPTIONS (library = "gs://httparchive/lib/css-utils.js")
+AS '''
+try {
+  function compute(ast) {
+    let ret = {};
+    walkDeclarations(ast, ({property, value}) => {
+      const propName = property.toLowerCase();
+
+      if (propName === 'font-variant') {
+        incrementByKey(ret, 'font-variant: ' + value)
+      } else if (propName.startsWith('font-variant-')) {
+        incrementByKey(ret, propName + ': ' + value);
+      }
+    });
+    return sortObject(ret);
+  }
+  let ast = JSON.parse(css);
+  let props = compute(ast);
+  return Object.entries(props).flatMap(([prop, freq]) => {
+    return Array(freq).fill(prop);
+  });
+}
+catch (e) {
+  return [];
+}
+''';
+
+WITH totals AS (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    COUNT(0) AS total_pages
+  FROM
+    `httparchive.summary_pages.2022_07_01_*`
+  GROUP BY
+    client
+)
+
+
+SELECT
+  client,
+  prop,
+  COUNT(DISTINCT page) AS pages,
+  ANY_VALUE(total_pages) AS total_pages,
+  COUNT(DISTINCT page) / ANY_VALUE(total_pages) AS pct_pages,
+  COUNT(0) AS freq,
+  SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct
+FROM
+  `httparchive.almanac.parsed_css`,
+  UNNEST(getProperties(css)) AS prop
+JOIN
+  totals
+USING
+  (client)
+WHERE
+  date = '2022-07-01'
+GROUP BY
+  client,
+  prop
+ORDER BY
+  pct DESC

--- a/sql/2022/fonts/font_variant_values.sql
+++ b/sql/2022/fonts/font_variant_values.sql
@@ -33,7 +33,7 @@ WITH totals AS (
     _TABLE_SUFFIX AS client,
     COUNT(0) AS total_pages
   FROM
-    `httparchive.summary_pages.2022_07_01_*`
+    `httparchive.summary_pages.2022_07_01_*` --noqa: L062
   GROUP BY
     client
 )

--- a/sql/2022/fonts/variable_font_animation.sql
+++ b/sql/2022/fonts/variable_font_animation.sql
@@ -5,8 +5,16 @@ OPTIONS(library = "gs://httparchive/lib/css-utils.js")
 AS '''
 try {
   var ast = JSON.parse(css);
-  // TODO: This only includes transitions, but most animations are most likely in keyframes.
-  return countDeclarations(ast.stylesheet.rules, {properties: 'transition', values: /font-variation-settings/}) > 0;
+  let count = 0;
+
+  walkRules(ast, rule => {
+    rule.keyframes.forEach(f => {
+      count += countDeclarations(f, { properties: 'font-variation-settings' });
+    });
+  }, { type: 'keyframes' });
+
+  count += countDeclarations(ast.stylesheet.rules, {properties: 'transition', values: /font-variation-settings/})
+  return count > 0;
 } catch (e) {
   return false;
 }


### PR DESCRIPTION
While going through the data I found two issues:

* The variable font animation query did not check in keyframes.
* The font-variant vs. font-feature-settings query included `normal` and `none` as values. These values are used in several popular CSS frameworks which heavily skewed the results. They are now explicitly excluded from the results.

While working on this, I thought it would also fit the chapter's narrative to have the following new queries:
* The most popular OpenType feature tags used in CSS (to contract with the easier to use font-variant properties and the tags actually available in the fonts.)
* The most popular font-variant values.