### PR TITLE
Add 2022 Methodology page and set 2022 as default year

### DIFF
--- a/src/server/config.py
+++ b/src/server/config.py
@@ -8,7 +8,7 @@ TEMPLATES_DIR = ROOT_DIR + "/templates"
 STATIC_DIR = ROOT_DIR + "/static"
 
 SUPPORTED_YEARS = []
-DEFAULT_YEAR = "2021"
+DEFAULT_YEAR = "2022"
 
 DEFAULT_AVATAR_FOLDER_PATH = "/static/images/avatars/"
 AVATAR_SIZE = 200

--- a/src/templates/en/2019/methodology.html
+++ b/src/templates/en/2019/methodology.html
@@ -235,7 +235,7 @@
       </p>
 
       <p>
-        HTTP Archive&#8217;s private instance of WebPageTest is kept in sync with the latest public version and augmented with <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/tree/master/custom_metrics">custom metrics</a>. These are snippets of JavaScript that are evaluated on each website at the end of the test. The <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/blob/master/custom_metrics/almanac.js">almanac.js</a> custom metric includes several metrics that were otherwise infeasible to calculate, for example those that depend on  DOM state.
+        HTTP Archive&#8217;s private instance of WebPageTest is kept in sync with the latest public version and augmented with <a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">custom metrics</a>. These are snippets of JavaScript that are evaluated on each website at the end of the test. The <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/blob/master/custom_metrics/almanac.js">almanac.js</a> custom metric includes several metrics that were otherwise infeasible to calculate, for example those that depend on  DOM state.
       </p>
 
       <p>

--- a/src/templates/en/2019/methodology.html
+++ b/src/templates/en/2019/methodology.html
@@ -67,7 +67,7 @@
         <h2 id="dataset"><a href="#dataset" class="anchor-link">About the dataset</a></h2>
 
         <p>
-          The HTTP Archive dataset is continuously updating with new data monthly. For the 2019 edition of the Web Almanac, unless otherwise noted in the chapter, all metrics were sourced from the July 2019 crawl. These results are <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/master/docs/gettingstarted_bigquery.md">publicly queryable</a> on BigQuery in tables prefixed with <code>2019_07_01</code>.
+          The HTTP Archive dataset is continuously updating with new data monthly. For the 2019 edition of the Web Almanac, unless otherwise noted in the chapter, all metrics were sourced from the July 2019 crawl. These results are <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/main/docs/gettingstarted_bigquery.md">publicly queryable</a> on BigQuery in tables prefixed with <code>2019_07_01</code>.
         </p>
 
         <p>

--- a/src/templates/en/2020/methodology.html
+++ b/src/templates/en/2020/methodology.html
@@ -244,7 +244,7 @@
       </p>
 
       <p>
-        HTTP Archive&#8217;s private instance of WebPageTest is kept in sync with the latest public version and augmented with <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/tree/master/custom_metrics">custom metrics</a>. These are snippets of JavaScript that are evaluated on each website at the end of the test. Thanks to the <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/commits/master/custom_metrics">contributions</a> of many data analysts, especially the <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/pulls?q=is%3Apr+author%3ATiggerito+sort%3Acreated-asc">herculean efforts</a> of <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='Tiggerito') }}">Tony McCreath</a>, the 2020 edition of the Web Almanac greatly expanded the capabilities of HTTP Archive&#8217;s test infrastructure with over 3,000 lines of new code.
+        HTTP Archive&#8217;s private instance of WebPageTest is kept in sync with the latest public version and augmented with <a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">custom metrics</a>. These are snippets of JavaScript that are evaluated on each website at the end of the test. Thanks to the <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/commits/master/custom_metrics">contributions</a> of many data analysts, especially the <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/pulls?q=is%3Apr+author%3ATiggerito+sort%3Acreated-asc">herculean efforts</a> of <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='Tiggerito') }}">Tony McCreath</a>, the 2020 edition of the Web Almanac greatly expanded the capabilities of HTTP Archive&#8217;s test infrastructure with over 3,000 lines of new code.
       </p>
 
       <p>
@@ -435,7 +435,7 @@
       <h3 id="analysis"><a href="#analysis" class="anchor-link">Analysis</a></h3>
 
       <p>
-        In July and August 2020, with the stable list of metrics and chapters, data analysts triaged the metrics for feasibility. In some cases, <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/tree/master/custom_metrics">custom metrics</a> were created to fill gaps in our analytic capabilities.
+        In July and August 2020, with the stable list of metrics and chapters, data analysts triaged the metrics for feasibility. In some cases, <a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">custom metrics</a> were created to fill gaps in our analytic capabilities.
       </p>
 
       <p>

--- a/src/templates/en/2020/methodology.html
+++ b/src/templates/en/2020/methodology.html
@@ -72,7 +72,7 @@
         <h2 id="dataset"><a href="#dataset" class="anchor-link">About the dataset</a></h2>
 
         <p>
-          The HTTP Archive dataset is continuously updating with new data monthly. For the 2020 edition of the Web Almanac, unless otherwise noted in the chapter, all metrics were sourced from the August 2020 crawl. These results are <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/master/docs/gettingstarted_bigquery.md">publicly queryable</a> on BigQuery in tables prefixed with <code>2020_08_01</code>.
+          The HTTP Archive dataset is continuously updating with new data monthly. For the 2020 edition of the Web Almanac, unless otherwise noted in the chapter, all metrics were sourced from the August 2020 crawl. These results are <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/main/docs/gettingstarted_bigquery.md">publicly queryable</a> on BigQuery in tables prefixed with <code>2020_08_01</code>.
         </p>
 
         <p>

--- a/src/templates/en/2021/methodology.html
+++ b/src/templates/en/2021/methodology.html
@@ -73,7 +73,7 @@
         <h2 id="dataset"><a href="#dataset" class="anchor-link">About the dataset</a></h2>
 
         <p>
-          The HTTP Archive dataset is continuously updating with new data monthly. For the {{ year }} edition of the Web Almanac, unless otherwise noted in the chapter, all metrics were sourced from the July {{ year }} crawl. These results are <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/master/docs/gettingstarted_bigquery.md">publicly queryable</a> on BigQuery in tables prefixed with <code>{{ year }}_07_01</code>.
+          The HTTP Archive dataset is continuously updating with new data monthly. For the {{ year }} edition of the Web Almanac, unless otherwise noted in the chapter, all metrics were sourced from the July {{ year }} crawl. These results are <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/main/docs/gettingstarted_bigquery.md">publicly queryable</a> on BigQuery in tables prefixed with <code>{{ year }}_07_01</code>.
         </p>
 
         <p>

--- a/src/templates/en/2021/methodology.html
+++ b/src/templates/en/2021/methodology.html
@@ -117,7 +117,7 @@
         <h3 id="websites"><a href="#websites" class="anchor-link">Websites</a></h3>
 
         <p>
-          There are 8,198,531 websites in the dataset. Among those, 7,499,763 are mobile websites and 6,294,605 are desktop websites. Most websites are included in both the mobile and desktop subsets.
+          There are 8,198,531 websites in the dataset. This represents an increase of 9% compared to the <a href="../2020/methodology#websites">2020 edition</a> of the Web Almanac. Among those, 7,499,763 are mobile websites and 6,294,605 are desktop websites. Most websites are included in both the mobile and desktop subsets.
         </p>
 
         <p>

--- a/src/templates/en/2021/methodology.html
+++ b/src/templates/en/2021/methodology.html
@@ -125,7 +125,7 @@
         </p>
 
         <p>
-          The June {{ year }} HTTP Archive crawl used by the Web Almanac used the most recently available Chrome UX Report release for its list of websites. The {{ year }}05 dataset was released on June 8, {{ year }} and captures websites visited by Chrome users during the month of May.
+          The July {{ year }} HTTP Archive crawl used by the Web Almanac used the most recently available Chrome UX Report release for its list of websites. The {{ year }}05 dataset was released on June 8, {{ year }} and captures websites visited by Chrome users during the month of May.
         </p>
 
         <p>

--- a/src/templates/en/2021/methodology.html
+++ b/src/templates/en/2021/methodology.html
@@ -214,7 +214,7 @@
           <tr>
             <td>Connection</td>
             <td>Cable (5/1 Mbps 28ms RTT)</td>
-            <td>3G (9 Mbps 170ms RTT)</td>
+            <td>3G (1.600/0.768 Mbps 300ms RTT)</td>
           </tr>
 
           <tr>

--- a/src/templates/en/2022/methodology.html
+++ b/src/templates/en/2022/methodology.html
@@ -116,7 +116,7 @@
         <h3 id="websites"><a href="#websites" class="anchor-link">Websites</a></h3>
 
         <p>
