### PR TITLE
Strip empty query param

### DIFF
--- a/src/server/helpers.py
+++ b/src/server/helpers.py
@@ -30,7 +30,11 @@ def render_template(template, *args, **kwargs):
     # If the template does not exist, then redirect to English version if it exists, else home
     if lang != "" and not (os.path.isfile(TEMPLATES_DIR + "/%s" % template)):
         if os.path.isfile(TEMPLATES_DIR + "/en/%s" % (template[langcode_length:])):
-            return redirect("/en%s" % (request.full_path[langcode_length:]), code=302)
+            # Strip empty query string if full_path returns this
+            path = request.full_path[langcode_length:]
+            if path[-1] == "?":
+                path = path[:-1]
+            return redirect("/en%s" % path, code=302)
         else:
             return redirect(url_for("home", lang=lang, year=year))
 

--- a/src/server/tests/routes_test.py
+++ b/src/server/tests/routes_test.py
@@ -126,6 +126,7 @@ def test_render_search_year(client):
 def test_render_search_year_slash(client):
     assert_route(client, "/en/2020/search/", 301, "/en/search")
 
+
 def test_render_sitemap(client):
     assert_route(client, "/sitemap.xml", 200)
 
@@ -156,7 +157,6 @@ def test_redirect_untranslated_chapter(client):
 
 def test_redirect_untranslated_chapter_qith_queryparam(client):
     assert_route(client, "/nl/2019/http?queryparam", 302, "/en/2019/http?queryparam")
-
 
 
 def test_render_robots(client):

--- a/src/server/tests/routes_test.py
+++ b/src/server/tests/routes_test.py
@@ -126,7 +126,6 @@ def test_render_search_year(client):
 def test_render_search_year_slash(client):
     assert_route(client, "/en/2020/search/", 301, "/en/search")
 
-
 def test_render_sitemap(client):
     assert_route(client, "/sitemap.xml", 200)
 
@@ -149,6 +148,15 @@ def test_render_en_2019_bad_chapter(client):
 
 def test_render_en_2019_good_chapter_slash(client):
     assert_route(client, "/en/2019/css/", 302, "/en/2019/css")
+
+
+def test_redirect_untranslated_chapter(client):
+    assert_route(client, "/nl/2019/http", 302, "/en/2019/http")
+
+
+def test_redirect_untranslated_chapter_qith_queryparam(client):
+    assert_route(client, "/nl/2019/http?queryparam", 302, "/en/2019/http?queryparam")
+
 
 
 def test_render_robots(client):


### PR DESCRIPTION
Noted that language redirects have started adding a blank query param.

e.g

https://almanac.httparchive.org/nl/2019/http is redirected to https://almanac.httparchive.org/en/2019/http?

Think this was due to a change in Flask.

This strips that ugly `?` from the URL.