### PR TITLE
Update contributor to stop lazy loading first tile

### DIFF
--- a/src/templates/base/contributors.html
+++ b/src/templates/base/contributors.html
@@ -305,7 +305,7 @@
               {{ self.join_the_team_text() }}
             </text>
           </svg>
-          <img src="/static/images/avatars/12.jpg" alt="" height="100" width="100" loading="lazy">
+          <img src="/static/images/avatars/12.jpg" alt="" height="100" width="100">
         </a>
       </li>
     {% for id, contributor in config.contributors.items() %}


### PR DESCRIPTION
Fix occasional Lighthouse failures [like this one](https://github.com/HTTPArchive/almanac.httparchive.org/actions/runs/6027523228) where, in certain languages, the "Join the team" image becomes the LCP.

Don't think we need `fetchpriority=high` as not always LCP (and it's pretty fast anyway), but also shouldn't lazy load as always on or near-viewport.