### PR TITLE
Fonts 2024 Queries

### DIFF
--- a/sql/2024/fonts/README.md
+++ b/sql/2024/fonts/README.md
@@ -43,7 +43,7 @@ functions appear in several queries are extracted into a common file:
 query, the query has the following line at the top:
 
 ```sql
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 ```
 
 It signalizes that, prior to executing the query, `common.sql` has to be

--- a/sql/2024/fonts/README.md
+++ b/sql/2024/fonts/README.md
@@ -34,7 +34,7 @@ normalization type:
 ```sql
 -- Section: Performance
 -- Question: What is the distribution of the file size broken down by table?
--- Normalization: Websites
+-- Normalization: Pages
 ```
 
 Many queries rely on temporary functions for convenience and clarity. The

--- a/sql/2024/fonts/README.md
+++ b/sql/2024/fonts/README.md
@@ -34,7 +34,7 @@ normalization type:
 ```sql
 -- Section: Performance
 -- Question: What is the distribution of the file size broken down by table?
--- Normalization: Sites
+-- Normalization: Websites
 ```
 
 Many queries rely on temporary functions for convenience and clarity. The

--- a/sql/2024/fonts/common.sql
+++ b/sql/2024/fonts/common.sql
@@ -77,12 +77,17 @@ CREATE TEMPORARY FUNCTION COLOR_FORMATS(payload STRING) AS (
   )
 );
 
--- Check if it is a color font given its payload.
+-- Check if the font is a color font given its payload.
 CREATE TEMPORARY FUNCTION IS_COLOR(payload STRING) AS (
   ARRAY_LENGTH(COLOR_FORMATS(payload)) > 0
 );
 
--- Check if it is a variable font given its payload.
+-- Check if the font was successfully parsed given its payload.
+CREATE TEMPORARY FUNCTION IS_PARSED(payload STRING) AS (
+  JSON_EXTRACT(payload, '$._font_details.table_sizes') IS NOT NULL
+);
+
+-- Check if the font is a variable font given its payload.
 CREATE TEMPORARY FUNCTION IS_VARIABLE(payload STRING) AS (
   REGEXP_CONTAINS(
     JSON_EXTRACT(payload, '$._font_details.table_sizes'),

--- a/sql/2024/fonts/common.sql
+++ b/sql/2024/fonts/common.sql
@@ -1,11 +1,23 @@
 -- Normalize a name. Used in FAMILY.
 CREATE TEMPORARY FUNCTION FAMILY_INNER(name STRING) AS (
-  IF(LENGTH(TRIM(name)) < 3, NULL, NULLIF(TRIM(name), ''))
+  CASE
+    WHEN REGEXP_CONTAINS(name, r'(?i)font\s?awesome') THEN 'Font Awesome'
+    ELSE IF(LENGTH(TRIM(name)) < 3, NULL, NULLIF(TRIM(name), ''))
+  END
 );
 
 -- Extract the family name from a payload.
 CREATE TEMPORARY FUNCTION FAMILY(payload STRING) AS (
-  FAMILY_INNER(JSON_EXTRACT_SCALAR(payload, '$._font_details.names[1]'))
+  FAMILY_INNER(
+    REGEXP_REPLACE(
+      COALESCE(
+        JSON_EXTRACT_SCALAR(payload, '$._font_details.names[16]'),
+        JSON_EXTRACT_SCALAR(payload, '$._font_details.names[1]')
+      ),
+      r'(?i)\s+(extra|semi|ultra)?\s?(condensed)?\s?(bold|book|heavy|light|medium|thin)?$',
+      ''
+    )
+  )
 );
 
 -- Extract the file format from an extension and a MIME type.

--- a/sql/2024/fonts/common.sql
+++ b/sql/2024/fonts/common.sql
@@ -14,7 +14,7 @@ CREATE TEMPORARY FUNCTION FAMILY(payload STRING) AS (
         JSON_EXTRACT_SCALAR(payload, '$._font_details.names[16]'),
         JSON_EXTRACT_SCALAR(payload, '$._font_details.names[1]')
       ),
-      r'(?i)([\s-]?(black|bold|book|cond(ensed)?|demi|extra|heavy|italic|light|medium|regular|semi|thin|ultra))+$',
+      r'(?i)([\s-]?(black|bold|book|cond(ensed)?|demi|ex(tra)?|heavy|italic|light|medium|narrow|regular|semi|thin|ultra|wide|\d00|\d+pt))+$',
       ''
     )
   )

--- a/sql/2024/fonts/common.sql
+++ b/sql/2024/fonts/common.sql
@@ -14,7 +14,7 @@ CREATE TEMPORARY FUNCTION FAMILY(payload STRING) AS (
         JSON_EXTRACT_SCALAR(payload, '$._font_details.names[16]'),
         JSON_EXTRACT_SCALAR(payload, '$._font_details.names[1]')
       ),
-      r'(?i)\s+(extra|semi|ultra)?\s?(condensed)?\s?(bold|book|heavy|light|medium|thin)?$',
+      r'(?i)([\s-]?(black|bold|book|cond(ensed)?|demi|extra|heavy|italic|light|medium|regular|semi|thin|ultra))+$',
       ''
     )
   )

--- a/sql/2024/fonts/design/fonts_designer.sql
+++ b/sql/2024/fonts/design/fonts_designer.sql
@@ -2,6 +2,8 @@
 -- Question: Which designers are popular?
 -- Normalization: Sites
 
