### PR TITLE
Reduce best practice score due to third-party cookies

### DIFF
--- a/.github/lighthouse/lighthouse-config-prod.json
+++ b/.github/lighthouse/lighthouse-config-prod.json
@@ -4,7 +4,7 @@
       "preset": "lighthouse:recommended",
       "assertions": {
         "categories:accessibility": ["error", {"minScore": 1}],
-        "categories:best-practices": ["error", {"minScore": 0.92}],
+        "categories:best-practices": ["error", {"minScore": 0.78}],
         "categories:seo": ["error", {"minScore": 1}],
         "bf-cache": "off",
         "bootup-time": "off",


### PR DESCRIPTION
Can increase it again maybe once embeds (like youtube!) stop sending them.