-          There are 8,360,179 websites in the dataset. This represents an increase of 9% compared to the <a href="../2021/methodology#websites">2021 edition</a> of the Web Almanac. Among those, 7,905,956 are mobile websites and 5,428,235 are desktop websites. Most websites are included in both the mobile and desktop subsets.
+          There are 8,360,179 websites in the dataset. Among those, 7,905,956 are mobile websites and 5,428,235 are desktop websites. Most websites are included in both the mobile and desktop subsets.
         </p>
 
         <p>

--- a/src/templates/en/2022/methodology.html
+++ b/src/templates/en/2022/methodology.html
@@ -124,7 +124,7 @@
         </p>
 
         <p>
-          The July {{ year }} HTTP Archive crawl used by the Web Almanac used the most recently available Chrome UX Report release for its list of websites. The {{ year }}04 dataset was released on May 3, {{ year }} and captures websites visited by Chrome users during the month of April.
+          The June {{ year }} HTTP Archive crawl used by the Web Almanac used the most recently available Chrome UX Report release for its list of websites. The {{ year }}04 dataset was released on May 3, {{ year }} and captures websites visited by Chrome users during the month of April.
         </p>
 
         <p>

--- a/src/templates/en/2022/methodology.html
+++ b/src/templates/en/2022/methodology.html
@@ -73,7 +73,7 @@
         <h2 id="dataset"><a href="#dataset" class="anchor-link">About the dataset</a></h2>
 
         <p>
-          The HTTP Archive dataset is continuously updating with new data monthly. For the {{ year }} edition of the Web Almanac, unless otherwise noted in the chapter, all metrics were sourced from the July {{ year }} crawl. These results are <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/master/docs/gettingstarted_bigquery.md">publicly queryable</a> on BigQuery in tables prefixed with <code>{{ year }}_07_01</code>.
+          The HTTP Archive dataset is continuously updating with new data monthly. For the {{ year }} edition of the Web Almanac, unless otherwise noted in the chapter, all metrics were sourced from the June {{ year }} crawl. These results are <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/master/docs/gettingstarted_bigquery.md">publicly queryable</a> on BigQuery in tables prefixed with <code>{{ year }}_06_01</code>.
         </p>
 
         <p>
