### PR TITLE
More LH audit fixes

### DIFF
--- a/.github/lighthouse/lighthouse-config-dev.json
+++ b/.github/lighthouse/lighthouse-config-dev.json
@@ -30,6 +30,7 @@
         "service-worker": "off",
         "speed-index": "off",
         "splash-screen": "off",
+        "target-size": "off",
         "td-has-header": "off",
         "themed-omnibox": "off",
         "third-party-cookies": "off",

--- a/.github/lighthouse/lighthouse-config-dev.json
+++ b/.github/lighthouse/lighthouse-config-dev.json
@@ -32,6 +32,7 @@
         "splash-screen": "off",
         "td-has-header": "off",
         "themed-omnibox": "off",
+        "third-party-cookies": "off",
         "third-party-facades": "off",
         "total-byte-weight": "off",
         "unminified-css": "off",

--- a/.github/lighthouse/lighthouse-config-prod.json
+++ b/.github/lighthouse/lighthouse-config-prod.json
@@ -31,6 +31,7 @@
         "service-worker": "off",
         "speed-index": "off",
         "splash-screen": "off",
+        "target-size": "off",
         "td-has-header": "off",
         "themed-omnibox": "off",
         "third-party-cookies": "off",

--- a/.github/lighthouse/lighthouse-config-prod.json
+++ b/.github/lighthouse/lighthouse-config-prod.json
@@ -33,6 +33,7 @@
         "splash-screen": "off",
         "td-has-header": "off",
         "themed-omnibox": "off",
+        "third-party-cookies": "off",
         "third-party-facades": "off",
         "total-byte-weight": "off",
         "unminified-css": "off",

--- a/src/content/en/2020/caching.md
+++ b/src/content/en/2020/caching.md
@@ -693,6 +693,7 @@ The table below details the cache TTL values for mobile requests by type:
 
 <figure>
   <table>
+    <thead>
       <tr>
         <th scope="col">Type</th>
         <th scope="col">10</th>

--- a/src/content/en/2020/caching.md
+++ b/src/content/en/2020/caching.md
@@ -693,10 +693,6 @@ The table below details the cache TTL values for mobile requests by type:
 
 <figure>
   <table>
-    <thead>
-      <tr>
-        <th colspan="6" scope="col">Cache TTL percentiles (in hours)</th>
-      </tr>
       <tr>
         <th scope="col">Type</th>
         <th scope="col">10</th>
@@ -789,7 +785,7 @@ The table below details the cache TTL values for mobile requests by type:
       </tr>
     </tbody>
   </table>
-  <figcaption>{{ figure_link(caption="Mobile cache TTL percentiles by resource type.", sheets_gid="676954337", sql_file="ttl_by_resource.sql") }}</figcaption>
+  <figcaption>{{ figure_link(caption="Mobile cache TTL hours by percentiles and resource type.", sheets_gid="676954337", sql_file="ttl_by_resource.sql") }}</figcaption>
 </figure>
 
 While most of the median TTLs are high, the lower percentiles highlight some of the missed caching opportunities. For example, the median TTL for images is 720 hours (1 month); however the 25<sup>th</sup> percentile is just 168 hours (1 week) and the 10<sup>th</sup> percentile has dropped to just a few hours. Compare this with fonts, which have a very high TTL of 8,760 hours (1 year) all the way down to the 25<sup>th</sup> percentile, with even the 10<sup>th</sup> percentile showing a TTL of 1 month.

--- a/src/content/ja/2020/caching.md
+++ b/src/content/ja/2020/caching.md
@@ -695,9 +695,6 @@ HTTPレスポンスの43.4％がVaryヘッダーを使用しており、その�
   <table>
     <thead>
       <tr>
-        <th colspan="6" scope="col">キャッシュのTTLパーセンタイル（単位：時間）</th>
-      </tr>
-      <tr>
         <th scope="col">タイプ</th>
         <th scope="col">10</th>
         <th scope="col">25</th>

--- a/src/content/nl/2020/caching.md
+++ b/src/content/nl/2020/caching.md
@@ -695,9 +695,6 @@ In de onderstaande tabel worden de cache-TTL-waarden voor mobiele verzoeken per 
   <table>
     <thead>
       <tr>
-        <th colspan="6" scope="col">TTL-percentielen in cache (in uren)</th>
-      </tr>
-      <tr>
         <th scope="col">Type</th>
         <th scope="col">10</th>
         <th scope="col">25</th>
@@ -789,7 +786,7 @@ In de onderstaande tabel worden de cache-TTL-waarden voor mobiele verzoeken per 
       </tr>
     </tbody>
   </table>
-  <figcaption>{{ figure_link(caption="TTL-percentielen voor mobiele cache per brontype.", sheets_gid="676954337", sql_file="ttl_by_resource.sql") }}</figcaption>
+  <figcaption>{{ figure_link(caption="TTL in uren voor mobiele cache per percentielen en brontype.", sheets_gid="676954337", sql_file="ttl_by_resource.sql") }}</figcaption>
 </figure>
 
 Hoewel de meeste mediane TTL's hoog zijn, benadrukken de lagere percentielen enkele van de gemiste cachemogelijkheden. De mediane TTL voor afbeeldingen is bijvoorbeeld 720 uur (1 maand); het 25<sup>e</sup> percentiel is echter slechts 168 uur (1 week) en het 10<sup>de</sup> percentiel is gedaald tot slechts een paar uur. Vergelijk dit met lettertypen, die een zeer hoge TTL hebben van 8.760 uur (1 jaar) helemaal tot aan het 25<sup>e</sup> percentiel, waarbij zelfs het 10<sup>de</sup> percentiel een TTL van 1 maand laat zien.


### PR DESCRIPTION
Turn off third-party-cookies audit
Turn off tap-target audit (new and flakey)
Remove fake table heading from 2020 caching chapters