### PR TITLE
Resolve iframe framing issues

### DIFF
--- a/src/static/js/almanac.js
+++ b/src/static/js/almanac.js
@@ -426,6 +426,8 @@ function upgradeInteractiveFigures() {
           iframe.setAttribute('scrolling', fig_img.dataset.scrolling || 'no');
           iframe.setAttribute('loading', fig_img.dataset.loading || 'lazy');
           iframe.setAttribute('src', fig_img.dataset.iframe);
+          // Set it to credentialless to avoid issues when it tries to embed the login screen
+          iframe.setAttribute('credentialless', true);
 
           //The figure should have a link
           var parentLink = fig_img.parentNode;


### PR DESCRIPTION
As noticed on the slack: https://httparchive.slack.com/archives/C5G26E678/p1724916571640009

To repeat, delete all cookies, close thew Web Almanac tabs, re-log into the browser, and then visit Web Almanac page in desktop mode. Notice you get CSP errors.