### PR TITLE
.devcontainer for Github Codespaces and VSCode (reopened)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,7 @@
         },
         "codespaces": {
             "openFiles": [
-                "README.md"
+                "src/README.md"
             ]
         }
     }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+{
+    "name": "Dev Container",
+    "build": {
+        "dockerfile": "../src/Dockerfile",
+        "context": "../src/",
+        "args": {
+            "IS_DEV_CONTAINER": "true",
+            "SKIPGC": "false"
+        }
+    },
+    "forwardPorts": [
+        8080
+    ],
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "python.defaultInterpreterPath": "/usr/local/bin/python",
+                "python.linting.enabled": true,
+                "python.linting.pylintEnabled": true
+            },
+            "extensions": [
+                "ms-python.python",
+                "ms-python.vscode-pylance"
+            ]
+        },
+        "codespaces": {
+            "openFiles": [
+                "README.md"
+            ]
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 [![Open Dev Pull Requests](https://img.shields.io/github/issues-pr/HTTPArchive/almanac.httparchive.org/development)](https://github.com/HTTPArchive/almanac.httparchive.org/pulls?q=is%3Apr+is%3Aopen+label%3Adevelopment) [![Open Analysis Pull Requests](https://img.shields.io/github/issues-pr/HTTPArchive/almanac.httparchive.org/analysis)](https://github.com/HTTPArchive/almanac.httparchive.org/pulls?q=is%3Apr+is%3Aopen+label%3Aanalysis) [![Open Translation Pull Requests](https://img.shields.io/github/issues-pr/HTTPArchive/almanac.httparchive.org/translation)](https://github.com/HTTPArchive/almanac.httparchive.org/pulls?q=is%3Apr+is%3Aopen+label%3Atranslation) [![Open Writing Pull Requests](https://img.shields.io/github/issues-pr/HTTPArchive/almanac.httparchive.org/writing)](https://github.com/HTTPArchive/almanac.httparchive.org/pulls?q=is%3Apr+is%3Aopen+label%3Awriting)
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/HTTPArchive/almanac.httparchive.org?quickstart=1)
-
 The Web Almanac is HTTP Archive's annual **state of the web** report.
 
 Our mission is to combine the raw stats and trends of the HTTP Archive with the expertise of the web community. The Web Almanac is a comprehensive report on the state of the web, backed by real data and trusted web experts. It is comprised of 20+ chapters spanning aspects of page content, user experience, publishing, and distribution.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 [![Open Dev Pull Requests](https://img.shields.io/github/issues-pr/HTTPArchive/almanac.httparchive.org/development)](https://github.com/HTTPArchive/almanac.httparchive.org/pulls?q=is%3Apr+is%3Aopen+label%3Adevelopment) [![Open Analysis Pull Requests](https://img.shields.io/github/issues-pr/HTTPArchive/almanac.httparchive.org/analysis)](https://github.com/HTTPArchive/almanac.httparchive.org/pulls?q=is%3Apr+is%3Aopen+label%3Aanalysis) [![Open Translation Pull Requests](https://img.shields.io/github/issues-pr/HTTPArchive/almanac.httparchive.org/translation)](https://github.com/HTTPArchive/almanac.httparchive.org/pulls?q=is%3Apr+is%3Aopen+label%3Atranslation) [![Open Writing Pull Requests](https://img.shields.io/github/issues-pr/HTTPArchive/almanac.httparchive.org/writing)](https://github.com/HTTPArchive/almanac.httparchive.org/pulls?q=is%3Apr+is%3Aopen+label%3Awriting)
 
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/HTTPArchive/almanac.httparchive.org?quickstart=1)
+
 The Web Almanac is HTTP Archive's annual **state of the web** report.
 
 Our mission is to combine the raw stats and trends of the HTTP Archive with the expertise of the web community. The Web Almanac is a comprehensive report on the state of the web, backed by real data and trusted web experts. It is comprised of 20+ chapters spanning aspects of page content, user experience, publishing, and distribution.

--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,8 @@
 # Developing the Web Almanac
 
-The Web Almanac can be developed on macOS, Windows or Linux. It requires Node v12, Python v3.8 and pip to be installed. Alternatively, use Docker to avoid manually configuring the development environment.
+The Web Almanac can be developed on macOS, Windows or Linux. It requires Node v12, Python v3.8 and pip to be installed. You can use Docker to avoid manually configuring the development environment.
+It can be quickly deployed as a development container in GitHub Codespaces to develop in cloud:
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/HTTPArchive/almanac.httparchive.org?quickstart=1)
 
 ## Style guide
 


### PR DESCRIPTION
#3150

#3404 reopened

- [x] Added base devcontainer.json (we can improve on with post create commands, IDE configurations, extensions, ...).
- [x] Added "Open in GitHub Codespaces" badge to README. [Test it out with this branch](https://codespaces.new/HTTPArchive/almanac.httparchive.org/tree/development-container?quickstart=1).


