### PR TITLE
Hide reaction tabs with 0 reactions

### DIFF
--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -909,6 +909,10 @@ pre {
   pointer-events: none;
 }
 
+.no-reactions {
+  display:none;
+}
+
 .webmention-likes,
 .webmention-reposts {
   display: flex;

--- a/src/static/css/page.css
+++ b/src/static/css/page.css
@@ -910,7 +910,7 @@ pre {
 }
 
 .no-reactions {
-  display:none;
+  display: none;
 }
 
 .webmention-likes,

--- a/src/static/js/webmentions.js
+++ b/src/static/js/webmentions.js
@@ -221,7 +221,7 @@ function renderWebmentions(webmentions) {
   renderReactions(webmentions, "replies", "in-reply-to");
   renderReactions(webmentions, "mentions", "mention-of");
 
-  // Set the first active tab (in case no ",likes" so it's hidden)
+  // Set the first active tab (in case no "likes" so that tab is hidden)
   setActiveTab();
 }
 

--- a/src/static/js/webmentions.js
+++ b/src/static/js/webmentions.js
@@ -75,8 +75,12 @@ function renderReactions(webmentions, reactionType, wmProperty) {
     return;
   }
 
-  // Add the count to the reaction tab
+  // Add the count to the reaction tab and, if non-zero then unhide
   document.querySelector(`#${reactionType}-count`).textContent = reactions.length;
+  if (reactions.length > 0) {
+    document.querySelector(`#${reactionType}-tab`).classList.remove("no-reactions");
+    document.querySelector('#reactions').classList.remove("no-reactions");
+  }
   const reactionLabel = document.querySelector(`#${reactionType}-label`);
 
   if (reactions && reactions.length) {
@@ -187,6 +191,25 @@ function renderReactions(webmentions, reactionType, wmProperty) {
   document.querySelector(`#${reactionType}-panel`).appendChild(webmentionReactionsList);
 }
 
+function setActiveTab() {
+
+  // The default is likes so we have "likes" then all good:
+  const likesTab = document.querySelector('#likes-tab');
+  if (!likesTab.classList.contains('no-reactions')) {
+    return;
+  }
+
+  // If no likes, then try each in turn and find the first one with reactions
+  for (const tab of ["reposts-tab", "replies-tab", "mentions-tab"]) {
+    const tabElement = document.querySelector(`#${tab}`);
+    if (!tabElement.classList.contains('no-reactions')) {
+      changeTabs(tabElement);
+      return;
+    }
+  }
+
+}
+
 // Parses and renders mentions into likes, reposts, replies and mentions
 function renderWebmentions(webmentions) {
   if (!webmentions.length) {
@@ -197,6 +220,9 @@ function renderWebmentions(webmentions) {
   renderReactions(webmentions, "reposts", "repost-of");
   renderReactions(webmentions, "replies", "in-reply-to");
   renderReactions(webmentions, "mentions", "mention-of");
+
+  // Set the first active tab (in case no ",likes" so it's hidden)
+  setActiveTab();
 }
 
 // Process webmention promise

--- a/src/static/js/webmentions.js
+++ b/src/static/js/webmentions.js
@@ -195,7 +195,7 @@ function setActiveTab() {
 
   // The default is likes so we have "likes" then all good:
   const likesTab = document.querySelector('#likes-tab');
-  if (!likesTab.classList.contains('no-reactions')) {
+  if (!likesTab || !likesTab.classList.contains('no-reactions')) {
     return;
   }
 

--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -195,35 +195,37 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
 {% endmacro %}
 
 {% macro render_webmentions() %}
-  <h2 id="reactions">
-    <a href="#reactions" class="anchor-link">{{ self.reactions() }}</a>
-  </h2>
-  <div class="reactions" data-source="{{ self.source() }}">
-    <div class="reaction-tabs" role="tablist" aria-label="{{ self.reactions() }}">
-      <button id="likes-tab" role="tab" aria-selected="true" aria-controls="likes-panel" tabindex="0">
-        <span id="likes-count">0</span>
-        <span id="likes-label" data-singular="{{ self.like() }}" data-plural="{{ self.likes() }}" data-plural-alt="{{ self.likesAlt() }}">{{ self.likes() }}</span>
-      </button>
-      <button id="reposts-tab" role="tab" aria-selected="false" aria-controls="reposts-panel" tabindex="-1">
-        <span id="reposts-count">0</span>
-        <span id="reposts-label" data-singular="{{ self.repost() }}" data-plural="{{ self.reposts() }}" data-plural-alt="{{ self.repostsAlt() }}">{{ self.reposts() }}</span>
-      </button>
-      <button id="replies-tab" role="tab" aria-selected="false" aria-controls="replies-panel" tabindex="-1">
-        <span id="replies-count">0</span>
-        <span id="replies-label" data-singular="{{ self.reply() }}" data-plural="{{ self.replies() }}" data-plural-alt="{{ self.repliesAlt() }}">{{ self.replies() }}</span>
-      </button>
-      <button id="mentions-tab" role="tab" aria-selected="false" aria-controls="mentions-panel" tabindex="-1">
-        <span id="mentions-count">0</span>
-        <span id="mentions-label" data-singular="{{ self.mention() }}" data-plural="{{ self.mentions() }}" data-plural-alt="{{ self.mentionsAlt() }}">{{ self.mentions() }}</span>
-      </button>
-    </div>
-    <div id="likes-panel" role="tabpanel" tabindex="0" aria-labelledby="likes-tab">
-    </div>
-    <div id="reposts-panel" role="tabpanel" tabindex="0" aria-labelledby="reposts-tab" hidden>
-    </div>
-    <div id="replies-panel" role="tabpanel" tabindex="0" aria-labelledby="replies-tab" hidden>
-    </div>
-    <div id="mentions-panel" role="tabpanel" tabindex="0" aria-labelledby="mentions-tab" hidden>
+  <div id="reactions" class="no-reactions">
+    <h2>
+      <a href="#reactions" class="anchor-link">{{ self.reactions() }}</a>
+    </h2>
+    <div class="reactions" data-source="{{ self.source() }}">
+      <div class="reaction-tabs" role="tablist" aria-label="{{ self.reactions() }}">
+        <button id="likes-tab" role="tab" aria-selected="true" aria-controls="likes-panel" tabindex="0" class="no-reactions">
+          <span id="likes-count">0</span>
+          <span id="likes-label" data-singular="{{ self.like() }}" data-plural="{{ self.likes() }}" data-plural-alt="{{ self.likesAlt() }}">{{ self.likes() }}</span>
+        </button>
+        <button id="reposts-tab" role="tab" aria-selected="false" aria-controls="reposts-panel" tabindex="-1" class="no-reactions">
+          <span id="reposts-count">0</span>
+          <span id="reposts-label" data-singular="{{ self.repost() }}" data-plural="{{ self.reposts() }}" data-plural-alt="{{ self.repostsAlt() }}">{{ self.reposts() }}</span>
+        </button>
+        <button id="replies-tab" role="tab" aria-selected="false" aria-controls="replies-panel" tabindex="-1" class="no-reactions">
+          <span id="replies-count">0</span>
+          <span id="replies-label" data-singular="{{ self.reply() }}" data-plural="{{ self.replies() }}" data-plural-alt="{{ self.repliesAlt() }}">{{ self.replies() }}</span>
+        </button>
+        <button id="mentions-tab" role="tab" aria-selected="false" aria-controls="mentions-panel" tabindex="-1" class="no-reactions">
+          <span id="mentions-count">0</span>
+          <span id="mentions-label" data-singular="{{ self.mention() }}" data-plural="{{ self.mentions() }}" data-plural-alt="{{ self.mentionsAlt() }}">{{ self.mentions() }}</span>
+        </button>
+      </div>
+      <div id="likes-panel" role="tabpanel" tabindex="0" aria-labelledby="likes-tab">
+      </div>
+      <div id="reposts-panel" role="tabpanel" tabindex="0" aria-labelledby="reposts-tab" hidden>
+      </div>
+      <div id="replies-panel" role="tabpanel" tabindex="0" aria-labelledby="replies-tab" hidden>
+      </div>
+      <div id="mentions-panel" role="tabpanel" tabindex="0" aria-labelledby="mentions-tab" hidden>
+      </div>
     </div>
   </div>
 {% endmacro %}


### PR DESCRIPTION
Makes progress on #3236 

Only shows Reaction tabs which have reactions:

For example Fonts has no likes or Reposts yet, so hide those and show Replies by default:

<img width="822" alt="image" src="https://user-images.githubusercontent.com/10931297/197207253-225677b8-9f74-4dcc-ad0c-3af91a843278.png">

Structured data has not been published yet, so no reactions, so hide the whole section:

<img width="671" alt="image" src="https://user-images.githubusercontent.com/10931297/197207482-a658def2-c4f4-40f1-ba62-c2eea89c984b.png">

CSS has a like, so show as normal (though hide reposts now as no reposts yet):

<img width="350" alt="image" src="https://user-images.githubusercontent.com/10931297/197207592-a3bfda71-b009-414b-913c-82d2b7da9b8a.png">

Privacy has all 4 so gets full showing:

<img width="428" alt="image" src="https://user-images.githubusercontent.com/10931297/197207745-09f811e2-87cf-4f86-a217-a67c15b8ff22.png">
