### PR TITLE
Super linter slim

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -31,8 +31,7 @@ jobs:
         run: |
           echo "VALIDATE_ALL_CODEBASE=false" >> $GITHUB_ENV
       - name: Lint Code Base
-        uses: github/super-linter@v4.10.1
-        #uses: docker://github/super-linter:v4.7.1
+        uses: github/super-linter/slim@v4.10.1
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_website.yml
+++ b/.github/workflows/test_website.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Use more complete checks for generated HTML linting
       run: cp -f .github/linters/.htmlhintrc_morechecks .github/linters/.htmlhintrc
     - name: Lint Generated HTML
-      uses: github/super-linter@v4.10.1
+      uses: github/super-linter/slim@v4.10.1
       env:
         DEFAULT_BRANCH: main
         FILTER_REGEX_INCLUDE: src/static/html/.*


### PR DESCRIPTION
From standard to [slim](https://github.com/github/super-linter#slim-image) docker image.
Pulling image takes 1:10 instead of 1:40 min now.