### PR TITLE
[review] Fix font specific queries and new queries

### DIFF
--- a/sql/2022/fonts/color_fonts.sql
+++ b/sql/2022/fonts/color_fonts.sql
@@ -4,6 +4,7 @@ WITH
 fonts AS (
   SELECT
     url,
+    client,
     JSON_EXTRACT(payload, '$._font_details.color.formats') AS payload
   FROM
     `httparchive.almanac.requests`
@@ -12,17 +13,21 @@ fonts AS (
     type = 'font'
   GROUP BY
     url,
+    client,
     payload
 )
 SELECT
+  client,
   format,
   COUNT(0) AS freq,
-  COUNT(0) / SUM(COUNT(0)) OVER () AS pct_freq
+  SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct_freq
 FROM
   fonts,
   # Color fonts have any of sbix, cbdt, svg, colrv0 or colrv1 tables.
   UNNEST(REGEXP_EXTRACT_ALL(payload, '(?i)(sbix|CBDT|SVG|COLRv0|COLRv1)')) AS format
 GROUP BY
+  client,
   format
 ORDER BY
   pct_freq DESC

--- a/sql/2022/fonts/color_fonts.sql
+++ b/sql/2022/fonts/color_fonts.sql
@@ -1,37 +1,28 @@
 #standardSQL
 #color_fonts
-SELECT
-  client,
-  format,
-  COUNT(DISTINCT page) AS pages_color,
-  total_page,
-  COUNT(DISTINCT page) / total_page AS pct_color
-FROM (
+WITH
+fonts AS (
   SELECT
-    client,
-    page,
-    format,
-    payload
+    url,
+    JSON_EXTRACT(payload, '$._font_details.color.formats') AS payload
   FROM
     `httparchive.almanac.requests`
   WHERE
     date = '2022-06-01' AND
-    type = 'font')
-JOIN (
-  SELECT
-    _TABLE_SUFFIX AS client,
-    COUNT(0) AS total_page
-  FROM
-    `httparchive.pages.2022_06_01_*`
+    type = 'font'
   GROUP BY
-    _TABLE_SUFFIX)
-USING
-  (client),
+    url,
+    payload
+)
+SELECT
+  format,
+  COUNT(0) AS freq,
+  COUNT(0) / SUM(COUNT(0)) OVER () AS pct_freq
+FROM
+  fonts,
   # Color fonts have any of sbix, cbdt, svg, colrv0 or colrv1 tables.
-  UNNEST(REGEXP_EXTRACT_ALL(JSON_EXTRACT(payload, '$._font_details.color.formats'), '(?i)(sbix|CBDT|SVG|COLRv0|COLRv1)')) AS format
+  UNNEST(REGEXP_EXTRACT_ALL(payload, '(?i)(sbix|CBDT|SVG|COLRv0|COLRv1)')) AS format
 GROUP BY
-  client,
-  total_page,
   format
 ORDER BY
-  pages_color DESC
+  pct_freq DESC

--- a/sql/2022/fonts/font_format_usage_without_services.sql
+++ b/sql/2022/fonts/font_format_usage_without_services.sql
@@ -1,0 +1,37 @@
+#standardSQL
+#font_formats
+SELECT
+  client,
+  LOWER(IFNULL(REGEXP_EXTRACT(mimeType, '/(?:x-)?(?:font-)?(.*)'), ext)) AS mime_type,
+  COUNT(0) AS freq,
+  SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct
+FROM
+  `httparchive.almanac.requests`
+WHERE
+  date = '2022-06-01' AND
+  type = 'font' AND
+  mimeType != '' AND
+  NOT (REGEXP_CONTAINS(url, r'(fonts\.(gstatic|googleapis)\.com)|(themes.googleusercontent.com/static/fonts)|(ssl.gstatic.com/fonts/)')
+    OR REGEXP_CONTAINS(url, r'(use|fonts)\.typekit\.(net|com)')
+    OR REGEXP_CONTAINS(url, r'(use\.edgefonts\.net|webfonts\.creativecloud\.com)')
+    OR REGEXP_CONTAINS(url, r'fast\.fonts\.(com|net)\/(jsapi|cssapi)')
+    OR REGEXP_CONTAINS(url, r'f\.fontdeck\.com')
+    OR REGEXP_CONTAINS(url, r'cloud\.webtype\.com')
+    OR REGEXP_CONTAINS(url, r'cloud\.typenetwork\.com')
+    OR REGEXP_CONTAINS(url, r'cloud\.typography\.com')
+    OR REGEXP_CONTAINS(url, r'fnt\.webink\.com')
+    OR REGEXP_CONTAINS(url, r'fonts\.typotheque\.com')
+    OR REGEXP_CONTAINS(url, r'webfonts\.fontstand\.com')
+    OR REGEXP_CONTAINS(url, r'typesquare\.com')
+    OR REGEXP_CONTAINS(url, r'webfont\.fontplus\.jp')
+    OR REGEXP_CONTAINS(url, r'fontawesome\.com')
+    OR REGEXP_CONTAINS(url, r'webfonts\.fontslive\.com')
+    OR REGEXP_CONTAINS(url, r'webfonts\.justanotherfoundry\.com') OR
+    REGEXP_CONTAINS(url, r'fonts\.typonine\.com'))
+GROUP BY
+  client,
+  mime_type
+ORDER BY
+  client,
+  pct DESC

--- a/sql/2022/fonts/font_kerning.sql
+++ b/sql/2022/fonts/font_kerning.sql
@@ -1,0 +1,43 @@
+CREATE TEMP FUNCTION hasGPOSKerning(data STRING) RETURNS BOOL LANGUAGE js AS '''
+try {
+  const json = JSON.parse(data);
+  const result = new Set();
+  for (const [table, scripts] of Object.entries(json)) {
+    for (const [script, languages] of Object.entries(scripts)) {
+      for (const [language, features] of Object.entries(languages)) {
+        features.forEach(feature => result.add(feature));
+      }
+    }
+  }
+  return Array.from(result).includes('kern');
+} catch (e) {
+  return false;
+}
+''';
+
+WITH
+fonts AS (
+  SELECT
+    url,
+    (hasGPOSKerning(JSON_EXTRACT(payload, '$._font_details.features')) OR IFNULL(REGEXP_CONTAINS(JSON_EXTRACT(payload,
+      '$._font_details.table_sizes'), '(?i)kern'), false)) AS kerning
+  FROM
+    `httparchive.almanac.requests`
+  WHERE
+    date = '2022-06-01' AND
+    type = 'font'
+  GROUP BY
+    url,
+    kerning
+)
+
+SELECT
+  kerning,
+  COUNT(0) AS freq,
+  COUNT(0) / SUM(COUNT(0)) OVER () AS pct_freq
+FROM
+  fonts
+GROUP BY
+  kerning
+ORDER BY
+  pct_freq DESC

--- a/sql/2022/fonts/font_kerning.sql
+++ b/sql/2022/fonts/font_kerning.sql
@@ -18,6 +18,7 @@ try {
 WITH
 fonts AS (
   SELECT
+    client,
     url,
     (hasGPOSKerning(JSON_EXTRACT(payload, '$._font_details.features')) OR IFNULL(REGEXP_CONTAINS(JSON_EXTRACT(payload,
       '$._font_details.table_sizes'), '(?i)kern'), false)) AS kerning
@@ -27,17 +28,21 @@ fonts AS (
     date = '2022-06-01' AND
     type = 'font'
   GROUP BY
+    client,
     url,
     kerning
 )
 
 SELECT
+  client,
   kerning,
   COUNT(0) AS freq,
-  COUNT(0) / SUM(COUNT(0)) OVER () AS pct_freq
+  SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct_freq
 FROM
   fonts
 GROUP BY
+  client,
   kerning
 ORDER BY
   pct_freq DESC

--- a/sql/2022/fonts/font_opentype_features_usage.sql
+++ b/sql/2022/fonts/font_opentype_features_usage.sql
@@ -2,7 +2,6 @@ CREATE TEMP FUNCTION getFeatures(data STRING) RETURNS ARRAY<STRING> LANGUAGE js 
 try {
   const json = JSON.parse(data);
   const result = new Set();
-
   for (const [table, scripts] of Object.entries(json)) {
     for (const [script, languages] of Object.entries(scripts)) {
       for (const [language, features] of Object.entries(languages)) {
@@ -16,24 +15,16 @@ try {
 }
 ''';
 SELECT
-  client,
   feature,
   COUNT(0) AS freq,
-  SUM(COUNT(0)) OVER (PARTITION BY client) AS total_freq,
-  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct_freq
-FROM (
-  SELECT
-    client,
-    page,
-    feature
-  FROM
-    `httparchive.almanac.requests`,
-    UNNEST(getFeatures(JSON_EXTRACT(payload, '$._font_details.features'))) AS feature
-  WHERE
-    date = '2022-06-01' AND
-    type = 'font')
+  COUNT(0) / SUM(COUNT(0)) OVER () AS pct_freq
+FROM
+  `httparchive.almanac.requests`,
+  UNNEST(getFeatures(JSON_EXTRACT(payload, '$._font_details.features'))) AS feature
+WHERE
+  date = '2022-06-01' AND
+  type = 'font'
 GROUP BY
-  client,
   feature
 ORDER BY
   pct_freq DESC

--- a/sql/2022/fonts/font_opentype_support.sql
+++ b/sql/2022/fonts/font_opentype_support.sql
@@ -2,7 +2,7 @@ WITH
 fonts AS (
   SELECT
     url,
-    JSON_EXTRACT(payload, '$._font_details.table_sizes') AS payload
+    REGEXP_CONTAINS(JSON_EXTRACT(payload, '$._font_details.table_sizes'), '(?i)GPOS|GSUB') AS has_ot_features
   FROM
     `httparchive.almanac.requests`
   WHERE
@@ -10,16 +10,16 @@ fonts AS (
     type = 'font'
   GROUP BY
     url,
-    payload
+    has_ot_features
 )
+
 SELECT
-  format,
+  has_ot_features,
   COUNT(0) AS freq,
   COUNT(0) / SUM(COUNT(0)) OVER () AS pct_freq
 FROM
-  fonts,
-  UNNEST(REGEXP_EXTRACT_ALL(payload, '(?i)(CFF |glyf|SVG|CFF2)')) AS format
+  fonts
 GROUP BY
-  format
+  has_ot_features
 ORDER BY
   pct_freq DESC

--- a/sql/2022/fonts/font_opentype_support.sql
+++ b/sql/2022/fonts/font_opentype_support.sql
@@ -2,6 +2,7 @@ WITH
 fonts AS (
   SELECT
     url,
+    client,
     REGEXP_CONTAINS(JSON_EXTRACT(payload, '$._font_details.table_sizes'), '(?i)GPOS|GSUB') AS has_ot_features
   FROM
     `httparchive.almanac.requests`
@@ -10,16 +11,20 @@ fonts AS (
     type = 'font'
   GROUP BY
     url,
+    client,
     has_ot_features
 )
 
 SELECT
+  client,
   has_ot_features,
   COUNT(0) AS freq,
-  COUNT(0) / SUM(COUNT(0)) OVER () AS pct_freq
+  SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct_freq
 FROM
   fonts
 GROUP BY
+  client,
   has_ot_features
 ORDER BY
   pct_freq DESC

--- a/sql/2022/fonts/font_size_quantiles_by_opentype_table.sql
+++ b/sql/2022/fonts/font_size_quantiles_by_opentype_table.sql
@@ -13,30 +13,38 @@ try {
 }
 ''';
 
+WITH
+fonts AS (
+  SELECT
+    url,
+    JSON_EXTRACT(payload, '$._font_details.table_sizes') AS payload
+  FROM
+    `httparchive.almanac.requests`
+  WHERE
+    date = '2022-06-01' AND
+    type = 'font'
+  GROUP BY
+    url,
+    payload
+)
+
 SELECT
   percentile,
-  client,
   table,
   COUNT(0) AS total,
   APPROX_QUANTILES(bytes, 1000)[OFFSET(percentile * 10)] AS bytes
 FROM (
   SELECT
-    client,
     percentile,
     key AS table,
     value AS bytes
   FROM
-    `httparchive.almanac.requests`,
-    UNNEST(getTableSizes(JSON_EXTRACT(payload, '$._font_details.table_sizes'))),
-    UNNEST([10, 25, 50, 75, 90, 100]) AS percentile
-  WHERE
-    (date = '2022-06-01' AND
-      type = 'font'))
+    fonts,
+    UNNEST(getTableSizes(payload)) AS table,
+    UNNEST([10, 25, 50, 75, 90, 100]) AS percentile)
 GROUP BY
-  client,
   table,
   percentile
 ORDER BY
-  client,
   table,
   percentile

--- a/sql/2022/fonts/font_size_quantiles_by_opentype_table.sql
+++ b/sql/2022/fonts/font_size_quantiles_by_opentype_table.sql
@@ -16,6 +16,7 @@ try {
 WITH
 fonts AS (
   SELECT
+    client,
     url,
     JSON_EXTRACT(payload, '$._font_details.table_sizes') AS payload
   FROM
@@ -24,17 +25,20 @@ fonts AS (
     date = '2022-06-01' AND
     type = 'font'
   GROUP BY
+    client,
     url,
     payload
 )
 
 SELECT
+  client,
   percentile,
   table,
   COUNT(0) AS total,
   APPROX_QUANTILES(bytes, 1000)[OFFSET(percentile * 10)] AS bytes
 FROM (
   SELECT
+    client,
     percentile,
     key AS table,
     value AS bytes
@@ -43,6 +47,7 @@ FROM (
     UNNEST(getTableSizes(payload)) AS table,
     UNNEST([10, 25, 50, 75, 90, 100]) AS percentile)
 GROUP BY
+  client,
   table,
   percentile
 ORDER BY

--- a/sql/2022/fonts/font_writing_scripts.sql
+++ b/sql/2022/fonts/font_writing_scripts.sql
@@ -13,6 +13,7 @@ if (codepoints && codepoints.length) {
 WITH
 fonts AS (
   SELECT
+    client,
     url,
     payload
   FROM
@@ -21,18 +22,22 @@ fonts AS (
     date = '2022-06-01' AND
     type = 'font'
   GROUP BY
+    client,
     url,
     payload
 )
 
 SELECT
+  client,
   writing_system,
   COUNT(0) AS freq,
-  COUNT(0) / SUM(COUNT(0)) OVER () AS pct_freq
+  SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct_freq
 FROM
   fonts,
   UNNEST(detect(JSON_EXTRACT_STRING_ARRAY(payload, '$._font_details.cmap.codepoints'))) AS writing_system
 GROUP BY
+  client,
   writing_system
 ORDER BY
   pct_freq DESC

--- a/sql/2022/fonts/font_writing_scripts.sql
+++ b/sql/2022/fonts/font_writing_scripts.sql
@@ -4,42 +4,35 @@ LANGUAGE js
 OPTIONS (library = ["gs://httparchive/lib/text-utils.js"])
 AS r"""
 if (codepoints && codepoints.length) {
-  return detectWritingScript(codepoints.map(c => parseInt(c, 10)), 0.25);
+  return detectWritingScript(codepoints.map(c => parseInt(c, 10)), 0.05);
 } else {
   return [];
 }
 """;
 
-SELECT
-  client,
-  script,
-  COUNT(DISTINCT page) AS pages_script,
-  total_page,
-  COUNT(DISTINCT page) / total_page AS pct_script
-FROM (
+WITH
+fonts AS (
   SELECT
-    client,
-    page,
+    url,
     payload
   FROM
     `httparchive.almanac.requests`
   WHERE
     date = '2022-06-01' AND
-    type = 'font')
-JOIN (
-  SELECT
-    _TABLE_SUFFIX AS client,
-    COUNT(0) AS total_page
-  FROM
-    `httparchive.pages.2022_06_01_*`
+    type = 'font'
   GROUP BY
-    _TABLE_SUFFIX)
-USING
-  (client),
-  UNNEST(detect(JSON_EXTRACT_STRING_ARRAY(payload, '$._font_details.cmap.codepoints'))) AS script
+    url,
+    payload
+)
+
+SELECT
+  writing_system,
+  COUNT(0) AS freq,
+  COUNT(0) / SUM(COUNT(0)) OVER () AS pct_freq
+FROM
+  fonts,
+  UNNEST(detect(JSON_EXTRACT_STRING_ARRAY(payload, '$._font_details.cmap.codepoints'))) AS writing_system
 GROUP BY
-  client,
-  total_page,
-  script
+  writing_system
 ORDER BY
-  pages_script DESC
+  pct_freq DESC

--- a/sql/2022/fonts/outline_formats.sql
+++ b/sql/2022/fonts/outline_formats.sql
@@ -1,6 +1,7 @@
 WITH
 fonts AS (
   SELECT
+    client,
     url,
     JSON_EXTRACT(payload, '$._font_details.table_sizes') AS payload
   FROM
@@ -9,17 +10,21 @@ fonts AS (
     date = '2022-06-01' AND
     type = 'font'
   GROUP BY
+    client,
     url,
     payload
 )
 SELECT
+  client,
   format,
   COUNT(0) AS freq,
-  COUNT(0) / SUM(COUNT(0)) OVER () AS pct_freq
+  SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct_freq
 FROM
   fonts,
   UNNEST(REGEXP_EXTRACT_ALL(payload, '(?i)(CFF |glyf|SVG|CFF2)')) AS format
 GROUP BY
+  client,
   format
 ORDER BY
   pct_freq DESC

--- a/sql/2022/fonts/variable_font_axes.sql
+++ b/sql/2022/fonts/variable_font_axes.sql
@@ -6,24 +6,16 @@ try {
 }
 ''';
 SELECT
-  client,
   axis,
   COUNT(0) AS freq,
-  SUM(COUNT(0)) OVER (PARTITION BY client) AS total_freq,
-  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct_freq
-FROM (
-  SELECT
-    client,
-    page,
-    axis
-  FROM
-    `httparchive.almanac.requests`,
-    UNNEST(getAxes(JSON_EXTRACT(payload, '$._font_details.fvar'))) AS axis
-  WHERE
-    date = '2022-06-01' AND
-    type = 'font')
+  COUNT(0) / SUM(COUNT(0)) OVER () AS pct_freq
+FROM
+  `httparchive.almanac.requests`,
+  UNNEST(getAxes(JSON_EXTRACT(payload, '$._font_details.fvar'))) AS axis
+WHERE
+  date = '2022-06-01' AND
+  type = 'font'
 GROUP BY
-  client,
   axis
 ORDER BY
   pct_freq DESC

--- a/sql/2022/fonts/variable_font_axes.sql
+++ b/sql/2022/fonts/variable_font_axes.sql
@@ -5,17 +5,35 @@ try {
   return [];
 }
 ''';
+
+WITH
+fonts AS (
+  SELECT
+    client,
+    url,
+    payload
+  FROM
+    `httparchive.almanac.requests`
+  WHERE
+    date = '2022-06-01' AND
+    type = 'font'
+  GROUP BY
+    client,
+    url,
+    payload
+)
+
 SELECT
+  client,
   axis,
   COUNT(0) AS freq,
-  COUNT(0) / SUM(COUNT(0)) OVER () AS pct_freq
+  SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct_freq
 FROM
-  `httparchive.almanac.requests`,
+  fonts,
   UNNEST(getAxes(JSON_EXTRACT(payload, '$._font_details.fvar'))) AS axis
-WHERE
-  date = '2022-06-01' AND
-  type = 'font'
 GROUP BY
+  client,
   axis
 ORDER BY
   pct_freq DESC

--- a/sql/2022/fonts/variable_font_axes_css.sql
+++ b/sql/2022/fonts/variable_font_axes_css.sql
@@ -1,0 +1,37 @@
+CREATE TEMPORARY FUNCTION getFontVariationSettings(css STRING)
+RETURNS ARRAY<STRING> LANGUAGE js AS '''
+try {
+    var reduceValues = (values, rule) => {
+        if ('rules' in rule) {
+            return rule.rules.reduce(reduceValues, values);
+        }
+        if (!('declarations' in rule)) {
+            return values;
+        }
+        return values.concat(rule.declarations.filter(d => d.property.toLowerCase() == 'font-variation-settings').map(d => d.value));
+    };
+    var $ = JSON.parse(css);
+    return $.stylesheet.rules.reduce(reduceValues, []);
+} catch (e) {
+    return [];
+}
+''';
+SELECT
+  client,
+  REGEXP_EXTRACT(LOWER(values), '[\'"]([\\w]{4})[\'"]') AS axis,
+  CAST(REGEXP_EXTRACT(value, '\\d+') AS NUMERIC) AS num_axis,
+  COUNT(DISTINCT page) AS pages,
+  SUM(COUNT(DISTINCT page)) OVER (PARTITION BY client) AS total,
+  COUNT(DISTINCT page) / SUM(COUNT(DISTINCT page)) OVER (PARTITION BY client) AS pct
+FROM
+  `httparchive.almanac.parsed_css`,
+  UNNEST(getFontVariationSettings(css)) AS value,
+  UNNEST(SPLIT(value, ',')) AS values
+WHERE
+  date = '2022-07-01'
+GROUP BY
+  client, axis, num_axis
+HAVING
+  axis IS NOT NULL
+ORDER BY
+  pages DESC


### PR DESCRIPTION
Progress on #2883 

This PR contains some fixes to font internals specific queries. The biggest change is that the font queries now no longer use pages, but instead only use requests. 

The reason for that is that a popular font can be included in the requests table many times which would skew the results. Instead the queries that look at font-internal data now look at the unique font requests, which produces a more much accurate reflection of what internal font formats are being created by type designers.

This PR also contains a couple of new queries that were requested during the writing process or the technical review.

The data sheet and chapter has already been updated with the most recent data.