### PR TITLE
Fix home page header inconsistency

### DIFF
--- a/src/static/css/index.css
+++ b/src/static/css/index.css
@@ -517,7 +517,9 @@ p {
   header .container,
   footer .container {
     padding-left: 20px;
+    padding-left: min(20px, 5vw);
     padding-right: 20px;
+    padding-right: min(20px, 5vw);
   }
 
   #maincontent {


### PR DESCRIPTION
The home page wraps differently than other pages on smaller page sizes (if using text zoom like I do on my iPhone):

<img width="318" alt="image" src="https://user-images.githubusercontent.com/10931297/192852963-89095ac5-6306-492d-9b39-00bd570f7888.png">

Compared to the other pages:

<img width="322" alt="image" src="https://user-images.githubusercontent.com/10931297/192853029-891574c0-e3b5-4ab3-8c45-45bc66099f38.png">

Turns out almanac.css has some extra responsive padding that index.css does not have:

https://github.com/HTTPArchive/almanac.httparchive.org/blob/f05de074e4b84f6e55de46699036a3f69cefd730/src/static/css/almanac.css#L326-L333

This PR add that,