### PR TITLE
Sustainability 2022: Updated queries

### DIFF
--- a/sql/2022/sustainability/green_third_party_requests.sql
+++ b/sql/2022/sustainability/green_third_party_requests.sql
@@ -32,7 +32,6 @@ pages AS (
 third_party AS (
   SELECT
     domain,
-    canonicalDomain,
     COUNT(DISTINCT page) AS page_usage
   FROM
     `httparchive.almanac.third_parties` tp
@@ -43,8 +42,7 @@ third_party AS (
     date = '2022-06-01' AND
     category NOT IN ('hosting')
   GROUP BY
-    domain,
-    canonicalDomain
+    domain
   HAVING
     page_usage >= 50
 ),
@@ -52,7 +50,6 @@ third_party AS (
 green_tp AS (
   SELECT
     domain,
-    canonicalDomain
   FROM
     `httparchive.almanac.third_parties` tp
   JOIN
@@ -62,8 +59,7 @@ green_tp AS (
     date = '2022-06-01' AND
     category NOT IN ('hosting')
   GROUP BY
-    domain,
-    canonicalDomain
+    domain
 ),
 
 base AS (
@@ -71,7 +67,7 @@ base AS (
     client,
     page,
     rank,
-    COUNT(canonicalDomain) AS third_parties_per_page
+    COUNT(domain) AS third_parties_per_page
   FROM
     requests
   LEFT JOIN
@@ -93,7 +89,7 @@ base_green AS (
     client,
     page,
     rank,
-    COUNT(canonicalDomain) AS green_third_parties_per_page
+    COUNT(domain) AS green_third_parties_per_page
   FROM
     requests
   LEFT JOIN

--- a/sql/2022/sustainability/green_third_party_requests.sql
+++ b/sql/2022/sustainability/green_third_party_requests.sql
@@ -49,7 +49,7 @@ third_party AS (
 
 green_tp AS (
   SELECT
-    domain,
+    domain
   FROM
     `httparchive.almanac.third_parties` tp
   JOIN


### PR DESCRIPTION
This PR fixes the `green_third_party_requests.sql` query to align with the results of the Third Parties chapter.

I can be left open while the chapter is under review, in case other modifications are required.