### PR TITLE
Add `npm run dev` command

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -20,6 +20,7 @@
     "watch": "node ./tools/generate/chapter_watcher",
     "ebooks": "node ./tools/generate/generate_ebook_pdfs",
     "deploy": "./tools/scripts/deploy.sh",
+    "dev": "source .venv/bin/activate && npm run start",
     "lint": "run-script-os",
     "lint:darwin:linux": "docker container run -it --rm -v \"$PWD/..\":/app -w /app/src --entrypoint=./tools/scripts/run_linter_locally.sh github/super-linter:slim-latest",
     "lint:win32": "docker container run --rm -v \"%cd%\\..\":/app -w /app/src --entrypoint=./tools/scripts/run_linter_locally.sh github/super-linter:slim-latest",


### PR DESCRIPTION
It's common to use `npm run dev` to start dev instances but we use `npm run start`. This adds an alias to allow you to use `npm run dev` too incase you're used to that.