### PR TITLE
Remove deploy.zip step of deployment

### DIFF
--- a/src/.gcloudignore
+++ b/src/.gcloudignore
@@ -43,5 +43,4 @@ static/pdfs/*
 **/.DS_Store
 Dockerfile
 .dockerignore
-deployed.zip
 .coverage

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -8,5 +8,4 @@ templates/*/rss.xml
 templates/sitemap.xml
 static/html/
 static/js/web-vitals.js
-deployed.zip
 .coverage

--- a/src/README.md
+++ b/src/README.md
@@ -376,7 +376,6 @@ The deploy script will do the following:
 - Ask you to complete any local tests and confirm good to deploy
 - Ask for a version number (suggesing the last verision tagged and incrementing the patch)
 - Tag the release (after asking you for the version number to use)
-- Generate a `deploy.zip` file of what has been deployed
 - Deploy to GCP
 - Push changes to `production` branch on GitHub
 - Switch you back to the `main` branch.

--- a/src/tools/scripts/deploy.sh
+++ b/src/tools/scripts/deploy.sh
@@ -167,15 +167,6 @@ LONG_DATE=$(date -u +%Y-%m-%d\ %H:%M:%S)
 git tag -a "${TAG_VERSION}" -m "Version ${TAG_VERSION} ${LONG_DATE}"
 echo "Tagged ${TAG_VERSION} with message 'Version ${TAG_VERSION} ${LONG_DATE}'"
 
-if [[ -f deployed.zip ]]; then
-  echo "Removing old deploy.zip"
-  rm -f deployed.zip
-fi
-
-echo "Zipping artifacts into deploy.zip"
-# Exclude chapter images as quite large and tracked in git anyway
-zip -q -r deployed . --exclude @.gcloudignore static/images/*/*/* static/pdfs/*
-
 echo "Deploying to GCP"
 echo "Y" | gcloud app deploy --project webalmanac --stop-previous-version
 
@@ -207,7 +198,6 @@ echo -e "${GREEN}Successfully deployed!${RESET_COLOR}"
 echo
 echo -e "${AMBER}Please update release on GitHub: https://github.com/HTTPArchive/almanac.httparchive.org/releases${RESET_COLOR}"
 echo -e "${AMBER}Using tag ${TAG_VERSION}@production${RESET_COLOR}"
-echo -e "${AMBER}Please upload deploy.zip as the release artifact${RESET_COLOR}"
 echo
 echo "Have a good one!"
 echo


### PR DESCRIPTION
We never used this this backup, and it's a slow step. Plus all the code is backed up anyway. Let's remove it.

@rviscomi make sure you delete your last zip file so avoid it showing as a difference.