@@ -92,24 +92,23 @@
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you&#8217;ll get the HTML #}
           {# Note extra attributes on pre tag to allow keyboard scroll so add them back in #}
           <pre role="region" aria-label="bytes_2021.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
-<span class="comment"># Sum of JS request bytes per page (2021)</span>
+<span class="comment"># Sum of JS request bytes per page (2022)</span>
 <span class="keyword">SELECT</span>
   percentile,
   _TABLE_SUFFIX <span class="keyword">AS</span> client,
   <span class="function call">APPROX_QUANTILES</span>(bytesJs / <span class="constant numeric">1024</span>, <span class="constant numeric">1000</span>)[<span class="function call">OFFSET</span>(percentile <span class="keyword operator">*</span> <span class="constant numeric">10</span>)] <span class="keyword">AS</span> js_kilobytes
 <span class="keyword">FROM</span>
-  <span class="string">`httparchive.summary_pages.2021_07_01_*`</span>,
+  <span class="string">`httparchive.summary_pages.2022_06_01_*`</span>,
   <span class="function call">UNNEST</span>([<span class="constant numeric">10</span>, <span class="constant numeric">25</span>, <span class="constant numeric">50</span>, <span class="constant numeric">75</span>, <span class="constant numeric">90</span>, <span class="constant numeric">100</span>]) <span class="keyword">AS</span> percentile
 <span class="keyword">GROUP</span> <span class="keyword">BY</span>
   percentile,
   client
 <span class="keyword">ORDER</span> <span class="keyword">BY</span>
-  percentile,
-  client</code></pre>
-        </div>
+  client,
+  percentile</code></pre></div>
 
         <p>
-          Results for each metric are publicly viewable in chapter-specific spreadsheets, for example <a href="https://docs.google.com/spreadsheets/d/1zU9rHpI3nC6jTz3xgN6w13afW7x34xAKBh2IPH-lVxk/edit#gid=18398250">JavaScript results</a>. Links to the raw results and queries are available at the bottom of each chapter. Metric-specific results and queries are also linked directly from each figure.
+          Results for each metric are publicly viewable in chapter-specific spreadsheets, for example <a href="https://docs.google.com/spreadsheets/d/1vOeFUyfEtWRen3Xj57ZsWav40n5tlcJoV0HmAxmNE_I/edit?usp=sharing">JavaScript results</a>. Links to the raw results and queries are available at the bottom of each chapter. Metric-specific results and queries are also linked directly from each figure.
         </p>
     </section>
 
@@ -117,7 +116,7 @@
         <h3 id="websites"><a href="#websites" class="anchor-link">Websites</a></h3>
 
         <p>
-          There are 8,198,531 websites in the dataset. Among those, 7,499,763 are mobile websites and 6,294,605 are desktop websites. Most websites are included in both the mobile and desktop subsets.
+          There are 8,360,179 websites in the dataset. This represents an increase of 9% compared to the <a href="../2021/methodology#websites">2021 edition</a> of the Web Almanac. Among those, 7,905,956 are mobile websites and 5,428,235 are desktop websites. Most websites are included in both the mobile and desktop subsets.
         </p>
 
         <p>
@@ -125,11 +124,11 @@
         </p>
 
         <p>
-          The June {{ year }} HTTP Archive crawl used by the Web Almanac used the most recently available Chrome UX Report release for its list of websites. The {{ year }}05 dataset was released on June 8, {{ year }} and captures websites visited by Chrome users during the month of May.
+          The July {{ year }} HTTP Archive crawl used by the Web Almanac used the most recently available Chrome UX Report release for its list of websites. The {{ year }}04 dataset was released on May 3, {{ year }} and captures websites visited by Chrome users during the month of April.
         </p>
 
         <p>
-          Due to resource limitations, the HTTP Archive can only test one page from each website in the Chrome UX report. To reconcile this, only the home pages are included. Be aware that this will introduce some bias into the results because a home page is not necessarily representative of the entire website.
+          Due to resource limitations, the HTTP Archive previously could only test one page from each website in the Chrome UX report and only home pages were included. Be aware that this will introduce some bias into the results because a home page is not necessarily representative of the entire website. This year, we <a hreflang="en" href="https://discuss.httparchive.org/t/improving-the-http-archive-pipeline-and-dataset-by-10x/2372">introduced secondary pages</a>, after the Web Almanac project was beginning and some chapters use this new data. Most chapters, however, used just the home pages. We expect future analsysis to make much more use of this new dataset.
         </p>
 
         <p>
@@ -194,10 +193,10 @@
           <tr>
             <td>User Agent</td>
             <td>
-              Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36 PTST/210702.163639
+              Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.61 Safari/537.36 PTST/220609.133020
             </td>
             <td>
-              Mozilla/5.0 (Linux; Android 6.0.1; Moto G (4)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Mobile Safari/537.36 PTST/210702.163639
+              Mozilla/5.0 (Linux; Android 8.1.0; Moto G (4)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.115 Mobile Safari/537.36 PTST/220609.133020
             </td>
           </tr>
 
@@ -214,7 +213,7 @@
           <tr>
             <td>Connection</td>
             <td>Cable (5/1 Mbps 28ms RTT)</td>
-            <td>3G (9 Mbps 170ms RTT)</td>
+            <td>4G (9 Mbps 170ms RTT)</td>
           </tr>
 
           <tr>
@@ -231,7 +230,7 @@
       </p>
 
       <p>
-        Mobile websites are run from within a mobile Chrome environment on an emulated Moto G4 device with a network speed equivalent to a 3G connection.
+        Mobile websites are run from within a mobile Chrome environment on an emulated Moto G4 device with a network speed equivalent to a 4G connection.
       </p>
 
       <p>
@@ -255,7 +254,7 @@
       </p>
 
       <p>
-        HTTP Archive runs the latest version of Lighthouse for all of its mobile web pages — desktop pages are not included because of limited resources. As of the July {{ year }} crawl, HTTP Archive used a combination of <a hreflang="en" href="https://github.com/GoogleChrome/lighthouse/releases/tag/v8.0.0">8.0.0</a> and <a hreflang="en" href="https://github.com/GoogleChrome/lighthouse/releases/tag/v8.1.0">8.1.0</a> versions of Lighthouse.
+        HTTP Archive runs the latest version of Lighthouse for all of its mobile web pages — desktop pages are not included because of limited resources. As of the June {{ year }} crawl, HTTP Archive used the <a hreflang="en" href="https://github.com/GoogleChrome/lighthouse/releases/tag/v9.6.2">9.6.2</a> versions of Lighthouse.
       </p>
 
       <p>
@@ -299,11 +298,11 @@
       <h3 id="wappalyzer"><a href="#wappalyzer" class="anchor-link">Wappalyzer</a></h3>
 
       <p>
-        <a hreflang="en" href="https://www.wappalyzer.com/">Wappalyzer</a> is a tool for detecting technologies used by web pages. There are <a hreflang="en" href="https://www.wappalyzer.com/technologies">90 categories</a> of technologies tested, ranging from JavaScript frameworks, to CMS platforms, and even cryptocurrency miners. There are over 2,600 supported technologies (an increase from 1,400 last year).
+        <a hreflang="en" href="https://www.wappalyzer.com/">Wappalyzer</a> is a tool for detecting technologies used by web pages. There are <a hreflang="en" href="https://www.wappalyzer.com/technologies">98 categories</a> of technologies tested, ranging from JavaScript frameworks, to CMS platforms, and even cryptocurrency miners. There are over 3,805 supported technologies (an increase from 2,600 last year).
       </p>
 
       <p>
-        HTTP Archive runs the latest version of Wappalyzer for all web pages. As of July {{ year }} the Web Almanac used the <a hreflang="en" href="https://github.com/AliasIO/Wappalyzer/releases/tag/v6.7.7">6.7.7 version</a> of Wappalyzer.
+        HTTP Archive runs the latest version of Wappalyzer for all web pages. As of July {{ year }} the Web Almanac used the <a hreflang="en" href="https://github.com/AliasIO/Wappalyzer/releases/tag/v6.10.26">6.10.26 version</a> of Wappalyzer.
       </p>
 
       <p>
@@ -323,11 +322,11 @@
       </p>
 
       <p>
-        As of this year, the Chrome UX Report dataset now includes relative <a href="https://developers.google.com/web/updates/2021/03/crux-rank-magnitude">website ranking data</a>. These are referred to as <em>rank magnitudes</em> because, as opposed to fine-grained ranks like the #1 or #116 most popular websites, websites are grouped into rank buckets from the top 1k, top 10k, up to the top 10M. Each website is ranked according to the number of <a href="https://developer.chrome.com/docs/crux/methodology/#eligibility">eligible</a> page views on all of its pages combined. This year's Web Almanac makes extensive use of this new data as a way to explore variations in the way the web is built by site popularity.
+        The Chrome UX Report dataset includes relative <a href="https://developers.google.com/web/updates/2021/03/crux-rank-magnitude">website ranking data</a>. These are referred to as <em>rank magnitudes</em> because, as opposed to fine-grained ranks like the #1 or #116 most popular websites, websites are grouped into rank buckets from the top 1k, top 10k, up to the top 10M. Each website is ranked according to the number of <a href="https://developer.chrome.com/docs/crux/methodology/#eligibility">eligible</a> page views on all of its pages combined. This year's Web Almanac makes extensive use of this new data as a way to explore variations in the way the web is built by site popularity.
       </p>
 
       <p>
-        For Web Almanac metrics that reference real-world user experience data from the Chrome UX Report, the July {{ year }} dataset ({{ year }}07) is used.
+        For Web Almanac metrics that reference real-world user experience data from the Chrome UX Report, the June {{ year }} dataset ({{ year }}06) is used.
       </p>
 
       <p>
@@ -383,7 +382,7 @@
       <h4 id="rework-utils"><a href="#rework-utils" class="anchor-link">Rework Utils</a></h4>
 
       <p>
-        This year&#8217;s <a href="{{ url_for('chapter', year=year, lang=lang, chapter='css') }}">CSS</a> chapter revisits many of the metrics introduced in last year's CSS chapter, which was led by <a href="{{ url_for('contributors', year=2019, lang=lang, _anchor='LeaVerou') }}">Lea Verou</a>. Lea wrote <a hreflang="en" href="https://github.com/LeaVerou/rework-utils">Rework Utils</a> to more easily extract insights from Rework CSS's output. Most of the stats you see in the CSS chapter continue to be powered by these scripts.
+        This year&#8217;s <a href="{{ url_for('chapter', year=year, lang=lang, chapter='css') }}">CSS</a> chapter revisits many of the metrics introduced in 2020's CSS chapter, which was led by <a href="{{ url_for('contributors', year=2019, lang=lang, _anchor='LeaVerou') }}">Lea Verou</a>. Lea wrote <a hreflang="en" href="https://github.com/LeaVerou/rework-utils">Rework Utils</a> to more easily extract insights from Rework CSS's output. Most of the stats you see in the CSS chapter continue to be powered by these scripts.
       </p>
     </section>
 
@@ -407,7 +406,7 @@
       <h3 id="planning"><a href="#planning" class="anchor-link">Planning</a></h3>
 
       <p>
-        The {{ year }} Web Almanac kicked off in April {{ year }} with a <a href="https://github.com/HTTPArchive/almanac.httparchive.org/issues/2167">call for contributors</a>. We initialized the project with all 23 chapters from previous years and the community suggested additional topics that became two new chapters this year: <a href="{{ url_for('chapter', year=year, lang=lang, chapter='structured-data') }}">Structured Data</a> and <a href="{{ url_for('chapter', year=year, lang=lang, chapter='webassembly') }}">WebAssembly</a>.
+        The {{ year }} Web Almanac kicked off in March {{ year }} with a <a href="https://twitter.com/HTTPArchive/status/1508506002383069192">call for contributors</a>. We initialized the project with all 22 chapters from previous years and the community suggested additional topics that became two new chapters this year: <a href="{{ url_for('chapter', year=year, lang=lang, chapter='interop') }}">Interoperability</a> and <a href="{{ url_for('chapter', year=year, lang=lang, chapter='sustainability') }}">Sustainability</a>.
       </p>
 
       <p>
@@ -419,7 +418,7 @@
       </blockquote>
 
       <p>
-        To that end, this year we&#8217;ve refined our <a href="https://github.com/HTTPArchive/almanac.httparchive.org/discussions/2165">author selection process</a>:
+        To that end, this year we&#8217;ve continued our <a href="https://github.com/HTTPArchive/almanac.httparchive.org/discussions/2165">author selection process</a>:
       </p>
 
       <ul>
@@ -443,15 +442,15 @@
       <h3 id="analysis"><a href="#analysis" class="anchor-link">Analysis</a></h3>
 
       <p>
-        In May and June {{ year }}, data analysts worked with authors and peer reviewers to come up with a list of metrics that would need to be queried for each chapter. In some cases, <a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">custom metrics</a> were created to fill gaps in our analytic capabilities.
+        In April and May {{ year }}, data analysts worked with authors and peer reviewers to come up with a list of metrics that would need to be queried for each chapter. In some cases, <a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">custom metrics</a> were created to fill gaps in our analytic capabilities.
       </p>
 
       <p>
-        Throughout July {{ year }}, the HTTP Archive data pipeline crawled several million websites, gathering the metadata to be used in the Web Almanac. These results were post-processed and saved to <a href="https://console.cloud.google.com/bigquery?p=httparchive&d=almanac&page=dataset">BigQuery</a>.
+        Throughout June {{ year }}, the HTTP Archive data pipeline crawled several million websites, gathering the metadata to be used in the Web Almanac. These results were post-processed and saved to <a href="https://console.cloud.google.com/bigquery?p=httparchive&d=almanac&page=dataset">BigQuery</a>.
       </p>
 
       <p>
-        Being our third year, we were able to update and reuse the queries written by previous analysts. Still, there were many new metrics that needed to be written from scratch. You can browse all of the queries by year and chapter in our open source <a hreflang="en" href="https://github.com/HTTPArchive/almanac.httparchive.org/tree/main/sql/{{ year }}">query repository</a> on GitHub.
+        Being our fourth year, we were able to update and reuse the queries written by previous analysts. Still, there were many new metrics that needed to be written from scratch. You can browse all of the queries by year and chapter in our open source <a hreflang="en" href="https://github.com/HTTPArchive/almanac.httparchive.org/tree/main/sql/{{ year }}">query repository</a> on GitHub.
       </p>
     </section>
 
@@ -475,11 +474,11 @@
       <h2 id="looking-ahead"><a href="#looking-ahead" class="anchor-link">Looking ahead</a></h2>
 
       <p>
-        The {{ year }} edition of the Web Almanac is the third in what we hope to continue as an annual tradition in the web community of introspection and a commitment to positive change. Getting to this point has been a monumental effort thanks to many dedicated <a href="{{ url_for('contributors', year=year, lang=lang) }}">contributors</a> and we hope to leverage as much of this work as possible to make future editions even more streamlined.
+        The {{ year }} edition of the Web Almanac is the fourth in what we hope to continue as an annual tradition in the web community of introspection and a commitment to positive change. Getting to this point has been a monumental effort thanks to many dedicated <a href="{{ url_for('contributors', year=year, lang=lang) }}">contributors</a> and we hope to leverage as much of this work as possible to make future editions even more streamlined.
       </p>
 
       <p>
-        If you&#8217;re interested in contributing to the 2022 edition of the Web Almanac, please fill out our <a hreflang="en" href="https://forms.gle/55uatdX9T3JZG2837">interest form</a>. Let&#8217;s work together to track the state of the web!
+        If you&#8217;re interested in contributing to the 2023 edition of the Web Almanac, please fill out our <a hreflang="en" href="https://forms.gle/55uatdX9T3JZG2837">interest form</a>. Let&#8217;s work together to track the state of the web!
       </p>
     </section>
 {% endblock main_content %}

--- a/src/templates/en/2022/methodology.html
+++ b/src/templates/en/2022/methodology.html
@@ -73,7 +73,7 @@
         <h2 id="dataset"><a href="#dataset" class="anchor-link">About the dataset</a></h2>
 
         <p>
-          The HTTP Archive dataset is continuously updating with new data monthly. For the {{ year }} edition of the Web Almanac, unless otherwise noted in the chapter, all metrics were sourced from the June {{ year }} crawl. These results are <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/master/docs/gettingstarted_bigquery.md">publicly queryable</a> on BigQuery in tables prefixed with <code>{{ year }}_06_01</code>.
+          The HTTP Archive dataset is continuously updating with new data monthly. For the {{ year }} edition of the Web Almanac, unless otherwise noted in the chapter, all metrics were sourced from the June {{ year }} crawl. These results are <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/main/docs/gettingstarted_bigquery.md">publicly queryable</a> on BigQuery in tables prefixed with <code>{{ year }}_06_01</code>.
         </p>
 
         <p>

--- a/src/templates/en/2022/methodology.html
+++ b/src/templates/en/2022/methodology.html
@@ -406,7 +406,7 @@
       <h3 id="planning"><a href="#planning" class="anchor-link">Planning</a></h3>
 
       <p>
-        The {{ year }} Web Almanac kicked off in March {{ year }} with a <a href="https://twitter.com/HTTPArchive/status/1508506002383069192">call for contributors</a>. We initialized the project with all 22 chapters from previous years and the community suggested additional topics that became two new chapters this year: <a href="{{ url_for('chapter', year=year, lang=lang, chapter='interop') }}">Interoperability</a> and <a href="{{ url_for('chapter', year=year, lang=lang, chapter='sustainability') }}">Sustainability</a>.
+        The {{ year }} Web Almanac kicked off in March {{ year }} with a <a href="https://twitter.com/HTTPArchive/status/1508506002383069192">call for contributors</a>. We initialized the project with all 26 chapters from previous years and the community suggested additional topics that became two new chapters this year: <a href="{{ url_for('chapter', year=year, lang=lang, chapter='interop') }}">Interoperability</a> and <a href="{{ url_for('chapter', year=year, lang=lang, chapter='sustainability') }}">Sustainability</a>.
       </p>
 
       <p>
@@ -478,7 +478,7 @@
       </p>
 
       <p>
-        If you&#8217;re interested in contributing to the 2023 edition of the Web Almanac, please fill out our <a hreflang="en" href="https://forms.gle/55uatdX9T3JZG2837">interest form</a>. Let&#8217;s work together to track the state of the web!
+        If you&#8217;re interested in contributing to the 2023 edition of the Web Almanac, please fill out our <a hreflang="en" href="https://forms.gle/zmk6wXfDrmkkKzXo8">interest form</a>. Let&#8217;s work together to track the state of the web!
       </p>
     </section>
 {% endblock main_content %}

--- a/src/templates/fr/2019/methodology.html
+++ b/src/templates/fr/2019/methodology.html
@@ -235,7 +235,7 @@
       </p>
 
       <p>
-        L’instance privée de WebPageTest de HTTP Archive est synchronisée avec la dernière version publique et complétée par des <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/tree/master/custom_metrics">indicateurs personnalisés</a>. Ils sont collectés par des portions de JavaScript qui sont évaluées et exécutées sur chaque site web à la fin du test. Le script sur-mesure  <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/blob/master/custom_metrics/almanac.js">almanac.js</a> collecte plusieurs métriques qui sont autrement impossibles à calculer comme, par exemple,  celles qui dépendent de l’état du DOM.
+        L’instance privée de WebPageTest de HTTP Archive est synchronisée avec la dernière version publique et complétée par des <a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">indicateurs personnalisés</a>. Ils sont collectés par des portions de JavaScript qui sont évaluées et exécutées sur chaque site web à la fin du test. Le script sur-mesure  <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/blob/master/custom_metrics/almanac.js">almanac.js</a> collecte plusieurs métriques qui sont autrement impossibles à calculer comme, par exemple,  celles qui dépendent de l’état du DOM.
       </p>
 
       <p>

--- a/src/templates/fr/2019/methodology.html
+++ b/src/templates/fr/2019/methodology.html
@@ -67,7 +67,7 @@
       <h2 id="dataset"><a href="#dataset" class="anchor-link">À propos du jeu de données</a></h2>
 
         <p>
-        Le jeu de données HTTP Archive est continuellement mis à jour avec de nouvelles données mensuelles. Pour l’édition 2019 du Web Almanac, sauf indication contraire dans le chapitre, tous les paramètres ont été obtenus à partir de l’index de juillet 2019. Ces résultats sont <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/master/docs/gettingstarted_bigquery.md">publiquement requêtables</a> sur BigQuery dans des tables préfixées par <code>2019_07_01</code>.
+        Le jeu de données HTTP Archive est continuellement mis à jour avec de nouvelles données mensuelles. Pour l’édition 2019 du Web Almanac, sauf indication contraire dans le chapitre, tous les paramètres ont été obtenus à partir de l’index de juillet 2019. Ces résultats sont <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/main/docs/gettingstarted_bigquery.md">publiquement requêtables</a> sur BigQuery dans des tables préfixées par <code>2019_07_01</code>.
         </p>
 
         <p>

--- a/src/templates/fr/2020/methodology.html
+++ b/src/templates/fr/2020/methodology.html
@@ -244,7 +244,7 @@
       </p>
 
       <p>
-        L’instance privée de WebPageTest de HTTP Archive est synchronisée avec la dernière version publique et complétée par des <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/tree/master/custom_metrics">indicateurs personnalisés</a>. Ils sont collectés par des portions de JavaScript qui sont évaluées et exécutées sur chaque site web à la fin du test. Grâce aux <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/commits/master/custom_metrics">contributions</a> de nombreux analystes de données, notamment les <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/pulls?q=is%3Apr+author%3ATiggerito+sort%3Acreated-asc">efforts herculéens</a> de <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='Tiggerito') }}" lang="en">Tony McCreath</a>, l’édition 2020 du Web Almanac a considérablement élargi les capacités de l’infrastructure de test de HTTP Archive avec plus de 3000 nouvelles lignes de code.
+        L’instance privée de WebPageTest de HTTP Archive est synchronisée avec la dernière version publique et complétée par des <a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">indicateurs personnalisés</a>. Ils sont collectés par des portions de JavaScript qui sont évaluées et exécutées sur chaque site web à la fin du test. Grâce aux <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/commits/master/custom_metrics">contributions</a> de nombreux analystes de données, notamment les <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/pulls?q=is%3Apr+author%3ATiggerito+sort%3Acreated-asc">efforts herculéens</a> de <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='Tiggerito') }}" lang="en">Tony McCreath</a>, l’édition 2020 du Web Almanac a considérablement élargi les capacités de l’infrastructure de test de HTTP Archive avec plus de 3000 nouvelles lignes de code.
       </p>
 
       <p>
@@ -435,7 +435,7 @@
       <h3 id="analysis"><a href="#analysis" class="anchor-link">Analyse</a></h3>
 
       <p>
-        En juillet et août 2020, ayant une liste bien établie de mesures et de chapitres, les analystes de données ont trié les mesures pour en déterminer la faisabilité. Dans certains cas, nous avons créé des <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/tree/master/custom_metrics">mesures personnalisées</a> pour combler les lacunes de nos capacités analytiques.
+        En juillet et août 2020, ayant une liste bien établie de mesures et de chapitres, les analystes de données ont trié les mesures pour en déterminer la faisabilité. Dans certains cas, nous avons créé des <a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">mesures personnalisées</a> pour combler les lacunes de nos capacités analytiques.
       </p>
 
       <p>

--- a/src/templates/fr/2020/methodology.html
+++ b/src/templates/fr/2020/methodology.html
@@ -72,7 +72,7 @@
         <h2 id="dataset"><a href="#dataset" class="anchor-link">À propos du jeu de données</a></h2>
 
         <p>
-          Le jeu de données HTTP Archive est continuellement mis à jour avec de nouvelles données mensuelles. Pour l’édition 2020 du Web Almanac, sauf indication contraire dans le chapitre, tous les paramètres ont été obtenus à partir de l’index de août 2020. Ces résultats sont <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/master/docs/gettingstarted_bigquery.md">publiquement requêtables</a> sur BigQuery dans des tables préfixées par <code>2020_08_01</code>.
+          Le jeu de données HTTP Archive est continuellement mis à jour avec de nouvelles données mensuelles. Pour l’édition 2020 du Web Almanac, sauf indication contraire dans le chapitre, tous les paramètres ont été obtenus à partir de l’index de août 2020. Ces résultats sont <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/main/docs/gettingstarted_bigquery.md">publiquement requêtables</a> sur BigQuery dans des tables préfixées par <code>2020_08_01</code>.
         </p>
 
         <p>

--- a/src/templates/hi/2019/methodology.html
+++ b/src/templates/hi/2019/methodology.html
@@ -235,7 +235,7 @@
       </p>
 
       <p>
-        WebPageTest के HTTP Archive का निजी उदाहरण नवीनतम सार्वजनिक संस्करण के साथ सिंक में और <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/tree/master/custom_metrics">कस्टम मैट्रिक्स</a> के साथ संवर्धित रखा जाता है। ये JavaScript के स्निपेट हैं जिनका परीक्षण के अंत में प्रत्येक वेबसाइट पर मूल्यांकन किया जाता है। <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/blob/master/custom_metrics/almanac.js">almanac.js</a> कस्टम मीट्रिक में कई मीट्रिक शामिल हैं जो अन्यथा गणना करने के लिए पर्याप्त हैं, उदाहरण के लिए जो DOM अवस्था पर निर्भर हैं।
+        WebPageTest के HTTP Archive का निजी उदाहरण नवीनतम सार्वजनिक संस्करण के साथ सिंक में और <a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">कस्टम मैट्रिक्स</a> के साथ संवर्धित रखा जाता है। ये JavaScript के स्निपेट हैं जिनका परीक्षण के अंत में प्रत्येक वेबसाइट पर मूल्यांकन किया जाता है। <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/blob/master/custom_metrics/almanac.js">almanac.js</a> कस्टम मीट्रिक में कई मीट्रिक शामिल हैं जो अन्यथा गणना करने के लिए पर्याप्त हैं, उदाहरण के लिए जो DOM अवस्था पर निर्भर हैं।
       </p>
 
       <p>

--- a/src/templates/hi/2019/methodology.html
+++ b/src/templates/hi/2019/methodology.html
@@ -67,7 +67,7 @@
         <h2 id="dataset"><a href="#dataset" class="anchor-link">डेटासेट के बारे में</a></h2>
 
         <p>
-          HTTP Archive डेटासेट लगातार नए मासिक डेटा के साथ अपडेट हो रहे है। Web Almanac के 2019 संस्करण के लिए, जब तक कि अन्यथा अध्याय में उल्लेख नहीं किया गया, जुलाई 2019 से सभी मैट्रिक्स क्रॉल किए गए थे। ये परिणाम <code>2019_07_01</code> के साथ उपसर्ग किए गए तालिकाओं में BigQuery पर <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/master/docs/gettingstarted_bigquery.md">सार्वजनिक रूप से क्वेरी करने योग्य</a> हैं।
+          HTTP Archive डेटासेट लगातार नए मासिक डेटा के साथ अपडेट हो रहे है। Web Almanac के 2019 संस्करण के लिए, जब तक कि अन्यथा अध्याय में उल्लेख नहीं किया गया, जुलाई 2019 से सभी मैट्रिक्स क्रॉल किए गए थे। ये परिणाम <code>2019_07_01</code> के साथ उपसर्ग किए गए तालिकाओं में BigQuery पर <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/main/docs/gettingstarted_bigquery.md">सार्वजनिक रूप से क्वेरी करने योग्य</a> हैं।
         </p>
 
         <p>

--- a/src/templates/hi/2020/methodology.html
+++ b/src/templates/hi/2020/methodology.html
@@ -72,7 +72,7 @@
         <h2 id="dataset"><a href="#dataset" class="anchor-link">डेटासेट के बारे में</a></h2>
 
         <p>
-          HTTP Archive डेटासेट लगातार नए मासिक डेटा के साथ अपडेट हो रहे है। Web Almanac के 2020 संस्करण के लिए, जब तक कि अन्यथा अध्याय में उल्लेख नहीं किया गया, अगस्त 2020 से सभी मैट्रिक्स क्रॉल किए गए थे। ये परिणाम <code>2020_08_01</code> के साथ उपसर्ग किए गए तालिकाओं में BigQuery पर <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/master/docs/gettingstarted_bigquery.md">सार्वजनिक रूप से क्वेरी करने योग्य</a> हैं।
+          HTTP Archive डेटासेट लगातार नए मासिक डेटा के साथ अपडेट हो रहे है। Web Almanac के 2020 संस्करण के लिए, जब तक कि अन्यथा अध्याय में उल्लेख नहीं किया गया, अगस्त 2020 से सभी मैट्रिक्स क्रॉल किए गए थे। ये परिणाम <code>2020_08_01</code> के साथ उपसर्ग किए गए तालिकाओं में BigQuery पर <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/main/docs/gettingstarted_bigquery.md">सार्वजनिक रूप से क्वेरी करने योग्य</a> हैं।
         </p>
 
         <p>

--- a/src/templates/hi/2020/methodology.html
+++ b/src/templates/hi/2020/methodology.html
@@ -244,7 +244,7 @@
       </p>
 
       <p>
-        WebPageTest के HTTP Archive का निजी उदाहरण नवीनतम सार्वजनिक संस्करण के साथ सिंक में और <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/tree/master/custom_metrics">कस्टम मैट्रिक्स</a> के साथ संवर्धित रखा जाता है। ये JavaScript के स्निपेट हैं जिनका परीक्षण के अंत में प्रत्येक वेबसाइट पर मूल्यांकन किया जाता है। कई डेटा विश्लेषकों के <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/commits/master/custom_metrics">योगदान</a>के लिए धन्यवाद, विशेष रूप से <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='Tiggerito') }}">टोनी मैकक्रेथ</a> के <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/pulls?q=is%3Apr+author%3ATiggerito+sort%3Acreated-asc">कठिन प्रयासों</a> का जिन्होंने, Web Almanac के 2020 संस्करण में HTTP Archive के परीक्षण बुनियादी ढांचे की 3,000 से अधिक लाइनों के साथ क्षमताओं का बहुत विस्तार किया।
+        WebPageTest के HTTP Archive का निजी उदाहरण नवीनतम सार्वजनिक संस्करण के साथ सिंक में और <a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">कस्टम मैट्रिक्स</a> के साथ संवर्धित रखा जाता है। ये JavaScript के स्निपेट हैं जिनका परीक्षण के अंत में प्रत्येक वेबसाइट पर मूल्यांकन किया जाता है। कई डेटा विश्लेषकों के <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/commits/master/custom_metrics">योगदान</a>के लिए धन्यवाद, विशेष रूप से <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='Tiggerito') }}">टोनी मैकक्रेथ</a> के <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/pulls?q=is%3Apr+author%3ATiggerito+sort%3Acreated-asc">कठिन प्रयासों</a> का जिन्होंने, Web Almanac के 2020 संस्करण में HTTP Archive के परीक्षण बुनियादी ढांचे की 3,000 से अधिक लाइनों के साथ क्षमताओं का बहुत विस्तार किया।
       </p>
 
       <p>
