### PR TITLE
Make pkill case insensitive

### DIFF
--- a/src/tools/scripts/deploy.sh
+++ b/src/tools/scripts/deploy.sh
@@ -102,7 +102,7 @@ git pull origin main
 
 if [ "$(pgrep -if 'python main.py')" ]; then
   echo "Killing existing server to run a fresh version"
-  pkill -9 python main.py
+  pkill -9 -if "python main.py"
 fi
 
 #Remove generated chapters and e-books (in case new one from other branch in there)
@@ -190,7 +190,7 @@ git checkout main
 
 if [ "$(pgrep -if 'python main.py')" ]; then
   echo "Killing server so backgrounded version isn't left there"
-  pkill -9 -f "python main.py"
+  pkill -9 -if "python main.py"
 fi
 
 echo

--- a/src/tools/scripts/run_and_test_website.sh
+++ b/src/tools/scripts/run_and_test_website.sh
@@ -53,12 +53,12 @@ fi
 
 if [ "$(pgrep -if 'python main.py')" ]; then
   echo "Killing existing server to run a fresh version"
-  pkill -9 -f "python main.py"
+  pkill -9 -if "python main.py"
 fi
 
 if [ "$(pgrep -if 'node ./tools/generate/chapter_watcher')" ]; then
   echo "Killing existing watcher to run a fresh version"
-  pkill -9 -f "node ./tools/generate/chapter_watcher"
+  pkill -9 -if "node ./tools/generate/chapter_watcher"
 fi
 
 echo "Installing and testing python environment"
@@ -105,7 +105,7 @@ if [ "${debug}" == "1" ]; then
 
   if [ "$(pgrep -if 'python main.py')" ]; then
     echo "Killing server to run a fresh version in debug mode"
-    pkill -9 -f "python main.py"
+    pkill -9 -if "python main.py"
   fi
 
   echo "Starting website in foreground mode so it reloads on file changes"

--- a/src/tools/scripts/stop_website.sh
+++ b/src/tools/scripts/stop_website.sh
@@ -9,7 +9,7 @@
 # It is useful as sometimes these are backgrounded so this offers a quick way of stopping them.
 #
 
-pkill -9 -f "python main.py"
-pkill -9 -f "./tools/generate/chapter_watcher"
+pkill -9 -if "python main.py"
+pkill -9 -if "./tools/generate/chapter_watcher"
 
 exit 0


### PR DESCRIPTION
Deploy script stopped working for me after pythin update due to it being called `Python` (with capital `P`). Let's make it case insensitive.