### PR TITLE
Update 2022 Methodology links

### DIFF
--- a/src/templates/en/2022/methodology.html
+++ b/src/templates/en/2022/methodology.html
@@ -85,13 +85,13 @@
         </p>
 
         <p>
-          For example, to understand the median number of bytes of JavaScript per desktop and mobile page, see <a hreflang="en" href="https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2021/javascript/bytes_2021.sql">bytes_2021.sql</a>:
+          For example, to understand the median number of bytes of JavaScript per desktop and mobile page, see <a hreflang="en" href="https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2022/javascript/bytes_2022.sql">bytes_2022.sql</a>:
         </p>
 
         <div class="code-block floating-card">
           {# To generate this markup temporarily add a ```sql code block to a chapter and generate that chapter and you&#8217;ll get the HTML #}
           {# Note extra attributes on pre tag to allow keyboard scroll so add them back in #}
-          <pre role="region" aria-label="bytes_2021.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
+          <pre role="region" aria-label="bytes_2022.sql" tabindex="0"><code class="sql language-sql"><span class="comment">#standardSQL</span>
 <span class="comment"># Sum of JS request bytes per page (2022)</span>
 <span class="keyword">SELECT</span>
   percentile,
@@ -250,7 +250,7 @@
       <h3 id="lighthouse"><a href="#lighthouse" class="anchor-link">Lighthouse</a></h3>
 
       <p>
-        <a hreflang="en" href="https://developers.google.com/web/tools/lighthouse/">Lighthouse</a> is an automated website quality assurance tool built by Google. It audits web pages to make sure they don&#8217;t include user experience antipatterns like unoptimized images and inaccessible content.
+        <a hreflang="en" href="https://developer.chrome.com/docs/lighthouse/overview/">Lighthouse</a> is an automated website quality assurance tool built by Google. It audits web pages to make sure they don&#8217;t include user experience antipatterns like unoptimized images and inaccessible content.
       </p>
 
       <p>
@@ -295,7 +295,7 @@
       </div></div>
 
       <p>
-        For more information about Lighthouse and the audits available in HTTP Archive, refer to the <a hreflang="en" href="https://developers.google.com/web/tools/lighthouse/">Lighthouse developer documentation</a>.
+        For more information about Lighthouse and the audits available in HTTP Archive, refer to the <a hreflang="en" href="https://developer.chrome.com/docs/lighthouse/overview/">Lighthouse developer documentation</a>.
       </p>
     </section>
 
@@ -323,11 +323,11 @@
       <h3 id="chrome-ux-report"><a href="#chrome-ux-report" class="anchor-link">Chrome UX Report</a></h3>
 
       <p>
-        The <a hreflang="en" href="https://developers.google.com/web/tools/chrome-user-experience-report">Chrome UX Report</a> is a public dataset of real-world Chrome user experiences. Experiences are grouped by websites&#8217; origin, for example <code>https://www.example.com</code>. The dataset includes distributions of UX metrics like paint, load, interaction, and layout stability. In addition to grouping by month, experiences may also be sliced by dimensions like country-level geography, form factor (desktop, phone, tablet), and effective connection type (4G, 3G, etc.).
+        The <a hreflang="en" href="https://developer.chrome.com/docs/crux/">Chrome UX Report</a> is a public dataset of real-world Chrome user experiences. Experiences are grouped by websites&#8217; origin, for example <code>https://www.example.com</code>. The dataset includes distributions of UX metrics like paint, load, interaction, and layout stability. In addition to grouping by month, experiences may also be sliced by dimensions like country-level geography, form factor (desktop, phone, tablet), and effective connection type (4G, 3G, etc.).
       </p>
 
       <p>
-        The Chrome UX Report dataset includes relative <a href="https://developers.google.com/web/updates/2021/03/crux-rank-magnitude">website ranking data</a>. These are referred to as <em>rank magnitudes</em> because, as opposed to fine-grained ranks like the #1 or #116 most popular websites, websites are grouped into rank buckets from the top 1k, top 10k, up to the top 10M. Each website is ranked according to the number of <a href="https://developer.chrome.com/docs/crux/methodology/#eligibility">eligible</a> page views on all of its pages combined. This year's Web Almanac makes extensive use of this new data as a way to explore variations in the way the web is built by site popularity.
+        The Chrome UX Report dataset includes relative <a href="https://developer.chrome.com/blog/crux-rank-magnitude/">website ranking data</a>. These are referred to as <em>rank magnitudes</em> because, as opposed to fine-grained ranks like the #1 or #116 most popular websites, websites are grouped into rank buckets from the top 1k, top 10k, up to the top 10M. Each website is ranked according to the number of <a href="https://developer.chrome.com/docs/crux/methodology/#eligibility">eligible</a> page views on all of its pages combined. This year's Web Almanac makes extensive use of this new data as a way to explore variations in the way the web is built by site popularity.
       </p>
 
       <p>


### PR DESCRIPTION
The 2022 Methodology page links to a 2021 query but shows it querying 2022 data. There are also a few links to old Google documentation with redirects.