@@ -435,7 +435,7 @@
       <h3 id="analysis"><a href="#analysis" class="anchor-link">विश्लेषण</a></h3>
 
       <p>
-        जुलाई और अगस्त 2020 में, मैट्रिक्स और अध्यायों की स्थिर सूची के साथ, डेटा विश्लेषकों ने व्यवहार्यता के लिए मीट्रिक को कम कर दिया। कुछ मामलों में, <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/tree/master/custom_metrics">कस्टम मेट्रिक्स</a> को हमारी विश्लेषणात्मक क्षमताओं में अंतराल को भरने के लिए बनाने की आवश्यकता हुई।
+        जुलाई और अगस्त 2020 में, मैट्रिक्स और अध्यायों की स्थिर सूची के साथ, डेटा विश्लेषकों ने व्यवहार्यता के लिए मीट्रिक को कम कर दिया। कुछ मामलों में, <a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">कस्टम मेट्रिक्स</a> को हमारी विश्लेषणात्मक क्षमताओं में अंतराल को भरने के लिए बनाने की आवश्यकता हुई।
       </p>
 
       <p>

--- a/src/templates/ja/2019/methodology.html
+++ b/src/templates/ja/2019/methodology.html
@@ -67,7 +67,7 @@
         <h2 id="dataset"><a href="#dataset" class="anchor-link">データセットについて</a></h2>
 
         <p>
