### PR TITLE
Handle no Methodology translation

### DIFF
--- a/src/server/__init__.py
+++ b/src/server/__init__.py
@@ -4,6 +4,7 @@ from werkzeug.http import HTTP_STATUS_CODES
 from .helpers import (
     get_view_args,
     chapter_lang_exists,
+    page_lang_exists,
     featured_chapters_exists,
     get_ebook_methodology,
     add_footnote_links,
@@ -63,6 +64,7 @@ app.config["SEND_FILE_MAX_AGE_DEFAULT"] = 10800
 # Make these functions available in templates.
 app.jinja_env.globals["get_view_args"] = get_view_args
 app.jinja_env.globals["chapter_lang_exists"] = chapter_lang_exists
+app.jinja_env.globals["page_lang_exists"] = page_lang_exists
 app.jinja_env.globals["featured_chapters_exists"] = featured_chapters_exists
 app.jinja_env.globals["HTTP_STATUS_CODES"] = HTTP_STATUS_CODES
 app.jinja_env.globals["get_ebook_methodology"] = get_ebook_methodology

--- a/src/server/helpers.py
+++ b/src/server/helpers.py
@@ -133,6 +133,15 @@ def chapter_lang_exists(lang, year, chapter):
         return False
 
 
+def page_lang_exists(lang, year, page):
+    if os.path.isfile(
+        TEMPLATES_DIR + "/%s/%s/%s.html" % (lang, year, page)
+    ):
+        return True
+    else:
+        return False
+
+
 def featured_chapters_exists(lang, year):
     if os.path.isfile(TEMPLATES_DIR + "/%s/%s/featured_chapters.html" % (lang, year)):
         return True

--- a/src/server/tests/helpers_test.py
+++ b/src/server/tests/helpers_test.py
@@ -3,6 +3,7 @@ from server.helpers import (
     get_versioned_filename,
     get_ebook_size_in_mb,
     chapter_lang_exists,
+    page_lang_exists,
     featured_chapters_exists,
     get_chapter_nextprev,
     get_chapter_config,
@@ -156,6 +157,14 @@ def test_chapter_lang_exists():
 
 def test_chapter_lang_not_exists():
     assert chapter_lang_exists("en", "2019", "random") is False
+
+
+def test_page_lang_exists():
+    assert page_lang_exists("en", "2019", "methodology") is True
+
+
+def test_page_lang_not_exists():
+    assert page_lang_exists("en", "2019", "random") is False
 
 
 def test_featured_chapters_exists():

--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -337,7 +337,11 @@
     </li>
     {% else %}
     <li class="nav-dropdown-list-chapter">
+      {% if page_lang_exists(lang, year, 'methodology') %}
       <a href="{{ url_for('methodology', year=year, lang=lang) }}">{{ self.methodology_title() }}</a>
+      {% else %}
+      <a href="{{ url_for('methodology', year=year, lang='en') }}">{{ self.methodology_title() }} <span class="not-translated">({{ self.translation_not_available() }})</span></a>
+      {% endif %}
     </li>
     {% endif %}
     {% if request.path.endswith("contributors") %}
@@ -346,7 +350,11 @@
     </li>
     {% else %}
     <li class="nav-dropdown-list-chapter">
+      {% if page_lang_exists(lang, year, 'contributors') %}
       <a href="{{ url_for('contributors', year=year, lang=lang) }}">{{ self.contributors_title() }}</a>
+      {% else %}
+      <a href="{{ url_for('contributors', year=year, lang='en') }}">{{ self.contributors_title() }} <span class="not-translated">({{ self.translation_not_available() }})</span></a>
+      {% endif %}
     </li>
     {% endif %}
 

--- a/src/templates/base/table_of_contents.html
+++ b/src/templates/base/table_of_contents.html
@@ -135,10 +135,18 @@
         <h2 id="appendices" class="part-name"><a href="#appendices" class="anchor-link">{{ self.appendices() }}</a></h2>
         <div class="chapters">
           <div class="chapter">
+            {% if page_lang_exists(lang, year, 'methodology') %}
             <a href="{{ url_for('methodology', year=year, lang=lang) }}">{{ self.methodology_title() }}</a>
+            {% else %}
+            <a href="{{ url_for('methodology', year=year, lang='en') }}">{{ self.methodology_title() }} <span class="not-translated">({{ self.translation_not_available() }})</span></a>
+            {% endif %}
           </div>
           <div class="chapter">
+            {% if page_lang_exists(lang, year, 'contributors') %}
             <a href="{{ url_for('contributors', year=year, lang=lang) }}">{{ self.contributors_title() }}</a>
+            {% else %}
+            <a href="{{ url_for('contributors', year=year, lang='en') }}">{{ self.contributors_title() }} <span class="not-translated">({{ self.translation_not_available() }})</span></a>
+            {% endif %}
           </div>
         </div>
       </section>


### PR DESCRIPTION
Quite often the Methodology translation doesn't exist, but currently we don't highlight that as not translationed, like we do for chapters. For example in Italian the HTTP chapter is marked as not existing, but Methodology is not:

<img width="675" alt="image" src="https://user-images.githubusercontent.com/10931297/207130502-ca5195d0-e67a-48bd-aa80-5d5aeb632456.png">

This PR adds that.