### PR TITLE
Enable ebook for 2022 English

### DIFF
--- a/src/config/2022.json
+++ b/src/config/2022.json
@@ -3,7 +3,7 @@
     {
       "is_live": true,
       "supported_languages": ["en","es","fr","hi","it","ja","nl","pt","ru","tr","uk","zh-CN","zh-TW"],
-      "ebook_languages": []
+      "ebook_languages": ["en"]
     }
   ],
   "outline": [


### PR DESCRIPTION
@rviscomi I presume we should enable the ebook even without some chapters? They just will be excluded.