-          HTTP Archiveデータセットは、毎月新しいデータで継続的に更新されています。Web Almanacの2019年版については、この章で特に断りのない限り、すべてのメトリクスは2019年7月のクロールからソースを得ています。これらの結果は、BigQuery上で接頭語のテーブル<code>2019_07_01</code>で<a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/master/docs/gettingstarted_bigquery.md">公開</a>できます。
+          HTTP Archiveデータセットは、毎月新しいデータで継続的に更新されています。Web Almanacの2019年版については、この章で特に断りのない限り、すべてのメトリクスは2019年7月のクロールからソースを得ています。これらの結果は、BigQuery上で接頭語のテーブル<code>2019_07_01</code>で<a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/main/docs/gettingstarted_bigquery.md">公開</a>できます。
         </p>
 
         <p>

--- a/src/templates/ja/2019/methodology.html
+++ b/src/templates/ja/2019/methodology.html
@@ -235,7 +235,7 @@
       </p>
 
       <p>
-        HTTP ArchiveのWebPageTestのプライベートインスタンスは、最新のパブリックバージョンと同期して維持され、<a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/tree/master/custom_metrics">カスタムメトリクス</a>で強化されています。これらは、テストの最後に各ウェブサイトで評価されるJavaScriptのスニペットです。<a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/blob/master/custom_metrics/almanac.js">almanac.js</a>カスタムメトリクスには、DOMの状態に依存するメトリクスなど、そうでなければ計算できないいくつかのメトリクスが含まれています。
+        HTTP ArchiveのWebPageTestのプライベートインスタンスは、最新のパブリックバージョンと同期して維持され、<a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">カスタムメトリクス</a>で強化されています。これらは、テストの最後に各ウェブサイトで評価されるJavaScriptのスニペットです。<a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/blob/master/custom_metrics/almanac.js">almanac.js</a>カスタムメトリクスには、DOMの状態に依存するメトリクスなど、そうでなければ計算できないいくつかのメトリクスが含まれています。
       </p>
 
       <p>

