### PR TITLE
Add inert to main content when mobile menu is open

### DIFF
--- a/src/static/js/almanac.js
+++ b/src/static/js/almanac.js
@@ -155,6 +155,8 @@ function handleNavMenu() {
 function handleMobileMenu() {
   var menuBtn = document.querySelector('.menu-btn');
   var menuNav = document.querySelector('#menu');
+  var main = document.querySelector('main');
+  var footer = document.querySelector('footer');
 
   function toggleNavMenu() {
     var menuOpen = document.body.classList.toggle('menu-open');
@@ -162,6 +164,10 @@ function handleMobileMenu() {
     menuBtn.setAttribute('aria-expanded', menuOpen);
     var ariaLabel = menuOpen ? menuBtn.getAttribute('data-close-text') : menuBtn.getAttribute('data-open-text');
     menuBtn.setAttribute('aria-label', ariaLabel);
+
+    // Toogle inert to keep focus in the menu and header
+    main.toggleAttribute('inert');
+    footer.toggleAttribute('inert');
 
     /* When you open the menu, add an event listener to close it when clicking outside the menu area */
     /* Remove it on closing the menu */


### PR DESCRIPTION
See https://twitter.com/simevidas/status/1621794018358185984?s=20&t=OIektJsa65qGkx-SKT-Bcg

Will be interested to see if we see any INP regression as per https://github.com/GoogleChrome/web.dev/pull/9409. I'm not seeing a massive recalc layout style like we did on web.dev - only 6ms on my machine. FYI @brendankenny . You can compare [staged](https://20230206t115221-dot-webalmanac.uk.r.appspot.com/en/2022/css) to [prod](https://almanac.httparchive.org/en./2022/css) to see if you can spot anything?