+-- INCLUDE ../common.sql
+
 WITH
 designers AS (
   SELECT
@@ -14,7 +16,8 @@ designers AS (
   WHERE
     date = '2024-07-01' AND
     type = 'font' AND
-    is_root_page
+    is_root_page AND
+    IS_PARSED(payload)
   GROUP BY
     client,
     designer

--- a/sql/2024/fonts/design/fonts_designer.sql
+++ b/sql/2024/fonts/design/fonts_designer.sql
@@ -1,6 +1,6 @@
 -- Section: Design
 -- Question: Which designers are popular?
--- Normalization: Sites
+-- Normalization: Websites
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
@@ -24,7 +24,7 @@ designers AS (
   QUALIFY
     rank <= 100
 ),
-sites AS (
+websites AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -46,7 +46,7 @@ SELECT
 FROM
   designers
 JOIN
-  sites USING (client)
+  websites USING (client)
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/design/fonts_designer.sql
+++ b/sql/2024/fonts/design/fonts_designer.sql
@@ -2,7 +2,7 @@
 -- Question: Which designers are popular?
 -- Normalization: Sites
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 designers AS (

--- a/sql/2024/fonts/design/fonts_designer.sql
+++ b/sql/2024/fonts/design/fonts_designer.sql
@@ -1,6 +1,6 @@
 -- Section: Design
 -- Question: Which designers are popular?
--- Normalization: Websites
+-- Normalization: Pages
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
@@ -24,7 +24,7 @@ designers AS (
   QUALIFY
     rank <= 100
 ),
-websites AS (
+pages AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -46,7 +46,7 @@ SELECT
 FROM
   designers
 JOIN
-  websites USING (client)
+  pages USING (client)
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/design/fonts_designer.sql
+++ b/sql/2024/fonts/design/fonts_designer.sql
@@ -13,8 +13,8 @@ designers AS (
     `httparchive.all.requests`
   WHERE
     date = '2024-07-01' AND
-    is_root_page AND
-    type = 'font'
+    type = 'font' AND
+    is_root_page
   GROUP BY
     client,
     designer

--- a/sql/2024/fonts/design/fonts_family_by_foundry.sql
+++ b/sql/2024/fonts/design/fonts_family_by_foundry.sql
@@ -4,24 +4,36 @@
 
 -- INCLUDE ../common.sql
 
+WITH
+links AS (
+  SELECT
+    client,
+    FOUNDRY(payload) AS foundry,
+    FAMILY(payload) AS family,
+    COUNT(0) OVER (PARTITION BY client) AS total
+  FROM
+    `httparchive.all.requests`
+  WHERE
+    date = '2024-07-01' AND
+    type = 'font' AND
+    is_root_page
+)
+
 SELECT
   client,
-  FOUNDRY(payload) AS foundry,
-  FAMILY(payload) AS family,
+  foundry,
+  family,
   COUNT(0) AS count,
-  SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
-  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS proportion,
+  total,
+  COUNT(0) / total AS proportion,
   ROW_NUMBER() OVER (PARTITION BY client ORDER BY COUNT(0) DESC) AS rank
 FROM
-  `httparchive.all.requests`
-WHERE
-  date = '2024-07-01' AND
-  type = 'font' AND
-  is_root_page
+  links
 GROUP BY
   client,
   foundry,
-  family
+  family,
+  total
 QUALIFY
   rank <= 100
 ORDER BY

--- a/sql/2024/fonts/design/fonts_family_by_foundry.sql
+++ b/sql/2024/fonts/design/fonts_family_by_foundry.sql
@@ -16,6 +16,7 @@ links AS (
   WHERE
     date = '2024-07-01' AND
     type = 'font' AND
+    IS_PARSED(payload) AND
     is_root_page
 )
 

--- a/sql/2024/fonts/design/fonts_family_by_foundry.sql
+++ b/sql/2024/fonts/design/fonts_family_by_foundry.sql
@@ -1,11 +1,11 @@
 -- Section: Design
 -- Question: Which families are used broken down by foundry?
--- Normalization: Links (parsed only)
+-- Normalization: Requests (parsed only)
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
-links AS (
+requests AS (
   SELECT
     client,
     FOUNDRY(payload) AS foundry,
@@ -29,7 +29,7 @@ SELECT
   COUNT(0) / total AS proportion,
   ROW_NUMBER() OVER (PARTITION BY client ORDER BY COUNT(0) DESC) AS rank
 FROM
-  links
+  requests
 GROUP BY
   client,
   foundry,

--- a/sql/2024/fonts/design/fonts_family_by_foundry.sql
+++ b/sql/2024/fonts/design/fonts_family_by_foundry.sql
@@ -16,8 +16,8 @@ FROM
   `httparchive.all.requests`
 WHERE
   date = '2024-07-01' AND
-  is_root_page AND
-  type = 'font'
+  type = 'font' AND
+  is_root_page
 GROUP BY
   client,
   foundry,

--- a/sql/2024/fonts/design/fonts_family_by_foundry.sql
+++ b/sql/2024/fonts/design/fonts_family_by_foundry.sql
@@ -2,7 +2,7 @@
 -- Question: Which families are used broken down by foundry?
 -- Normalization: Links (parsed only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 links AS (

--- a/sql/2024/fonts/design/fonts_family_by_foundry.sql
+++ b/sql/2024/fonts/design/fonts_family_by_foundry.sql
@@ -1,6 +1,6 @@
 -- Section: Design
 -- Question: Which families are used broken down by foundry?
--- Normalization: Links
+-- Normalization: Links (parsed only)
 
 -- INCLUDE ../common.sql
 

--- a/sql/2024/fonts/design/fonts_family_by_script.sql
+++ b/sql/2024/fonts/design/fonts_family_by_script.sql
@@ -1,11 +1,11 @@
 -- Section: Design
 -- Question: Which families are used broken down by script?
--- Normalization: Links (parsed only)
+-- Normalization: Requests (parsed only)
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
-links AS (
+requests AS (
   SELECT
     client,
     SCRIPTS(payload) AS scripts,
@@ -29,7 +29,7 @@ SELECT
   COUNT(0) / total AS proportion,
   ROW_NUMBER() OVER (PARTITION BY client, script ORDER BY COUNT(0) DESC) AS rank
 FROM
-  links,
+  requests,
   UNNEST(scripts) AS script
 WHERE
   family != 'Adobe Blank'
@@ -37,7 +37,7 @@ GROUP BY
   client,
   script,
   family,
-  links.total
+  requests.total
 QUALIFY
   rank <= 10
 ORDER BY

--- a/sql/2024/fonts/design/fonts_family_by_script.sql
+++ b/sql/2024/fonts/design/fonts_family_by_script.sql
@@ -1,6 +1,6 @@
 -- Section: Design
 -- Question: Which families are used broken down by script?
--- Normalization: Links
+-- Normalization: Links (parsed only)
 
 -- INCLUDE ../common.sql
 

--- a/sql/2024/fonts/design/fonts_family_by_script.sql
+++ b/sql/2024/fonts/design/fonts_family_by_script.sql
@@ -2,7 +2,7 @@
 -- Question: Which families are used broken down by script?
 -- Normalization: Links (parsed only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 links AS (

--- a/sql/2024/fonts/design/fonts_family_by_script.sql
+++ b/sql/2024/fonts/design/fonts_family_by_script.sql
@@ -17,16 +17,15 @@ links AS (
     date = '2024-07-01' AND
     type = 'font' AND
     is_root_page AND
-    IS_PARSED(payload) AND
-    RAND() > 0.5
+    IS_PARSED(payload)
 )
 
 SELECT
   client,
   script,
   family,
-  2 * COUNT(0) AS count,
-  2 * total AS total,
+  COUNT(0) AS count,
+  total,
   COUNT(0) / total AS proportion,
   ROW_NUMBER() OVER (PARTITION BY client, script ORDER BY COUNT(0) DESC) AS rank
 FROM

--- a/sql/2024/fonts/design/fonts_family_by_script.sql
+++ b/sql/2024/fonts/design/fonts_family_by_script.sql
@@ -4,27 +4,40 @@
 
 -- INCLUDE ../common.sql
 
+WITH
+links AS (
+  SELECT
+    client,
+    SCRIPTS(payload) AS scripts,
+    FAMILY(payload) AS family,
+    COUNT(0) OVER (PARTITION BY client) AS total
+  FROM
+    `httparchive.all.requests`
+  WHERE
+    date = '2024-07-01' AND
+    type = 'font' AND
+    is_root_page AND
+    RAND() > 0.5
+)
+
 SELECT
   client,
   script,
-  FAMILY(payload) AS family,
+  family,
   2 * COUNT(0) AS count,
-  2 * SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
-  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS proportion,
+  2 * total AS total,
+  COUNT(0) / total AS proportion,
   ROW_NUMBER() OVER (PARTITION BY client, script ORDER BY COUNT(0) DESC) AS rank
 FROM
-  `httparchive.all.requests`,
-  UNNEST(SCRIPTS(payload)) AS script
+  links,
+  UNNEST(scripts) AS script
 WHERE
-  date = '2024-07-01' AND
-  type = 'font' AND
-  is_root_page AND
-  FAMILY(payload) NOT IN ('Adobe Blank') AND
-  RAND() > 0.5
+  family != 'Adobe Blank'
 GROUP BY
   client,
   script,
-  family
+  family,
+  links.total
 QUALIFY
   rank <= 10
 ORDER BY

--- a/sql/2024/fonts/design/fonts_family_by_script.sql
+++ b/sql/2024/fonts/design/fonts_family_by_script.sql
@@ -17,8 +17,8 @@ FROM
   UNNEST(SCRIPTS(payload)) AS script
 WHERE
   date = '2024-07-01' AND
-  is_root_page AND
   type = 'font' AND
+  is_root_page AND
   FAMILY(payload) NOT IN ('Adobe Blank') AND
   RAND() > 0.5
 GROUP BY

--- a/sql/2024/fonts/design/fonts_family_by_script.sql
+++ b/sql/2024/fonts/design/fonts_family_by_script.sql
@@ -17,6 +17,7 @@ links AS (
     date = '2024-07-01' AND
     type = 'font' AND
     is_root_page AND
+    IS_PARSED(payload) AND
     RAND() > 0.5
 )
 

--- a/sql/2024/fonts/design/fonts_foundry.sql
+++ b/sql/2024/fonts/design/fonts_foundry.sql
@@ -16,7 +16,8 @@ foundries AS (
   WHERE
     date = '2024-07-01' AND
     type = 'font' AND
-    is_root_page
+    is_root_page AND
+    IS_PARSED(payload)
   GROUP BY
     client,
     foundry

--- a/sql/2024/fonts/design/fonts_foundry.sql
+++ b/sql/2024/fonts/design/fonts_foundry.sql
@@ -1,6 +1,6 @@
 -- Section: Design
 -- Question: Which foundries are popular?
--- Normalization: Sites
+-- Normalization: Websites
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
@@ -24,7 +24,7 @@ foundries AS (
   QUALIFY
     rank <= 100
 ),
-sites AS (
+websites AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -46,7 +46,7 @@ SELECT
 FROM
   foundries
 JOIN
-  sites USING (client)
+  websites USING (client)
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/design/fonts_foundry.sql
+++ b/sql/2024/fonts/design/fonts_foundry.sql
@@ -15,8 +15,8 @@ foundries AS (
     `httparchive.all.requests`
   WHERE
     date = '2024-07-01' AND
-    is_root_page AND
-    type = 'font'
+    type = 'font' AND
+    is_root_page
   GROUP BY
     client,
     foundry

--- a/sql/2024/fonts/design/fonts_foundry.sql
+++ b/sql/2024/fonts/design/fonts_foundry.sql
@@ -1,6 +1,6 @@
 -- Section: Design
 -- Question: Which foundries are popular?
--- Normalization: Websites
+-- Normalization: Pages
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
@@ -24,7 +24,7 @@ foundries AS (
   QUALIFY
     rank <= 100
 ),
-websites AS (
+pages AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -46,7 +46,7 @@ SELECT
 FROM
   foundries
 JOIN
-  websites USING (client)
+  pages USING (client)
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/design/fonts_foundry.sql
+++ b/sql/2024/fonts/design/fonts_foundry.sql
@@ -2,7 +2,7 @@
 -- Question: Which foundries are popular?
 -- Normalization: Sites
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 foundries AS (

--- a/sql/2024/fonts/design/fonts_license.sql
+++ b/sql/2024/fonts/design/fonts_license.sql
@@ -22,7 +22,6 @@ sites AS (
     `httparchive.all.requests`
   WHERE
     date = '2024-07-01' AND
-    type = 'font' AND
     is_root_page
   GROUP BY
     client

--- a/sql/2024/fonts/design/fonts_license.sql
+++ b/sql/2024/fonts/design/fonts_license.sql
@@ -2,7 +2,7 @@
 -- Question: Which licenses are used?
 -- Normalization: Sites
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 CREATE TEMPORARY FUNCTION LICENSE(value STRING) AS (
   CASE

--- a/sql/2024/fonts/design/fonts_license.sql
+++ b/sql/2024/fonts/design/fonts_license.sql
@@ -22,8 +22,8 @@ sites AS (
     `httparchive.all.requests`
   WHERE
     date = '2024-07-01' AND
-    is_root_page AND
-    type = 'font'
+    type = 'font' AND
+    is_root_page
   GROUP BY
     client
 )
@@ -41,8 +41,8 @@ INNER JOIN
   sites USING (client)
 WHERE
   date = '2024-07-01' AND
-  is_root_page AND
-  type = 'font'
+  type = 'font' AND
+  is_root_page
 GROUP BY
   client,
   license,

--- a/sql/2024/fonts/design/fonts_license.sql
+++ b/sql/2024/fonts/design/fonts_license.sql
@@ -1,6 +1,6 @@
 -- Section: Design
 -- Question: Which licenses are used?
--- Normalization: Websites
+-- Normalization: Pages
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
@@ -16,7 +16,7 @@ CREATE TEMPORARY FUNCTION LICENSE(value STRING) AS (
 );
 
 WITH
-websites AS (
+pages AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -39,7 +39,7 @@ SELECT
 FROM
   `httparchive.all.requests`
 INNER JOIN
-  websites USING (client)
+  pages USING (client)
 WHERE
   date = '2024-07-01' AND
   type = 'font' AND

--- a/sql/2024/fonts/design/fonts_license.sql
+++ b/sql/2024/fonts/design/fonts_license.sql
@@ -1,6 +1,6 @@
 -- Section: Design
 -- Question: Which licenses are used?
--- Normalization: Sites
+-- Normalization: Websites
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
@@ -16,7 +16,7 @@ CREATE TEMPORARY FUNCTION LICENSE(value STRING) AS (
 );
 
 WITH
-sites AS (
+websites AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -39,7 +39,7 @@ SELECT
 FROM
   `httparchive.all.requests`
 INNER JOIN
-  sites USING (client)
+  websites USING (client)
 WHERE
   date = '2024-07-01' AND
   type = 'font' AND

--- a/sql/2024/fonts/design/fonts_license.sql
+++ b/sql/2024/fonts/design/fonts_license.sql
@@ -2,6 +2,8 @@
 -- Question: Which licenses are used?
 -- Normalization: Sites
 
+-- INCLUDE ../common.sql
+
 CREATE TEMPORARY FUNCTION LICENSE(value STRING) AS (
   CASE
     WHEN REGEXP_CONTAINS(value, 'adobe|typekit') THEN 'Adobe'
@@ -41,7 +43,8 @@ INNER JOIN
 WHERE
   date = '2024-07-01' AND
   type = 'font' AND
-  is_root_page
+  is_root_page AND
+  IS_PARSED(payload)
 GROUP BY
   client,
   license,

--- a/sql/2024/fonts/design/fonts_metric.sql
+++ b/sql/2024/fonts/design/fonts_metric.sql
@@ -12,8 +12,8 @@ fonts AS (
     `httparchive.all.requests`
   WHERE
     date = '2024-07-01' AND
-    is_root_page AND
-    type = 'font'
+    type = 'font' AND
+    is_root_page
   GROUP BY
     client,
     url

--- a/sql/2024/fonts/design/fonts_metric.sql
+++ b/sql/2024/fonts/design/fonts_metric.sql
@@ -2,7 +2,7 @@
 -- Question: What is the distribution of metrics?
 -- Normalization: Fonts (parsed only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 fonts AS (

--- a/sql/2024/fonts/design/fonts_metric.sql
+++ b/sql/2024/fonts/design/fonts_metric.sql
@@ -106,7 +106,7 @@ SELECT
   metric.name AS metric,
   percentile,
   COUNT(0) AS count,
-  APPROX_QUANTILES(value / granularity, 1000)[OFFSET(percentile * 10)] AS value
+  APPROX_QUANTILES(SAFE_DIVIDE(value, granularity), 1000)[OFFSET(percentile * 10)] AS value
 FROM
   fonts,
   UNNEST(metrics) AS metric,

--- a/sql/2024/fonts/design/fonts_metric.sql
+++ b/sql/2024/fonts/design/fonts_metric.sql
@@ -1,6 +1,6 @@
 -- Section: Performance
 -- Question: What is the distribution of metrics?
--- Normalization: Fonts
+-- Normalization: Fonts (parsed only)
 
 -- INCLUDE ../common.sql
 

--- a/sql/2024/fonts/design/fonts_metric.sql
+++ b/sql/2024/fonts/design/fonts_metric.sql
@@ -7,7 +7,98 @@ fonts AS (
   SELECT
     client,
     url,
-    ANY_VALUE(payload) AS payload
+    [
+      STRUCT(
+        'granularity' AS name,
+        SAFE_CAST(
+          JSON_EXTRACT_SCALAR(
+            ANY_VALUE(payload),
+            '$._font_details.head.unitsPerEm'
+          ) AS INTEGER
+        ) AS value
+      ),
+      STRUCT(
+        'clipping_ascender' AS name,
+        SAFE_CAST(
+          JSON_EXTRACT_SCALAR(
+            ANY_VALUE(payload),
+            '$._font_details.OS2.usWinAscent'
+          ) AS INTEGER
+        ) AS value
+      ),
+      STRUCT(
+        'ascender' AS name,
+        SAFE_CAST(
+          JSON_EXTRACT_SCALAR(
+            ANY_VALUE(payload),
+            '$._font_details.OS2.sTypoAscender'
+          ) AS INTEGER
+        ) AS value
+      ),
+      STRUCT(
+        'cap_height' AS name,
+        SAFE_CAST(
+          JSON_EXTRACT_SCALAR(
+            ANY_VALUE(payload),
+            '$._font_details.OS2.sCapHeight'
+          ) AS INTEGER
+        ) AS value
+      ),
+      STRUCT(
+        'x_height' AS name,
+        SAFE_CAST(
+          JSON_EXTRACT_SCALAR(
+            ANY_VALUE(payload),
+            '$._font_details.OS2.sxHeight'
+          ) AS INTEGER
+        ) AS value
+      ),
+      STRUCT(
+        'baseline_at_zero' AS name,
+        SAFE_CAST(
+          JSON_EXTRACT_SCALAR(
+            ANY_VALUE(payload),
+            '$._font_details.OS2.flags'
+          ) AS INTEGER
+        ) & 1 AS value
+      ),
+      STRUCT(
+        'descender' AS name,
+        SAFE_CAST(
+          JSON_EXTRACT_SCALAR(
+            ANY_VALUE(payload),
+            '$._font_details.OS2.sTypoDescender'
+          ) AS INTEGER
+        ) AS value
+      ),
+      STRUCT(
+        'clipping_descender' AS name,
+        -SAFE_CAST(
+          JSON_EXTRACT_SCALAR(
+            ANY_VALUE(payload),
+            '$._font_details.OS2.usWinDescent'
+          ) AS INTEGER
+        ) AS value
+      ),
+      STRUCT(
+        'line_gap' AS name,
+        SAFE_CAST(
+          JSON_EXTRACT_SCALAR(
+            ANY_VALUE(payload),
+            '$._font_details.OS2.sTypoLineGap'
+          ) AS INTEGER
+        ) AS value
+      ),
+      STRUCT(
+        'use_typographic_metrics' AS name,
+        SAFE_CAST(
+          JSON_EXTRACT_SCALAR(
+            ANY_VALUE(payload),
+            '$._font_details.OS2.fsSelection'
+          ) AS INTEGER
+        ) & 128 AS value
+      )
+    ] AS metrics
   FROM
     `httparchive.all.requests`
   WHERE
@@ -25,18 +116,7 @@ metrics AS (
     metric.value
   FROM
     fonts,
-    UNNEST([
-      STRUCT('granularity' AS name, SAFE_CAST(JSON_EXTRACT_SCALAR(payload, '$._font_details.head.unitsPerEm') AS INTEGER) AS value),
-      STRUCT('clipping_ascender' AS name, SAFE_CAST(JSON_EXTRACT_SCALAR(payload, '$._font_details.OS2.usWinAscent') AS INTEGER) AS value),
-      STRUCT('ascender' AS name, SAFE_CAST(JSON_EXTRACT_SCALAR(payload, '$._font_details.OS2.sTypoAscender') AS INTEGER) AS value),
-      STRUCT('cap_height' AS name, SAFE_CAST(JSON_EXTRACT_SCALAR(payload, '$._font_details.OS2.sCapHeight') AS INTEGER) AS value),
-      STRUCT('x_height' AS name, SAFE_CAST(JSON_EXTRACT_SCALAR(payload, '$._font_details.OS2.sxHeight') AS INTEGER) AS value),
-      STRUCT('baseline_at_zero' AS name, SAFE_CAST(JSON_EXTRACT_SCALAR(payload, '$._font_details.OS2.flags') AS INTEGER) & 1 AS value),
-      STRUCT('descender' AS name, SAFE_CAST(JSON_EXTRACT_SCALAR(payload, '$._font_details.OS2.sTypoDescender') AS INTEGER) AS value),
-      STRUCT('clipping_descender' AS name, -SAFE_CAST(JSON_EXTRACT_SCALAR(payload, '$._font_details.OS2.usWinDescent') AS INTEGER) AS value),
-      STRUCT('line_gap' AS name, SAFE_CAST(JSON_EXTRACT_SCALAR(payload, '$._font_details.OS2.sTypoLineGap') AS INTEGER) AS value),
-      STRUCT('use_typographic_metrics' AS name, SAFE_CAST(JSON_EXTRACT_SCALAR(payload, '$._font_details.OS2.fsSelection') AS INTEGER) & 128 AS value)
-    ]) AS metric
+    UNNEST(metrics) AS metric
 )
 
 SELECT

--- a/sql/2024/fonts/design/fonts_metric.sql
+++ b/sql/2024/fonts/design/fonts_metric.sql
@@ -56,15 +56,6 @@ fonts AS (
         ) AS value
       ),
       STRUCT(
-        'baseline_at_zero' AS name,
-        SAFE_CAST(
-          JSON_EXTRACT_SCALAR(
-            ANY_VALUE(payload),
-            '$._font_details.OS2.flags'
-          ) AS INTEGER
-        ) & 1 AS value
-      ),
-      STRUCT(
         'descender' AS name,
         SAFE_CAST(
           JSON_EXTRACT_SCALAR(

--- a/sql/2024/fonts/design/fonts_metric.sql
+++ b/sql/2024/fonts/design/fonts_metric.sql
@@ -2,6 +2,8 @@
 -- Question: What is the distribution of metrics?
 -- Normalization: Fonts
 
+-- INCLUDE ../common.sql
+
 WITH
 fonts AS (
   SELECT
@@ -104,7 +106,8 @@ fonts AS (
   WHERE
     date = '2024-07-01' AND
     type = 'font' AND
-    is_root_page
+    is_root_page AND
+    IS_PARSED(payload)
   GROUP BY
     client,
     url

--- a/sql/2024/fonts/design/fonts_script.sql
+++ b/sql/2024/fonts/design/fonts_script.sql
@@ -9,7 +9,7 @@ fonts AS (
   SELECT
     client,
     url,
-    ANY_VALUE(payload) AS payload,
+    SCRIPTS(ANY_VALUE(payload)) AS scripts,
     COUNT(0) OVER (PARTITION BY client) AS total
   FROM
     `httparchive.all.requests`
@@ -30,7 +30,7 @@ SELECT
   COUNT(DISTINCT url) / total AS proportion
 FROM
   fonts,
-  UNNEST(SCRIPTS(payload)) AS script
+  UNNEST(scripts) AS script
 GROUP BY
   client,
   script,

--- a/sql/2024/fonts/design/fonts_script.sql
+++ b/sql/2024/fonts/design/fonts_script.sql
@@ -15,8 +15,8 @@ fonts AS (
     `httparchive.all.requests`
   WHERE
     date = '2024-07-01' AND
-    is_root_page AND
-    type = 'font'
+    type = 'font' AND
+    is_root_page
   GROUP BY
     client,
     url

--- a/sql/2024/fonts/design/fonts_script.sql
+++ b/sql/2024/fonts/design/fonts_script.sql
@@ -2,7 +2,7 @@
 -- Question: Which scripts does one design for?
 -- Normalization: Fonts (parsed only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 fonts AS (

--- a/sql/2024/fonts/design/fonts_script.sql
+++ b/sql/2024/fonts/design/fonts_script.sql
@@ -16,7 +16,8 @@ fonts AS (
   WHERE
     date = '2024-07-01' AND
     type = 'font' AND
-    is_root_page
+    is_root_page AND
+    IS_PARSED(payload)
   GROUP BY
     client,
     url

--- a/sql/2024/fonts/design/fonts_script.sql
+++ b/sql/2024/fonts/design/fonts_script.sql
@@ -1,6 +1,6 @@
 -- Section: Design
 -- Question: Which scripts does one design for?
--- Normalization: Fonts
+-- Normalization: Fonts (parsed only)
 
 -- INCLUDE ../common.sql
 

--- a/sql/2024/fonts/design/fonts_script.sql
+++ b/sql/2024/fonts/design/fonts_script.sql
@@ -9,7 +9,8 @@ fonts AS (
   SELECT
     client,
     url,
-    ANY_VALUE(payload) AS payload
+    ANY_VALUE(payload) AS payload,
+    COUNT(0) OVER (PARTITION BY client) AS total
   FROM
     `httparchive.all.requests`
   WHERE
@@ -25,14 +26,15 @@ SELECT
   client,
   script,
   COUNT(DISTINCT url) AS count,
-  SUM(COUNT(DISTINCT url)) OVER (PARTITION BY client) AS total,
-  COUNT(DISTINCT url) / SUM(COUNT(DISTINCT url)) OVER (PARTITION BY client) AS proportion
+  total,
+  COUNT(DISTINCT url) / total AS proportion
 FROM
   fonts,
   UNNEST(SCRIPTS(payload)) AS script
 GROUP BY
   client,
-  script
+  script,
+  total
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/design/styles_family.sql
+++ b/sql/2024/fonts/design/styles_family.sql
@@ -2,6 +2,8 @@
 -- Question: Which families are popular in CSS?
 -- Normalization: Sites
 
+-- INCLUDE ../common.sql
+
 CREATE TEMPORARY FUNCTION FAMILIES(json STRING)
 RETURNS ARRAY<STRING>
 LANGUAGE js
@@ -26,7 +28,7 @@ WITH
 families AS (
   SELECT
     client,
-    family,
+    FAMILY_INNER(family) AS family,
     COUNT(DISTINCT page) AS count,
     ROW_NUMBER() OVER (PARTITION BY client ORDER BY COUNT(DISTINCT page) DESC) AS rank
   FROM

--- a/sql/2024/fonts/design/styles_family.sql
+++ b/sql/2024/fonts/design/styles_family.sql
@@ -1,6 +1,6 @@
 -- Section: Design
 -- Question: Which families are popular in CSS?
--- Normalization: Websites
+-- Normalization: Pages
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
@@ -43,7 +43,7 @@ families AS (
   QUALIFY
     rank <= 100
 ),
-websites AS (
+pages AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -65,7 +65,7 @@ SELECT
 FROM
   families
 JOIN
-  websites USING (client)
+  pages USING (client)
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/design/styles_family.sql
+++ b/sql/2024/fonts/design/styles_family.sql
@@ -1,6 +1,6 @@
 -- Section: Design
 -- Question: Which families are popular in CSS?
--- Normalization: Sites
+-- Normalization: Websites
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
@@ -43,7 +43,7 @@ families AS (
   QUALIFY
     rank <= 100
 ),
-sites AS (
+websites AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -65,7 +65,7 @@ SELECT
 FROM
   families
 JOIN
-  sites USING (client)
+  websites USING (client)
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/design/styles_family.sql
+++ b/sql/2024/fonts/design/styles_family.sql
@@ -2,7 +2,7 @@
 -- Question: Which families are popular in CSS?
 -- Normalization: Sites
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 CREATE TEMPORARY FUNCTION FAMILIES(json STRING)
 RETURNS ARRAY<STRING>

--- a/sql/2024/fonts/design/styles_family_system.sql
+++ b/sql/2024/fonts/design/styles_family_system.sql
@@ -1,6 +1,6 @@
 -- Section: Design
 -- Question: Which system families are popular?
--- Normalization: Sites
+-- Normalization: Websites
 
 CREATE TEMPORARY FUNCTION FAMILIES(json STRING)
 RETURNS ARRAY<STRING>
@@ -64,7 +64,7 @@ families AS (
     client,
     family
 ),
-sites AS (
+websites AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -86,7 +86,7 @@ SELECT
 FROM
   families
 JOIN
-  sites USING (client)
+  websites USING (client)
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/design/styles_family_system.sql
+++ b/sql/2024/fonts/design/styles_family_system.sql
@@ -1,6 +1,6 @@
 -- Section: Design
 -- Question: Which system families are popular?
--- Normalization: Websites
+-- Normalization: Pages
 
 CREATE TEMPORARY FUNCTION FAMILIES(json STRING)
 RETURNS ARRAY<STRING>
@@ -64,7 +64,7 @@ families AS (
     client,
     family
 ),
-websites AS (
+pages AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -86,7 +86,7 @@ SELECT
 FROM
   families
 JOIN
-  websites USING (client)
+  pages USING (client)
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/development/fonts_color.sql
+++ b/sql/2024/fonts/development/fonts_color.sql
@@ -1,6 +1,6 @@
 -- Section: Development
 -- Question: How popular are color fonts?
--- Normalization: Websites
+-- Normalization: Pages
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
@@ -21,7 +21,7 @@ fonts AS (
     date,
     client
 ),
-websites AS (
+pages AS (
   SELECT
     date,
     client,
@@ -45,7 +45,7 @@ SELECT
 FROM
   fonts
 JOIN
-  websites USING (date, client)
+  pages USING (date, client)
 ORDER BY
   date,
   proportion DESC

--- a/sql/2024/fonts/development/fonts_color.sql
+++ b/sql/2024/fonts/development/fonts_color.sql
@@ -1,6 +1,6 @@
 -- Section: Development
 -- Question: How popular are color fonts?
--- Normalization: Sites
+-- Normalization: Websites
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
@@ -21,7 +21,7 @@ fonts AS (
     date,
     client
 ),
-sites AS (
+websites AS (
   SELECT
     date,
     client,
@@ -45,7 +45,7 @@ SELECT
 FROM
   fonts
 JOIN
-  sites USING (date, client)
+  websites USING (date, client)
 ORDER BY
   date,
   proportion DESC

--- a/sql/2024/fonts/development/fonts_color.sql
+++ b/sql/2024/fonts/development/fonts_color.sql
@@ -2,7 +2,7 @@
 -- Question: How popular are color fonts?
 -- Normalization: Sites
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 fonts AS (

--- a/sql/2024/fonts/development/fonts_color.sql
+++ b/sql/2024/fonts/development/fonts_color.sql
@@ -14,8 +14,8 @@ fonts AS (
     `httparchive.all.requests`
   WHERE
     date IN ('2022-07-01', '2023-07-01', '2024-07-01') AND
-    is_root_page AND
     type = 'font' AND
+    is_root_page AND
     IS_COLOR(payload)
   GROUP BY
     date,

--- a/sql/2024/fonts/development/fonts_color_color.sql
+++ b/sql/2024/fonts/development/fonts_color_color.sql
@@ -37,8 +37,8 @@ FROM
   UNNEST(COLORS(JSON_EXTRACT(payload, '$._font_details.color.palettes'))) AS color
 WHERE
   date = '2024-07-01' AND
-  is_root_page AND
   type = 'font' AND
+  is_root_page AND
   IS_COLOR(payload)
 GROUP BY
   client,

--- a/sql/2024/fonts/development/fonts_color_color.sql
+++ b/sql/2024/fonts/development/fonts_color_color.sql
@@ -31,12 +31,7 @@ fonts AS (
   SELECT
     client,
     url,
-    COLORS(
-      JSON_EXTRACT(
-        ANY_VALUE(payload),
-        '$._font_details.color.palettes'
-      )
-    ) AS colors,
+    COLORS(JSON_EXTRACT(ANY_VALUE(payload), '$._font_details.color.palettes')) AS colors,
     COUNT(0) OVER (PARTITION BY client) AS total
   FROM
     `httparchive.all.requests`

--- a/sql/2024/fonts/development/fonts_color_color.sql
+++ b/sql/2024/fonts/development/fonts_color_color.sql
@@ -2,7 +2,7 @@
 -- Question: What is the distribution of color palettes?
 -- Normalization: Fonts (color only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 CREATE TEMPORARY FUNCTION COLORS(json STRING)
 RETURNS ARRAY<STRING>

--- a/sql/2024/fonts/development/fonts_color_emoji.sql
+++ b/sql/2024/fonts/development/fonts_color_emoji.sql
@@ -40,8 +40,8 @@ FROM
   `httparchive.all.requests`
 WHERE
   date IN ('2022-07-01', '2023-07-01', '2024-07-01') AND
-  is_root_page AND
   type = 'font' AND
+  is_root_page AND
   IS_COLOR(payload)
 GROUP BY
   date,

--- a/sql/2024/fonts/development/fonts_color_emoji.sql
+++ b/sql/2024/fonts/development/fonts_color_emoji.sql
@@ -34,12 +34,7 @@ links AS (
   SELECT
     date,
     client,
-    HAS_EMOJI(
-      JSON_EXTRACT_STRING_ARRAY(
-        payload,
-        '$._font_details.cmap.codepoints'
-      )
-    ) AS emoji,
+    HAS_EMOJI(JSON_EXTRACT_STRING_ARRAY(payload, '$._font_details.cmap.codepoints')) AS emoji,
     COUNT(0) OVER (PARTITION BY date, client) AS total
   FROM
     `httparchive.all.requests`

--- a/sql/2024/fonts/development/fonts_color_emoji.sql
+++ b/sql/2024/fonts/development/fonts_color_emoji.sql
@@ -1,6 +1,6 @@
 -- Section: Development
 -- Question: Are color fonts used for the sake of emojis?
--- Normalization: Links (color only)
+-- Normalization: Requests (color only)
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
@@ -30,7 +30,7 @@ if (codepoints && codepoints.length) {
 """;
 
 WITH
-links AS (
+requests AS (
   SELECT
     date,
     client,
@@ -53,7 +53,7 @@ SELECT
   total,
   COUNT(0) / total AS proportion
 FROM
-  links
+  requests
 GROUP BY
   date,
   client,

--- a/sql/2024/fonts/development/fonts_color_emoji.sql
+++ b/sql/2024/fonts/development/fonts_color_emoji.sql
@@ -2,7 +2,7 @@
 -- Question: Are color fonts used for the sake of emojis?
 -- Normalization: Links (color only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 CREATE TEMPORARY FUNCTION HAS_EMOJI(codepoints ARRAY<STRING>)
 RETURNS BOOL

--- a/sql/2024/fonts/development/fonts_color_entry.sql
+++ b/sql/2024/fonts/development/fonts_color_entry.sql
@@ -14,8 +14,8 @@ FROM
   `httparchive.all.requests`
 WHERE
   date = '2024-07-01' AND
-  is_root_page AND
   type = 'font' AND
+  is_root_page AND
   IS_COLOR(payload)
 GROUP BY
   client,

--- a/sql/2024/fonts/development/fonts_color_entry.sql
+++ b/sql/2024/fonts/development/fonts_color_entry.sql
@@ -1,25 +1,45 @@
 -- Section: Development
 -- Question: How many entries are there in color palettes?
--- Normalization: Fonts
+-- Normalization: Fonts (color only)
 
 -- INCLUDE ../common.sql
 
+WITH
+fonts AS (
+  SELECT
+    client,
+    url,
+    SAFE_CAST(
+      JSON_EXTRACT_SCALAR(
+        ANY_VALUE(payload),
+        '$._font_details.color.numPaletteEntries'
+      ) AS INT64
+    ) AS entries,
+    COUNT(*) OVER (PARTITION BY client) AS total
+  FROM
+    `httparchive.all.requests`
+  WHERE
+    date = '2024-07-01' AND
+    type = 'font' AND
+    is_root_page AND
+    IS_COLOR(payload)
+  GROUP BY
+    client,
+    url
+)
+
 SELECT
   client,
-  SAFE_CAST(JSON_EXTRACT_SCALAR(payload, '$._font_details.color.numPaletteEntries') AS INT64) AS entries,
-  COUNT(DISTINCT url) AS count,
-  SUM(COUNT(DISTINCT url)) OVER (PARTITION BY client) AS total,
-  COUNT(DISTINCT url) / SUM(COUNT(DISTINCT url)) OVER (PARTITION BY client) AS proportion
+  entries,
+  COUNT(0) AS count,
+  total,
+  COUNT(0) / total AS proportion
 FROM
-  `httparchive.all.requests`
-WHERE
-  date = '2024-07-01' AND
-  type = 'font' AND
-  is_root_page AND
-  IS_COLOR(payload)
+  fonts
 GROUP BY
   client,
-  entries
+  entries,
+  total
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/development/fonts_color_entry.sql
+++ b/sql/2024/fonts/development/fonts_color_entry.sql
@@ -15,7 +15,7 @@ fonts AS (
         '$._font_details.color.numPaletteEntries'
       ) AS INT64
     ) AS entries,
-    COUNT(*) OVER (PARTITION BY client) AS total
+    COUNT(0) OVER (PARTITION BY client) AS total
   FROM
     `httparchive.all.requests`
   WHERE

--- a/sql/2024/fonts/development/fonts_color_entry.sql
+++ b/sql/2024/fonts/development/fonts_color_entry.sql
@@ -2,7 +2,7 @@
 -- Question: How many entries are there in color palettes?
 -- Normalization: Fonts (color only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 fonts AS (

--- a/sql/2024/fonts/development/fonts_color_family.sql
+++ b/sql/2024/fonts/development/fonts_color_family.sql
@@ -15,8 +15,8 @@ FROM
   `httparchive.all.requests`
 WHERE
   date = '2024-07-01' AND
-  is_root_page AND
   type = 'font' AND
+  is_root_page AND
   IS_COLOR(payload)
 GROUP BY
   client,

--- a/sql/2024/fonts/development/fonts_color_family.sql
+++ b/sql/2024/fonts/development/fonts_color_family.sql
@@ -1,11 +1,11 @@
 -- Section: Development
 -- Question: Which color families are used?
--- Normalization: Links (color only)
+-- Normalization: Requests (color only)
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
-links AS (
+requests AS (
   SELECT
     client,
     FAMILY(payload) AS family,
@@ -27,7 +27,7 @@ SELECT
   COUNT(0) / total AS proportion,
   ROW_NUMBER() OVER (PARTITION BY client ORDER BY COUNT(0) DESC) AS rank
 FROM
-  links
+  requests
 GROUP BY
   client,
   family,

--- a/sql/2024/fonts/development/fonts_color_family.sql
+++ b/sql/2024/fonts/development/fonts_color_family.sql
@@ -2,7 +2,7 @@
 -- Question: Which color families are used?
 -- Normalization: Links (color only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 links AS (

--- a/sql/2024/fonts/development/fonts_color_format.sql
+++ b/sql/2024/fonts/development/fonts_color_format.sql
@@ -2,7 +2,7 @@
 -- Question: Which color-font formats are used?
 -- Normalization: Fonts (color only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 fonts AS (

--- a/sql/2024/fonts/development/fonts_color_format.sql
+++ b/sql/2024/fonts/development/fonts_color_format.sql
@@ -15,8 +15,8 @@ FROM
   UNNEST(COLOR_FORMATS(payload)) AS format
 WHERE
   date = '2024-07-01' AND
-  is_root_page AND
-  type = 'font'
+  type = 'font' AND
+  is_root_page
 GROUP BY
   client,
   format

--- a/sql/2024/fonts/development/fonts_color_format.sql
+++ b/sql/2024/fonts/development/fonts_color_format.sql
@@ -7,6 +7,7 @@
 WITH
 fonts AS (
   SELECT
+    date,
     client,
     url,
     COLOR_FORMATS(ANY_VALUE(payload)) AS formats,
@@ -14,16 +15,18 @@ fonts AS (
   FROM
     `httparchive.all.requests`
   WHERE
-    date = '2024-07-01' AND
+    date IN ('2022-07-01', '2023-07-01', '2024-07-01') AND
     type = 'font' AND
     is_root_page AND
     IS_COLOR(payload)
   GROUP BY
+    date,
     client,
     url
 )
 
 SELECT
+  date,
   client,
   format,
   COUNT(DISTINCT url) AS count,
@@ -33,9 +36,11 @@ FROM
   fonts,
   UNNEST(formats) AS format
 GROUP BY
+  date,
   client,
   format,
   total
 ORDER BY
+  date,
   client,
   proportion DESC

--- a/sql/2024/fonts/development/fonts_color_format.sql
+++ b/sql/2024/fonts/development/fonts_color_format.sql
@@ -11,7 +11,7 @@ fonts AS (
     client,
     url,
     COLOR_FORMATS(ANY_VALUE(payload)) AS formats,
-    COUNT(0) OVER (PARTITION BY client) AS total
+    COUNT(0) OVER (PARTITION BY date, client) AS total
   FROM
     `httparchive.all.requests`
   WHERE

--- a/sql/2024/fonts/development/fonts_color_format_by_family.sql
+++ b/sql/2024/fonts/development/fonts_color_format_by_family.sql
@@ -30,7 +30,8 @@ SELECT
   family,
   COUNT(0) AS count,
   total,
-  COUNT(0) / total AS proportion
+  COUNT(0) / total AS proportion,
+  ANY_VALUE(url) AS example
 FROM
   fonts,
   UNNEST(formats) AS format

--- a/sql/2024/fonts/development/fonts_color_format_by_family.sql
+++ b/sql/2024/fonts/development/fonts_color_format_by_family.sql
@@ -1,5 +1,5 @@
 -- Section: Development
--- Question: Which color families are used broken down by format?
+-- Question: Which color formats are used broken down by family?
 -- Normalization: Fonts (color only)
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql

--- a/sql/2024/fonts/development/fonts_color_format_by_family.sql
+++ b/sql/2024/fonts/development/fonts_color_format_by_family.sql
@@ -30,8 +30,7 @@ SELECT
   family,
   COUNT(0) AS count,
   total,
-  COUNT(0) / total AS proportion,
-  ROW_NUMBER() OVER (PARTITION BY client, format ORDER BY COUNT(0) DESC) AS rank
+  COUNT(0) / total AS proportion
 FROM
   fonts,
   UNNEST(formats) AS format
@@ -40,8 +39,6 @@ GROUP BY
   format,
   family,
   total
-QUALIFY
-  rank <= 10
 ORDER BY
   client,
   format,

--- a/sql/2024/fonts/development/fonts_color_palette.sql
+++ b/sql/2024/fonts/development/fonts_color_palette.sql
@@ -14,8 +14,8 @@ FROM
   `httparchive.all.requests`
 WHERE
   date = '2024-07-01' AND
-  is_root_page AND
   type = 'font' AND
+  is_root_page AND
   IS_COLOR(payload)
 GROUP BY
   client,

--- a/sql/2024/fonts/development/fonts_color_palette.sql
+++ b/sql/2024/fonts/development/fonts_color_palette.sql
@@ -1,25 +1,45 @@
 -- Section: Development
 -- Question: How many palettes are there in color fonts?
--- Normalization: Fonts
+-- Normalization: Fonts (color only)
 
 -- INCLUDE ../common.sql
 
+WITH
+fonts AS (
+  SELECT
+    client,
+    url,
+    SAFE_CAST(
+      JSON_EXTRACT_SCALAR(
+        ANY_VALUE(payload),
+        '$._font_details.color.numPalettes'
+      ) AS INT64
+    ) AS entries,
+    COUNT(0) OVER (PARTITION BY client) AS total
+  FROM
+    `httparchive.all.requests`
+  WHERE
+    date = '2024-07-01' AND
+    type = 'font' AND
+    is_root_page AND
+    IS_COLOR(payload)
+  GROUP BY
+    client,
+    url
+)
+
 SELECT
   client,
-  SAFE_CAST(JSON_EXTRACT_SCALAR(payload, '$._font_details.color.numPalettes') AS INT64) AS entries,
-  COUNT(DISTINCT url) AS count,
-  SUM(COUNT(DISTINCT url)) OVER (PARTITION BY client) AS total,
-  COUNT(DISTINCT url) / SUM(COUNT(DISTINCT url)) OVER (PARTITION BY client) AS proportion
+  entries,
+  COUNT(0) AS count,
+  total,
+  COUNT(0) / total AS proportion
 FROM
-  `httparchive.all.requests`
-WHERE
-  date = '2024-07-01' AND
-  type = 'font' AND
-  is_root_page AND
-  IS_COLOR(payload)
+  fonts
 GROUP BY
   client,
-  entries
+  entries,
+  total
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/development/fonts_color_palette.sql
+++ b/sql/2024/fonts/development/fonts_color_palette.sql
@@ -2,7 +2,7 @@
 -- Question: How many palettes are there in color fonts?
 -- Normalization: Fonts (color only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 fonts AS (

--- a/sql/2024/fonts/development/fonts_compiler.sql
+++ b/sql/2024/fonts/development/fonts_compiler.sql
@@ -1,6 +1,8 @@
 -- Section: Design
 -- Question: Which compilers are used?
--- Normalization: Fonts
+-- Normalization: Fonts (parsed only)
+
+-- INCLUDE ../common.sql
 
 CREATE TEMPORARY FUNCTION COMPILER(version STRING) AS (
   CASE
@@ -25,7 +27,8 @@ fonts AS (
   WHERE
     date = '2024-07-01' AND
     type = 'font' AND
-    is_root_page
+    is_root_page AND
+    IS_PARSED(payload)
   GROUP BY
     client,
     url

--- a/sql/2024/fonts/development/fonts_compiler.sql
+++ b/sql/2024/fonts/development/fonts_compiler.sql
@@ -1,4 +1,4 @@
--- Section: Design
+-- Section: Development
 -- Question: Which compilers are used?
 -- Normalization: Fonts (parsed only)
 

--- a/sql/2024/fonts/development/fonts_compiler.sql
+++ b/sql/2024/fonts/development/fonts_compiler.sql
@@ -23,8 +23,8 @@ fonts AS (
     `httparchive.all.requests`
   WHERE
     date = '2024-07-01' AND
-    is_root_page AND
-    type = 'font'
+    type = 'font' AND
+    is_root_page
   GROUP BY
     client,
     url

--- a/sql/2024/fonts/development/fonts_compiler.sql
+++ b/sql/2024/fonts/development/fonts_compiler.sql
@@ -18,7 +18,7 @@ fonts AS (
   SELECT
     client,
     url,
-    ANY_VALUE(COMPILER(JSON_EXTRACT_SCALAR(payload, '$._font_details.names[5]'))) AS compiler,
+    COMPILER(JSON_EXTRACT_SCALAR(ANY_VALUE(payload), '$._font_details.names[5]')) AS compiler,
     COUNT(0) OVER (PARTITION BY client) AS total
   FROM
     `httparchive.all.requests`

--- a/sql/2024/fonts/development/fonts_compiler.sql
+++ b/sql/2024/fonts/development/fonts_compiler.sql
@@ -2,7 +2,7 @@
 -- Question: Which compilers are used?
 -- Normalization: Fonts (parsed only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 CREATE TEMPORARY FUNCTION COMPILER(version STRING) AS (
   CASE

--- a/sql/2024/fonts/development/fonts_feature.sql
+++ b/sql/2024/fonts/development/fonts_feature.sql
@@ -1,6 +1,8 @@
 -- Section: Development
 -- Question: Which features are used in fonts?
--- Normalization: Fonts
+-- Normalization: Fonts (parsed only)
+
+-- INCLUDE ../common.sql
 
 CREATE TEMPORARY FUNCTION FEATURES(data STRING)
 RETURNS ARRAY<STRING>
@@ -34,7 +36,8 @@ fonts AS (
   WHERE
     date = '2024-07-01' AND
     type = 'font' AND
-    is_root_page
+    is_root_page AND
+    IS_PARSED(payload)
   GROUP BY
     client,
     url

--- a/sql/2024/fonts/development/fonts_feature.sql
+++ b/sql/2024/fonts/development/fonts_feature.sql
@@ -2,7 +2,7 @@
 -- Question: Which features are used in fonts?
 -- Normalization: Fonts (parsed only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 CREATE TEMPORARY FUNCTION FEATURES(data STRING)
 RETURNS ARRAY<STRING>

--- a/sql/2024/fonts/development/fonts_feature.sql
+++ b/sql/2024/fonts/development/fonts_feature.sql
@@ -33,8 +33,8 @@ fonts AS (
     UNNEST(FEATURES(JSON_EXTRACT(payload, '$._font_details.features'))) AS feature
   WHERE
     date = '2024-07-01' AND
-    is_root_page AND
-    type = 'font'
+    type = 'font' AND
+    is_root_page
   GROUP BY
     client,
     url,

--- a/sql/2024/fonts/development/fonts_feature_kerning.sql
+++ b/sql/2024/fonts/development/fonts_feature_kerning.sql
@@ -71,5 +71,4 @@ GROUP BY
 ORDER BY
   date,
   client,
-  support,
-  proportion DESC
+  support

--- a/sql/2024/fonts/development/fonts_feature_kerning.sql
+++ b/sql/2024/fonts/development/fonts_feature_kerning.sql
@@ -2,7 +2,7 @@
 -- Question: How prevalent is kerning support?
 -- Normalization: Fonts (parsed only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 CREATE TEMPORARY FUNCTION HAS_KERNING(data STRING)
 RETURNS BOOL

--- a/sql/2024/fonts/development/fonts_feature_kerning.sql
+++ b/sql/2024/fonts/development/fonts_feature_kerning.sql
@@ -36,8 +36,8 @@ fonts AS (
     `httparchive.all.requests`
   WHERE
     date IN ('2022-07-01', '2023-07-01', '2024-07-01') AND
-    is_root_page AND
-    type = 'font'
+    type = 'font' AND
+    is_root_page
   GROUP BY
     date,
     client,

--- a/sql/2024/fonts/development/fonts_feature_kerning.sql
+++ b/sql/2024/fonts/development/fonts_feature_kerning.sql
@@ -1,6 +1,8 @@
 -- Section: Development
 -- Question: How prevalent is kerning support?
--- Normalization: Fonts
+-- Normalization: Fonts (parsed only)
+
+-- INCLUDE ../common.sql
 
 CREATE TEMPORARY FUNCTION HAS_KERNING(data STRING)
 RETURNS BOOL
@@ -44,7 +46,8 @@ fonts AS (
   WHERE
     date IN ('2022-07-01', '2023-07-01', '2024-07-01') AND
     type = 'font' AND
-    is_root_page
+    is_root_page AND
+    IS_PARSED(payload)
   GROUP BY
     date,
     client,

--- a/sql/2024/fonts/development/fonts_feature_opentype.sql
+++ b/sql/2024/fonts/development/fonts_feature_opentype.sql
@@ -2,7 +2,7 @@
 -- Question: How prevalent is OpenType support?
 -- Normalization: Fonts (parsed only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 fonts AS (

--- a/sql/2024/fonts/development/fonts_feature_opentype.sql
+++ b/sql/2024/fonts/development/fonts_feature_opentype.sql
@@ -16,8 +16,8 @@ fonts AS (
     `httparchive.all.requests`
   WHERE
     date IN ('2022-07-01', '2023-07-01', '2024-07-01') AND
-    is_root_page AND
-    type = 'font'
+    type = 'font' AND
+    is_root_page
   GROUP BY
     date,
     client,

--- a/sql/2024/fonts/development/fonts_feature_opentype.sql
+++ b/sql/2024/fonts/development/fonts_feature_opentype.sql
@@ -45,5 +45,4 @@ GROUP BY
 ORDER BY
   date,
   client,
-  support,
-  proportion DESC
+  support

--- a/sql/2024/fonts/development/fonts_feature_opentype.sql
+++ b/sql/2024/fonts/development/fonts_feature_opentype.sql
@@ -1,6 +1,8 @@
 -- Section: Development
 -- Question: How prevalent is OpenType support?
--- Normalization: Fonts
+-- Normalization: Fonts (parsed only)
+
+-- INCLUDE ../common.sql
 
 WITH
 fonts AS (
@@ -18,7 +20,8 @@ fonts AS (
   WHERE
     date IN ('2022-07-01', '2023-07-01', '2024-07-01') AND
     type = 'font' AND
-    is_root_page
+    is_root_page AND
+    IS_PARSED(payload)
   GROUP BY
     date,
     client,

--- a/sql/2024/fonts/development/fonts_feature_opentype.sql
+++ b/sql/2024/fonts/development/fonts_feature_opentype.sql
@@ -9,9 +9,10 @@ fonts AS (
     client,
     url,
     REGEXP_CONTAINS(
-      JSON_EXTRACT(payload, '$._font_details.table_sizes'),
+      JSON_EXTRACT(ANY_VALUE(payload), '$._font_details.table_sizes'),
       '(?i)GPOS|GSUB'
-    ) AS support
+    ) AS support,
+    COUNT(0) OVER (PARTITION BY date, client) AS total
   FROM
     `httparchive.all.requests`
   WHERE
@@ -21,23 +22,23 @@ fonts AS (
   GROUP BY
     date,
     client,
-    url,
-    support
+    url
 )
 
 SELECT
   date,
   client,
   support,
-  COUNT(DISTINCT url) AS count,
-  SUM(COUNT(DISTINCT url)) OVER (PARTITION BY date, client) AS total,
-  COUNT(DISTINCT url) / SUM(COUNT(DISTINCT url)) OVER (PARTITION BY date, client) AS proportion
+  COUNT(0) AS count,
+  total,
+  COUNT(0) / total AS proportion
 FROM
   fonts
 GROUP BY
   date,
   client,
-  support
+  support,
+  total
 ORDER BY
   date,
   client,

--- a/sql/2024/fonts/development/fonts_format_outline.sql
+++ b/sql/2024/fonts/development/fonts_format_outline.sql
@@ -1,4 +1,4 @@
--- Section: Performance
+-- Section: Development
 -- Question: Which outline formats are used?
 -- Normalization: Fonts (parsed only)
 

--- a/sql/2024/fonts/development/fonts_hinting.sql
+++ b/sql/2024/fonts/development/fonts_hinting.sql
@@ -20,7 +20,7 @@ CREATE TEMPORARY FUNCTION IS_AUTOHINTED(payload STRING) AS (
 );
 
 WITH
-sites AS (
+websites AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -42,7 +42,7 @@ SELECT
 FROM
   `httparchive.all.requests`
 INNER JOIN
-  sites USING (client)
+  websites USING (client)
 WHERE
   date = '2024-07-01' AND
   type = 'font' AND

--- a/sql/2024/fonts/development/fonts_hinting.sql
+++ b/sql/2024/fonts/development/fonts_hinting.sql
@@ -20,7 +20,7 @@ CREATE TEMPORARY FUNCTION IS_AUTOHINTED(payload STRING) AS (
 );
 
 WITH
-websites AS (
+pages AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -42,7 +42,7 @@ SELECT
 FROM
   `httparchive.all.requests`
 INNER JOIN
-  websites USING (client)
+  pages USING (client)
 WHERE
   date = '2024-07-01' AND
   type = 'font' AND

--- a/sql/2024/fonts/development/fonts_hinting.sql
+++ b/sql/2024/fonts/development/fonts_hinting.sql
@@ -1,0 +1,58 @@
+-- Section: Development
+-- Question: How prevalent is autohinting?
+-- Normalization: Fonts (parsed only)
+
+-- INCLUDE ../common.sql
+
+CREATE TEMPORARY FUNCTION IS_HINTED(payload STRING) AS (
+  REGEXP_CONTAINS(
+    JSON_EXTRACT(payload, '$._font_details.table_sizes'),
+    '(?i)fpgm|prep'
+  )
+);
+
+
+CREATE TEMPORARY FUNCTION IS_AUTOHINTED(payload STRING) AS (
+  REGEXP_CONTAINS(
+    JSON_EXTRACT_SCALAR(payload, '$._font_details.names[5]'),
+    'autohint'
+  )
+);
+
+WITH
+sites AS (
+  SELECT
+    client,
+    COUNT(DISTINCT page) AS total
+  FROM
+    `httparchive.all.requests`
+  WHERE
+    date = '2024-07-01' AND
+    is_root_page
+  GROUP BY
+    client
+)
+
+SELECT
+  client,
+  IS_AUTOHINTED(payload) AS autohinted,
+  COUNT(DISTINCT page) AS count,
+  total,
+  COUNT(DISTINCT page) / total AS proportion
+FROM
+  `httparchive.all.requests`
+INNER JOIN
+  sites USING (client)
+WHERE
+  date = '2024-07-01' AND
+  type = 'font' AND
+  is_root_page AND
+  IS_PARSED(payload) AND
+  IS_HINTED(payload)
+GROUP BY
+  client,
+  autohinted,
+  total
+ORDER BY
+  client,
+  autohinted

--- a/sql/2024/fonts/development/fonts_hinting.sql
+++ b/sql/2024/fonts/development/fonts_hinting.sql
@@ -2,7 +2,7 @@
 -- Question: How prevalent is autohinting?
 -- Normalization: Fonts (parsed only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 CREATE TEMPORARY FUNCTION IS_HINTED(payload STRING) AS (
   REGEXP_CONTAINS(

--- a/sql/2024/fonts/development/fonts_variable.sql
+++ b/sql/2024/fonts/development/fonts_variable.sql
@@ -2,7 +2,7 @@
 -- Question: How popular are variable fonts?
 -- Normalization: Sites
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 fonts AS (

--- a/sql/2024/fonts/development/fonts_variable.sql
+++ b/sql/2024/fonts/development/fonts_variable.sql
@@ -14,8 +14,8 @@ fonts AS (
     `httparchive.all.requests`
   WHERE
     date IN ('2022-07-01', '2023-07-01', '2024-07-01') AND
-    is_root_page AND
     type = 'font' AND
+    is_root_page AND
     IS_VARIABLE(payload)
   GROUP BY
     date,

--- a/sql/2024/fonts/development/fonts_variable.sql
+++ b/sql/2024/fonts/development/fonts_variable.sql
@@ -1,6 +1,6 @@
 -- Section: Development
 -- Question: How popular are variable fonts?
--- Normalization: Websites
+-- Normalization: Pages
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
@@ -21,7 +21,7 @@ fonts AS (
     date,
     client
 ),
-websites AS (
+pages AS (
   SELECT
     date,
     client,
@@ -45,7 +45,7 @@ SELECT
 FROM
   fonts
 JOIN
-  websites USING (date, client)
+  pages USING (date, client)
 ORDER BY
   date,
   client,

--- a/sql/2024/fonts/development/fonts_variable.sql
+++ b/sql/2024/fonts/development/fonts_variable.sql
@@ -1,6 +1,6 @@
 -- Section: Development
 -- Question: How popular are variable fonts?
--- Normalization: Sites
+-- Normalization: Websites
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
@@ -21,7 +21,7 @@ fonts AS (
     date,
     client
 ),
-sites AS (
+websites AS (
   SELECT
     date,
     client,
@@ -45,7 +45,7 @@ SELECT
 FROM
   fonts
 JOIN
-  sites USING (date, client)
+  websites USING (date, client)
 ORDER BY
   date,
   client,

--- a/sql/2024/fonts/development/fonts_variable_axis.sql
+++ b/sql/2024/fonts/development/fonts_variable_axis.sql
@@ -24,8 +24,8 @@ fonts AS (
     UNNEST(AXES(JSON_EXTRACT(payload, '$._font_details.fvar'))) AS axis
   WHERE
     date = '2024-07-01' AND
-    is_root_page AND
     type = 'font'
+    is_root_page AND
   GROUP BY
     client,
     url,

--- a/sql/2024/fonts/development/fonts_variable_axis.sql
+++ b/sql/2024/fonts/development/fonts_variable_axis.sql
@@ -2,7 +2,7 @@
 -- Question: Which axes are used in variable fonts?
 -- Normalization: Fonts (variable only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 CREATE TEMPORARY FUNCTION AXES(json STRING)
 RETURNS ARRAY<STRING>

--- a/sql/2024/fonts/development/fonts_variable_family.sql
+++ b/sql/2024/fonts/development/fonts_variable_family.sql
@@ -1,11 +1,11 @@
 -- Section: Development
 -- Question: Which variable families are used?
--- Normalization: Links (variable only)
+-- Normalization: Requests (variable only)
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
-links AS (
+requests AS (
   SELECT
     client,
     FAMILY(payload) AS family,
@@ -27,7 +27,7 @@ SELECT
   COUNT(0) / total AS proportion,
   ROW_NUMBER() OVER (PARTITION BY client ORDER BY COUNT(0) DESC) AS rank
 FROM
-  links
+  requests
 GROUP BY
   client,
   family,

--- a/sql/2024/fonts/development/fonts_variable_family.sql
+++ b/sql/2024/fonts/development/fonts_variable_family.sql
@@ -15,8 +15,8 @@ FROM
   `httparchive.all.requests`
 WHERE
   date = '2024-07-01' AND
-  is_root_page AND
   type = 'font' AND
+  is_root_page AND
   IS_VARIABLE(payload)
 GROUP BY
   client,

--- a/sql/2024/fonts/development/fonts_variable_family.sql
+++ b/sql/2024/fonts/development/fonts_variable_family.sql
@@ -1,26 +1,37 @@
 -- Section: Development
 -- Question: Which variable families are used?
--- Normalization: Links
+-- Normalization: Links (variable only)
 
 -- INCLUDE ../common.sql
 
+WITH
+links AS (
+  SELECT
+    client,
+    FAMILY(payload) AS family,
+    COUNT(0) OVER (PARTITION BY client) AS total
+  FROM
+    `httparchive.all.requests`
+  WHERE
+    date = '2024-07-01' AND
+    type = 'font' AND
+    is_root_page AND
+    IS_VARIABLE(payload)
+)
+
 SELECT
   client,
-  FAMILY(payload) AS family,
+  family,
   COUNT(0) AS count,
-  SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
-  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS proportion,
+  total,
+  COUNT(0) / total AS proportion,
   ROW_NUMBER() OVER (PARTITION BY client ORDER BY COUNT(0) DESC) AS rank
 FROM
-  `httparchive.all.requests`
-WHERE
-  date = '2024-07-01' AND
-  type = 'font' AND
-  is_root_page AND
-  IS_VARIABLE(payload)
+  links
 GROUP BY
   client,
-  family
+  family,
+  total
 QUALIFY
   rank <= 100
 ORDER BY

--- a/sql/2024/fonts/development/fonts_variable_family.sql
+++ b/sql/2024/fonts/development/fonts_variable_family.sql
@@ -2,7 +2,7 @@
 -- Question: Which variable families are used?
 -- Normalization: Links (variable only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 links AS (

--- a/sql/2024/fonts/development/fonts_variable_format.sql
+++ b/sql/2024/fonts/development/fonts_variable_format.sql
@@ -16,8 +16,8 @@ fonts AS (
     UNNEST(VARIABLE_FORMATS(payload)) AS format
   WHERE
     date IN ('2022-07-01', '2023-07-01', '2024-07-01') AND
-    is_root_page AND
     type = 'font' AND
+    is_root_page AND
     IS_VARIABLE(payload)
   GROUP BY
     date,

--- a/sql/2024/fonts/development/fonts_variable_format.sql
+++ b/sql/2024/fonts/development/fonts_variable_format.sql
@@ -2,7 +2,7 @@
 -- Question: Which outline formats are used in variable fonts?
 -- Normalization: Fonts (variable only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 fonts AS (

--- a/sql/2024/fonts/development/fonts_variable_range.sql
+++ b/sql/2024/fonts/development/fonts_variable_range.sql
@@ -1,6 +1,6 @@
 -- Section: Development
 -- Question: What are the distributions of axes?
--- Normalization: Fonts
+-- Normalization: Fonts (variable only)
 
 -- INCLUDE ../common.sql
 

--- a/sql/2024/fonts/development/fonts_variable_range.sql
+++ b/sql/2024/fonts/development/fonts_variable_range.sql
@@ -2,7 +2,7 @@
 -- Question: What are the distributions of axes?
 -- Normalization: Fonts (variable only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 CREATE TEMPORARY FUNCTION AXES(json STRING)
 RETURNS ARRAY<STRUCT<name STRING, minimum FLOAT64, medium FLOAT64, maximum FLOAT64>>

--- a/sql/2024/fonts/development/fonts_variable_range.sql
+++ b/sql/2024/fonts/development/fonts_variable_range.sql
@@ -37,8 +37,8 @@ fonts AS (
     UNNEST(AXES(JSON_EXTRACT(payload, '$._font_details.fvar'))) AS axis
   WHERE
     date = '2024-07-01' AND
-    is_root_page AND
     type = 'font' AND
+    is_root_page AND
     IS_VARIABLE(payload)
   GROUP BY
     client,

--- a/sql/2024/fonts/development/fonts_variable_service.sql
+++ b/sql/2024/fonts/development/fonts_variable_service.sql
@@ -1,27 +1,44 @@
 -- Section: Development
 -- Question: Who is serving variable fonts?
--- Normalization: Links
+-- Normalization: Fonts (only variable)
 
 -- INCLUDE ../common.sql
+
+WITH
+fonts AS (
+  SELECT
+    date,
+    client,
+    url,
+    SERVICE(url) AS service,
+    COUNT(0) OVER (PARTITION BY date, client) AS total
+  FROM
+    `httparchive.all.requests`
+  WHERE
+    date IN ('2022-07-01', '2023-07-01', '2024-07-01') AND
+    type = 'font' AND
+    is_root_page AND
+    IS_VARIABLE(payload)
+  GROUP BY
+    date,
+    client,
+    url
+)
 
 SELECT
   date,
   client,
-  SERVICE(url) AS service,
+  service,
   COUNT(0) AS count,
-  SUM(COUNT(0)) OVER (PARTITION BY date, client) AS total,
-  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY date, client) AS proportion
+  total,
+  COUNT(0) / total AS proportion
 FROM
-  `httparchive.all.requests`
-WHERE
-  date IN ('2022-07-01', '2023-07-01', '2024-07-01') AND
-  type = 'font' AND
-  is_root_page AND
-  IS_VARIABLE(payload)
+  fonts
 GROUP BY
   date,
   client,
-  service
+  service,
+  total
 ORDER BY
   date,
   client,

--- a/sql/2024/fonts/development/fonts_variable_service.sql
+++ b/sql/2024/fonts/development/fonts_variable_service.sql
@@ -2,7 +2,7 @@
 -- Question: Who is serving variable fonts?
 -- Normalization: Links (variable only) and fonts (variable only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 links AS (

--- a/sql/2024/fonts/development/fonts_variable_service.sql
+++ b/sql/2024/fonts/development/fonts_variable_service.sql
@@ -1,28 +1,25 @@
 -- Section: Development
 -- Question: Who is serving variable fonts?
--- Normalization: Fonts (variable only)
+-- Normalization: Links (variable only) and fonts (variable only)
 
 -- INCLUDE ../common.sql
 
 WITH
-fonts AS (
+links AS (
   SELECT
     date,
     client,
     url,
     SERVICE(url) AS service,
-    COUNT(0) OVER (PARTITION BY date, client) AS total
+    COUNT(0) OVER (PARTITION BY date, client) AS total,
+    COUNT(DISTINCT url) OVER (PARTITION BY date, client) AS total_secondary
   FROM
     `httparchive.all.requests`
   WHERE
-    date IN ('2022-07-01', '2023-07-01', '2024-07-01') AND
+    date IN ('2022-06-01', '2022-07-01', '2023-07-01', '2024-07-01') AND
     type = 'font' AND
     is_root_page AND
     IS_VARIABLE(payload)
-  GROUP BY
-    date,
-    client,
-    url
 )
 
 SELECT
@@ -30,15 +27,19 @@ SELECT
   client,
   service,
   COUNT(0) AS count,
+  COUNT(DISTINCT url) AS count_secondary,
   total,
-  COUNT(0) / total AS proportion
+  total_secondary,
+  COUNT(0) / total AS proportion,
+  COUNT(DISTINCT url) / total_secondary AS proportion_secondary
 FROM
-  fonts
+  links
 GROUP BY
   date,
   client,
   service,
-  total
+  total,
+  total_secondary
 ORDER BY
   date,
   client,

--- a/sql/2024/fonts/development/fonts_variable_service.sql
+++ b/sql/2024/fonts/development/fonts_variable_service.sql
@@ -15,8 +15,8 @@ FROM
   `httparchive.all.requests`
 WHERE
   date IN ('2022-07-01', '2023-07-01', '2024-07-01') AND
-  is_root_page AND
   type = 'font' AND
+  is_root_page AND
   IS_VARIABLE(payload)
 GROUP BY
   date,

--- a/sql/2024/fonts/development/fonts_variable_service.sql
+++ b/sql/2024/fonts/development/fonts_variable_service.sql
@@ -1,11 +1,11 @@
 -- Section: Development
 -- Question: Who is serving variable fonts?
--- Normalization: Links (variable only) and fonts (variable only)
+-- Normalization: Requests (variable only) and fonts (variable only)
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
-links AS (
+requests AS (
   SELECT
     date,
     client,
@@ -33,7 +33,7 @@ SELECT
   COUNT(0) / total AS proportion,
   COUNT(DISTINCT url) / total_secondary AS proportion_secondary
 FROM
-  links
+  requests
 GROUP BY
   date,
   client,

--- a/sql/2024/fonts/development/fonts_variable_service.sql
+++ b/sql/2024/fonts/development/fonts_variable_service.sql
@@ -1,6 +1,6 @@
 -- Section: Development
 -- Question: Who is serving variable fonts?
--- Normalization: Fonts (only variable)
+-- Normalization: Fonts (variable only)
 
 -- INCLUDE ../common.sql
 

--- a/sql/2024/fonts/development/styles_family_system.sql
+++ b/sql/2024/fonts/development/styles_family_system.sql
@@ -1,4 +1,4 @@
--- Section: Design
+-- Section: Development
 -- Question: Which system families are popular?
 -- Normalization: Pages
 

--- a/sql/2024/fonts/development/styles_feature_control.sql
+++ b/sql/2024/fonts/development/styles_feature_control.sql
@@ -1,6 +1,6 @@
 -- Section: Development
 -- Question: How are features used in CSS?
--- Normalization: Sites
+-- Normalization: Websites
 
 CREATE TEMPORARY FUNCTION PROPERTIES(json STRING)
 RETURNS ARRAY<STRING>
@@ -53,7 +53,7 @@ properties AS (
     client,
     property
 ),
-sites AS (
+websites AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -75,7 +75,7 @@ SELECT
 FROM
   properties
 JOIN
-  sites USING (client)
+  websites USING (client)
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/development/styles_feature_control.sql
+++ b/sql/2024/fonts/development/styles_feature_control.sql
@@ -1,6 +1,6 @@
 -- Section: Development
 -- Question: How are features used in CSS?
--- Normalization: Websites
+-- Normalization: Pages
 
 CREATE TEMPORARY FUNCTION PROPERTIES(json STRING)
 RETURNS ARRAY<STRING>
@@ -53,7 +53,7 @@ properties AS (
     client,
     property
 ),
-websites AS (
+pages AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -75,7 +75,7 @@ SELECT
 FROM
   properties
 JOIN
-  websites USING (client)
+  pages USING (client)
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/development/styles_font_feature_settings.sql
+++ b/sql/2024/fonts/development/styles_font_feature_settings.sql
@@ -1,6 +1,6 @@
 -- Section: Development
 -- Question: Which features are used via font-feature-settings in CSS?
--- Normalization: Websites
+-- Normalization: Pages
 
 CREATE TEMPORARY FUNCTION FEATURES(json STRING)
 RETURNS ARRAY<STRING>
@@ -53,7 +53,7 @@ features AS (
     client,
     feature
 ),
-websites AS (
+pages AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -75,7 +75,7 @@ SELECT
 FROM
   features
 JOIN
-  websites USING (client)
+  pages USING (client)
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/development/styles_font_feature_settings.sql
+++ b/sql/2024/fonts/development/styles_font_feature_settings.sql
@@ -1,6 +1,6 @@
 -- Section: Development
 -- Question: Which features are used via font-feature-settings in CSS?
--- Normalization: Sites
+-- Normalization: Websites
 
 CREATE TEMPORARY FUNCTION FEATURES(json STRING)
 RETURNS ARRAY<STRING>
@@ -53,7 +53,7 @@ features AS (
     client,
     feature
 ),
-sites AS (
+websites AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -75,7 +75,7 @@ SELECT
 FROM
   features
 JOIN
-  sites USING (client)
+  websites USING (client)
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/development/styles_font_variable_settings_axis.sql
+++ b/sql/2024/fonts/development/styles_font_variable_settings_axis.sql
@@ -1,6 +1,6 @@
 -- Section: Development
 -- Question: Which axes are used in CSS?
--- Normalization: Sites (variable only)
+-- Normalization: Websites (variable only)
 
 CREATE TEMPORARY FUNCTION PROPERTIES(json STRING)
 RETURNS ARRAY<STRING>
@@ -29,7 +29,7 @@ try {
 ''';
 
 WITH
-sites AS (
+websites AS (
   SELECT
     client,
     page,
@@ -57,7 +57,7 @@ SELECT
   total,
   COUNT(0) / total AS proportion
 FROM
-  sites
+  websites
 GROUP BY
   client,
   axis,

--- a/sql/2024/fonts/development/styles_font_variable_settings_axis.sql
+++ b/sql/2024/fonts/development/styles_font_variable_settings_axis.sql
@@ -1,6 +1,6 @@
 -- Section: Development
 -- Question: Which axes are used in CSS?
--- Normalization: Websites (variable only)
+-- Normalization: Pages (variable only)
 
 CREATE TEMPORARY FUNCTION PROPERTIES(json STRING)
 RETURNS ARRAY<STRING>
@@ -29,7 +29,7 @@ try {
 ''';
 
 WITH
-websites AS (
+pages AS (
   SELECT
     client,
     page,
@@ -57,7 +57,7 @@ SELECT
   total,
   COUNT(0) / total AS proportion
 FROM
-  websites
+  pages
 GROUP BY
   client,
   axis,

--- a/sql/2024/fonts/development/styles_font_variant.sql
+++ b/sql/2024/fonts/development/styles_font_variant.sql
@@ -1,6 +1,6 @@
 -- Section: Development
 -- Question: Which features are used via font-variant in CSS?
--- Normalization: Sites
+-- Normalization: Websites
 
 CREATE TEMPORARY FUNCTION PROPERTIES(json STRING)
 RETURNS ARRAY<STRING>
@@ -46,7 +46,7 @@ properties AS (
     client,
     property
 ),
-sites AS (
+websites AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -68,7 +68,7 @@ SELECT
 FROM
   properties
 JOIN
-  sites USING (client)
+  websites USING (client)
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/development/styles_font_variant.sql
+++ b/sql/2024/fonts/development/styles_font_variant.sql
@@ -1,6 +1,6 @@
 -- Section: Development
 -- Question: Which features are used via font-variant in CSS?
--- Normalization: Websites
+-- Normalization: Pages
 
 CREATE TEMPORARY FUNCTION PROPERTIES(json STRING)
 RETURNS ARRAY<STRING>
@@ -46,7 +46,7 @@ properties AS (
     client,
     property
 ),
-websites AS (
+pages AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -68,7 +68,7 @@ SELECT
 FROM
   properties
 JOIN
-  websites USING (client)
+  pages USING (client)
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/development/styles_metric_override.sql
+++ b/sql/2024/fonts/development/styles_metric_override.sql
@@ -1,6 +1,6 @@
 -- Section: Development
 -- Question: How and how often is metrics override used in CSS?
--- Normalization: Websites
+-- Normalization: Pages
 
 CREATE TEMPORARY FUNCTION PROPERTIES(json STRING)
 RETURNS ARRAY<STRING>
@@ -38,7 +38,7 @@ properties AS (
     client,
     property
 ),
-websites AS (
+pages AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -60,7 +60,7 @@ SELECT
 FROM
   properties
 JOIN
-  websites USING (client)
+  pages USING (client)
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/development/styles_metric_override.sql
+++ b/sql/2024/fonts/development/styles_metric_override.sql
@@ -1,6 +1,6 @@
 -- Section: Development
 -- Question: How and how often is metrics override used in CSS?
--- Normalization: Sites
+-- Normalization: Websites
 
 CREATE TEMPORARY FUNCTION PROPERTIES(json STRING)
 RETURNS ARRAY<STRING>
@@ -38,7 +38,7 @@ properties AS (
     client,
     property
 ),
-sites AS (
+websites AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -60,7 +60,7 @@ SELECT
 FROM
   properties
 JOIN
-  sites USING (client)
+  websites USING (client)
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/development/styles_smoothing.sql
+++ b/sql/2024/fonts/development/styles_smoothing.sql
@@ -1,6 +1,6 @@
 -- Section: Development
 -- Question: How and how often is smoothing used in CSS?
--- Normalization: Websites
+-- Normalization: Pages
 
 CREATE TEMPORARY FUNCTION PROPERTIES(json STRING)
 RETURNS ARRAY<STRING>
@@ -40,7 +40,7 @@ properties AS (
   QUALIFY
     rank <= 10
 ),
-websites AS (
+pages AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -62,7 +62,7 @@ SELECT
 FROM
   properties
 JOIN
-  websites USING (client)
+  pages USING (client)
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/development/styles_smoothing.sql
+++ b/sql/2024/fonts/development/styles_smoothing.sql
@@ -1,6 +1,6 @@
 -- Section: Development
 -- Question: How and how often is smoothing used in CSS?
--- Normalization: Sites
+-- Normalization: Websites
 
 CREATE TEMPORARY FUNCTION PROPERTIES(json STRING)
 RETURNS ARRAY<STRING>
@@ -40,7 +40,7 @@ properties AS (
   QUALIFY
     rank <= 10
 ),
-sites AS (
+websites AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -62,7 +62,7 @@ SELECT
 FROM
   properties
 JOIN
-  sites USING (client)
+  websites USING (client)
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/development/styles_variable_animation.sql
+++ b/sql/2024/fonts/development/styles_variable_animation.sql
@@ -1,6 +1,6 @@
 -- Section: Development
 -- Question: How popular is variable-font animimation in CSS?
--- Normalization: Sites
+-- Normalization: Websites
 
 CREATE TEMPORARY FUNCTION HAS_ANIMATION(json STRING)
 RETURNS BOOLEAN
@@ -51,7 +51,7 @@ properties AS (
   GROUP BY
     client
 ),
-sites AS (
+websites AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -72,7 +72,7 @@ SELECT
 FROM
   properties
 JOIN
-  sites USING (client)
+  websites USING (client)
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/development/styles_variable_animation.sql
+++ b/sql/2024/fonts/development/styles_variable_animation.sql
@@ -12,14 +12,24 @@ try {
   let count = 0;
   walkRules($, rule => {
     rule.keyframes.forEach((frame) => {
-      count += countDeclarations(frame, { properties: 'font-variation-settings' });
+      count += countDeclarations(
+        frame,
+        {
+          properties: [
+            'font-stretch',
+            'font-style',
+            'font-variation-settings',
+            'font-weight'
+          ]
+        }
+      );
     });
   }, {
     type: 'keyframes'
   });
   count += countDeclarations($.stylesheet.rules, {
     properties: 'transition',
-    values: /font-variation-settings/
+    values: /font-stretch|font-style|font-variation-settings|font-weight/
   });
   return count > 0;
 } catch (e) {

--- a/sql/2024/fonts/development/styles_variable_animation.sql
+++ b/sql/2024/fonts/development/styles_variable_animation.sql
@@ -10,7 +10,7 @@ AS '''
 try {
   const $ = JSON.parse(json);
   let count = 0;
-  walkRules($, rule => {
+  walkRules($, (rule) => {
     rule.keyframes.forEach((frame) => {
       count += countDeclarations(
         frame,

--- a/sql/2024/fonts/development/styles_variable_animation.sql
+++ b/sql/2024/fonts/development/styles_variable_animation.sql
@@ -1,6 +1,6 @@
 -- Section: Development
 -- Question: How popular is variable-font animimation in CSS?
--- Normalization: Websites
+-- Normalization: Pages
 
 CREATE TEMPORARY FUNCTION HAS_ANIMATION(json STRING)
 RETURNS BOOLEAN
@@ -51,7 +51,7 @@ properties AS (
   GROUP BY
     client
 ),
-websites AS (
+pages AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -72,7 +72,7 @@ SELECT
 FROM
   properties
 JOIN
-  websites USING (client)
+  pages USING (client)
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/performance/fonts.sql
+++ b/sql/2024/fonts/performance/fonts.sql
@@ -1,6 +1,6 @@
 -- Section: Performance
 -- Question: What is the font usage over time?
--- Normalization: Sites
+-- Normalization: Websites
 
 SELECT
   date,

--- a/sql/2024/fonts/performance/fonts.sql
+++ b/sql/2024/fonts/performance/fonts.sql
@@ -1,6 +1,6 @@
 -- Section: Performance
 -- Question: What is the font usage over time?
--- Normalization: Websites
+-- Normalization: Pages
 
 SELECT
   date,

--- a/sql/2024/fonts/performance/fonts.sql
+++ b/sql/2024/fonts/performance/fonts.sql
@@ -1,0 +1,21 @@
+-- Section: Performance
+-- Question: What is the font usage over time?
+-- Normalization: Sites
+
+SELECT
+  date,
+  client,
+  COUNT(DISTINCT IF(type = 'font', page, NULL)) AS count,
+  COUNT(DISTINCT page) AS total,
+  COUNT(DISTINCT IF(type = 'font', page, NULL)) / COUNT(DISTINCT page) AS proportion
+FROM
+  `httparchive.all.requests`
+WHERE
+  date IS NOT NULL AND
+  is_root_page
+GROUP BY
+  client,
+  date
+ORDER BY
+  date,
+  client

--- a/sql/2024/fonts/performance/fonts_family_by_service.sql
+++ b/sql/2024/fonts/performance/fonts_family_by_service.sql
@@ -2,7 +2,7 @@
 -- Question: Which families are used broken down by service?
 -- Normalization: Links (parsed only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 links AS (

--- a/sql/2024/fonts/performance/fonts_family_by_service.sql
+++ b/sql/2024/fonts/performance/fonts_family_by_service.sql
@@ -16,7 +16,8 @@ links AS (
   WHERE
     date = '2024-07-01' AND
     type = 'font' AND
-    is_root_page
+    is_root_page AND
+    IS_PARSED(payload)
 )
 
 SELECT

--- a/sql/2024/fonts/performance/fonts_family_by_service.sql
+++ b/sql/2024/fonts/performance/fonts_family_by_service.sql
@@ -9,7 +9,8 @@ links AS (
   SELECT
     client,
     SERVICE(url) AS service,
-    FAMILY(payload) AS family
+    FAMILY(payload) AS family,
+    COUNT(0) OVER (PARTITION BY client) AS total
   FROM
     `httparchive.all.requests`
   WHERE
@@ -23,15 +24,16 @@ SELECT
   service,
   family,
   COUNT(0) AS count,
-  SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
-  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS proportion,
+  total,
+  COUNT(0) / total AS proportion,
   ROW_NUMBER() OVER (PARTITION BY client, service ORDER BY COUNT(0) DESC) AS rank
 FROM
   links
 GROUP BY
   client,
   service,
-  family
+  family,
+  total
 QUALIFY
   rank <= 10
 ORDER BY

--- a/sql/2024/fonts/performance/fonts_family_by_service.sql
+++ b/sql/2024/fonts/performance/fonts_family_by_service.sql
@@ -36,7 +36,7 @@ GROUP BY
   family,
   total
 QUALIFY
-  rank <= 10
+  rank <= 100
 ORDER BY
   client,
   service,

--- a/sql/2024/fonts/performance/fonts_family_by_service.sql
+++ b/sql/2024/fonts/performance/fonts_family_by_service.sql
@@ -14,8 +14,8 @@ links AS (
     `httparchive.all.requests`
   WHERE
     date = '2024-07-01' AND
-    is_root_page AND
-    type = 'font'
+    type = 'font' AND
+    is_root_page
 )
 
 SELECT

--- a/sql/2024/fonts/performance/fonts_family_by_service.sql
+++ b/sql/2024/fonts/performance/fonts_family_by_service.sql
@@ -1,6 +1,6 @@
 -- Section: Performance
 -- Question: Which families are used broken down by service?
--- Normalization: Links
+-- Normalization: Links (parsed only)
 
 -- INCLUDE ../common.sql
 

--- a/sql/2024/fonts/performance/fonts_family_by_service.sql
+++ b/sql/2024/fonts/performance/fonts_family_by_service.sql
@@ -1,11 +1,11 @@
 -- Section: Performance
 -- Question: Which families are used broken down by service?
--- Normalization: Links (parsed only)
+-- Normalization: Requests (parsed only)
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
-links AS (
+requests AS (
   SELECT
     client,
     SERVICE(url) AS service,
@@ -29,7 +29,7 @@ SELECT
   COUNT(0) / total AS proportion,
   ROW_NUMBER() OVER (PARTITION BY client, service ORDER BY COUNT(0) DESC) AS rank
 FROM
-  links
+  requests
 GROUP BY
   client,
   service,

--- a/sql/2024/fonts/performance/fonts_format_file.sql
+++ b/sql/2024/fonts/performance/fonts_format_file.sql
@@ -1,6 +1,6 @@
 -- Section: Performance
 -- Question: Which file formats are used?
--- Normalization: Links (primary) and fonts (secondary)
+-- Normalization: Links and fonts
 
 -- INCLUDE ../common.sql
 

--- a/sql/2024/fonts/performance/fonts_format_file.sql
+++ b/sql/2024/fonts/performance/fonts_format_file.sql
@@ -1,11 +1,11 @@
 -- Section: Performance
 -- Question: Which file formats are used?
--- Normalization: Links and fonts
+-- Normalization: Requests and fonts
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
-links AS (
+requests AS (
   SELECT
     client,
     url,
@@ -34,7 +34,7 @@ SELECT
   COUNT(DISTINCT url) / total_secondary AS proportion_secondary,
   ROW_NUMBER() OVER (PARTITION BY client ORDER BY COUNT(0) DESC) AS rank
 FROM
-  links
+  requests
 GROUP BY
   client,
   format,

--- a/sql/2024/fonts/performance/fonts_format_file.sql
+++ b/sql/2024/fonts/performance/fonts_format_file.sql
@@ -2,7 +2,7 @@
 -- Question: Which file formats are used?
 -- Normalization: Links and fonts
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 links AS (

--- a/sql/2024/fonts/performance/fonts_format_file_by_service.sql
+++ b/sql/2024/fonts/performance/fonts_format_file_by_service.sql
@@ -1,6 +1,6 @@
 -- Section: Performance
 -- Question: Which file formats are used broken down by service?
--- Normalization: Links (primary) and fonts (secondary)
+-- Normalization: Links and fonts
 
 -- INCLUDE ../common.sql
 

--- a/sql/2024/fonts/performance/fonts_format_file_by_service.sql
+++ b/sql/2024/fonts/performance/fonts_format_file_by_service.sql
@@ -13,7 +13,9 @@ links AS (
     FILE_FORMAT(
       JSON_EXTRACT_SCALAR(summary, '$.ext'),
       JSON_EXTRACT_SCALAR(summary, '$.mimeType')
-    ) AS format
+    ) AS format,
+    COUNT(0) OVER (PARTITION BY client) AS total,
+    COUNT(DISTINCT url) OVER (PARTITION BY client) AS total_secondary
   FROM
     `httparchive.all.requests`
   WHERE
@@ -28,17 +30,19 @@ SELECT
   format,
   COUNT(0) AS count,
   COUNT(DISTINCT url) AS count_secondary,
-  SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
-  SUM(COUNT(DISTINCT url)) OVER (PARTITION BY client) AS total_secondary,
-  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS proportion,
-  COUNT(DISTINCT url) / SUM(COUNT(DISTINCT url)) OVER (PARTITION BY client) AS proportion_secondary,
+  total,
+  total_secondary,
+  COUNT(0) / total AS proportion,
+  COUNT(DISTINCT url) / total_secondary AS proportion_secondary,
   ROW_NUMBER() OVER (PARTITION BY client, service ORDER BY COUNT(0) DESC) AS rank
 FROM
   links
 GROUP BY
   client,
   service,
-  format
+  format,
+  total,
+  total_secondary
 QUALIFY
   rank <= 10
 ORDER BY

--- a/sql/2024/fonts/performance/fonts_format_file_by_service.sql
+++ b/sql/2024/fonts/performance/fonts_format_file_by_service.sql
@@ -1,11 +1,11 @@
 -- Section: Performance
 -- Question: Which file formats are used broken down by service?
--- Normalization: Links and fonts
+-- Normalization: Requests and fonts
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
-links AS (
+requests AS (
   SELECT
     client,
     url,
@@ -36,7 +36,7 @@ SELECT
   COUNT(DISTINCT url) / total_secondary AS proportion_secondary,
   ROW_NUMBER() OVER (PARTITION BY client, service ORDER BY COUNT(0) DESC) AS rank
 FROM
-  links
+  requests
 GROUP BY
   client,
   service,

--- a/sql/2024/fonts/performance/fonts_format_file_by_service.sql
+++ b/sql/2024/fonts/performance/fonts_format_file_by_service.sql
@@ -2,7 +2,7 @@
 -- Question: Which file formats are used broken down by service?
 -- Normalization: Links and fonts
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 links AS (

--- a/sql/2024/fonts/performance/fonts_format_file_by_service.sql
+++ b/sql/2024/fonts/performance/fonts_format_file_by_service.sql
@@ -20,8 +20,8 @@ links AS (
     `httparchive.all.requests`
   WHERE
     date = '2024-07-01' AND
-    is_root_page AND
-    type = 'font'
+    type = 'font' AND
+    is_root_page
 )
 
 SELECT

--- a/sql/2024/fonts/performance/fonts_format_outline.sql
+++ b/sql/2024/fonts/performance/fonts_format_outline.sql
@@ -9,10 +9,7 @@ fonts AS (
     client,
     url,
     REGEXP_EXTRACT_ALL(
-      JSON_EXTRACT(
-        ANY_VALUE(payload),
-        '$._font_details.table_sizes'
-      ),
+      JSON_EXTRACT(ANY_VALUE(payload), '$._font_details.table_sizes'),
       '(?i)(CFF |glyf|SVG|CFF2)'
     ) AS formats,
     COUNT(0) OVER (PARTITION BY date, client) AS total

--- a/sql/2024/fonts/performance/fonts_format_outline.sql
+++ b/sql/2024/fonts/performance/fonts_format_outline.sql
@@ -8,8 +8,8 @@ fonts AS (
     date,
     client,
     url,
-    COUNT(0) OVER (PARTITION BY date, client) AS total,
-    JSON_EXTRACT(ANY_VALUE(payload), '$._font_details.table_sizes') AS payload
+    JSON_EXTRACT(ANY_VALUE(payload), '$._font_details.table_sizes') AS payload,
+    COUNT(0) OVER (PARTITION BY date, client) AS total
   FROM
     `httparchive.all.requests`
   WHERE

--- a/sql/2024/fonts/performance/fonts_format_outline.sql
+++ b/sql/2024/fonts/performance/fonts_format_outline.sql
@@ -14,8 +14,8 @@ fonts AS (
     `httparchive.all.requests`
   WHERE
     date IN ('2022-07-01', '2023-07-01', '2024-07-01') AND
-    is_root_page AND
-    type = 'font'
+    type = 'font' AND
+    is_root_page
   GROUP BY
     date,
     client,

--- a/sql/2024/fonts/performance/fonts_format_outline.sql
+++ b/sql/2024/fonts/performance/fonts_format_outline.sql
@@ -8,7 +8,13 @@ fonts AS (
     date,
     client,
     url,
-    JSON_EXTRACT(ANY_VALUE(payload), '$._font_details.table_sizes') AS payload,
+    REGEXP_EXTRACT_ALL(
+      JSON_EXTRACT(
+        ANY_VALUE(payload),
+        '$._font_details.table_sizes'
+      ),
+      '(?i)(CFF |glyf|SVG|CFF2)'
+    ) AS formats,
     COUNT(0) OVER (PARTITION BY date, client) AS total
   FROM
     `httparchive.all.requests`
@@ -31,7 +37,7 @@ SELECT
   COUNT(0) / total AS proportion
 FROM
   fonts,
-  UNNEST(REGEXP_EXTRACT_ALL(payload, '(?i)(CFF |glyf|SVG|CFF2)')) AS format
+  UNNEST(formats) AS format
 GROUP BY
   date,
   client,

--- a/sql/2024/fonts/performance/fonts_format_outline.sql
+++ b/sql/2024/fonts/performance/fonts_format_outline.sql
@@ -2,6 +2,8 @@
 -- Question: Which outline formats are used?
 -- Normalization: Fonts
 
+-- INCLUDE ../common.sql
+
 WITH
 fonts AS (
   SELECT
@@ -18,7 +20,8 @@ fonts AS (
   WHERE
     date IN ('2022-07-01', '2023-07-01', '2024-07-01') AND
     type = 'font' AND
-    is_root_page
+    is_root_page AND
+    IS_PARSED(payload)
   GROUP BY
     date,
     client,

--- a/sql/2024/fonts/performance/fonts_format_outline.sql
+++ b/sql/2024/fonts/performance/fonts_format_outline.sql
@@ -1,6 +1,6 @@
 -- Section: Performance
 -- Question: Which outline formats are used?
--- Normalization: Fonts
+-- Normalization: Fonts (parsed only)
 
 -- INCLUDE ../common.sql
 

--- a/sql/2024/fonts/performance/fonts_format_outline.sql
+++ b/sql/2024/fonts/performance/fonts_format_outline.sql
@@ -2,7 +2,7 @@
 -- Question: Which outline formats are used?
 -- Normalization: Fonts (parsed only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 fonts AS (

--- a/sql/2024/fonts/performance/fonts_service.sql
+++ b/sql/2024/fonts/performance/fonts_service.sql
@@ -2,7 +2,7 @@
 -- Question: Which services are popular?
 -- Normalization: Sites
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 sites AS (

--- a/sql/2024/fonts/performance/fonts_service.sql
+++ b/sql/2024/fonts/performance/fonts_service.sql
@@ -1,11 +1,11 @@
 -- Section: Performance
 -- Question: Which services are popular?
--- Normalization: Sites
+-- Normalization: Websites
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
-sites AS (
+websites AS (
   SELECT
     date,
     client,
@@ -30,7 +30,7 @@ SELECT
 FROM
   `httparchive.all.requests`
 INNER JOIN
-  sites USING (date, client)
+  websites USING (date, client)
 WHERE
   date IN ('2022-07-01', '2023-07-01', '2024-07-01') AND
   type = 'font' AND

--- a/sql/2024/fonts/performance/fonts_service.sql
+++ b/sql/2024/fonts/performance/fonts_service.sql
@@ -15,7 +15,7 @@ sites AS (
   WHERE
     date IN ('2022-07-01', '2023-07-01', '2024-07-01') AND
     is_root_page
-  GROUP By
+  GROUP BY
     date,
     client
 )

--- a/sql/2024/fonts/performance/fonts_service.sql
+++ b/sql/2024/fonts/performance/fonts_service.sql
@@ -1,11 +1,11 @@
 -- Section: Performance
 -- Question: Which services are popular?
--- Normalization: Websites
+-- Normalization: Pages
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
-websites AS (
+pages AS (
   SELECT
     date,
     client,
@@ -30,7 +30,7 @@ SELECT
 FROM
   `httparchive.all.requests`
 INNER JOIN
-  websites USING (date, client)
+  pages USING (date, client)
 WHERE
   date IN ('2022-07-01', '2023-07-01', '2024-07-01') AND
   type = 'font' AND

--- a/sql/2024/fonts/performance/fonts_service.sql
+++ b/sql/2024/fonts/performance/fonts_service.sql
@@ -33,8 +33,8 @@ INNER JOIN
   sites USING (date, client)
 WHERE
   date IN ('2022-07-01', '2023-07-01', '2024-07-01') AND
-  is_root_page AND
-  type = 'font'
+  type = 'font' AND
+  is_root_page
 GROUP BY
   date,
   client,

--- a/sql/2024/fonts/performance/fonts_services.sql
+++ b/sql/2024/fonts/performance/fonts_services.sql
@@ -15,8 +15,8 @@ services_1 AS (
     `httparchive.all.requests`
   WHERE
     date IN ('2022-07-01', '2023-07-01', '2024-07-01') AND
-    is_root_page AND
-    type = 'font'
+    type = 'font' AND
+    is_root_page
   GROUP BY
     date,
     client,

--- a/sql/2024/fonts/performance/fonts_services.sql
+++ b/sql/2024/fonts/performance/fonts_services.sql
@@ -1,6 +1,6 @@
 -- Section: Performance
 -- Question: Which service combinations are popular?
--- Normalization: Websites
+-- Normalization: Pages
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
@@ -35,7 +35,7 @@ services_2 AS (
     client,
     services
 ),
-websites AS (
+pages AS (
   SELECT
     date,
     client,
@@ -60,7 +60,7 @@ SELECT
 FROM
   services_2
 JOIN
-  websites USING (date, client)
+  pages USING (date, client)
 ORDER BY
   date,
   client,

--- a/sql/2024/fonts/performance/fonts_services.sql
+++ b/sql/2024/fonts/performance/fonts_services.sql
@@ -1,6 +1,6 @@
 -- Section: Performance
 -- Question: Which service combinations are popular?
--- Normalization: Sites
+-- Normalization: Websites
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
@@ -35,7 +35,7 @@ services_2 AS (
     client,
     services
 ),
-sites AS (
+websites AS (
   SELECT
     date,
     client,
@@ -60,7 +60,7 @@ SELECT
 FROM
   services_2
 JOIN
-  sites USING (date, client)
+  websites USING (date, client)
 ORDER BY
   date,
   client,

--- a/sql/2024/fonts/performance/fonts_services.sql
+++ b/sql/2024/fonts/performance/fonts_services.sql
@@ -2,7 +2,7 @@
 -- Question: Which service combinations are popular?
 -- Normalization: Sites
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 services_1 AS (

--- a/sql/2024/fonts/performance/fonts_size.sql
+++ b/sql/2024/fonts/performance/fonts_size.sql
@@ -12,8 +12,8 @@ fonts AS (
     `httparchive.all.requests`
   WHERE
     date = '2024-07-01' AND
-    is_root_page AND
-    type = 'font'
+    type = 'font' AND
+    is_root_page
   GROUP BY
     client,
     url

--- a/sql/2024/fonts/performance/fonts_size.sql
+++ b/sql/2024/fonts/performance/fonts_size.sql
@@ -2,7 +2,7 @@
 -- Question: What is the distribution of the file size?
 -- Normalization: Fonts (parsed only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 fonts AS (

--- a/sql/2024/fonts/performance/fonts_size.sql
+++ b/sql/2024/fonts/performance/fonts_size.sql
@@ -2,6 +2,8 @@
 -- Question: What is the distribution of the file size?
 -- Normalization: Fonts
 
+-- INCLUDE ../common.sql
+
 WITH
 fonts AS (
   SELECT
@@ -13,7 +15,8 @@ fonts AS (
   WHERE
     date = '2024-07-01' AND
     type = 'font' AND
-    is_root_page
+    is_root_page AND
+    IS_PARSED(payload)
   GROUP BY
     client,
     url

--- a/sql/2024/fonts/performance/fonts_size.sql
+++ b/sql/2024/fonts/performance/fonts_size.sql
@@ -1,6 +1,6 @@
 -- Section: Performance
 -- Question: What is the distribution of the file size?
--- Normalization: Fonts
+-- Normalization: Fonts (parsed only)
 
 -- INCLUDE ../common.sql
 

--- a/sql/2024/fonts/performance/fonts_size_by_country.sql
+++ b/sql/2024/fonts/performance/fonts_size_by_country.sql
@@ -29,7 +29,8 @@ links AS (
   WHERE
     date = '2024-07-01' AND
     type = 'font' AND
-    is_root_page
+    is_root_page AND
+    IS_PARSED(payload)
 )
 
 SELECT

--- a/sql/2024/fonts/performance/fonts_size_by_country.sql
+++ b/sql/2024/fonts/performance/fonts_size_by_country.sql
@@ -28,8 +28,8 @@ links AS (
     `httparchive.all.requests`
   WHERE
     date = '2024-07-01' AND
-    is_root_page AND
-    type = 'font'
+    type = 'font' AND
+    is_root_page
 )
 
 SELECT

--- a/sql/2024/fonts/performance/fonts_size_by_country.sql
+++ b/sql/2024/fonts/performance/fonts_size_by_country.sql
@@ -1,6 +1,6 @@
 -- Section: Performance
 -- Question: What is the distribution of the file size broken down by country?
--- Normalization: Links
+-- Normalization: Links (parsed only)
 
 -- INCLUDE ../common.sql
 

--- a/sql/2024/fonts/performance/fonts_size_by_country.sql
+++ b/sql/2024/fonts/performance/fonts_size_by_country.sql
@@ -2,7 +2,7 @@
 -- Question: What is the distribution of the file size broken down by country?
 -- Normalization: Links (parsed only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 countries AS (

--- a/sql/2024/fonts/performance/fonts_size_by_country.sql
+++ b/sql/2024/fonts/performance/fonts_size_by_country.sql
@@ -1,6 +1,6 @@
 -- Section: Performance
 -- Question: What is the distribution of the file size broken down by country?
--- Normalization: Links (parsed only)
+-- Normalization: Requests (parsed only)
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
@@ -19,7 +19,7 @@ countries AS (
     domain,
     country
 ),
-links AS (
+requests AS (
   SELECT
     client,
     NET.HOST(page) AS domain,
@@ -39,7 +39,7 @@ SELECT
   COUNT(0) AS count,
   ROUND(APPROX_QUANTILES(size, 1000)[OFFSET(500)]) AS size
 FROM
-  links
+  requests
 INNER JOIN
   countries USING (client, domain)
 GROUP BY

--- a/sql/2024/fonts/performance/fonts_size_by_format.sql
+++ b/sql/2024/fonts/performance/fonts_size_by_format.sql
@@ -2,7 +2,7 @@
 -- Question: What is the distribution of the file size broken down by format?
 -- Normalization: Fonts (parsed only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 fonts AS (

--- a/sql/2024/fonts/performance/fonts_size_by_format.sql
+++ b/sql/2024/fonts/performance/fonts_size_by_format.sql
@@ -1,6 +1,6 @@
 -- Section: Performance
 -- Question: What is the distribution of the file size broken down by format?
--- Normalization: Fonts
+-- Normalization: Fonts (parsed only)
 
 -- INCLUDE ../common.sql
 

--- a/sql/2024/fonts/performance/fonts_size_by_format.sql
+++ b/sql/2024/fonts/performance/fonts_size_by_format.sql
@@ -18,8 +18,8 @@ fonts AS (
     `httparchive.all.requests`
   WHERE
     date = '2024-07-01' AND
-    is_root_page AND
-    type = 'font'
+    type = 'font' AND
+    is_root_page
   GROUP BY
     client,
     url

--- a/sql/2024/fonts/performance/fonts_size_by_format.sql
+++ b/sql/2024/fonts/performance/fonts_size_by_format.sql
@@ -19,7 +19,8 @@ fonts AS (
   WHERE
     date = '2024-07-01' AND
     type = 'font' AND
-    is_root_page
+    is_root_page AND
+    IS_PARSED(payload)
   GROUP BY
     client,
     url

--- a/sql/2024/fonts/performance/fonts_size_by_service.sql
+++ b/sql/2024/fonts/performance/fonts_size_by_service.sql
@@ -23,8 +23,7 @@ fonts AS (
     is_root_page
   GROUP BY
     client,
-    url,
-    service
+    url
 ),
 formats AS (
   SELECT

--- a/sql/2024/fonts/performance/fonts_size_by_service.sql
+++ b/sql/2024/fonts/performance/fonts_size_by_service.sql
@@ -1,6 +1,6 @@
 -- Section: Performance
 -- Question: What is the distribution of the file size broken down by service?
--- Normalization: Fonts
+-- Normalization: Fonts (parsed only)
 
 -- INCLUDE ../common.sql
 

--- a/sql/2024/fonts/performance/fonts_size_by_service.sql
+++ b/sql/2024/fonts/performance/fonts_size_by_service.sql
@@ -2,7 +2,7 @@
 -- Question: What is the distribution of the file size broken down by service?
 -- Normalization: Fonts (parsed only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 WITH
 fonts AS (

--- a/sql/2024/fonts/performance/fonts_size_by_service.sql
+++ b/sql/2024/fonts/performance/fonts_size_by_service.sql
@@ -19,8 +19,8 @@ fonts AS (
     `httparchive.all.requests`
   WHERE
     date = '2024-07-01' AND
-    is_root_page AND
-    type = 'font'
+    type = 'font' AND
+    is_root_page
   GROUP BY
     client,
     url,

--- a/sql/2024/fonts/performance/fonts_size_by_service.sql
+++ b/sql/2024/fonts/performance/fonts_size_by_service.sql
@@ -20,7 +20,8 @@ fonts AS (
   WHERE
     date = '2024-07-01' AND
     type = 'font' AND
-    is_root_page
+    is_root_page AND
+    IS_PARSED(payload)
   GROUP BY
     client,
     url

--- a/sql/2024/fonts/performance/fonts_size_by_table.sql
+++ b/sql/2024/fonts/performance/fonts_size_by_table.sql
@@ -2,6 +2,8 @@
 -- Question: What is the distribution of the file size broken down by table?
 -- Normalization: Fonts
 
+-- INCLUDE ../common.sql
+
 CREATE TEMPORARY FUNCTION TABLES(json STRING)
 RETURNS ARRAY<STRUCT<name STRING, size INT64>>
 LANGUAGE js AS '''
@@ -24,7 +26,8 @@ fonts AS (
   WHERE
     date = '2024-07-01' AND
     type = 'font' AND
-    is_root_page
+    is_root_page AND
+    IS_PARSED(payload)
   GROUP BY
     client,
     url

--- a/sql/2024/fonts/performance/fonts_size_by_table.sql
+++ b/sql/2024/fonts/performance/fonts_size_by_table.sql
@@ -3,11 +3,11 @@
 -- Normalization: Fonts
 
 CREATE TEMPORARY FUNCTION TABLES(json STRING)
-RETURNS ARRAY<STRUCT<name STRING, value INT64>>
+RETURNS ARRAY<STRUCT<name STRING, size INT64>>
 LANGUAGE js AS '''
 try {
   const $ = JSON.parse(json);
-  return Object.entries($).map(([name, value]) => ({ name, value }));
+  return Object.entries($).map(([name, size]) => ({ name, size }));
 } catch (e) {
   return [];
 }
@@ -33,7 +33,7 @@ tables AS (
   SELECT
     client,
     table.name AS table,
-    table.value AS size
+    table.size
   FROM
     fonts,
     UNNEST(TABLES(payload)) AS table

--- a/sql/2024/fonts/performance/fonts_size_by_table.sql
+++ b/sql/2024/fonts/performance/fonts_size_by_table.sql
@@ -23,8 +23,8 @@ fonts AS (
     `httparchive.all.requests`
   WHERE
     date = '2024-07-01' AND
-    is_root_page AND
-    type = 'font'
+    type = 'font' AND
+    is_root_page
   GROUP BY
     client,
     url

--- a/sql/2024/fonts/performance/fonts_size_by_table.sql
+++ b/sql/2024/fonts/performance/fonts_size_by_table.sql
@@ -1,6 +1,6 @@
 -- Section: Performance
 -- Question: What is the distribution of the file size broken down by table?
--- Normalization: Fonts
+-- Normalization: Fonts (parsed only)
 
 -- INCLUDE ../common.sql
 

--- a/sql/2024/fonts/performance/fonts_size_by_table.sql
+++ b/sql/2024/fonts/performance/fonts_size_by_table.sql
@@ -2,7 +2,7 @@
 -- Question: What is the distribution of the file size broken down by table?
 -- Normalization: Fonts (parsed only)
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 CREATE TEMPORARY FUNCTION TABLES(json STRING)
 RETURNS ARRAY<STRUCT<name STRING, size INT64>>

--- a/sql/2024/fonts/performance/fonts_size_by_table.sql
+++ b/sql/2024/fonts/performance/fonts_size_by_table.sql
@@ -18,7 +18,7 @@ fonts AS (
   SELECT
     client,
     url,
-    JSON_EXTRACT(ANY_VALUE(payload), '$._font_details.table_sizes') AS payload
+    TABLES(JSON_EXTRACT(ANY_VALUE(payload), '$._font_details.table_sizes')) AS tables
   FROM
     `httparchive.all.requests`
   WHERE
@@ -28,25 +28,17 @@ fonts AS (
   GROUP BY
     client,
     url
-),
-tables AS (
-  SELECT
-    client,
-    table.name AS table,
-    table.size
-  FROM
-    fonts,
-    UNNEST(TABLES(payload)) AS table
 )
 
 SELECT
   client,
-  table,
+  table.name AS table,
   percentile,
   COUNT(0) AS count,
   ROUND(APPROX_QUANTILES(size, 1000)[OFFSET(percentile * 10)]) AS size
 FROM
-  tables,
+  fonts,
+  UNNEST(tables) AS table,
   UNNEST([10, 25, 50, 75, 90, 99]) AS percentile
 GROUP BY
   client,

--- a/sql/2024/fonts/performance/pages_link_relationship.sql
+++ b/sql/2024/fonts/performance/pages_link_relationship.sql
@@ -1,6 +1,6 @@
 -- Section: Performance
 -- Question: What is the usage of link relationship in HTML?
--- Normalization: Websites
+-- Normalization: Pages
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
@@ -62,7 +62,7 @@ hints AS (
     client,
     hint
 ),
-websites AS (
+pages AS (
   SELECT
     date,
     client,
@@ -87,7 +87,7 @@ SELECT
 FROM
   hints
 LEFT JOIN
-  websites USING (date, client)
+  pages USING (date, client)
 ORDER BY
   date,
   client,

--- a/sql/2024/fonts/performance/pages_link_relationship.sql
+++ b/sql/2024/fonts/performance/pages_link_relationship.sql
@@ -34,6 +34,7 @@ try {
 WITH
 hints AS (
   SELECT
+    pages.date,
     pages.client,
     hint.name AS hint,
     COUNT(DISTINCT pages.page) AS count
@@ -43,13 +44,13 @@ hints AS (
   LEFT JOIN
     `httparchive.all.requests` AS requests
   ON
-    requests.date = '2024-07-01' AND
+    requests.date IN ('2022-06-01', '2022-07-01', '2023-07-01', '2024-07-01') AND
     requests.type = 'font' AND
     requests.is_root_page AND
     pages.page = requests.page AND
     hint.url = requests.url
   WHERE
-    pages.date = '2024-07-01' AND
+    pages.date IN ('2022-06-01', '2022-07-01', '2023-07-01', '2024-07-01') AND
     pages.is_root_page AND
     (
       requests.url IS NOT NULL OR
@@ -57,23 +58,27 @@ hints AS (
       SERVICE(hint.url) != 'self-hosted'
     )
   GROUP BY
+    date,
     client,
     hint
 ),
 sites AS (
   SELECT
+    date,
     client,
     COUNT(DISTINCT page) AS total
   FROM
     `httparchive.all.pages`
   WHERE
-    date = '2024-07-01' AND
+    date IN ('2022-06-01', '2022-07-01', '2023-07-01', '2024-07-01') AND
     is_root_page
   GROUP BY
+    date,
     client
 )
 
 SELECT
+  date,
   client,
   hint,
   count,
@@ -82,7 +87,8 @@ SELECT
 FROM
   hints
 LEFT JOIN
-  sites USING (client)
+  sites USING (date, client)
 ORDER BY
+  date,
   client,
   proportion DESC

--- a/sql/2024/fonts/performance/pages_link_relationship.sql
+++ b/sql/2024/fonts/performance/pages_link_relationship.sql
@@ -2,7 +2,7 @@
 -- Question: What is the usage of link relationship in HTML?
 -- Normalization: Sites
 
--- INCLUDE ../common.sql
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
 CREATE TEMPORARY FUNCTION HINTS(json STRING)
 RETURNS ARRAY<STRUCT<name STRING, type STRING, url STRING>>

--- a/sql/2024/fonts/performance/pages_link_relationship.sql
+++ b/sql/2024/fonts/performance/pages_link_relationship.sql
@@ -1,6 +1,6 @@
 -- Section: Performance
 -- Question: What is the usage of link relationship in HTML?
--- Normalization: Sites
+-- Normalization: Websites
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
@@ -62,7 +62,7 @@ hints AS (
     client,
     hint
 ),
-sites AS (
+websites AS (
   SELECT
     date,
     client,
@@ -87,7 +87,7 @@ SELECT
 FROM
   hints
 LEFT JOIN
-  sites USING (date, client)
+  websites USING (date, client)
 ORDER BY
   date,
   client,

--- a/sql/2024/fonts/performance/scripts_font_face.sql
+++ b/sql/2024/fonts/performance/scripts_font_face.sql
@@ -12,8 +12,8 @@ scripts AS (
     `httparchive.all.requests`
   WHERE
     date IN ('2022-07-01', '2023-07-01', '2024-07-01') AND
-    is_root_page AND
     type = 'script' AND
+    is_root_page AND
     REGEXP_CONTAINS(response_body, r'new FontFace\(')
   GROUP BY
     date,

--- a/sql/2024/fonts/performance/scripts_font_face.sql
+++ b/sql/2024/fonts/performance/scripts_font_face.sql
@@ -1,6 +1,6 @@
 -- Section: Performance
 -- Question: What is the usage of FontFace in JavaScript?
--- Normalization: Sites
+-- Normalization: Websites
 
 WITH
 scripts AS (
@@ -19,7 +19,7 @@ scripts AS (
     date,
     client
 ),
-sites AS (
+websites AS (
   SELECT
     date,
     client,
@@ -43,7 +43,7 @@ SELECT
 FROM
   scripts
 JOIN
-  sites USING (date, client)
+  websites USING (date, client)
 ORDER BY
   date,
   client

--- a/sql/2024/fonts/performance/scripts_font_face.sql
+++ b/sql/2024/fonts/performance/scripts_font_face.sql
@@ -1,6 +1,6 @@
 -- Section: Performance
 -- Question: What is the usage of FontFace in JavaScript?
--- Normalization: Websites
+-- Normalization: Pages
 
 WITH
 scripts AS (
@@ -19,7 +19,7 @@ scripts AS (
     date,
     client
 ),
-websites AS (
+pages AS (
   SELECT
     date,
     client,
@@ -43,7 +43,7 @@ SELECT
 FROM
   scripts
 JOIN
-  websites USING (date, client)
+  pages USING (date, client)
 ORDER BY
   date,
   client

--- a/sql/2024/fonts/performance/scripts_font_face.sql
+++ b/sql/2024/fonts/performance/scripts_font_face.sql
@@ -11,7 +11,7 @@ scripts AS (
   FROM
     `httparchive.all.requests`
   WHERE
-    date IN ('2022-07-01', '2023-07-01', '2024-07-01') AND
+    date IN ('2022-06-01', '2022-07-01', '2023-07-01', '2024-07-01') AND
     type = 'script' AND
     is_root_page AND
     REGEXP_CONTAINS(response_body, r'new FontFace\(')
@@ -27,7 +27,7 @@ sites AS (
   FROM
     `httparchive.all.requests`
   WHERE
-    date IN ('2022-07-01', '2023-07-01', '2024-07-01') AND
+    date IN ('2022-06-01', '2022-07-01', '2023-07-01', '2024-07-01') AND
     is_root_page
   GROUP BY
     client,

--- a/sql/2024/fonts/performance/styles_font_display.sql
+++ b/sql/2024/fonts/performance/styles_font_display.sql
@@ -1,6 +1,6 @@
 -- Section: Performance
 -- Question: What is the usage of font-display in CSS?
--- Normalization: Websites
+-- Normalization: Pages
 
 CREATE TEMPORARY FUNCTION PROPERTIES(json STRING)
 RETURNS ARRAY<STRING>
@@ -40,7 +40,7 @@ properties AS (
     client,
     property
 ),
-websites AS (
+pages AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -62,7 +62,7 @@ SELECT
 FROM
   properties
 JOIN
-  websites USING (client)
+  pages USING (client)
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/performance/styles_font_display.sql
+++ b/sql/2024/fonts/performance/styles_font_display.sql
@@ -1,6 +1,6 @@
 -- Section: Performance
 -- Question: What is the usage of font-display in CSS?
--- Normalization: Sites
+-- Normalization: Websites
 
 CREATE TEMPORARY FUNCTION PROPERTIES(json STRING)
 RETURNS ARRAY<STRING>
@@ -40,7 +40,7 @@ properties AS (
     client,
     property
 ),
-sites AS (
+websites AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -62,7 +62,7 @@ SELECT
 FROM
   properties
 JOIN
-  sites USING (client)
+  websites USING (client)
 ORDER BY
   client,
   proportion DESC

--- a/sql/2024/fonts/performance/styles_font_display.sql
+++ b/sql/2024/fonts/performance/styles_font_display.sql
@@ -29,8 +29,7 @@ properties AS (
   SELECT
     client,
     NULLIF(property, 'other') AS property,
-    COUNT(DISTINCT page) AS count,
-    ROW_NUMBER() OVER (PARTITION BY client ORDER BY COUNT(DISTINCT page) DESC) AS rank
+    COUNT(DISTINCT page) AS count
   FROM
     `httparchive.all.parsed_css`,
     UNNEST(PROPERTIES(css)) AS property
@@ -40,8 +39,6 @@ properties AS (
   GROUP BY
     client,
     property
-  QUALIFY
-    rank <= 10
 ),
 sites AS (
   SELECT

--- a/sql/2024/fonts/performance/styles_font_display.sql
+++ b/sql/2024/fonts/performance/styles_font_display.sql
@@ -8,10 +8,12 @@ LANGUAGE js
 OPTIONS(library = "gs://httparchive/lib/css-utils.js")
 AS '''
 try {
+  const values = ['auto', 'block', 'fallback', 'optional', 'swap'];
   const $ = JSON.parse(json);
   const result = [];
   walkDeclarations($, (declaration) => {
-    result.push(declaration.value.replaceAll(/['"]/g, ''));
+    const value = declaration.value.toLowerCase();
+    result.push(values.find((other) => value.includes(other)) || 'other');
   }, {
     properties: 'font-display',
     rules: (rule) => rule.type.toLowerCase() === 'font-face'
@@ -26,7 +28,7 @@ WITH
 properties AS (
   SELECT
     client,
-    property,
+    NULLIF(property, 'other') AS property,
     COUNT(DISTINCT page) AS count,
     ROW_NUMBER() OVER (PARTITION BY client ORDER BY COUNT(DISTINCT page) DESC) AS rank
   FROM

--- a/sql/2024/fonts/performance/styles_font_display_by_family.sql
+++ b/sql/2024/fonts/performance/styles_font_display_by_family.sql
@@ -1,0 +1,94 @@
+-- Section: Performance
+-- Question: What is the usage of font-display in CSS broken down by family?
+-- Normalization: Sites
+
+-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
+
+CREATE TEMPORARY FUNCTION PROPERTIES(json STRING)
+RETURNS ARRAY<STRUCT<family STRING, display STRING>>
+LANGUAGE js
+OPTIONS (library = ["gs://httparchive/lib/css-font-parser.js", "gs://httparchive/lib/css-utils.js"])
+AS '''
+try {
+  const values = ['auto', 'block', 'fallback', 'optional', 'swap'];
+  const $ = JSON.parse(json);
+  const result = [];
+  walkRules($, (rule) => {
+    let found = false;
+    let family = undefined;
+    let display = undefined;
+    for (const declaration of rule.declarations) {
+      const name = declaration.property.toLowerCase();
+      if (name === 'font-family') {
+        family = parseFontFamilyProperty(declaration.value)[0];
+      }
+      if (name === 'font-display') {
+        found = true;
+        const value = declaration.value.toLowerCase();
+        display = values.find((other) => value.includes(other));
+      }
+      if (family && display) {
+        break;
+      }
+    }
+    if (found) {
+      result.push({ family, display });
+    }
+  }, {
+    type: 'font-face'
+  });
+  return result;
+} catch (e) {
+  return [];
+}
+''';
+
+WITH
+properties AS (
+  SELECT
+    client,
+    display AS property,
+    FAMILY_INNER(family) AS family,
+    COUNT(DISTINCT page) AS count,
+    ROW_NUMBER() OVER (PARTITION BY client, display ORDER BY COUNT(DISTINCT page) DESC) AS rank
+  FROM
+    `httparchive.all.parsed_css`,
+    UNNEST(PROPERTIES(css)) AS property
+  WHERE
+    date = '2024-07-01' AND
+    is_root_page
+  GROUP BY
+    client,
+    property,
+    family
+  QUALIFY
+    rank <= 10
+),
+sites AS (
+  SELECT
+    client,
+    COUNT(DISTINCT page) AS total
+  FROM
+    `httparchive.all.requests`
+  WHERE
+    date = '2024-07-01' AND
+    is_root_page
+  GROUP BY
+    client
+)
+
+SELECT
+  client,
+  property,
+  family,
+  count,
+  total,
+  count / total AS proportion
+FROM
+  properties
+JOIN
+  sites USING (client)
+ORDER BY
+  client,
+  property,
+  proportion DESC

--- a/sql/2024/fonts/performance/styles_font_display_by_family.sql
+++ b/sql/2024/fonts/performance/styles_font_display_by_family.sql
@@ -1,6 +1,6 @@
 -- Section: Performance
 -- Question: What is the usage of font-display in CSS broken down by family?
--- Normalization: Sites
+-- Normalization: Websites
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
@@ -64,7 +64,7 @@ properties AS (
   QUALIFY
     rank <= 10
 ),
-sites AS (
+websites AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -87,7 +87,7 @@ SELECT
 FROM
   properties
 JOIN
-  sites USING (client)
+  websites USING (client)
 ORDER BY
   client,
   property,

--- a/sql/2024/fonts/performance/styles_font_display_by_family.sql
+++ b/sql/2024/fonts/performance/styles_font_display_by_family.sql
@@ -1,6 +1,6 @@
 -- Section: Performance
 -- Question: What is the usage of font-display in CSS broken down by family?
--- Normalization: Websites
+-- Normalization: Pages
 
 -- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
 
@@ -64,7 +64,7 @@ properties AS (
   QUALIFY
     rank <= 10
 ),
-websites AS (
+pages AS (
   SELECT
     client,
     COUNT(DISTINCT page) AS total
@@ -87,7 +87,7 @@ SELECT
 FROM
   properties
 JOIN
-  websites USING (client)
+  pages USING (client)
 ORDER BY
   client,
   property,


### PR DESCRIPTION
In this PR, the queries from 2022 are copied to 2024 and are updated as follows:

## Changes

* The data source is exclusively `httparchive.all`.
* All queries are annotated with the question they answer.
* All queries follow the same structure and style.
* Queries are split by the section in the chapter where they are used.
* Repeated parts are extracted into common functions.

## Structure

The queries are split by the section where they are used:

* `design/` is about foundries and families,
* `development/` is about tools and technologies, and
* `performance/` is about hosting and serving.

Each file name starts with one of the following prefixes indicating the primary subject of the corresponding analysis:

* `fonts_` is about font files,
* `pages_` is about HTML pages,
* `scripts_` is about JavaScript scripts, and
* `styles_` is about CSS style sheets.

The prefix is followed by the property studied given in singular, potentially extended one or several suffixes narrowing down the scope, as in `fonts_size_by_table.sql` and `pages_link_relation.sql`.

## Contents

Each query starts with a preamble indicating the section, question, and normalization type:

```sql
-- Section: Performance
-- Question: What is the distribution of the file size broken down by table?
-- Normalization: Websites
```

Many queries rely on temporary functions for convenience and clarity. The functions appear in several queries are extracted into a common file: `common.sql`. Whenever any of the functions defined in `common.sql` is used by a query, the query has the following line at the top:

```sql
-- INCLUDE https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2024/fonts/common.sql
```

It signalizes that, prior to executing the query, `common.sql` has to be inlined.