--- a/src/templates/ja/2020/methodology.html
+++ b/src/templates/ja/2020/methodology.html
@@ -244,7 +244,7 @@
       </p>
 
       <p>
-        HTTP ArchiveのWebPageTestのプライベートインスタンスは、最新のパブリックバージョンと同期して維持され、<a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/tree/master/custom_metrics">カスタムメトリクス</a>で強化されています。これらは、テストの最後に各ウェブサイトで評価されるJavaScriptのスニペットです。多くのデータアナリストの<a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/commits/master/custom_metrics">貢献</a>に感謝します、特に<a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/pulls?q=is%3Apr+author%3ATiggerito+sort%3Acreated-asc">献身的な努力</a>をした<a href="{{ url_for('contributors', year=year, lang=lang, _anchor='Tiggerito')}}">Tony McCreathのおかげで</a>、Web Almanacの2020年版では、HTTPアーカイブのテストインフラストラクチャの機能が3,000行以上の新しいコードで大幅に拡張されました。
+        HTTP ArchiveのWebPageTestのプライベートインスタンスは、最新のパブリックバージョンと同期して維持され、<a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">カスタムメトリクス</a>で強化されています。これらは、テストの最後に各ウェブサイトで評価されるJavaScriptのスニペットです。多くのデータアナリストの<a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/commits/master/custom_metrics">貢献</a>に感謝します、特に<a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/pulls?q=is%3Apr+author%3ATiggerito+sort%3Acreated-asc">献身的な努力</a>をした<a href="{{ url_for('contributors', year=year, lang=lang, _anchor='Tiggerito')}}">Tony McCreathのおかげで</a>、Web Almanacの2020年版では、HTTPアーカイブのテストインフラストラクチャの機能が3,000行以上の新しいコードで大幅に拡張されました。
       </p>
 
       <p>
@@ -435,7 +435,7 @@
       <h3 id="analysis"><a href="#analysis" class="anchor-link">分析</a></h3>
 
       <p>
-        2020年7月と8月に、メトリクスとチャプターの安定したリストを持って、データアナリストは、実現可能性のためにメトリクスをトリアージしました。場合によっては、分析能力のギャップを埋めるために、<a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/tree/master/custom_metrics">カスタムメトリクス</a>を作成されました。
+        2020年7月と8月に、メトリクスとチャプターの安定したリストを持って、データアナリストは、実現可能性のためにメトリクスをトリアージしました。場合によっては、分析能力のギャップを埋めるために、<a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">カスタムメトリクス</a>を作成されました。
       </p>
 
       <p>

--- a/src/templates/ja/2020/methodology.html
+++ b/src/templates/ja/2020/methodology.html
@@ -72,7 +72,7 @@
         <h2 id="dataset"><a href="#dataset" class="anchor-link">データセットについて</a></h2>
 
         <p>
-          HTTP Archiveデータセットは、毎月新しいデータで継続的に更新されています。Web Almanacの2020年版については、この章で特に断りのない限り、すべてのメトリクスは2020年8月のクロールからソースを得ています。これらの結果は、BigQuery上で接頭語のテーブル<code>2020_08_01</code>で<a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/master/docs/gettingstarted_bigquery.md">公開</a>できます。
+          HTTP Archiveデータセットは、毎月新しいデータで継続的に更新されています。Web Almanacの2020年版については、この章で特に断りのない限り、すべてのメトリクスは2020年8月のクロールからソースを得ています。これらの結果は、BigQuery上で接頭語のテーブル<code>2020_08_01</code>で<a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/main/docs/gettingstarted_bigquery.md">公開</a>できます。
         </p>
 
         <p>

--- a/src/templates/nl/2019/methodology.html
+++ b/src/templates/nl/2019/methodology.html
@@ -235,7 +235,7 @@
       </p>
 
       <p>
-        Het privé-exemplaar van WebPageTest van HTTP Archive wordt gesynchroniseerd met de laatste openbare versie en aangevuld met <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/tree/master/custom_metrics">aangepaste statistieken</a>. Dit zijn fragmenten van JavaScript die aan het einde van de test op elke website worden geëvalueerd. De aangepaste statistiek <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/blob/master/custom_metrics/almanac.js">almanac.js</a> bevat verschillende statistieken die anders niet haalbaar waren berekend, bijvoorbeeld degene die afhankelijk zijn van de DOM-status.
+        Het privé-exemplaar van WebPageTest van HTTP Archive wordt gesynchroniseerd met de laatste openbare versie en aangevuld met <a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">aangepaste statistieken</a>. Dit zijn fragmenten van JavaScript die aan het einde van de test op elke website worden geëvalueerd. De aangepaste statistiek <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/blob/master/custom_metrics/almanac.js">almanac.js</a> bevat verschillende statistieken die anders niet haalbaar waren berekend, bijvoorbeeld degene die afhankelijk zijn van de DOM-status.
       </p>
 
       <p>

--- a/src/templates/nl/2019/methodology.html
+++ b/src/templates/nl/2019/methodology.html
@@ -67,7 +67,7 @@
         <h2 id="dataset"><a href="#dataset" class="anchor-link">Over de dataset</a></h2>
 
         <p>
-          De HTTP Archive-dataset wordt maandelijks continu bijgewerkt met nieuwe gegevens. Voor de 2019-editie van de Web Almanac zijn, tenzij anders vermeld in het hoofdstuk, alle statistieken afkomstig van de crawl van juli 2019. Deze resultaten zijn <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/master/docs/gettingstarted_bigquery.md">openbaar doorzoekbaar</a> op BigQuery in tabellen met het voorvoegsel <code>2019_07_01</code>.
+          De HTTP Archive-dataset wordt maandelijks continu bijgewerkt met nieuwe gegevens. Voor de 2019-editie van de Web Almanac zijn, tenzij anders vermeld in het hoofdstuk, alle statistieken afkomstig van de crawl van juli 2019. Deze resultaten zijn <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/main/docs/gettingstarted_bigquery.md">openbaar doorzoekbaar</a> op BigQuery in tabellen met het voorvoegsel <code>2019_07_01</code>.
         </p>
 
         <p>

--- a/src/templates/nl/2020/methodology.html
+++ b/src/templates/nl/2020/methodology.html
@@ -244,7 +244,7 @@
       </p>
 
       <p>
