### PR TITLE
python 3.12

### DIFF
--- a/.github/workflows/code-static-analysis.yml
+++ b/.github/workflows/code-static-analysis.yml
@@ -33,11 +33,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         if: ${{ matrix.language == 'python' }}
         uses: actions/setup-python@v5.1.1
         with:
-          python-version: '3.8'
+          python-version: '3.11'
       - name: Install dependencies
         if: ${{ matrix.language == 'python' }}
         run: |

--- a/.github/workflows/code-static-analysis.yml
+++ b/.github/workflows/code-static-analysis.yml
@@ -33,11 +33,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         if: ${{ matrix.language == 'python' }}
         uses: actions/setup-python@v5.1.1
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install dependencies
         if: ${{ matrix.language == 'python' }}
         run: |

--- a/.github/workflows/lintsql.yml
+++ b/.github/workflows/lintsql.yml
@@ -18,10 +18,10 @@ jobs:
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5.1.1
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Lint SQL code
         if: |
             github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/lintsql.yml
+++ b/.github/workflows/lintsql.yml
@@ -18,10 +18,10 @@ jobs:
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5.1.1
         with:
-          python-version: '3.8'
+          python-version: '3.11'
       - name: Lint SQL code
         if: |
             github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/predeploy.yml
+++ b/.github/workflows/predeploy.yml
@@ -36,10 +36,10 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20'
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5.1.1
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Install Asian Fonts
       if: ${{ github.event.inputs.ebooks == 'true' }}
       run: |

--- a/.github/workflows/predeploy.yml
+++ b/.github/workflows/predeploy.yml
@@ -36,10 +36,10 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20'
-    - name: Set up Python 3.8
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5.1.1
       with:
-        python-version: '3.8'
+        python-version: '3.11'
     - name: Install Asian Fonts
       if: ${{ github.event.inputs.ebooks == 'true' }}
       run: |

--- a/.github/workflows/test_website.yml
+++ b/.github/workflows/test_website.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20'
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5.1.1
       with:
         python-version: '3.11'

--- a/.github/workflows/test_website.yml
+++ b/.github/workflows/test_website.yml
@@ -29,10 +29,10 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20'
-    - name: Set up Python 3.8
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5.1.1
       with:
-        python-version: '3.8'
+        python-version: '3.11'
     - name: Run the website
       run: ./src/tools/scripts/run_and_test_website.sh
     - name: Remove node modules to avoid linting errors

--- a/.github/workflows/test_website.yml
+++ b/.github/workflows/test_website.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Set up Python 3.12
       uses: actions/setup-python@v5.1.1
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Run the website
       run: ./src/tools/scripts/run_and_test_website.sh
     - name: Remove node modules to avoid linting errors

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-ARG     PYVER=3.11
+ARG     PYVER=3.12
 FROM    python:${PYVER} as base
 
 # Enable unbuffered STDOUT logging

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,10 +1,10 @@
-ARG     PYVER=3.8
+ARG     PYVER=3.11
 FROM    python:${PYVER} as base
 
 # Enable unbuffered STDOUT logging
 ENV     PYTHONUNBUFFERED=1
 
