### PR TITLE
Privacy - fingerprinting_most_common_apis: improve resilience to malformed JSON

### DIFF
--- a/sql/2024/privacy/fingerprinting_most_common_apis.sql
+++ b/sql/2024/privacy/fingerprinting_most_common_apis.sql
@@ -1,9 +1,19 @@
 CREATE TEMP FUNCTION getFingerprintingTypes(input STRING)
 RETURNS ARRAY<STRING>
-LANGUAGE js AS """return Object.keys(JSON.parse(input).privacy?.fingerprinting?.counts || {})""";
+LANGUAGE js AS """
+if (input) {
+  try {
+    return Object.keys(JSON.parse(input))
+  } catch (e) {
+    return []
+  }
+} else {
+  return []
+}
+""";
 
 WITH pages AS (
-  SELECT client, page, fingerprinting_type FROM `httparchive.all.pages`, -- TABLESAMPLE SYSTEM (0.001 PERCENT)
-    unnest(getFingerprintingTypes(custom_metrics)) AS fingerprinting_type WHERE date = '2024-06-01'
+  SELECT client, page, fingerprinting_type FROM `httparchive.all.pages`,
+    unnest(getFingerprintingTypes(JSON_EXTRACT(custom_metrics, '$.privacy.fingerprinting.counts'))) AS fingerprinting_type WHERE date = '2024-06-01'
 )
 SELECT client, fingerprinting_type, count(DISTINCT page) AS page_count FROM pages GROUP BY client, fingerprinting_type ORDER BY page_count DESC


### PR DESCRIPTION
@max-ostapenko 

I believe this error: `SyntaxError: Unexpected token 'N', ..."","words":NaN,"chara"... is not valid JSON at undefined line 1, columns 595052-595053` is coming from this metric: https://github.com/HTTPArchive/custom-metrics/blob/main/dist/wpt_bodies.js#L520. JSON.parse doesn't handle NaN at all apparently, but I think the BigQuery JSON_* functions do (since they're used in many other places and we haven't seen this issue until now).

I looked for pages with NaN's on a 0.25% sample using the following query, and didn't find any, so I don't think this issue is widespread:
```
CREATE TEMP FUNCTION isValid(input STRING)
RETURNS BOOLEAN
LANGUAGE js AS """
  try {
    JSON.parse(input)
    return true
  } catch (e) {
    return false
  }
""";

select count(distinct page) as page_count, isValid(custom_metrics) as is_custom_metrics_valid_json FROM `httparchive.all.pages` TABLESAMPLE SYSTEM (0.25 PERCENT) WHERE date = '2024-06-01' group by is_custom_metrics_valid_json
```