-        Het privé-exemplaar van WebPageTest van HTTP Archive wordt gesynchroniseerd met de laatste openbare versie en aangevuld met <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/tree/master/custom_metrics">aangepaste statistieken</a>. Dit zijn fragmenten van JavaScript die aan het einde van de test op elke website worden geëvalueerd. Dankzij de <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/commits/master/custom_metrics">bijdragen</a> van veel data-analisten, vooral de <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/pulls?q=is%3Apr+author%3ATiggerito+sort%3Acreated-asc">enorme inspanningen</a> van <a href="{{ url_for('contributors', year=year, lang=lang, _anchor ='Tiggerito') }}">Tony McCreath</a>, heeft de 2020-editie van de Web Almanac de mogelijkheden van de testinfrastructuur van HTTP Archive aanzienlijk uitgebreid met meer dan 3.000 regels nieuwe code.
+        Het privé-exemplaar van WebPageTest van HTTP Archive wordt gesynchroniseerd met de laatste openbare versie en aangevuld met <a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">aangepaste statistieken</a>. Dit zijn fragmenten van JavaScript die aan het einde van de test op elke website worden geëvalueerd. Dankzij de <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/commits/master/custom_metrics">bijdragen</a> van veel data-analisten, vooral de <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/pulls?q=is%3Apr+author%3ATiggerito+sort%3Acreated-asc">enorme inspanningen</a> van <a href="{{ url_for('contributors', year=year, lang=lang, _anchor ='Tiggerito') }}">Tony McCreath</a>, heeft de 2020-editie van de Web Almanac de mogelijkheden van de testinfrastructuur van HTTP Archive aanzienlijk uitgebreid met meer dan 3.000 regels nieuwe code.
       </p>
 
       <p>
@@ -435,7 +435,7 @@
       <h3 id="analysis"><a href="#analysis" class="anchor-link">Analyse</a></h3>
 
       <p>
-        In juli en augustus 2020, met de stabiele lijst van statistieken en hoofdstukken, hebben data-analisten de statistieken getoetst op haalbaarheid. In sommige gevallen zijn <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/tree/master/custom_metrics">aangepaste statistieken</a> gemaakt om hiaten in onze analytische mogelijkheden op te vullen.
+        In juli en augustus 2020, met de stabiele lijst van statistieken en hoofdstukken, hebben data-analisten de statistieken getoetst op haalbaarheid. In sommige gevallen zijn <a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">aangepaste statistieken</a> gemaakt om hiaten in onze analytische mogelijkheden op te vullen.
       </p>
 
       <p>

--- a/src/templates/nl/2020/methodology.html
+++ b/src/templates/nl/2020/methodology.html
@@ -72,7 +72,7 @@
         <h2 id="dataset"><a href="#dataset" class="anchor-link">Over de dataset</a></h2>
 
         <p>
-          De HTTP Archive-dataset wordt maandelijks continu bijgewerkt met nieuwe gegevens. Voor de 2020-editie van de Web Almanac zijn, tenzij anders vermeld in het hoofdstuk, alle statistieken afkomstig van de crawl van augustus 2020. Deze resultaten zijn <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/master/docs/gettingstarted_bigquery.md">openbaar doorzoekbaar</a> op BigQuery in tabellen met het voorvoegsel <code>2020_08_01</code>.
+          De HTTP Archive-dataset wordt maandelijks continu bijgewerkt met nieuwe gegevens. Voor de 2020-editie van de Web Almanac zijn, tenzij anders vermeld in het hoofdstuk, alle statistieken afkomstig van de crawl van augustus 2020. Deze resultaten zijn <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/main/docs/gettingstarted_bigquery.md">openbaar doorzoekbaar</a> op BigQuery in tabellen met het voorvoegsel <code>2020_08_01</code>.
         </p>
 
         <p>

--- a/src/templates/ru/2019/methodology.html
+++ b/src/templates/ru/2019/methodology.html
@@ -67,7 +67,7 @@
         <h2 id="dataset"><a href="#dataset" class="anchor-link">О наборе данных</a></h2>
 
         <p>
-          Набор данных HTTP Archive постоянно растёт каждый месяц. Для издания Web Almanac 2019 года, если в главе не указано иное, все метрики были взяты из сканирования сайтов за июль 2019 года. Эти показатели можно <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/master/docs/gettingstarted_bigquery.md">свободно запросить</a> из таблиц с префиксом <code>2019_07_01</code> на BigQuery.
+          Набор данных HTTP Archive постоянно растёт каждый месяц. Для издания Web Almanac 2019 года, если в главе не указано иное, все метрики были взяты из сканирования сайтов за июль 2019 года. Эти показатели можно <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/main/docs/gettingstarted_bigquery.md">свободно запросить</a> из таблиц с префиксом <code>2019_07_01</code> на BigQuery.
         </p>
 
         <p>

--- a/src/templates/ru/2019/methodology.html
+++ b/src/templates/ru/2019/methodology.html
@@ -235,7 +235,7 @@
       </p>
 
       <p>
-        Приватный экземпляр WebPageTest в HTTP Archive синхронизирован с последней публичной версией и дополнен  <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/tree/master/custom_metrics">собственными метриками</a>. Это фрагменты JavaScript-кода, которые выполняются на каждом сайте в конце теста. Собственная метрика в файле <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/blob/master/custom_metrics/almanac.js">almanac.js</a> включает в себя несколько метрик, которые зависят от состояния DOM.
+        Приватный экземпляр WebPageTest в HTTP Archive синхронизирован с последней публичной версией и дополнен  <a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">собственными метриками</a>. Это фрагменты JavaScript-кода, которые выполняются на каждом сайте в конце теста. Собственная метрика в файле <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/blob/master/custom_metrics/almanac.js">almanac.js</a> включает в себя несколько метрик, которые зависят от состояния DOM.
       </p>
 
       <p>

--- a/src/templates/ru/2020/methodology.html
+++ b/src/templates/ru/2020/methodology.html
@@ -244,7 +244,7 @@
       </p>
 
       <p>
-        Приватный экземпляр WebPageTest в HTTP Archive синхронизирован с последней публичной версией и дополнен  <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/tree/master/custom_metrics">собственными метриками</a>. Это фрагменты JavaScript-кода, которые выполняются на каждом сайте в конце теста. Благодаря <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/commits/master/custom_metrics">помощи</a> многих аналитиков данных, в частности, <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/pulls?q=is%3Apr+author%3ATiggerito+sort%3Acreated-asc">титаническим усилиям</a> <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='Tiggerito') }}">Тони МакКреа (Tony McCreath)</a>, выпуск Web Almanac от 2020 года  значительно расширил возможности тестовой инфраструктуры HTTP Archive вместе с более 3000 строк нового кода.
+        Приватный экземпляр WebPageTest в HTTP Archive синхронизирован с последней публичной версией и дополнен  <a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">собственными метриками</a>. Это фрагменты JavaScript-кода, которые выполняются на каждом сайте в конце теста. Благодаря <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/commits/master/custom_metrics">помощи</a> многих аналитиков данных, в частности, <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/pulls?q=is%3Apr+author%3ATiggerito+sort%3Acreated-asc">титаническим усилиям</a> <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='Tiggerito') }}">Тони МакКреа (Tony McCreath)</a>, выпуск Web Almanac от 2020 года  значительно расширил возможности тестовой инфраструктуры HTTP Archive вместе с более 3000 строк нового кода.
       </p>
 
       <p>
@@ -435,7 +435,7 @@
       <h3 id="analysis"><a href="#analysis" class="anchor-link">Анализ</a></h3>
 
       <p>
-        В июле и августе 2020 года, имея составленный список метрик и глав, аналитики данных отсортировали метрики для дальнейшего анализа. В некоторых случаях мы создали <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/tree/master/custom_metrics">собственные метрики</a> для заполнения пробелов в нашем аналитическом потенциале.
+        В июле и августе 2020 года, имея составленный список метрик и глав, аналитики данных отсортировали метрики для дальнейшего анализа. В некоторых случаях мы создали <a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">собственные метрики</a> для заполнения пробелов в нашем аналитическом потенциале.
       </p>
 
       <p>

--- a/src/templates/ru/2020/methodology.html
+++ b/src/templates/ru/2020/methodology.html
@@ -72,7 +72,7 @@
         <h2 id="dataset"><a href="#dataset" class="anchor-link">О наборе данных</a></h2>
 
         <p>
-          Набор данных HTTP Archive постоянно растёт каждый месяц. Для издания Web Almanac 2020 года, если в главе не указано иное, все метрики были взяты из сканирования сайтов за август 2020 года. Эти показатели можно <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/master/docs/gettingstarted_bigquery.md">свободно запросить</a> из таблиц с префиксом <code>2020_08_01</code> на BigQuery.
+          Набор данных HTTP Archive постоянно растёт каждый месяц. Для издания Web Almanac 2020 года, если в главе не указано иное, все метрики были взяты из сканирования сайтов за август 2020 года. Эти показатели можно <a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/main/docs/gettingstarted_bigquery.md">свободно запросить</a> из таблиц с префиксом <code>2020_08_01</code> на BigQuery.
         </p>
 
         <p>

--- a/src/templates/zh-CN/2019/methodology.html
+++ b/src/templates/zh-CN/2019/methodology.html
@@ -235,7 +235,7 @@
       </p>
 
       <p>