-ARG     NODEVER=16.x
+ARG     NODEVER=20.x
 RUN     curl -sL https://deb.nodesource.com/setup_${NODEVER} | bash -
 
 RUN     apt update && apt install -y nodejs && rm -rf /var/lib/apt/lists/* \

--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,6 @@
 # Developing the Web Almanac
 
-The Web Almanac can be developed on macOS, Windows or Linux. It requires Node v20, Python v3.11 and pip to be installed. You can use Docker to avoid manually configuring the development environment.
+The Web Almanac can be developed on macOS, Windows or Linux. It requires Node v20, Python v3.12 and pip to be installed. You can use Docker to avoid manually configuring the development environment.
 It can be quickly deployed as a development container in GitHub Codespaces to develop in cloud:
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/HTTPArchive/almanac.httparchive.org?quickstart=1)
 
@@ -14,7 +14,7 @@ An `.editorconfig` file exists for those using [EditorConfig](https://editorconf
 
 Make sure you run the following commands from within the `src` directory by executing `cd src` first.
 
-Make sure Python (3.11 or above), pip and NodeJS (v20 or above) are installed on your machine.
+Make sure Python (3.12 or above), pip and NodeJS (v20 or above) are installed on your machine.
 
 1. If you don't have virtualenv, install it using pip.
 
@@ -31,7 +31,7 @@ py -m pip install --user virtualenv
 2. Create an isolated Python environment, and install dependencies:
 
 ```
-virtualenv --python python3.11 .venv
+virtualenv --python python3.12 .venv
 source .venv/bin/activate
 ```
 
@@ -49,7 +49,7 @@ npm install
 npm run start
 ```
 
-4. In your web browser, enter the following address: http://127.0.0.1:8080
+4. In your web browser, enter the following address: <http://127.0.0.1:8080>
 
 To stop the server run the following:
 
@@ -164,9 +164,9 @@ Generating for chapter: pwa for year 2021
 
 Authors can delete images and rerun if they want to, to regenerate images.
 
-Images will automatically be compressed by our Calibre GitHub Action when uploaded to GitHub, but you can get a lot more compression (about 44% more!) by running them through https://tinypng.com instead (at which point the Calibre Action will usually not find any further compression gains). It's quite simple to drag them up, and download them, so would encourage analysts/authors to take this step.
+Images will automatically be compressed by our Calibre GitHub Action when uploaded to GitHub, but you can get a lot more compression (about 44% more!) by running them through <https://tinypng.com> instead (at which point the Calibre Action will usually not find any further compression gains). It's quite simple to drag them up, and download them, so would encourage analysts/authors to take this step.
 
-Running them through https://tinypng.com also has the added advantage of the compression being repeatable each time. So if you are not sure which images you have changed, you can delete them all, regenerate them all, run them through TinyPNG, and then a `git diff` will only show differences on the images that have changed. This will not be the case if you use the Calibre GitHub Action and it will look like all images have changed.
+Running them through <https://tinypng.com> also has the added advantage of the compression being repeatable each time. So if you are not sure which images you have changed, you can delete them all, regenerate them all, run them through TinyPNG, and then a `git diff` will only show differences on the images that have changed. This will not be the case if you use the Calibre GitHub Action and it will look like all images have changed.
 
 ## Linting files
 
@@ -214,6 +214,7 @@ All Finished 📜 🎉!
 ```
 
 This states that:
+
 - On line 25, in position 26 you are using lowercase for keywords (e.g. `as` instead of `AS`) so failed rule L010.
 - Similarly on line 26, position 37.
 - And finally on line 34, position 63 you have an unnecessary comma (e.g. `SELECT a,b, FROM table`) and so failed rule L038. Remove the extra comma.
@@ -243,7 +244,6 @@ Are you sure you wish to attempt to fix these? [Y/n]
 ```
 
 If you lint again you should see most of the errors are fixed. Note that not all errors can be autofixed and some will require manual intervention but autofixing is useful for the simple errors. So while it's generally OK to run the `fix` command, do run the `lint` command when all clean to make sure the `fix` command didn't miss any issues.
-
 
 ## Generating Ebooks
 
@@ -318,7 +318,7 @@ prince "http://127.0.0.1:8080/en/2019/ebook?cover&spine=25&pageWidth=148&pageHei
 
 Note, similar to above, this will create one extra page at the begining which will need to be removed with a PDF editor to start with a clean page for printing. Please remove this before checking in versions into git.
 
-With the print-ready eBook and Cover you can send them to a printer. I used https://www.digitalprintingireland.ie/ before and they were excellent and charge about €35 for a full-colour A5 ebook. Most of the settings above are for them, so tweak them based on your own printer's requirements.
+With the print-ready eBook and Cover you can send them to a printer. I used <https://www.digitalprintingireland.ie/> before and they were excellent and charge about €35 for a full-colour A5 ebook. Most of the settings above are for them, so tweak them based on your own printer's requirements.
 
 ## Deploying changes
 
@@ -360,13 +360,14 @@ npm run stage -- -s 20211111t105151
 
 To deploy the site to production run the following:
 
-_Make sure you have updated the timestamps and generated the ebooks PDFs first in the main branch, by running the "Predeploy script" GitHub Action_
+*Make sure you have updated the timestamps and generated the ebooks PDFs first in the main branch, by running the "Predeploy script" GitHub Action*
 
 ```
 npm run deploy
 ```
 
 The deploy script will do the following:
+
 - Ask you to confirm you've run the pre-deploy script via GitHub Actions
 - Switch to the production branch
 - Merge changes from main
@@ -399,7 +400,7 @@ docker image build -t webalmanac .
 docker container run --rm -it -v "$PWD":/app -p 8080:8080 webalmanac
 ```
 
-3. Open http://localhost:8080 in your web browser to access the site. You can kill the server when it is no longer needed using `Ctrl+C`.
+3. Open <http://localhost:8080> in your web browser to access the site. You can kill the server when it is no longer needed using `Ctrl+C`.
 
 4. Make changes in the code using any text editor and run tests (need to build the image again if any Python or Node dependencies are changed):
 
@@ -420,7 +421,7 @@ root@[CID]:/app# exit
 6. To customize the image use `PYVER`, `NODEVER`, and `SKIPGC` build arguments to control which versions of Python and Node are used and whether Google Cloud SDK is installed.
 
 ```
-docker image build --build-arg PYVER=3.11 --build-arg NODEVER=20.x --build-arg SKIPGC=false -t webalmanac:custom .
+docker image build --build-arg PYVER=3.12 --build-arg NODEVER=20.x --build-arg SKIPGC=false -t webalmanac:custom .
 ```
 
 7. If you want to run the GitHub Super-Linter without `npm` being installed you need to call the command directly as given in `package.json`.

--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,6 @@
 # Developing the Web Almanac
 
-The Web Almanac can be developed on macOS, Windows or Linux. It requires Node v16, Python v3.8 and pip to be installed. You can use Docker to avoid manually configuring the development environment.
+The Web Almanac can be developed on macOS, Windows or Linux. It requires Node v20, Python v3.11 and pip to be installed. You can use Docker to avoid manually configuring the development environment.
 It can be quickly deployed as a development container in GitHub Codespaces to develop in cloud:
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/HTTPArchive/almanac.httparchive.org?quickstart=1)
 
@@ -14,7 +14,7 @@ An `.editorconfig` file exists for those using [EditorConfig](https://editorconf
 
 Make sure you run the following commands from within the `src` directory by executing `cd src` first.
 
-Make sure Python (3.8 or above), pip and NodeJS (v20 or above) are installed on your machine.
+Make sure Python (3.11 or above), pip and NodeJS (v20 or above) are installed on your machine.
 
 1. If you don't have virtualenv, install it using pip.
 
@@ -31,7 +31,7 @@ py -m pip install --user virtualenv
 2. Create an isolated Python environment, and install dependencies:
 
 ```
-virtualenv --python python3.8 .venv
+virtualenv --python python3.11 .venv
 source .venv/bin/activate
 ```
 
@@ -420,7 +420,7 @@ root@[CID]:/app# exit
 6. To customize the image use `PYVER`, `NODEVER`, and `SKIPGC` build arguments to control which versions of Python and Node are used and whether Google Cloud SDK is installed.
 
 ```
-docker image build --build-arg PYVER=3.8 --build-arg NODEVER=14.x --build-arg SKIPGC=false -t webalmanac:custom .
+docker image build --build-arg PYVER=3.11 --build-arg NODEVER=20.x --build-arg SKIPGC=false -t webalmanac:custom .
 ```
 
 7. If you want to run the GitHub Super-Linter without `npm` being installed you need to call the command directly as given in `package.json`.

--- a/src/app.yaml
+++ b/src/app.yaml
@@ -1,4 +1,4 @@
-runtime: python311
+runtime: python312
 entrypoint: gunicorn -b :$PORT main:app
 default_expiration: 3h
 

--- a/src/app.yaml
+++ b/src/app.yaml
@@ -1,4 +1,4 @@
-runtime: python38
+runtime: python311
 entrypoint: gunicorn -b :$PORT main:app
 default_expiration: 3h
 

--- a/src/tools/scripts/run_and_test_website.bat
+++ b/src/tools/scripts/run_and_test_website.bat
@@ -6,7 +6,7 @@ rem # This script installs all the required dependencies needed to run the
 rem # Web Almanac website providing you have python and node installed.
 rem #
 rem # It 's a simplified version of run_and_test_website.sh for windows users
-rem # It depends on Python 3.11, pip and nodejs 20 being installed already
+rem # It depends on Python 3.12, pip and nodejs 20 being installed already
 rem #
 
 echo "Kill any existing instances of the webserver"

--- a/src/tools/scripts/run_and_test_website.bat
+++ b/src/tools/scripts/run_and_test_website.bat
@@ -6,7 +6,7 @@ rem # This script installs all the required dependencies needed to run the
 rem # Web Almanac website providing you have python and node installed.
 rem #
 rem # It 's a simplified version of run_and_test_website.sh for windows users
-rem # It depends on Python 3.8, pip and nodejs 12 being installed already
+rem # It depends on Python 3.11, pip and nodejs 20 being installed already
 rem #
 
 echo "Kill any existing instances of the webserver"


### PR DESCRIPTION
When adding analytical dependencies to the `src/requirements.txt` I [failed tests](https://github.com/HTTPArchive/almanac.httparchive.org/actions/runs/10396895786/job/28791696553) as the repo is on Python version 3.8, which is not compatible with some recent package versions (e.g. `pandas`).

3.8 will [soon be deprecated](https://devguide.python.org/versions/).

I adjusted the version.