-        HTTP Archive 的 WebPageTest 私有实例和最新的公有版本保持一致，使用 <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/tree/master/custom_metrics">自定义指标</a>来增强。 这些是测试结尾时在每个网站上评估测试的JavaScript片段<a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/blob/master/custom_metrics/almanac.js">almanac.js</a> 。自定义指标包括一些其他情况下无法计算的指标，例如那些依赖于DOM状态的指标。
+        HTTP Archive 的 WebPageTest 私有实例和最新的公有版本保持一致，使用 <a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">自定义指标</a>来增强。 这些是测试结尾时在每个网站上评估测试的JavaScript片段<a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/blob/master/custom_metrics/almanac.js">almanac.js</a> 。自定义指标包括一些其他情况下无法计算的指标，例如那些依赖于DOM状态的指标。
       </p>
 
       <p>

--- a/src/templates/zh-CN/2019/methodology.html
+++ b/src/templates/zh-CN/2019/methodology.html
@@ -67,7 +67,7 @@
         <h2 id="dataset"><a href="#dataset" class="anchor-link">关于数据集</a></h2>
 
         <p>
-          HTTP Archive 数据集每月持续更新新的数据。对于2019年版的Web Almanac，除非本章另有说明，否则所有的指标都来自于2019年7月的抓取。这些结果<a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/master/docs/gettingstarted_bigquery.md">可以用 <code>2019_07_01</code>为前缀在BigQuery公开的查询</a>
+          HTTP Archive 数据集每月持续更新新的数据。对于2019年版的Web Almanac，除非本章另有说明，否则所有的指标都来自于2019年7月的抓取。这些结果<a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/main/docs/gettingstarted_bigquery.md">可以用 <code>2019_07_01</code>为前缀在BigQuery公开的查询</a>
         </p>
 
         <p>

--- a/src/templates/zh-CN/2020/methodology.html
+++ b/src/templates/zh-CN/2020/methodology.html
@@ -72,7 +72,7 @@
         <h2 id="dataset"><a href="#dataset" class="anchor-link">关于数据集</a></h2>
 
         <p>
-          HTTP Archive 数据集每月持续更新新的数据。对于2020年版的Web Almanac，除非本章另有说明，否则所有的指标都来自于2020年8月的抓取。这些结果<a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/master/docs/gettingstarted_bigquery.md">可以用<code>2020_08_01</code>为前缀在BigQuery公开的查询</a>。
+          HTTP Archive 数据集每月持续更新新的数据。对于2020年版的Web Almanac，除非本章另有说明，否则所有的指标都来自于2020年8月的抓取。这些结果<a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/main/docs/gettingstarted_bigquery.md">可以用<code>2020_08_01</code>为前缀在BigQuery公开的查询</a>。
         </p>
 
         <p>

--- a/src/templates/zh-CN/2020/methodology.html
+++ b/src/templates/zh-CN/2020/methodology.html
@@ -244,7 +244,7 @@
       </p>
 
       <p>
-        HTTP Archive 的 WebPageTest 私有实例和最新的公有版本保持一致，使用 <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/tree/master/custom_metrics">自定义指标</a>来增强。这些是测试结尾时在每个网站上评估测试的JavaScript片段。感谢众多数据分析师的 <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/commits/master/custom_metrics">贡献</a> ， 特别是<a href="{{ url_for('contributors', year=year, lang=lang, _anchor='Tiggerito') }}">Tony McCreath</a>的<a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/pulls?q=is%3Apr+author%3ATiggerito+sort%3Acreated-asc">艰巨的努力</a>， 2020年版的Web Almanac 网络年鉴极大地扩展了HTTP Archive的测试基础架构的功能，增加了3000多行新代码。
+        HTTP Archive 的 WebPageTest 私有实例和最新的公有版本保持一致，使用 <a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">自定义指标</a>来增强。这些是测试结尾时在每个网站上评估测试的JavaScript片段。感谢众多数据分析师的 <a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/commits/master/custom_metrics">贡献</a> ， 特别是<a href="{{ url_for('contributors', year=year, lang=lang, _anchor='Tiggerito') }}">Tony McCreath</a>的<a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/pulls?q=is%3Apr+author%3ATiggerito+sort%3Acreated-asc">艰巨的努力</a>， 2020年版的Web Almanac 网络年鉴极大地扩展了HTTP Archive的测试基础架构的功能，增加了3000多行新代码。
       </p>
 
       <p>
@@ -435,7 +435,7 @@
       <h3 id="analysis"><a href="#analysis" class="anchor-link">分析</a></h3>
 
       <p>
-        在2020的7月和8月, 随着指标和章节的列表稳定下来，数据分析师对指标的可行性进行了筛选。在一些情况下，<a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/tree/master/custom_metrics">自定义指标</a> 需要被创建来填补我们分析能力的空白。
+        在2020的7月和8月, 随着指标和章节的列表稳定下来，数据分析师对指标的可行性进行了筛选。在一些情况下，<a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">自定义指标</a> 需要被创建来填补我们分析能力的空白。
       </p>
 
       <p>

--- a/src/templates/zh-TW/2020/methodology.html
+++ b/src/templates/zh-TW/2020/methodology.html
@@ -72,7 +72,7 @@
         <h2 id="dataset"><a href="#dataset" class="anchor-link">關於資料集</a></h2>
 
         <p>
-          HTTP Archive 資料集每月持續更新數據，除各章節另有說明外，2020年版所有指標都來自2020年8月。這些結果可以透過<a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/master/docs/gettingstarted_bigquery.md">設置 BigQuery</a> 公共資料集的相關日期探索查詢，例如<code>2020_08_01</code>。
+          HTTP Archive 資料集每月持續更新數據，除各章節另有說明外，2020年版所有指標都來自2020年8月。這些結果可以透過<a hreflang="en" href="https://github.com/HTTPArchive/httparchive.org/blob/main/docs/gettingstarted_bigquery.md">設置 BigQuery</a> 公共資料集的相關日期探索查詢，例如<code>2020_08_01</code>。
         </p>
 
         <p>

--- a/src/templates/zh-TW/2020/methodology.html
+++ b/src/templates/zh-TW/2020/methodology.html
@@ -244,7 +244,7 @@
       </p>
 
       <p>
-        HTTP Archive 在 WebPageTest 的私有實例保持與最新的公共版本同步，且增加使用<a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/tree/master/custom_metrics">自訂指標</a>。在測試的尾聲透過片段的 JavaScript 評估每個網站。感謝許多數據分析的<a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/commits/master/custom_metrics">貢獻者</a>，特別是<a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/pulls?q=is%3Apr+author%3ATiggerito+sort%3Acreated-asc">熱血拋顱</a>的 <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='Tiggerito') }}">Tony McCreath</a>。 Web Almanac 網路年鑑2020年版致力拓展 HTTP Archive 的基礎測試架構功能，揮灑超過三千行的新程式碼。
+        HTTP Archive 在 WebPageTest 的私有實例保持與最新的公共版本同步，且增加使用<a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">自訂指標</a>。在測試的尾聲透過片段的 JavaScript 評估每個網站。感謝許多數據分析的<a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/commits/master/custom_metrics">貢獻者</a>，特別是<a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/pulls?q=is%3Apr+author%3ATiggerito+sort%3Acreated-asc">熱血拋顱</a>的 <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='Tiggerito') }}">Tony McCreath</a>。 Web Almanac 網路年鑑2020年版致力拓展 HTTP Archive 的基礎測試架構功能，揮灑超過三千行的新程式碼。
       </p>
 
       <p>
@@ -435,7 +435,7 @@
       <h3 id="analysis"><a href="#analysis" class="anchor-link">分析</a></h3>
 
       <p>
-        2020年7月和8月，在指標和章節的列表拍板後，數據分析師對指標的可行性進行篩選。在某些情況，<a hreflang="en" href="https://github.com/HTTPArchive/legacy.httparchive.org/tree/master/custom_metrics">自訂指標</a>已經產生，且用來填補分析的能力。
+        2020年7月和8月，在指標和章節的列表拍板後，數據分析師對指標的可行性進行篩選。在某些情況，<a hreflang="en" href="https://github.com/HTTPArchive/custom-metrics">自訂指標</a>已經產生，且用來填補分析的能力。
       </p>
 
       <p>

--- a/src/tools/test/test_status_codes.js
+++ b/src/tools/test/test_status_codes.js
@@ -4,7 +4,7 @@ const convert = require('xml-js');
 
 const { get_yearly_configs } = require('../generate/shared');
 
-const default_year = 2021;
+const default_year = 2022;
 const default_language = 'en';
 const base_url = "http://127.0.0.1:8080";
 


### PR DESCRIPTION
Makes the following changes:
- Adds 2022 Methodology page.
- Corrects some errors in 2021 Methodology page.
- Updates links in previous Methodology pages.
- Sets 2022 as default, in preparation of new chapters.

