### PR TITLE
Adds 2024 base templates

### DIFF
--- a/src/config/2024.json
+++ b/src/config/2024.json
@@ -1,8 +1,8 @@
 {
   "settings": [
     {
-      "is_live": false,
-      "supported_languages": ["en"],
+      "is_live": true,
+      "supported_languages": ["en","es","fr","hi","it","ja","nl","pt","ru","tr","uk","zh-CN","zh-TW"],
       "ebook_languages": []
     }
   ],

--- a/src/server/config.py
+++ b/src/server/config.py
@@ -90,6 +90,8 @@ def update_config():
             elif ".json" in file:
                 config_files.append(file[0:4])
 
+    config_files.sort()
+
     for year in config_files:
         config_filename = "config/%s.json" % year
         with open(config_filename, "r") as config_file:

--- a/src/server/config.py
+++ b/src/server/config.py
@@ -90,6 +90,7 @@ def update_config():
             elif ".json" in file:
                 config_files.append(file[0:4])
 
+    # Sort the config files so read in year order
     config_files.sort()
 
     for year in config_files:

--- a/src/server/helpers.py
+++ b/src/server/helpers.py
@@ -292,7 +292,6 @@ def year_live(year):
     return year in SUPPORTED_YEARS
 
 
-
 # A simple function to strip accents rather than having to import a 3rd party
 # library like unicodedata
 def strip_accents(string):

--- a/src/server/helpers.py
+++ b/src/server/helpers.py
@@ -15,7 +15,8 @@ import datetime
 import logging
 
 
-# This checks whether a requested year is live - used to control the year selector
+# This gets the previous year as can no longer assume it's this year -1 as
+# skip some years (e.g. 2024)
 def get_previous_year(year):
     if year in SUPPORTED_YEARS:
         year_index = SUPPORTED_YEARS.index(year)

--- a/src/server/helpers.py
+++ b/src/server/helpers.py
@@ -15,10 +15,23 @@ import datetime
 import logging
 
 
+# This checks whether a requested year is live - used to control the year selector
+def get_previous_year(year):
+    if year in SUPPORTED_YEARS:
+        year_index = SUPPORTED_YEARS.index(year)
+        if year_index > 0:
+            return SUPPORTED_YEARS[year_index - 1]
+        else:
+            return None  # No previous year if it's the first one
+    else:
+        return None  # Return None if the year is not in the list
+
+
 def render_template(template, *args, **kwargs):
     # If the year has already been set (e.g. for error pages) then use that
     # Otherwise the requested year, otherwise the default year
     year = kwargs.get("year", request.view_args.get("year", DEFAULT_YEAR))
+    previous_year = get_previous_year(year)
     config = kwargs.get("config", get_config(year))
 
     # If the lang has already been set (e.g. for error pages) then use that
@@ -79,6 +92,7 @@ def render_template(template, *args, **kwargs):
 
     kwargs.update(
         year=year,
+        previous_year=previous_year,
         lang=lang,
         language=language,
         supported_languages=template_supported_languages,
@@ -275,6 +289,7 @@ def add_footnote_links(html):
 # This checks whether a requested year is live - used to control the year selector
 def year_live(year):
     return year in SUPPORTED_YEARS
+
 
 
 # A simple function to strip accents rather than having to import a 3rd party

--- a/src/server/tests/helpers_test.py
+++ b/src/server/tests/helpers_test.py
@@ -292,14 +292,6 @@ def test_previous_year_2019():
     assert previous_year("2019") is None
 
 
-def test_previous_year_2020():
-    assert previous_year("2020") == "2019"
-
-
-def test_previous_year_2021():
-    assert previous_year("2021") == "2020"
-
-
 def test_previous_year_2022():
     assert previous_year("2022") == "2021"
 

--- a/src/server/tests/helpers_test.py
+++ b/src/server/tests/helpers_test.py
@@ -10,7 +10,7 @@ from server.helpers import (
     convert_old_image_path,
     add_footnote_links,
     year_live,
-    previous_year,
+    get_previous_year,
     strip_accents,
     accentless_sort,
     render_template,
@@ -285,19 +285,19 @@ def test_year_live_2020():
 
 
 def test_previous_year_2018():
-    assert previous_year("2018") is None
+    assert get_previous_year("2018") is None
 
 
 def test_previous_year_2019():
-    assert previous_year("2019") is None
+    assert get_previous_year("2019") is None
 
 
 def test_previous_year_2022():
-    assert previous_year("2022") == "2021"
+    assert get_previous_year("2022") == "2021"
 
 
 def test_previous_year_2024():
-    assert previous_year("2024") == "2022"
+    assert get_previous_year("2024") == "2022"
 
 
 def test_strip_accents_fr_edition():

--- a/src/server/tests/helpers_test.py
+++ b/src/server/tests/helpers_test.py
@@ -10,6 +10,7 @@ from server.helpers import (
     convert_old_image_path,
     add_footnote_links,
     year_live,
+    previous_year,
     strip_accents,
     accentless_sort,
     render_template,
@@ -281,6 +282,30 @@ def test_year_live_2019():
 
 def test_year_live_2020():
     assert year_live("2020") is True
+
+
+def test_previous_year_2018():
+    assert previous_year("2018") is None
+
+
+def test_previous_year_2019():
+    assert previous_year("2019") is None
+
+
+def test_previous_year_2020():
+    assert previous_year("2020") == "2019"
+
+
+def test_previous_year_2021():
+    assert previous_year("2021") == "2020"
+
+
+def test_previous_year_2022():
+    assert previous_year("2022") == "2021"
+
+
+def test_previous_year_2024():
+    assert previous_year("2024") == "2022"
 
 
 def test_strip_accents_fr_edition():

--- a/src/templates/base/index.html
+++ b/src/templates/base/index.html
@@ -60,12 +60,8 @@
       <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}" class="btn">
         {{ self.start_exploring() }}
       </a>
-      {% elif year == "2024" %}
-      <a href="{{ url_for('table_of_contents', year=year|int -2, lang=lang) }}" class="btn">
-        {{ self.read_last_years_almanac() }}
-      </a>
       {% else %}
-      <a href="{{ url_for('table_of_contents', year=year|int -1, lang=lang) }}" class="btn">
+      <a href="{{ url_for('table_of_contents', year=previous_year, lang=lang) }}" class="btn">
         {{ self.read_last_years_almanac() }}
       </a>
       {% endif %}
@@ -169,6 +165,10 @@
     {% include "%s/%s/featured_chapters.html" % (lang, year|int -1) %}
     {% elif featured_chapters_exists('en', year|int -1) %}
     {% include "en/%s/featured_chapters.html" % (year|int -1) %}
+    {% elif featured_chapters_exists(lang, year|int -2) %}
+    {% include "%s/%s/featured_chapters.html" % (lang, year|int -2) %}
+    {% elif featured_chapters_exists('en', year|int -2) %}
+    {% include "en/%s/featured_chapters.html" % (year|int -2) %}
     {% endif %}
   {% endif %}
   {% endblock %}

--- a/src/templates/base/index.html
+++ b/src/templates/base/index.html
@@ -60,6 +60,10 @@
       <a href="{{ url_for('table_of_contents', year=year, lang=lang) }}" class="btn">
         {{ self.start_exploring() }}
       </a>
+      {% elif year == "2024" %}
+      <a href="{{ url_for('table_of_contents', year=year|int -2, lang=lang) }}" class="btn">
+        {{ self.read_last_years_almanac() }}
+      </a>
       {% else %}
       <a href="{{ url_for('table_of_contents', year=year|int -1, lang=lang) }}" class="btn">
         {{ self.read_last_years_almanac() }}

--- a/src/templates/base/index.html
+++ b/src/templates/base/index.html
@@ -147,7 +147,7 @@
         {{ read_chapter(localizedChapterTitles[featured_chapter]) }}
       </a>
       {% else %}
-      <a href="{{ url_for('chapter', year=year|int -1, chapter=featured_chapter, lang=lang) }}" class="btn">
+      <a href="{{ url_for('chapter', year=previous_year, chapter=featured_chapter, lang=lang) }}" class="btn">
         {{ read_last_years_chapter(localizedChapterTitles[featured_chapter]) }}
       </a>
       {% endif %}
@@ -161,14 +161,10 @@
     {% include "en/%s/featured_chapters.html" % year %}
     {% endif %}
   {% else %}
-    {% if featured_chapters_exists(lang, year|int -1) %}
-    {% include "%s/%s/featured_chapters.html" % (lang, year|int -1) %}
-    {% elif featured_chapters_exists('en', year|int -1) %}
-    {% include "en/%s/featured_chapters.html" % (year|int -1) %}
-    {% elif featured_chapters_exists(lang, year|int -2) %}
-    {% include "%s/%s/featured_chapters.html" % (lang, year|int -2) %}
-    {% elif featured_chapters_exists('en', year|int -2) %}
-    {% include "en/%s/featured_chapters.html" % (year|int -2) %}
+    {% if featured_chapters_exists(lang, previous_year) %}
+    {% include "%s/%s/featured_chapters.html" % (lang, previous_year) %}
+    {% elif featured_chapters_exists('en', previous_year) %}
+    {% include "en/%s/featured_chapters.html" % previous_year %}
     {% endif %}
   {% endif %}
   {% endblock %}

--- a/src/templates/en/2024/base.html
+++ b/src/templates/en/2024/base.html
@@ -1,8 +1,8 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}8.36M{% endblock %}
-{% block methodology_stat_2 %}43.88 TB{% endblock %}
-{% block total_websites %}nearly 8.4 million{% endblock %}
+{% block methodology_stat_1 %}16.9M{% endblock %}
+{% block methodology_stat_2 %}82.61 TB{% endblock %}
+{% block total_websites %}nearly 17 million{% endblock %}
 {% block dataset %}June 2022{% endblock %}
 {% block read_last_years_almanac %}Read the {{ year | int - 2 }} Web Almanac{% endblock %}
 

--- a/src/templates/en/2024/base.html
+++ b/src/templates/en/2024/base.html
@@ -3,7 +3,7 @@
 {% block methodology_stat_1 %}16.9M{% endblock %}
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}nearly 17 million{% endblock %}
-{% block dataset %}June 2022{% endblock %}
+{% block dataset %}June 2024{% endblock %}
 {% block read_last_years_almanac %}Read the {{ year | int - 2 }} Web Almanac{% endblock %}
 
 {% block foreword %}

--- a/src/templates/en/2024/base.html
+++ b/src/templates/en/2024/base.html
@@ -1,0 +1,11 @@
+{% extends "%s/base.html" % lang %}
+
+{% block methodology_stat_1 %}8.36M{% endblock %}
+{% block methodology_stat_2 %}43.88 TB{% endblock %}
+{% block total_websites %}nearly 8.4 million{% endblock %}
+{% block dataset %}June 2022{% endblock %}
+{% block read_last_years_almanac %}Read the {{ year | int - 2 }} Web Almanac{% endblock %}
+
+{% block foreword %}
+{# TODO #}
+{% endblock %}

--- a/src/templates/en/2024/base.html
+++ b/src/templates/en/2024/base.html
@@ -4,7 +4,7 @@
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}nearly 17 million{% endblock %}
 {% block dataset %}June 2024{% endblock %}
-{% block read_last_years_almanac %}Read the {{ year | int - 2 }} Web Almanac{% endblock %}
+{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/en/2024/base.html
+++ b/src/templates/en/2024/base.html
@@ -4,7 +4,6 @@
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}nearly 17 million{% endblock %}
 {% block dataset %}June 2024{% endblock %}
-{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/en/2024/contributors.html
+++ b/src/templates/en/2024/contributors.html
@@ -1,0 +1,11 @@
+{% extends "base/contributors.html" %}
+
+{% block title %}{{ year }} Contributors | The Web Almanac by HTTP Archive{% endblock %}
+
+{% block description %}The {{ config.contributors.items() | length }} people who contributed to the {{ year }} Web Almanac as Analysts, Authors, Designers, Developers, Editors, Leaders, Reviewers and Translators.{% endblock %}
+
+{% block filter_by_team %}Filter by team: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> of <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> contributors.{% endblock %}
+{% block filter_by %}Filter by{% endblock %}
+
+{% block join_the_team_title%}Join the Web Almanac team{% endblock %}
+{% block join_the_team_text%}Join the team!{% endblock %}

--- a/src/templates/en/2024/index.html
+++ b/src/templates/en/2024/index.html
@@ -1,0 +1,6 @@
+{% extends "base/index.html" %}
+
+{% block title %}The {{ year }} Web Almanac{% endblock %}
+{% block description %}The Web Almanac is an annual state of the web report combining the expertise of the web community with the data and trends of the HTTP Archive.{% endblock %}
+
+{% block twitter_image_alt %}The {{ year }} Web Almanac{% endblock %}

--- a/src/templates/en/2024/table_of_contents.html
+++ b/src/templates/en/2024/table_of_contents.html
@@ -1,0 +1,7 @@
+{% extends "base/table_of_contents.html" %}
+
+{% block title %}Table of Contents | Web Almanac {{ year }}{% endblock %}
+
+{% block description %}Table of Contents for the {{ year }} Web Almanac, listing each section: Page Contents, User Experience, Content Publishing, Content Distribution.{% endblock %}
+
+{% block twitter_image_alt %}{{ year }} Web Almanac methodology{% endblock %}

--- a/src/templates/en/base.html
+++ b/src/templates/en/base.html
@@ -24,7 +24,7 @@ Our mission is to combine the raw stats and trends of the HTTP Archive with the 
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}Read the {{ self.previous_year() }} Web Almanac{% endblock %}
+{% block read_last_years_almanac %}Read the {{ previous_year }} Web Almanac{% endblock %}
 
 {% block http_archive_link %}HTTP Archive home{% endblock %}
 
@@ -123,17 +123,15 @@ Our mission is to combine the raw stats and trends of the HTTP Archive with the 
 {% block accessibility_statement %}Accessibility Statement{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
-{% block previous_year %}{{ year|int - 1 }}{% endblock %}
-
 {% block featured_chapter %}Featured Chapter{% endblock %}
-{% block featured_chapter_last_year %}Featured Chapter<br>from the {{ self.previous_year() }} Web Almanac{% endblock %}
+{% block featured_chapter_last_year %}Featured Chapter<br>from the {{ previous_year }} Web Almanac{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}Read the <span class="featured-chapter-name">{{ chapter }}</span> chapter{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}Read the {{ self.previous_year() }} <span class="featured-chapter-name">{{ chapter }}</span> chapter{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}Read the {{ previous_year }} <span class="featured-chapter-name">{{ chapter }}</span> chapter{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/en/base.html
+++ b/src/templates/en/base.html
@@ -24,7 +24,7 @@ Our mission is to combine the raw stats and trends of the HTTP Archive with the 
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}Read the {{ year | int - 1 }} Web Almanac{% endblock %}
+{% block read_last_years_almanac %}Read the {{ self.previous_year() }} Web Almanac{% endblock %}
 
 {% block http_archive_link %}HTTP Archive home{% endblock %}
 
@@ -123,15 +123,17 @@ Our mission is to combine the raw stats and trends of the HTTP Archive with the 
 {% block accessibility_statement %}Accessibility Statement{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
+{% block previous_year %}{{ year|int - 1 }}{% endblock %}
+
 {% block featured_chapter %}Featured Chapter{% endblock %}
-{% block featured_chapter_last_year %}Featured Chapter<br>from the {{ year|int -1 }} Web Almanac{% endblock %}
+{% block featured_chapter_last_year %}Featured Chapter<br>from the {{ self.previous_year() }} Web Almanac{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}Read the <span class="featured-chapter-name">{{ chapter }}</span> chapter{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}Read the {{ year|int-1 }} <span class="featured-chapter-name">{{ chapter }}</span> chapter{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}Read the {{ self.previous_year() }} <span class="featured-chapter-name">{{ chapter }}</span> chapter{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/es/2024/base.html
+++ b/src/templates/es/2024/base.html
@@ -4,7 +4,7 @@
 {% block methodology_stat_2 %}82,61 TB{% endblock %}
 {% block total_websites %}aproximadamente de 17 millones{% endblock %}
 {% block dataset %}Junio de 2024{% endblock %}
-{% block read_last_years_almanac %}Lea el Web Almanac {{ year | int - 2 }}{% endblock %}
+{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/es/2024/base.html
+++ b/src/templates/es/2024/base.html
@@ -3,7 +3,7 @@
 {% block methodology_stat_1 %}16,9M{% endblock %}
 {% block methodology_stat_2 %}82,61 TB{% endblock %}
 {% block total_websites %}aproximadamente de 17 millones{% endblock %}
-{% block dataset %}Junio de 2022{% endblock %}
+{% block dataset %}Junio de 2024{% endblock %}
 {% block read_last_years_almanac %}Lea el Web Almanac {{ year | int - 2 }}{% endblock %}
 
 {% block foreword %}

--- a/src/templates/es/2024/base.html
+++ b/src/templates/es/2024/base.html
@@ -4,7 +4,6 @@
 {% block methodology_stat_2 %}82,61 TB{% endblock %}
 {% block total_websites %}aproximadamente de 17 millones{% endblock %}
 {% block dataset %}Junio de 2024{% endblock %}
-{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/es/2024/base.html
+++ b/src/templates/es/2024/base.html
@@ -1,0 +1,11 @@
+{% extends "%s/base.html" % lang %}
+
+{% block methodology_stat_1 %}8,36M{% endblock %}
+{% block methodology_stat_2 %}43,88 TB{% endblock %}
+{% block total_websites %}aproximadamente de 8.4 millones{% endblock %}
+{% block dataset %}Junio de 2022{% endblock %}
+{% block read_last_years_almanac %}Lea el Web Almanac {{ year | int - 2 }}{% endblock %}
+
+{% block foreword %}
+{# TODO #}
+{% endblock %}

--- a/src/templates/es/2024/base.html
+++ b/src/templates/es/2024/base.html
@@ -1,8 +1,8 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}8,36M{% endblock %}
-{% block methodology_stat_2 %}43,88 TB{% endblock %}
-{% block total_websites %}aproximadamente de 8.4 millones{% endblock %}
+{% block methodology_stat_1 %}16,9M{% endblock %}
+{% block methodology_stat_2 %}82,61 TB{% endblock %}
+{% block total_websites %}aproximadamente de 17 millones{% endblock %}
 {% block dataset %}Junio de 2022{% endblock %}
 {% block read_last_years_almanac %}Lea el Web Almanac {{ year | int - 2 }}{% endblock %}
 

--- a/src/templates/es/2024/contributors.html
+++ b/src/templates/es/2024/contributors.html
@@ -1,0 +1,11 @@
+{% extends "base/contributors.html" %}
+
+{% block title %}{{ year }} Contribuidores | Web Almanac por HTTP Archive{% endblock %}
+
+{% block description %}El {{ config.contributors.items() | length }} personas que contribuyeron al {{ year }} Web Almanac commo Analistas, Autores, Diseñadores, Desarrolladores, Editores, Revisores y Traductores.{% endblock %}
+
+{% block filter_by_team %}Filtrar por equipo: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> de <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> contributors.{% endblock %}
+{% block filter_by %}Filtrar por{% endblock %}
+
+{% block join_the_team_title%}Únete al equipo de Web Almanac{% endblock %}
+{% block join_the_team_text%}¡Únete al equipo!{% endblock %}

--- a/src/templates/es/2024/index.html
+++ b/src/templates/es/2024/index.html
@@ -1,0 +1,6 @@
+{% extends "base/index.html" %}
+
+{% block title %}Web Almanac {{ year }}{% endblock %}
+{% block description %}Web Almanac es un informe anual sobre el estado de la web que combina las estadísticas y tendencias sin procesar del HTTP Archive con la experiencia de la comunidad web.{% endblock %}
+
+{% block twitter_image_alt %}Web Almanac {{ year }}{% endblock %}

--- a/src/templates/es/2024/table_of_contents.html
+++ b/src/templates/es/2024/table_of_contents.html
@@ -1,0 +1,7 @@
+{% extends "base/table_of_contents.html" %}
+
+{% block title %}Tabla de Contenidos | Web Almanac {{ year }}{% endblock %}
+
+{% block description %}Tabla de contenidos del Web Almanac {{ year }} de HTTP Archive, que enumera cada sección: contenido de la página, experiencia del usuario, publicación de contenido, distribución de contenido{% endblock %}
+
+{% block twitter_image_alt %}{{ year }} Web Almanac methodology{% endblock %}

--- a/src/templates/es/base.html
+++ b/src/templates/es/base.html
@@ -24,7 +24,7 @@
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}Lea el Web Almanac {{ self.previous_year() }}{% endblock %}
+{% block read_last_years_almanac %}Lea el Web Almanac {{ previous_year }}{% endblock %}
 
 {% block http_archive_link %}Página de inicio HTTP Archive{% endblock %}
 
@@ -123,17 +123,15 @@
 {% block accessibility_statement %}Declaración de accesibilidad{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
-{% block previous_year %}{{ year|int - 1 }}{% endblock %}
-
 {% block featured_chapter %}Capítulo destacado{% endblock %}
-{% block featured_chapter_last_year %}Capítulo destacado<br>del Web Almanac {{ self.previous_year() }}{% endblock %}
+{% block featured_chapter_last_year %}Capítulo destacado<br>del Web Almanac {{ previous_year }}{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}Lea el capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}Lea el {{ self.previous_year() }} capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}Lea el {{ previous_year }} capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/es/base.html
+++ b/src/templates/es/base.html
@@ -24,7 +24,7 @@
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}Lea el Web Almanac {{ year | int - 1 }}{% endblock %}
+{% block read_last_years_almanac %}Lea el Web Almanac {{ self.previous_year() }}{% endblock %}
 
 {% block http_archive_link %}Página de inicio HTTP Archive{% endblock %}
 
@@ -123,15 +123,17 @@
 {% block accessibility_statement %}Declaración de accesibilidad{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
+{% block previous_year %}{{ year|int - 1 }}{% endblock %}
+
 {% block featured_chapter %}Capítulo destacado{% endblock %}
-{% block featured_chapter_last_year %}Capítulo destacado<br>del Web Almanac {{ year|int -1 }}{% endblock %}
+{% block featured_chapter_last_year %}Capítulo destacado<br>del Web Almanac {{ self.previous_year() }}{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}Lea el capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}Lea el {{ year|int -1 }} capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}Lea el {{ self.previous_year() }} capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/fr/2024/base.html
+++ b/src/templates/fr/2024/base.html
@@ -4,7 +4,6 @@
 {% block methodology_stat_2 %}82,61&nbsp;To{% endblock %}
 {% block total_websites %}près de 8,4 millions{% endblock %}
 {% block dataset %}juin 2024{% endblock %}
-{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/fr/2024/base.html
+++ b/src/templates/fr/2024/base.html
@@ -4,7 +4,7 @@
 {% block methodology_stat_2 %}82,61&nbsp;To{% endblock %}
 {% block total_websites %}près de 8,4 millions{% endblock %}
 {% block dataset %}juin 2024{% endblock %}
-{% block read_last_years_almanac %}Lire le Web Almanac {{ year | int - 2 }}{% endblock %}
+{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/fr/2024/base.html
+++ b/src/templates/fr/2024/base.html
@@ -1,7 +1,7 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}8,36&nbsp;M{% endblock %}
-{% block methodology_stat_2 %}43,88&nbsp;To{% endblock %}
+{% block methodology_stat_1 %}16,9&nbsp;M{% endblock %}
+{% block methodology_stat_2 %}82,61&nbsp;To{% endblock %}
 {% block total_websites %}près de 8,4 millions{% endblock %}
 {% block dataset %}juin 2022{% endblock %}
 {% block read_last_years_almanac %}Lire le Web Almanac {{ year | int - 2 }}{% endblock %}

--- a/src/templates/fr/2024/base.html
+++ b/src/templates/fr/2024/base.html
@@ -1,0 +1,11 @@
+{% extends "%s/base.html" % lang %}
+
+{% block methodology_stat_1 %}8,36&nbsp;M{% endblock %}
+{% block methodology_stat_2 %}43,88&nbsp;To{% endblock %}
+{% block total_websites %}près de 8,4 millions{% endblock %}
+{% block dataset %}juin 2022{% endblock %}
+{% block read_last_years_almanac %}Lire le Web Almanac {{ year | int - 2 }}{% endblock %}
+
+{% block foreword %}
+{# TODO #}
+{% endblock %}

--- a/src/templates/fr/2024/base.html
+++ b/src/templates/fr/2024/base.html
@@ -3,7 +3,7 @@
 {% block methodology_stat_1 %}16,9&nbsp;M{% endblock %}
 {% block methodology_stat_2 %}82,61&nbsp;To{% endblock %}
 {% block total_websites %}près de 8,4 millions{% endblock %}
-{% block dataset %}juin 2022{% endblock %}
+{% block dataset %}juin 2024{% endblock %}
 {% block read_last_years_almanac %}Lire le Web Almanac {{ year | int - 2 }}{% endblock %}
 
 {% block foreword %}

--- a/src/templates/fr/2024/contributors.html
+++ b/src/templates/fr/2024/contributors.html
@@ -1,0 +1,11 @@
+{% extends "base/contributors.html" %}
+
+{% block title %}Contributeurs et contributrices {{ year }} | Web Almanac par HTTP Archive{% endblock %}
+
+{% block description %}Les {{ config.contributors.items() | length }} personnes ayant contribué au Web Almanac {{ year }} par leurs analyses, leurs écrits, leurs participations au design, leur code, leurs éditions, leurs relectures, ou leurs traductions.{% endblock %}
+
+{% block filter_by_team %}Filtrer par équipe&nbsp;: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> sur <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> contributeurs et contributrices.{% endblock %}
+{% block filter_by %}Filtrer par{% endblock %}
+
+{% block join_the_team_title %}Rejoignez les équipe Web Almanac{% endblock %}
+{% block join_the_team_text %}Rejoignez l'équipe&nbsp;!{% endblock %}

--- a/src/templates/fr/2024/index.html
+++ b/src/templates/fr/2024/index.html
@@ -1,0 +1,6 @@
+{% extends "base/index.html" %}
+
+{% block title %}Web Almanac 2022{% endblock %}
+{% block description %}Le Web Almanac est un rapport annuel sur l’état du Web qui combine l’expertise de la communauté Web avec les données et tendances de HTTP Archive.{% endblock %}
+
+{% block twitter_image_alt %}Web Almanac {{ year }}{% endblock %}

--- a/src/templates/fr/2024/index.html
+++ b/src/templates/fr/2024/index.html
@@ -1,6 +1,6 @@
 {% extends "base/index.html" %}
 
-{% block title %}Web Almanac 2022{% endblock %}
+{% block title %}Web Almanac 2024{% endblock %}
 {% block description %}Le Web Almanac est un rapport annuel sur l’état du Web qui combine l’expertise de la communauté Web avec les données et tendances de HTTP Archive.{% endblock %}
 
 {% block twitter_image_alt %}Web Almanac {{ year }}{% endblock %}

--- a/src/templates/fr/2024/table_of_contents.html
+++ b/src/templates/fr/2024/table_of_contents.html
@@ -1,0 +1,7 @@
+{% extends "base/table_of_contents.html" %}
+
+{% block title %}Table des matières | Web Almanac {{ year }}{% endblock %}
+
+{% block description %}Table des matières du Web Almanac {{ year }}, listant chaque section : Contenu des pages, Expérience utilisateur, Publication du contenu, Diffusion du contenu.{% endblock %}
+
+{% block twitter_image_alt %}Méthodologie du Web Almanac {{ year }}{% endblock %}

--- a/src/templates/fr/base.html
+++ b/src/templates/fr/base.html
@@ -24,7 +24,7 @@ Notre mission est de combiner les statistiques brutes et les tendances de HTTP A
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}Lire le Web Almanac {{ year | int - 1 }}{% endblock %}
+{% block read_last_years_almanac %}Lire le Web Almanac {{ self.previous_year() }}{% endblock %}
 
 {% block http_archive_link %}HTTP Archive home{% endblock %}
 
@@ -123,15 +123,17 @@ Notre mission est de combiner les statistiques brutes et les tendances de HTTP A
 {% block accessibility_statement %}Déclaration d’accessibilité{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
+{% block previous_year %}{{ year|int - 1 }}{% endblock %}
+
 {% block featured_chapter %}Focus sur le chapitre…{% endblock %}
-{% block featured_chapter_last_year %}Focus sur le chapitre<br>du Web Almanac {{ year|int-1 }}{% endblock %}
+{% block featured_chapter_last_year %}Focus sur le chapitre<br>du Web Almanac {{ self.previous_year() }}{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}Lire le chapitre&nbsp;: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}Lire le chapitre {{ year|int-1 }}&nbsp;: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}Lire le chapitre {{ self.previous_year() }}&nbsp;: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/fr/base.html
+++ b/src/templates/fr/base.html
@@ -24,7 +24,7 @@ Notre mission est de combiner les statistiques brutes et les tendances de HTTP A
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}Lire le Web Almanac {{ self.previous_year() }}{% endblock %}
+{% block read_last_years_almanac %}Lire le Web Almanac {{ previous_year }}{% endblock %}
 
 {% block http_archive_link %}HTTP Archive home{% endblock %}
 
@@ -123,17 +123,15 @@ Notre mission est de combiner les statistiques brutes et les tendances de HTTP A
 {% block accessibility_statement %}Déclaration d’accessibilité{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
-{% block previous_year %}{{ year|int - 1 }}{% endblock %}
-
 {% block featured_chapter %}Focus sur le chapitre…{% endblock %}
-{% block featured_chapter_last_year %}Focus sur le chapitre<br>du Web Almanac {{ self.previous_year() }}{% endblock %}
+{% block featured_chapter_last_year %}Focus sur le chapitre<br>du Web Almanac {{ previous_year }}{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}Lire le chapitre&nbsp;: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}Lire le chapitre {{ self.previous_year() }}&nbsp;: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}Lire le chapitre {{ previous_year }}&nbsp;: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/hi/2024/base.html
+++ b/src/templates/hi/2024/base.html
@@ -4,7 +4,6 @@
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}लगभग 8 मिलियन{% endblock %}
 {% block dataset %}जून 2024{% endblock %}
-{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/hi/2024/base.html
+++ b/src/templates/hi/2024/base.html
@@ -1,7 +1,7 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}8.36M{% endblock %}
-{% block methodology_stat_2 %}43.88 TB{% endblock %}
+{% block methodology_stat_1 %}16.9M{% endblock %}
+{% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}लगभग 8 मिलियन{% endblock %}
 {% block dataset %}जून 2022{% endblock %}
 {% block read_last_years_almanac %}{{ year | int - 2 }} Web Almanac को पढ़िए{% endblock %}

--- a/src/templates/hi/2024/base.html
+++ b/src/templates/hi/2024/base.html
@@ -1,0 +1,11 @@
+{% extends "%s/base.html" % lang %}
+
+{% block methodology_stat_1 %}8.36M{% endblock %}
+{% block methodology_stat_2 %}43.88 TB{% endblock %}
+{% block total_websites %}लगभग 8 मिलियन{% endblock %}
+{% block dataset %}जून 2022{% endblock %}
+{% block read_last_years_almanac %}{{ year | int - 2 }} Web Almanac को पढ़िए{% endblock %}
+
+{% block foreword %}
+{# TODO #}
+{% endblock %}

--- a/src/templates/hi/2024/base.html
+++ b/src/templates/hi/2024/base.html
@@ -3,7 +3,7 @@
 {% block methodology_stat_1 %}16.9M{% endblock %}
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}लगभग 8 मिलियन{% endblock %}
-{% block dataset %}जून 2022{% endblock %}
+{% block dataset %}जून 2024{% endblock %}
 {% block read_last_years_almanac %}{{ year | int - 2 }} Web Almanac को पढ़िए{% endblock %}
 
 {% block foreword %}

--- a/src/templates/hi/2024/base.html
+++ b/src/templates/hi/2024/base.html
@@ -4,7 +4,7 @@
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}लगभग 8 मिलियन{% endblock %}
 {% block dataset %}जून 2024{% endblock %}
-{% block read_last_years_almanac %}{{ year | int - 2 }} Web Almanac को पढ़िए{% endblock %}
+{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/hi/2024/contributors.html
+++ b/src/templates/hi/2024/contributors.html
@@ -1,0 +1,11 @@
+{% extends "base/contributors.html" %}
+
+{% block title %}{{ year }} योगदानकर्ता | HTTP Archive द्वारा Web Almanac{% endblock %}
+
+{% block description %}{{ config.contributors.items() | length }} लोग जिन्होंने {{ year }} Web Almanac में विश्लेषक, लेखक, डिजाइनर, डेवलपर्स, संपादक, लीडर, समीक्षक और अनुवादक के रूप में योगदान दिया।{% endblock %}
+
+{% block filter_by_team %}टीम द्वारा फ़िल्टर करें: <span id="contributors-total">{{ config.contributors.items() | length }}</span><span id="contributors-total-text" class="hidden"> में से <span id="filtered-contributors">{{ self.contributors() }}</span></span> योगदानकर्ता।{% endblock %}
+{% block filter_by %}फ़िल्टर करें{% endblock %}
+
+{% block join_the_team_title%}Web Almanac टीम में शामिल हों{% endblock %}
+{% block join_the_team_text%}टीम में शामिल हों!{% endblock %}

--- a/src/templates/hi/2024/index.html
+++ b/src/templates/hi/2024/index.html
@@ -1,0 +1,6 @@
+{% extends "base/index.html" %}
+
+{% block title %}{{ year }} Web Almanac{% endblock %}
+{% block description %}Web Almanac वेब रिपोर्ट की एक वार्षिक स्थिति है जो वेब समुदाय की विशेषज्ञता को HTTP संग्रह के डेटा और रुझानों के साथ जोड़ती है।{% endblock %}
+
+{% block twitter_image_alt %}{{ year }} Web Almanac{% endblock %}

--- a/src/templates/hi/2024/table_of_contents.html
+++ b/src/templates/hi/2024/table_of_contents.html
@@ -1,0 +1,7 @@
+{% extends "base/table_of_contents.html" %}
+
+{% block title %}विषय - सूची | Web Almanac {{ year }}{% endblock %}
+
+{% block description %}{{ year }} Web Almanac के लिए सामग्री की तालिका के, प्रत्येक अनुभाग सूचीबद्ध है: पृष्ठ सामग्री, उपयोगकर्ता अनुभव, सामग्री प्रकाशन, सामग्री वितरण।{% endblock %}
+
+{% block twitter_image_alt %}{{ year }} Web Almanac की कार्यप्रणाली{% endblock %}

--- a/src/templates/hi/base.html
+++ b/src/templates/hi/base.html
@@ -24,7 +24,7 @@
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}{{ year | int - 1 }} Web Almanac को पढ़िए{% endblock %}
+{% block read_last_years_almanac %}{{ self.previous_year() }} Web Almanac को पढ़िए{% endblock %}
 
 {% block http_archive_link %}HTTP Archive होम{% endblock %}
 
@@ -123,15 +123,17 @@
 {% block accessibility_statement %}अभिगम्यता विवरण{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
+{% block previous_year %}{{ year|int - 1 }}{% endblock %}
+
 {% block featured_chapter %}विशेष अध्याय{% endblock %}
-{% block featured_chapter_last_year %}विशेष अध्याय<br>{{ year|int -1 }} Web Almanac से {% endblock %}
+{% block featured_chapter_last_year %}विशेष अध्याय<br>{{ self.previous_year() }} Web Almanac से {% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}अध्याय <span class="featured-chapter-name">{{ chapter }}</span> पढ़ें{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}अध्याय {{ year|int-1 }} <span class="featured-chapter-name">{{ chapter }}</span> पढ़ें{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}अध्याय {{ self.previous_year() }} <span class="featured-chapter-name">{{ chapter }}</span> पढ़ें{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/hi/base.html
+++ b/src/templates/hi/base.html
@@ -24,7 +24,7 @@
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}{{ self.previous_year() }} Web Almanac को पढ़िए{% endblock %}
+{% block read_last_years_almanac %}{{ previous_year }} Web Almanac को पढ़िए{% endblock %}
 
 {% block http_archive_link %}HTTP Archive होम{% endblock %}
 
@@ -123,17 +123,15 @@
 {% block accessibility_statement %}अभिगम्यता विवरण{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
-{% block previous_year %}{{ year|int - 1 }}{% endblock %}
-
 {% block featured_chapter %}विशेष अध्याय{% endblock %}
-{% block featured_chapter_last_year %}विशेष अध्याय<br>{{ self.previous_year() }} Web Almanac से {% endblock %}
+{% block featured_chapter_last_year %}विशेष अध्याय<br>{{ previous_year }} Web Almanac से {% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}अध्याय <span class="featured-chapter-name">{{ chapter }}</span> पढ़ें{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}अध्याय {{ self.previous_year() }} <span class="featured-chapter-name">{{ chapter }}</span> पढ़ें{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}अध्याय {{ previous_year }} <span class="featured-chapter-name">{{ chapter }}</span> पढ़ें{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/it/2024/base.html
+++ b/src/templates/it/2024/base.html
@@ -1,0 +1,11 @@
+{% extends "%s/base.html" % lang %}
+
+{% block methodology_stat_1 %}8.36M{% endblock %}
+{% block methodology_stat_2 %}43.88 TB{% endblock %}
+{% block total_websites %}quasi 8,4 milioni{% endblock %}
+{% block dataset %}giugno 2022{% endblock %}
+{% block read_last_years_almanac %}Leggi il Web Almanac del {{ year | int - 2 }}{% endblock %}
+
+{% block foreword %}
+{# TODO #}
+{% endblock %}

--- a/src/templates/it/2024/base.html
+++ b/src/templates/it/2024/base.html
@@ -4,7 +4,6 @@
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}quasi 8,4 milioni{% endblock %}
 {% block dataset %}giugno 2024{% endblock %}
-{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/it/2024/base.html
+++ b/src/templates/it/2024/base.html
@@ -1,7 +1,7 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}8.36M{% endblock %}
-{% block methodology_stat_2 %}43.88 TB{% endblock %}
+{% block methodology_stat_1 %}16.9M{% endblock %}
+{% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}quasi 8,4 milioni{% endblock %}
 {% block dataset %}giugno 2022{% endblock %}
 {% block read_last_years_almanac %}Leggi il Web Almanac del {{ year | int - 2 }}{% endblock %}

--- a/src/templates/it/2024/base.html
+++ b/src/templates/it/2024/base.html
@@ -3,7 +3,7 @@
 {% block methodology_stat_1 %}16.9M{% endblock %}
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}quasi 8,4 milioni{% endblock %}
-{% block dataset %}giugno 2022{% endblock %}
+{% block dataset %}giugno 2024{% endblock %}
 {% block read_last_years_almanac %}Leggi il Web Almanac del {{ year | int - 2 }}{% endblock %}
 
 {% block foreword %}

--- a/src/templates/it/2024/base.html
+++ b/src/templates/it/2024/base.html
@@ -4,7 +4,7 @@
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}quasi 8,4 milioni{% endblock %}
 {% block dataset %}giugno 2024{% endblock %}
-{% block read_last_years_almanac %}Leggi il Web Almanac del {{ year | int - 2 }}{% endblock %}
+{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/it/2024/contributors.html
+++ b/src/templates/it/2024/contributors.html
@@ -1,0 +1,11 @@
+{% extends "base/contributors.html" %}
+
+{% block title %}{{ year }} Collaboratori | Il Web Almanac di HTTP Archive{% endblock %}
+
+{% block description %}Le {{ config.contributors.items() | length }} persone che hanno contribuito al {{ year }} Web Almanac come Analisti, Autori, Designer, Sviluppatori, Editori, Revisori e Traduttori.{% endblock %}
+
+{% block filter_by_team %}Filtra per squadra: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> di <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> collaboratori.{% endblock %}
+{% block filter_by %}Filtra per{% endblock %}
+
+{% block join_the_team_title%}Unisciti al team di Web Almanac{% endblock %}
+{% block join_the_team_text%}Unisciti alla squadra!{% endblock %}

--- a/src/templates/it/2024/index.html
+++ b/src/templates/it/2024/index.html
@@ -1,0 +1,6 @@
+{% extends "base/index.html" %}
+
+{% block title %}Web Almanac {{ year }}{% endblock %}
+{% block description %}Il Web Almanac è un report annuale sullo stato del Web che combina l'esperienza della comunità Web con i dati e le tendenze del HTTP Archive.{% endblock %}
+
+{% block twitter_image_alt %}Web Almanac {{ year }}{% endblock %}

--- a/src/templates/it/2024/table_of_contents.html
+++ b/src/templates/it/2024/table_of_contents.html
@@ -1,0 +1,7 @@
+{% extends "base/table_of_contents.html" %}
+
+{% block title %}Sommario | Web Almanac {{ year }}{% endblock %}
+
+{% block description %}Sommario per il Web Almanac {{ year }}, elencando ciascuna sezione: Page Contents, User Experience, Content Publishing, Content Distribution.{% endblock %}
+
+{% block twitter_image_alt %}{{ year }} Web Almanac methodology{% endblock %}

--- a/src/templates/it/base.html
+++ b/src/templates/it/base.html
@@ -24,7 +24,7 @@ La nostra missione è combinare le statistiche grezze e le tendenze del HTTP Arc
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}Leggi il Web Almanac del {{ year | int - 1 }}{% endblock %}
+{% block read_last_years_almanac %}Leggi il Web Almanac del {{ self.previous_year() }}{% endblock %}
 
 {% block http_archive_link %}Pagina iniziale HTTP Archive{% endblock %}
 
@@ -123,15 +123,17 @@ La nostra missione è combinare le statistiche grezze e le tendenze del HTTP Arc
 {% block accessibility_statement %}Dichiarazione di accessibilità{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
+{% block previous_year %}{{ year|int - 1 }}{% endblock %}
+
 {% block featured_chapter %}Capitolo in primo piano{% endblock %}
-{% block featured_chapter_last_year %}Capitolo in primo piano<br>dal Web Almanac {{ year|int -1 }}{% endblock %}
+{% block featured_chapter_last_year %}Capitolo in primo piano<br>dal Web Almanac {{ self.previous_year() }}{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}Leggi il capitolo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}Leggi il capitolo {{ year|int-1 }} <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}Leggi il capitolo {{ self.previous_year() }} <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/it/base.html
+++ b/src/templates/it/base.html
@@ -24,7 +24,7 @@ La nostra missione è combinare le statistiche grezze e le tendenze del HTTP Arc
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}Leggi il Web Almanac del {{ self.previous_year() }}{% endblock %}
+{% block read_last_years_almanac %}Leggi il Web Almanac del {{ previous_year }}{% endblock %}
 
 {% block http_archive_link %}Pagina iniziale HTTP Archive{% endblock %}
 
@@ -123,17 +123,15 @@ La nostra missione è combinare le statistiche grezze e le tendenze del HTTP Arc
 {% block accessibility_statement %}Dichiarazione di accessibilità{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
-{% block previous_year %}{{ year|int - 1 }}{% endblock %}
-
 {% block featured_chapter %}Capitolo in primo piano{% endblock %}
-{% block featured_chapter_last_year %}Capitolo in primo piano<br>dal Web Almanac {{ self.previous_year() }}{% endblock %}
+{% block featured_chapter_last_year %}Capitolo in primo piano<br>dal Web Almanac {{ previous_year }}{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}Leggi il capitolo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}Leggi il capitolo {{ self.previous_year() }} <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}Leggi il capitolo {{ previous_year }} <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/ja/2024/base.html
+++ b/src/templates/ja/2024/base.html
@@ -1,7 +1,7 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}8.36M{% endblock %}
-{% block methodology_stat_2 %}43.88 TB{% endblock %}
+{% block methodology_stat_1 %}16.9M{% endblock %}
+{% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}約840万の{% endblock %}
 {% block dataset %}2022年6{% endblock %}
 {% block read_last_years_almanac %}{{ year | int - 2 }} Web Almanacを読む{% endblock %}

--- a/src/templates/ja/2024/base.html
+++ b/src/templates/ja/2024/base.html
@@ -4,7 +4,7 @@
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}約840万の{% endblock %}
 {% block dataset %}2024年6{% endblock %}
-{% block read_last_years_almanac %}{{ year | int - 2 }} Web Almanacを読む{% endblock %}
+{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/ja/2024/base.html
+++ b/src/templates/ja/2024/base.html
@@ -3,7 +3,7 @@
 {% block methodology_stat_1 %}16.9M{% endblock %}
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}約840万の{% endblock %}
-{% block dataset %}2022年6{% endblock %}
+{% block dataset %}2024年6{% endblock %}
 {% block read_last_years_almanac %}{{ year | int - 2 }} Web Almanacを読む{% endblock %}
 
 {% block foreword %}

--- a/src/templates/ja/2024/base.html
+++ b/src/templates/ja/2024/base.html
@@ -1,0 +1,11 @@
+{% extends "%s/base.html" % lang %}
+
+{% block methodology_stat_1 %}8.36M{% endblock %}
+{% block methodology_stat_2 %}43.88 TB{% endblock %}
+{% block total_websites %}約840万の{% endblock %}
+{% block dataset %}2022年6{% endblock %}
+{% block read_last_years_almanac %}{{ year | int - 2 }} Web Almanacを読む{% endblock %}
+
+{% block foreword %}
+{# TODO #}
+{% endblock %}

--- a/src/templates/ja/2024/base.html
+++ b/src/templates/ja/2024/base.html
@@ -4,7 +4,6 @@
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}約840万の{% endblock %}
 {% block dataset %}2024年6{% endblock %}
-{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/ja/2024/contributors.html
+++ b/src/templates/ja/2024/contributors.html
@@ -1,0 +1,11 @@
+{% extends "base/contributors.html" %}
+
+{% block title %}{{ year }} 貢献者 | HTTP ArchiveによるWeb Almanac{% endblock %}
+
+{% block description %}{{ config.contributors.items() | length }} アナリスト、著者、デザイナー、開発者、編集者、レビュアー、翻訳者として{ year }}年のWeb Almanacに貢献した人々。{% endblock %}
+
+{% block filter_by_team %}チームでフィルタリング： <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> の <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> 貢献者。{% endblock %}
+{% block filter_by %}フィルタリング{% endblock %}
+
+{% block join_the_team_title%}Web Almanacチームに参加しましょう{% endblock %}
+{% block join_the_team_text%}チームに参加しよう！{% endblock %}

--- a/src/templates/ja/2024/index.html
+++ b/src/templates/ja/2024/index.html
@@ -1,0 +1,6 @@
+{% extends "base/index.html" %}
+
+{% block title %}{{ year }} Web Almanac{% endblock %}
+{% block description %}Web Almanacは、Webコミュニティの専門知識とHTTP Archiveのデータやトレンドを組み合わせた、毎年恒例のWeb状態のレポートです。{% endblock %}
+
+{% block twitter_image_alt %}{{ year }} Web Almanac{% endblock %}

--- a/src/templates/ja/2024/table_of_contents.html
+++ b/src/templates/ja/2024/table_of_contents.html
@@ -1,0 +1,7 @@
+{% extends "base/table_of_contents.html" %}
+
+{% block title %}目次 | Web Almanac {{ year }}{% endblock %}
+
+{% block description %}{{ year }}年版Web Almanacの目次、各セクションを一覧表示しています。ページコンテンツ、ユーザー体験、コンテンツ公開、コンテンツ配信。{% endblock %}
+
+{% block twitter_image_alt %}{{ year }} Web Almanac方法論{% endblock %}

--- a/src/templates/ja/base.html
+++ b/src/templates/ja/base.html
@@ -24,7 +24,7 @@
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}{{ self.previous_year() }} Web Almanacを読む{% endblock %}
+{% block read_last_years_almanac %}{{ previous_year }} Web Almanacを読む{% endblock %}
 
 {% block http_archive_link %}HTTP ArchiveによるWeb Almanac{% endblock %}
 
@@ -123,17 +123,15 @@
 {% block accessibility_statement %}アクセシビリティに関する声明{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
-{% block previous_year %}{{ year|int - 1 }}{% endblock %}
-
 {% block featured_chapter %}注目の章{% endblock %}
-{% block featured_chapter_last_year %}{{ self.previous_year() }} Web Almanac<br>注目の章{% endblock %}
+{% block featured_chapter_last_year %}{{ previous_year }} Web Almanac<br>注目の章{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}<span class="featured-chapter-name">{{ chapter }}</span>の章を読む{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}<span class="featured-chapter-name">{{ chapter }}</span>の章を読む{{ self.previous_year() }}{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}<span class="featured-chapter-name">{{ chapter }}</span>の章を読む{{ previous_year }}{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/ja/base.html
+++ b/src/templates/ja/base.html
@@ -24,7 +24,7 @@
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}{{ year | int - 1 }} Web Almanacを読む{% endblock %}
+{% block read_last_years_almanac %}{{ self.previous_year() }} Web Almanacを読む{% endblock %}
 
 {% block http_archive_link %}HTTP ArchiveによるWeb Almanac{% endblock %}
 
@@ -123,15 +123,17 @@
 {% block accessibility_statement %}アクセシビリティに関する声明{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
+{% block previous_year %}{{ year|int - 1 }}{% endblock %}
+
 {% block featured_chapter %}注目の章{% endblock %}
-{% block featured_chapter_last_year %}{{ year|int -1 }} Web Almanac<br>注目の章{% endblock %}
+{% block featured_chapter_last_year %}{{ self.previous_year() }} Web Almanac<br>注目の章{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}<span class="featured-chapter-name">{{ chapter }}</span>の章を読む{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}<span class="featured-chapter-name">{{ chapter }}</span>の章を読む{{ year|int -1 }}{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}<span class="featured-chapter-name">{{ chapter }}</span>の章を読む{{ self.previous_year() }}{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/nl/2024/base.html
+++ b/src/templates/nl/2024/base.html
@@ -4,7 +4,6 @@
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}bijna 8,4 miljoen{% endblock %}
 {% block dataset %}juni 2024{% endblock %}
-{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/nl/2024/base.html
+++ b/src/templates/nl/2024/base.html
@@ -1,7 +1,7 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}8.36M{% endblock %}
-{% block methodology_stat_2 %}43.88 TB{% endblock %}
+{% block methodology_stat_1 %}16.9M{% endblock %}
+{% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}bijna 8,4 miljoen{% endblock %}
 {% block dataset %}juni 2022{% endblock %}
 {% block read_last_years_almanac %}Lees de {{ year | int - 2 }} Web Almanac{% endblock %}

--- a/src/templates/nl/2024/base.html
+++ b/src/templates/nl/2024/base.html
@@ -3,7 +3,7 @@
 {% block methodology_stat_1 %}16.9M{% endblock %}
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}bijna 8,4 miljoen{% endblock %}
-{% block dataset %}juni 2022{% endblock %}
+{% block dataset %}juni 2024{% endblock %}
 {% block read_last_years_almanac %}Lees de {{ year | int - 2 }} Web Almanac{% endblock %}
 
 {% block foreword %}

--- a/src/templates/nl/2024/base.html
+++ b/src/templates/nl/2024/base.html
@@ -1,0 +1,11 @@
+{% extends "%s/base.html" % lang %}
+
+{% block methodology_stat_1 %}8.36M{% endblock %}
+{% block methodology_stat_2 %}43.88 TB{% endblock %}
+{% block total_websites %}bijna 8,4 miljoen{% endblock %}
+{% block dataset %}juni 2022{% endblock %}
+{% block read_last_years_almanac %}Lees de {{ year | int - 2 }} Web Almanac{% endblock %}
+
+{% block foreword %}
+{# TODO #}
+{% endblock %}

--- a/src/templates/nl/2024/base.html
+++ b/src/templates/nl/2024/base.html
@@ -4,7 +4,7 @@
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}bijna 8,4 miljoen{% endblock %}
 {% block dataset %}juni 2024{% endblock %}
-{% block read_last_years_almanac %}Lees de {{ year | int - 2 }} Web Almanac{% endblock %}
+{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/nl/2024/contributors.html
+++ b/src/templates/nl/2024/contributors.html
@@ -1,0 +1,11 @@
+{% extends "base/contributors.html" %}
+
+{% block title %}{{ year }} Bijdragers | De Web Almanac door HTTP Archive{% endblock %}
+
+{% block description %}De {{ config.contributors.items() | length }} mensen die hebben bijgedragen aan de Web Almanac van {{ year }} als analisten, auteurs, ontwerpers, ontwikkelaars, redacteuren, leiders, recensenten en vertalers.{% endblock %}
+
+{% block filter_by_team %}Filter op team: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> van <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> bijdragers.{% endblock %}
+{% block filter_by %}Filter op{% endblock %}
+
+{% block join_the_team_title%}Word lid van de Web Almanac team{% endblock %}
+{% block join_the_team_text%}Kom bij het team!{% endblock %}

--- a/src/templates/nl/2024/index.html
+++ b/src/templates/nl/2024/index.html
@@ -1,0 +1,6 @@
+{% extends "base/index.html" %}
+
+{% block title %}De {{ year }} Web Almanac{% endblock %}
+{% block description %}De Web Almanac is een jaarlijks staat van het webrapport waarin de expertise van de webgemeenschap wordt gecombineerd met de gegevens en trends van het HTTP Archive.{% endblock %}
+
+{% block twitter_image_alt %}De {{ year }} Web Almanac{% endblock %}

--- a/src/templates/nl/2024/table_of_contents.html
+++ b/src/templates/nl/2024/table_of_contents.html
@@ -1,0 +1,7 @@
+{% extends "base/table_of_contents.html" %}
+
+{% block title %}Inhoudsopgave | Web Almanac {{ year }}{% endblock %}
+
+{% block description %}Inhoudsopgave voor de Web Almanac {{ year }}, met een opsomming van elke sectie: pagina-inhoud, gebruikerservaring, inhoud publiceren, inhoudsdistributie.{% endblock %}
+
+{% block twitter_image_alt %}{{ year }} Web Almanac methodologie{% endblock %}

--- a/src/templates/nl/base.html
+++ b/src/templates/nl/base.html
@@ -24,7 +24,7 @@
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}Lees de {{ year | int - 1 }} Web Almanac{% endblock %}
+{% block read_last_years_almanac %}Lees de {{ self.previous_year() }} Web Almanac{% endblock %}
 
 {% block http_archive_link %}HTTP Archive home{% endblock %}
 
@@ -123,15 +123,17 @@
 {% block accessibility_statement %}Toegankelijkheidsverklaring{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
+{% block previous_year %}{{ year|int - 1 }}{% endblock %}
+
 {% block featured_chapter %}Uitgelicht Hoofdstuk{% endblock %}
-{% block featured_chapter_last_year %}Uitgelicht Hoofdstuk<br>van de {{ year|int -1 }} Web Almanac{% endblock %}
+{% block featured_chapter_last_year %}Uitgelicht Hoofdstuk<br>van de {{ self.previous_year() }} Web Almanac{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}Lees het <span class="featured-chapter-name">{{ chapter }}</span> hoofdstuk{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}Lees het {{ year|int-1 }} <span class="featured-chapter-name">{{ chapter }}</span> hoofdstuk{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}Lees het {{ self.previous_year() }} <span class="featured-chapter-name">{{ chapter }}</span> hoofdstuk{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/nl/base.html
+++ b/src/templates/nl/base.html
@@ -24,7 +24,7 @@
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}Lees de {{ self.previous_year() }} Web Almanac{% endblock %}
+{% block read_last_years_almanac %}Lees de {{ previous_year }} Web Almanac{% endblock %}
 
 {% block http_archive_link %}HTTP Archive home{% endblock %}
 
@@ -123,17 +123,15 @@
 {% block accessibility_statement %}Toegankelijkheidsverklaring{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
-{% block previous_year %}{{ year|int - 1 }}{% endblock %}
-
 {% block featured_chapter %}Uitgelicht Hoofdstuk{% endblock %}
-{% block featured_chapter_last_year %}Uitgelicht Hoofdstuk<br>van de {{ self.previous_year() }} Web Almanac{% endblock %}
+{% block featured_chapter_last_year %}Uitgelicht Hoofdstuk<br>van de {{ previous_year }} Web Almanac{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}Lees het <span class="featured-chapter-name">{{ chapter }}</span> hoofdstuk{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}Lees het {{ self.previous_year() }} <span class="featured-chapter-name">{{ chapter }}</span> hoofdstuk{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}Lees het {{ previous_year }} <span class="featured-chapter-name">{{ chapter }}</span> hoofdstuk{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/pt/2024/base.html
+++ b/src/templates/pt/2024/base.html
@@ -1,8 +1,8 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}8.36M{% endblock %}
-{% block methodology_stat_2 %}43.88 TB{% endblock %}
-{% block total_websites %}cerca de 8.4 milhões{% endblock %}
+{% block methodology_stat_1 %}16.9M{% endblock %}
+{% block methodology_stat_2 %}82.61 TB{% endblock %}
+{% block total_websites %}cerca de 17 milhões{% endblock %}
 {% block dataset %}junho de 2022{% endblock %}
 {% block read_last_years_almanac %}Leia o  {{ year | int - 2 }} Web Almanac{% endblock %}
 

--- a/src/templates/pt/2024/base.html
+++ b/src/templates/pt/2024/base.html
@@ -3,7 +3,7 @@
 {% block methodology_stat_1 %}16.9M{% endblock %}
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}cerca de 17 milhões{% endblock %}
-{% block dataset %}junho de 2022{% endblock %}
+{% block dataset %}junho de 2024{% endblock %}
 {% block read_last_years_almanac %}Leia o  {{ year | int - 2 }} Web Almanac{% endblock %}
 
 {% block foreword %}

--- a/src/templates/pt/2024/base.html
+++ b/src/templates/pt/2024/base.html
@@ -4,7 +4,7 @@
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}cerca de 17 milhões{% endblock %}
 {% block dataset %}junho de 2024{% endblock %}
-{% block read_last_years_almanac %}Leia o  {{ year | int - 2 }} Web Almanac{% endblock %}
+{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/pt/2024/base.html
+++ b/src/templates/pt/2024/base.html
@@ -4,7 +4,6 @@
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}cerca de 17 milhões{% endblock %}
 {% block dataset %}junho de 2024{% endblock %}
-{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/pt/2024/base.html
+++ b/src/templates/pt/2024/base.html
@@ -1,0 +1,11 @@
+{% extends "%s/base.html" % lang %}
+
+{% block methodology_stat_1 %}8.36M{% endblock %}
+{% block methodology_stat_2 %}43.88 TB{% endblock %}
+{% block total_websites %}cerca de 8.4 milhões{% endblock %}
+{% block dataset %}junho de 2022{% endblock %}
+{% block read_last_years_almanac %}Leia o  {{ year | int - 2 }} Web Almanac{% endblock %}
+
+{% block foreword %}
+{# TODO #}
+{% endblock %}

--- a/src/templates/pt/2024/contributors.html
+++ b/src/templates/pt/2024/contributors.html
@@ -1,0 +1,11 @@
+{% extends "base/contributors.html" %}
+
+{% block title %}{{ year }} Colaboradores | O Web Almanac por HTTP Archive{% endblock %}
+
+{% block description %}O {{ config.contributors.items() | length }} pessoas que contribuíram para o Web Almanac {{ year }} como analistas, autores, pensadores, designers, desenvolvedores, editores, revisores e tradutores.{% endblock %}
+
+{% block filter_by_team %}Filtrar por equipe: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> de <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> contribuidores.{% endblock %}
+{% block filter_by %}Filtrar por{% endblock %}
+
+{% block join_the_team_title%}Junte-se à equipe do Web Almanac{% endblock %}
+{% block join_the_team_text%}Junte-se ao time!{% endblock %}

--- a/src/templates/pt/2024/index.html
+++ b/src/templates/pt/2024/index.html
@@ -1,0 +1,6 @@
+{% extends "base/index.html" %}
+
+{% block title %}Web Almanac {{ year }} {% endblock %}
+{% block description %}Web Almanac é um relatório anual sobre o estado da web que combina a experiência da comunidade da web com os dados e tendências do HTTP Archive.{% endblock %}
+
+{% block twitter_image_alt %}Web Almanac {{ year }} {% endblock %}

--- a/src/templates/pt/2024/table_of_contents.html
+++ b/src/templates/pt/2024/table_of_contents.html
@@ -1,0 +1,7 @@
+{% extends "base/table_of_contents.html" %}
+
+{% block title %}Tabela de Conteúdos | Web Almanac {{ year }}{% endblock %}
+
+{% block description %}Tabela de Conteúdos de Web Almanac de {{ year }} , listando cada seção: Conteúdo da página, Experiência do usuário, Publicação de conteúdo, Distribuição de conteúdo.{% endblock %}
+
+{% block twitter_image_alt %}Web Almanac metodologia {{ year }}{% endblock %}

--- a/src/templates/pt/base.html
+++ b/src/templates/pt/base.html
@@ -24,7 +24,7 @@ Nossa missão é combinar as estatísticas brutas e as tendências do HTTP Archi
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}Leia o  {{ year | int - 1 }} Web Almanac{% endblock %}
+{% block read_last_years_almanac %}Leia o  {{ self.previous_year() }} Web Almanac{% endblock %}
 
 {% block http_archive_link %}Página inicial HTTP Archive{% endblock %}
 
@@ -123,15 +123,17 @@ Nossa missão é combinar as estatísticas brutas e as tendências do HTTP Archi
 {% block accessibility_statement %}Declaração de acessibilidade{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
+{% block previous_year %}{{ year|int - 1 }}{% endblock %}
+
 {% block featured_chapter %}Capítulo em Destaque{% endblock %}
-{% block featured_chapter_last_year %}Capítulo em Destaque<br>do Web Almanac {{ year|int -1 }}{% endblock %}
+{% block featured_chapter_last_year %}Capítulo em Destaque<br>do Web Almanac {{ self.previous_year() }}{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}Leia o capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}Leia o {{ year|int -1 }} capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}Leia o {{ self.previous_year() }} capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/pt/base.html
+++ b/src/templates/pt/base.html
@@ -24,7 +24,7 @@ Nossa missão é combinar as estatísticas brutas e as tendências do HTTP Archi
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}Leia o  {{ self.previous_year() }} Web Almanac{% endblock %}
+{% block read_last_years_almanac %}Leia o  {{ previous_year }} Web Almanac{% endblock %}
 
 {% block http_archive_link %}Página inicial HTTP Archive{% endblock %}
 
@@ -123,17 +123,15 @@ Nossa missão é combinar as estatísticas brutas e as tendências do HTTP Archi
 {% block accessibility_statement %}Declaração de acessibilidade{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
-{% block previous_year %}{{ year|int - 1 }}{% endblock %}
-
 {% block featured_chapter %}Capítulo em Destaque{% endblock %}
-{% block featured_chapter_last_year %}Capítulo em Destaque<br>do Web Almanac {{ self.previous_year() }}{% endblock %}
+{% block featured_chapter_last_year %}Capítulo em Destaque<br>do Web Almanac {{ previous_year }}{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}Leia o capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}Leia o {{ self.previous_year() }} capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}Leia o {{ previous_year }} capítulo: <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/ru/2024/base.html
+++ b/src/templates/ru/2024/base.html
@@ -3,7 +3,7 @@
 {% block methodology_stat_1 %}16.9 млн{% endblock %}
 {% block methodology_stat_2 %}82.61 Тб{% endblock %}
 {% block total_websites %}около 8,4 миллионов{% endblock %}
-{% block dataset %}июнь 2022{% endblock %}
+{% block dataset %}июнь 2024{% endblock %}
 {% block read_last_years_almanac %}Прочитать отчёт Web Almanac за {{ year | int - 2 }} год{% endblock %}
 
 {% block foreword %}

--- a/src/templates/ru/2024/base.html
+++ b/src/templates/ru/2024/base.html
@@ -1,7 +1,7 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}8.36 млн{% endblock %}
-{% block methodology_stat_2 %}43.88 Тб{% endblock %}
+{% block methodology_stat_1 %}16.9 млн{% endblock %}
+{% block methodology_stat_2 %}82.61 Тб{% endblock %}
 {% block total_websites %}около 8,4 миллионов{% endblock %}
 {% block dataset %}июнь 2022{% endblock %}
 {% block read_last_years_almanac %}Прочитать отчёт Web Almanac за {{ year | int - 2 }} год{% endblock %}

--- a/src/templates/ru/2024/base.html
+++ b/src/templates/ru/2024/base.html
@@ -1,0 +1,11 @@
+{% extends "%s/base.html" % lang %}
+
+{% block methodology_stat_1 %}8.36 млн{% endblock %}
+{% block methodology_stat_2 %}43.88 Тб{% endblock %}
+{% block total_websites %}около 8,4 миллионов{% endblock %}
+{% block dataset %}июнь 2022{% endblock %}
+{% block read_last_years_almanac %}Прочитать отчёт Web Almanac за {{ year | int - 2 }} год{% endblock %}
+
+{% block foreword %}
+{# TODO #}
+{% endblock %}

--- a/src/templates/ru/2024/base.html
+++ b/src/templates/ru/2024/base.html
@@ -4,7 +4,6 @@
 {% block methodology_stat_2 %}82.61 Тб{% endblock %}
 {% block total_websites %}около 8,4 миллионов{% endblock %}
 {% block dataset %}июнь 2024{% endblock %}
-{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/ru/2024/base.html
+++ b/src/templates/ru/2024/base.html
@@ -4,7 +4,7 @@
 {% block methodology_stat_2 %}82.61 Тб{% endblock %}
 {% block total_websites %}около 8,4 миллионов{% endblock %}
 {% block dataset %}июнь 2024{% endblock %}
-{% block read_last_years_almanac %}Прочитать отчёт Web Almanac за {{ year | int - 2 }} год{% endblock %}
+{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/ru/2024/contributors.html
+++ b/src/templates/ru/2024/contributors.html
@@ -1,0 +1,11 @@
+{% extends "base//contributors.html" %}
+
+{% block title %}Участники за {{ year }} год | Web Almanac от HTTP Archive{% endblock %}
+
+{% block description %}{{ config.contributors.items() | length }} {{ plural_ru(config.contributors.items() | length | int, ["человек", "человека", "человек"]) }}, внесших свой вклад в Web Almanac за {{ year }} год — это аналитики, авторы, дизайнеры, разработчики, редакторы, руководители, проверяющие и переводчики.{% endblock %}
+
+{% block filter_by_team %}Фильтр по ролям в команде: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> из <span id="contributors-total">{{ config.contributors.items() | length }}</span> {{ plural_ru(config.contributors.items() | length | int, ["участника", "участников", "участников"]) }}</span><span id="contributors-total-text-non-filtered"> {{ plural_ru(config.contributors.items() | length | int, ["участника", "участников", "участников"]) }}</span>.{% endblock %}
+{% block filter_by %}Отфильтровать по{% endblock %}
+
+{% block join_the_team_title%}Присоединяйтесь к команде Web Almanac{% endblock %}
+{% block join_the_team_text%}Здесь могли быть вы!{% endblock %}

--- a/src/templates/ru/2024/index.html
+++ b/src/templates/ru/2024/index.html
@@ -1,0 +1,6 @@
+{% extends "base//index.html" %}
+
+{% block title %}Web Almanac за {{ year }} год{% endblock %}
+{% block description %}Web Almanac — это ежегодный отчёт о состоянии веба на основе данных и тенденций, собранных HTTP Archive и с учётом мнения сообщества.{% endblock %}
+
+{% block twitter_image_alt %}Web Almanac за {{ year }} год{% endblock %}

--- a/src/templates/ru/2024/table_of_contents.html
+++ b/src/templates/ru/2024/table_of_contents.html
@@ -1,0 +1,7 @@
+{% extends "base//table_of_contents.html" %}
+
+{% block title %}Содержание | Web Almanac {{ year }}{% endblock %}
+
+{% block description %}Оглавление содержания Web Almanac от {{ year }} года: Контент страницы, Пользовательские ощущения, Публикация контента, Распространение контента.{% endblock %}
+
+{% block twitter_image_alt %}Методология Web Almanac в {{ year }} году{% endblock %}

--- a/src/templates/ru/base.html
+++ b/src/templates/ru/base.html
@@ -24,7 +24,7 @@
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}Прочитать отчёт Web Almanac за {{ self.previous_year() }} год{% endblock %}
+{% block read_last_years_almanac %}Прочитать отчёт Web Almanac за {{ previous_year }} год{% endblock %}
 
 {% block http_archive_link %}Главная страница HTTP Archive{% endblock %}
 
@@ -123,17 +123,15 @@
 {% block accessibility_statement %}Информация о доступности{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
-{% block previous_year %}{{ year|int - 1 }}{% endblock %}
-
 {% block featured_chapter %}Лучшая глава{% endblock %}
-{% block featured_chapter_last_year %}Лучшая глава<br>в Web Almanac из {{ self.previous_year() }} года{% endblock %}
+{% block featured_chapter_last_year %}Лучшая глава<br>в Web Almanac из {{ previous_year }} года{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}Перейти к главе <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}Перейти к главе <span class="featured-chapter-name">{{ chapter }}</span> от {{ self.previous_year() }} года{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}Перейти к главе <span class="featured-chapter-name">{{ chapter }}</span> от {{ previous_year }} года{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/ru/base.html
+++ b/src/templates/ru/base.html
@@ -24,7 +24,7 @@
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}Прочитать отчёт Web Almanac за {{ year | int - 1 }} год{% endblock %}
+{% block read_last_years_almanac %}Прочитать отчёт Web Almanac за {{ self.previous_year() }} год{% endblock %}
 
 {% block http_archive_link %}Главная страница HTTP Archive{% endblock %}
 
@@ -123,15 +123,17 @@
 {% block accessibility_statement %}Информация о доступности{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
+{% block previous_year %}{{ year|int - 1 }}{% endblock %}
+
 {% block featured_chapter %}Лучшая глава{% endblock %}
-{% block featured_chapter_last_year %}Лучшая глава<br>в Web Almanac из {{ year|int -1 }} года{% endblock %}
+{% block featured_chapter_last_year %}Лучшая глава<br>в Web Almanac из {{ self.previous_year() }} года{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}Перейти к главе <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}Перейти к главе <span class="featured-chapter-name">{{ chapter }}</span> от {{ year|int-1 }} года{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}Перейти к главе <span class="featured-chapter-name">{{ chapter }}</span> от {{ self.previous_year() }} года{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/tr/2024/base.html
+++ b/src/templates/tr/2024/base.html
@@ -4,7 +4,7 @@
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}yaklaşık 17 milyon{% endblock %}
 {% block dataset %}Haziran 2024{% endblock %}
-{% block read_last_years_almanac %} {{ year | int - 2 }} Web Almanac&#8217;ı Oku{% endblock %}
+{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/tr/2024/base.html
+++ b/src/templates/tr/2024/base.html
@@ -1,8 +1,8 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}8.36M{% endblock %}
-{% block methodology_stat_2 %}43.88 TB{% endblock %}
-{% block total_websites %}yaklaşık 8.4 milyon{% endblock %}
+{% block methodology_stat_1 %}16.9M{% endblock %}
+{% block methodology_stat_2 %}82.61 TB{% endblock %}
+{% block total_websites %}yaklaşık 17 milyon{% endblock %}
 {% block dataset %}Haziran 2022{% endblock %}
 {% block read_last_years_almanac %} {{ year | int - 2 }} Web Almanac&#8217;ı Oku{% endblock %}
 

--- a/src/templates/tr/2024/base.html
+++ b/src/templates/tr/2024/base.html
@@ -3,7 +3,7 @@
 {% block methodology_stat_1 %}16.9M{% endblock %}
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}yaklaşık 17 milyon{% endblock %}
-{% block dataset %}Haziran 2022{% endblock %}
+{% block dataset %}Haziran 2024{% endblock %}
 {% block read_last_years_almanac %} {{ year | int - 2 }} Web Almanac&#8217;ı Oku{% endblock %}
 
 {% block foreword %}

--- a/src/templates/tr/2024/base.html
+++ b/src/templates/tr/2024/base.html
@@ -4,7 +4,6 @@
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}yaklaşık 17 milyon{% endblock %}
 {% block dataset %}Haziran 2024{% endblock %}
-{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/tr/2024/base.html
+++ b/src/templates/tr/2024/base.html
@@ -1,0 +1,11 @@
+{% extends "%s/base.html" % lang %}
+
+{% block methodology_stat_1 %}8.36M{% endblock %}
+{% block methodology_stat_2 %}43.88 TB{% endblock %}
+{% block total_websites %}yaklaşık 8.4 milyon{% endblock %}
+{% block dataset %}Haziran 2022{% endblock %}
+{% block read_last_years_almanac %} {{ year | int - 2 }} Web Almanac&#8217;ı Oku{% endblock %}
+
+{% block foreword %}
+{# TODO #}
+{% endblock %}

--- a/src/templates/tr/2024/contributors.html
+++ b/src/templates/tr/2024/contributors.html
@@ -1,0 +1,11 @@
+{% extends "base/contributors.html" %}
+
+{% block title %}{{ year }} Katkıda bulunanlar | HTTP Archive'dan Web Almanac{% endblock %}
+
+{% block description %}{{ year }}Web Almanac'a Analistler, Yazarlar, Tasarımcılar, Geliştiriciler, Editörler, Liderler, İnceleyiciler ve Çevirmenler olarak katkıda bulunan {{ config.contributors.items() | length }}kişi.{% endblock %}
+
+{% block filter_by_team %}Takıma göre filtrele: Katkıda bulunan <span id="contributors-total">{{ config.contributors.items() | length }}</span><span id="contributors-total-text" class="hidden"> kişinin <span id="filtered-contributors">{{ self.contributors() }}</span></span>{% endblock %}
+{% block filter_by %}Filtrele{% endblock %}
+
+{% block join_the_team_title%}Web Almanac takımına katılın{% endblock %}
+{% block join_the_team_text%}Takıma katılın!{% endblock %}

--- a/src/templates/tr/2024/index.html
+++ b/src/templates/tr/2024/index.html
@@ -1,0 +1,6 @@
+{% extends "base/index.html" %}
+
+{% block title %}{{ year }}Web Almanac{% endblock %}
+{% block description %}Web Almanac, web topluluğunun uzmanlığını HTTP Archive verileri ve eğilimleri ile birleştiren yıllık bir web raporudur.{% endblock %}
+
+{% block twitter_image_alt %}{{ year }}Web Almanac{% endblock %}

--- a/src/templates/tr/2024/table_of_contents.html
+++ b/src/templates/tr/2024/table_of_contents.html
@@ -1,0 +1,7 @@
+{% extends "base/table_of_contents.html" %}
+
+{% block title %}İçindekiler Tablosu | Web Almanac {{ year }}{% endblock %}
+
+{% block description %}{{ year }} Web Almanac için İçindekiler Tablosu, her bölümü listelemek: Sayfa İçerikleri, Kullanıcı Deneyimi, İçerik Yayınlama, İçerik Dağıtımı.{% endblock %}
+
+{% block twitter_image_alt %}{{ year }} Web Almanac Metodolojisi{% endblock %}

--- a/src/templates/tr/base.html
+++ b/src/templates/tr/base.html
@@ -24,7 +24,7 @@ Misyonumuz, HTTP Archive&#8217;ın ham istatistiklerini ve eğilimlerini web top
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %} {{ self.previous_year() }} Web Almanac&#8217;ı Oku{% endblock %}
+{% block read_last_years_almanac %} {{ previous_year }} Web Almanac&#8217;ı Oku{% endblock %}
 
 {% block http_archive_link %}HTTP Archive Ana Sayfa{% endblock %}
 
@@ -123,17 +123,15 @@ Misyonumuz, HTTP Archive&#8217;ın ham istatistiklerini ve eğilimlerini web top
 {% block accessibility_statement %}Erişilebilirlik Bildirimi{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
-{% block previous_year %}{{ year|int - 1 }}{% endblock %}
-
 {% block featured_chapter %}Öne Çıkan Bölüm{% endblock %}
-{% block featured_chapter_last_year %}{{ self.previous_year() }} Web Almanac'tan <br>Öne Çıkan Bölüm{% endblock %}
+{% block featured_chapter_last_year %}{{ previous_year }} Web Almanac'tan <br>Öne Çıkan Bölüm{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}<span class="featured-chapter-name">{{ chapter }}</span> Bölümünü Okuyun{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %} {{ self.previous_year() }} <span class="featured-chapter-name">{{ chapter }}</span> Bölümünü Okuyun{% endmacro %}
+{% macro read_last_years_chapter(chapter) %} {{ previous_year }} <span class="featured-chapter-name">{{ chapter }}</span> Bölümünü Okuyun{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/tr/base.html
+++ b/src/templates/tr/base.html
@@ -24,7 +24,7 @@ Misyonumuz, HTTP Archive&#8217;ın ham istatistiklerini ve eğilimlerini web top
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %} {{ year | int - 1 }} Web Almanac&#8217;ı Oku{% endblock %}
+{% block read_last_years_almanac %} {{ self.previous_year() }} Web Almanac&#8217;ı Oku{% endblock %}
 
 {% block http_archive_link %}HTTP Archive Ana Sayfa{% endblock %}
 
@@ -123,15 +123,17 @@ Misyonumuz, HTTP Archive&#8217;ın ham istatistiklerini ve eğilimlerini web top
 {% block accessibility_statement %}Erişilebilirlik Bildirimi{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
+{% block previous_year %}{{ year|int - 1 }}{% endblock %}
+
 {% block featured_chapter %}Öne Çıkan Bölüm{% endblock %}
-{% block featured_chapter_last_year %}{{ year|int -1 }} Web Almanac'tan <br>Öne Çıkan Bölüm{% endblock %}
+{% block featured_chapter_last_year %}{{ self.previous_year() }} Web Almanac'tan <br>Öne Çıkan Bölüm{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}<span class="featured-chapter-name">{{ chapter }}</span> Bölümünü Okuyun{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %} {{ year|int-1 }} <span class="featured-chapter-name">{{ chapter }}</span> Bölümünü Okuyun{% endmacro %}
+{% macro read_last_years_chapter(chapter) %} {{ self.previous_year() }} <span class="featured-chapter-name">{{ chapter }}</span> Bölümünü Okuyun{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/uk/2024/base.html
+++ b/src/templates/uk/2024/base.html
@@ -4,7 +4,7 @@
 {% block methodology_stat_2 %}82,61&nbsp;ТБ{% endblock %}
 {% block total_websites %}майже 8 мільйонів{% endblock %}
 {% block dataset %}червень 2024{% endblock %}
-{% block read_last_years_almanac %}Читати Web Almanac за {{ year | int - 2 }} рік{% endblock %}
+{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/uk/2024/base.html
+++ b/src/templates/uk/2024/base.html
@@ -1,7 +1,7 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}8,36&nbsp;млн{% endblock %}
-{% block methodology_stat_2 %}43,88&nbsp;ТБ{% endblock %}
+{% block methodology_stat_1 %}16,9&nbsp;млн{% endblock %}
+{% block methodology_stat_2 %}82,61&nbsp;ТБ{% endblock %}
 {% block total_websites %}майже 8 мільйонів{% endblock %}
 {% block dataset %}червень 2022{% endblock %}
 {% block read_last_years_almanac %}Читати Web Almanac за {{ year | int - 2 }} рік{% endblock %}

--- a/src/templates/uk/2024/base.html
+++ b/src/templates/uk/2024/base.html
@@ -3,7 +3,7 @@
 {% block methodology_stat_1 %}16,9&nbsp;млн{% endblock %}
 {% block methodology_stat_2 %}82,61&nbsp;ТБ{% endblock %}
 {% block total_websites %}майже 8 мільйонів{% endblock %}
-{% block dataset %}червень 2022{% endblock %}
+{% block dataset %}червень 2024{% endblock %}
 {% block read_last_years_almanac %}Читати Web Almanac за {{ year | int - 2 }} рік{% endblock %}
 
 {% block foreword %}

--- a/src/templates/uk/2024/base.html
+++ b/src/templates/uk/2024/base.html
@@ -1,0 +1,11 @@
+{% extends "%s/base.html" % lang %}
+
+{% block methodology_stat_1 %}8,36&nbsp;млн{% endblock %}
+{% block methodology_stat_2 %}43,88&nbsp;ТБ{% endblock %}
+{% block total_websites %}майже 8 мільйонів{% endblock %}
+{% block dataset %}червень 2022{% endblock %}
+{% block read_last_years_almanac %}Читати Web Almanac за {{ year | int - 2 }} рік{% endblock %}
+
+{% block foreword %}
+{# TODO #}
+{% endblock %}

--- a/src/templates/uk/2024/base.html
+++ b/src/templates/uk/2024/base.html
@@ -4,7 +4,6 @@
 {% block methodology_stat_2 %}82,61&nbsp;ТБ{% endblock %}
 {% block total_websites %}майже 8 мільйонів{% endblock %}
 {% block dataset %}червень 2024{% endblock %}
-{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/uk/2024/contributors.html
+++ b/src/templates/uk/2024/contributors.html
@@ -1,0 +1,11 @@
+{% extends "base/contributors.html" %}
+
+{% block title %}Контриб'ютори {{ year }} року | Web Almanac від HTTP Archive{% endblock %}
+
+{% block description %}{{ config.contributors.items() | length }} {{ plural_ru(config.contributors.items() | length | int, ["неймовірна людина", "неймовірні людини", "неймовірних людей"]) }}, які долучилися до створення Web Almanac {{ year }} як аналітики, автори, дизайнери, розробники, рецензенти, керівники, редактори та перекладачі.{% endblock %}
+
+{% block filter_by_team %}Фільтрувати за роллю в команді: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> з <span id="contributors-total">{{ config.contributors.items() | length }}</span> {{ plural_ru(config.contributors.items() | length | int, ["контриб'ютора", "контриб'юторів", "контриб'юторів"]) }}</span><span id="contributors-total-text-non-filtered"> {{ plural_ru(config.contributors.items() | length | int, ["контриб'ютор", "контриб'ютори", "контриб'юторів"]) }}</span>.{% endblock %}
+{% block filter_by %}Фільтрувати за{% endblock %}
+
+{% block join_the_team_title%}Приєднуйся до команди Web Almanac{% endblock %}
+{% block join_the_team_text%}Приєднуйся до нас!{% endblock %}

--- a/src/templates/uk/2024/index.html
+++ b/src/templates/uk/2024/index.html
@@ -1,0 +1,6 @@
+{% extends "base/index.html" %}
+
+{% block title %}Web Almanac {{ year }}{% endblock %}
+{% block description %}Web Almanac - це щорічний звіт про стан вебу, який поєднує досвід веб-спільноти з даними і трендами від HTTP Archive.{% endblock %}
+
+{% block twitter_image_alt %}Web Almanac {{ year }}{% endblock %}

--- a/src/templates/uk/2024/table_of_contents.html
+++ b/src/templates/uk/2024/table_of_contents.html
@@ -1,0 +1,7 @@
+{% extends "base/table_of_contents.html" %}
+
+{% block title %}Зміст | Web Almanac {{ year }}{% endblock %}
+
+{% block description %}Зміст Web Almanac {{ year }} з переліком кожного розділу: Контент сторінки, Досвід користування, Публікація контенту, Розповсюдження контенту.{% endblock %}
+
+{% block twitter_image_alt %}Методологія Web Almanac {{ year }}{% endblock %}

--- a/src/templates/uk/base.html
+++ b/src/templates/uk/base.html
@@ -24,7 +24,7 @@
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}Читати Web Almanac за {{ year | int - 1 }} рік{% endblock %}
+{% block read_last_years_almanac %}Читати Web Almanac за {{ self.previous_year() }} рік{% endblock %}
 
 {% block http_archive_link %}HTTP Archive home{% endblock %}
 
@@ -123,15 +123,17 @@
 {% block accessibility_statement %}Заява про доступність{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
+{% block previous_year %}{{ year|int - 1 }}{% endblock %}
+
 {% block featured_chapter %}Рекомендований розділ{% endblock %}
-{% block featured_chapter_last_year %}Рекомендований розділ<br>з Web Almanac {{ year|int -1 }}{% endblock %}
+{% block featured_chapter_last_year %}Рекомендований розділ<br>з Web Almanac {{ self.previous_year() }}{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}Читати розділ <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}Читати розділ <span class="featured-chapter-name">{{ chapter }}</span> {{ year|int-1 }} року{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}Читати розділ <span class="featured-chapter-name">{{ chapter }}</span> {{ self.previous_year() }} року{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/uk/base.html
+++ b/src/templates/uk/base.html
@@ -24,7 +24,7 @@
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}Читати Web Almanac за {{ self.previous_year() }} рік{% endblock %}
+{% block read_last_years_almanac %}Читати Web Almanac за {{ previous_year }} рік{% endblock %}
 
 {% block http_archive_link %}HTTP Archive home{% endblock %}
 
@@ -123,17 +123,15 @@
 {% block accessibility_statement %}Заява про доступність{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
-{% block previous_year %}{{ year|int - 1 }}{% endblock %}
-
 {% block featured_chapter %}Рекомендований розділ{% endblock %}
-{% block featured_chapter_last_year %}Рекомендований розділ<br>з Web Almanac {{ self.previous_year() }}{% endblock %}
+{% block featured_chapter_last_year %}Рекомендований розділ<br>з Web Almanac {{ previous_year }}{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}Читати розділ <span class="featured-chapter-name">{{ chapter }}</span>{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}Читати розділ <span class="featured-chapter-name">{{ chapter }}</span> {{ self.previous_year() }} року{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}Читати розділ <span class="featured-chapter-name">{{ chapter }}</span> {{ previous_year }} року{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/zh-CN/2024/base.html
+++ b/src/templates/zh-CN/2024/base.html
@@ -3,7 +3,7 @@
 {% block methodology_stat_1 %}16.9M{% endblock %}
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}大约840万个{% endblock %}
-{% block dataset %}2022年6{% endblock %}
+{% block dataset %}2024年6{% endblock %}
 {% block read_last_years_almanac %}阅读 {{ year | int - 2 }} Web Almanac{% endblock %}
 
 {% block foreword %}

--- a/src/templates/zh-CN/2024/base.html
+++ b/src/templates/zh-CN/2024/base.html
@@ -1,0 +1,11 @@
+{% extends "%s/base.html" % lang %}
+
+{% block methodology_stat_1 %}8.36M{% endblock %}
+{% block methodology_stat_2 %}43.88 TB{% endblock %}
+{% block total_websites %}大约840万个{% endblock %}
+{% block dataset %}2022年6{% endblock %}
+{% block read_last_years_almanac %}阅读 {{ year | int - 2 }} Web Almanac{% endblock %}
+
+{% block foreword %}
+{# TODO #}
+{% endblock %}

--- a/src/templates/zh-CN/2024/base.html
+++ b/src/templates/zh-CN/2024/base.html
@@ -1,7 +1,7 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}8.36M{% endblock %}
-{% block methodology_stat_2 %}43.88 TB{% endblock %}
+{% block methodology_stat_1 %}16.9M{% endblock %}
+{% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}大约840万个{% endblock %}
 {% block dataset %}2022年6{% endblock %}
 {% block read_last_years_almanac %}阅读 {{ year | int - 2 }} Web Almanac{% endblock %}

--- a/src/templates/zh-CN/2024/base.html
+++ b/src/templates/zh-CN/2024/base.html
@@ -4,7 +4,7 @@
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}大约840万个{% endblock %}
 {% block dataset %}2024年6{% endblock %}
-{% block read_last_years_almanac %}阅读 {{ year | int - 2 }} Web Almanac{% endblock %}
+{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/zh-CN/2024/base.html
+++ b/src/templates/zh-CN/2024/base.html
@@ -4,7 +4,6 @@
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}大约840万个{% endblock %}
 {% block dataset %}2024年6{% endblock %}
-{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/zh-CN/2024/contributors.html
+++ b/src/templates/zh-CN/2024/contributors.html
@@ -1,0 +1,11 @@
+{% extends "base/contributors.html" %}
+
+{% block title %}{{ year }} 贡献者 | Web Almanac 源于 HTTP Archive{% endblock %}
+
+{% block description %}The {{ config.contributors.items() | length }} 为 {{ year }} Web Almanac 贡献的人员，包括分析者, 作者, 设计者, 开发者, 编辑者, 领导者，审稿者和翻译者。{% endblock %}
+
+{% block filter_by_team %}按组过滤: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> of <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> contributors.{% endblock %}
+{% block filter_by %}过滤{% endblock %}
+
+{% block join_the_team_title%}加入 Web Almanac 团队{% endblock %}
+{% block join_the_team_text%}加入团队!{% endblock %}

--- a/src/templates/zh-CN/2024/index.html
+++ b/src/templates/zh-CN/2024/index.html
@@ -1,0 +1,6 @@
+{% extends "base/index.html" %}
+
+{% block title %}{{ year }} Web Almanac 网络年鉴{% endblock %}
+{% block description %}Web Almanac是结合了网络社区的专业知识和HTTP Archive的数据和趋势的网络年度报告，{% endblock %}
+
+{% block twitter_image_alt %}{{ year }} Web Almanac网络年鉴{% endblock %}

--- a/src/templates/zh-CN/2024/table_of_contents.html
+++ b/src/templates/zh-CN/2024/table_of_contents.html
@@ -1,0 +1,7 @@
+{% extends "base/table_of_contents.html" %}
+
+{% block title %}目录 | Web Almanac {{ year }}{% endblock %}
+
+{% block description %}{{ year }} Web Almanac 表单内容, 列出以下部分: 页面内容、用户体验、内容发布、内容分发。{% endblock %}
+
+{% block twitter_image_alt %}{{ year }} Web Almanac 方法论{% endblock %}

--- a/src/templates/zh-CN/base.html
+++ b/src/templates/zh-CN/base.html
@@ -24,7 +24,7 @@
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}阅读 {{ self.previous_year() }} Web Almanac{% endblock %}
+{% block read_last_years_almanac %}阅读 {{ previous_year }} Web Almanac{% endblock %}
 
 {% block http_archive_link %}HTTP Archive主页{% endblock %}
 
@@ -123,17 +123,15 @@
 {% block accessibility_statement %}无障碍可访问声明{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
-{% block previous_year %}{{ year|int - 1 }}{% endblock %}
-
 {% block featured_chapter %}章节精选{% endblock %}
-{% block featured_chapter_last_year %}{{ self.previous_year() }} Web Almanac<br>章节精选{% endblock %}
+{% block featured_chapter_last_year %}{{ previous_year }} Web Almanac<br>章节精选{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}阅读 <span class="featured-chapter-name">{{ chapter }}</span> 章节{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}阅读 {{ self.previous_year() }} <span class="featured-chapter-name">{{ chapter }}</span> 章节{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}阅读 {{ previous_year }} <span class="featured-chapter-name">{{ chapter }}</span> 章节{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/zh-CN/base.html
+++ b/src/templates/zh-CN/base.html
@@ -24,7 +24,7 @@
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}阅读 {{ year | int - 1 }} Web Almanac{% endblock %}
+{% block read_last_years_almanac %}阅读 {{ self.previous_year() }} Web Almanac{% endblock %}
 
 {% block http_archive_link %}HTTP Archive主页{% endblock %}
 
@@ -123,15 +123,17 @@
 {% block accessibility_statement %}无障碍可访问声明{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
+{% block previous_year %}{{ year|int - 1 }}{% endblock %}
+
 {% block featured_chapter %}章节精选{% endblock %}
-{% block featured_chapter_last_year %}{{ year|int -1 }} Web Almanac<br>章节精选{% endblock %}
+{% block featured_chapter_last_year %}{{ self.previous_year() }} Web Almanac<br>章节精选{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}阅读 <span class="featured-chapter-name">{{ chapter }}</span> 章节{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}阅读 {{ year|int -1 }} <span class="featured-chapter-name">{{ chapter }}</span> 章节{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}阅读 {{ self.previous_year() }} <span class="featured-chapter-name">{{ chapter }}</span> 章节{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/zh-TW/2024/base.html
+++ b/src/templates/zh-TW/2024/base.html
@@ -3,7 +3,7 @@
 {% block methodology_stat_1 %}16.9 M{% endblock %}
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}近17百萬{% endblock %}
-{% block dataset %}2022年6{% endblock %}
+{% block dataset %}2024年6{% endblock %}
 {% block read_last_years_almanac %}閱讀 {{ year | int - 2 }} Web Almanac{% endblock %}
 
 {% block foreword %}

--- a/src/templates/zh-TW/2024/base.html
+++ b/src/templates/zh-TW/2024/base.html
@@ -1,0 +1,11 @@
+{% extends "%s/base.html" % lang %}
+
+{% block methodology_stat_1 %}8.36 M{% endblock %}
+{% block methodology_stat_2 %}43.88 TB{% endblock %}
+{% block total_websites %}近8.4百萬{% endblock %}
+{% block dataset %}2022年6{% endblock %}
+{% block read_last_years_almanac %}閱讀 {{ year | int - 2 }} Web Almanac{% endblock %}
+
+{% block foreword %}
+{# TODO #}
+{% endblock %}

--- a/src/templates/zh-TW/2024/base.html
+++ b/src/templates/zh-TW/2024/base.html
@@ -4,7 +4,7 @@
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}近17百萬{% endblock %}
 {% block dataset %}2024年6{% endblock %}
-{% block read_last_years_almanac %}閱讀 {{ year | int - 2 }} Web Almanac{% endblock %}
+{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/zh-TW/2024/base.html
+++ b/src/templates/zh-TW/2024/base.html
@@ -4,7 +4,6 @@
 {% block methodology_stat_2 %}82.61 TB{% endblock %}
 {% block total_websites %}近17百萬{% endblock %}
 {% block dataset %}2024年6{% endblock %}
-{% block previous_year %}{{ year|int - 2 }} {% endblock %}
 
 {% block foreword %}
 {# TODO #}

--- a/src/templates/zh-TW/2024/base.html
+++ b/src/templates/zh-TW/2024/base.html
@@ -1,8 +1,8 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}8.36 M{% endblock %}
-{% block methodology_stat_2 %}43.88 TB{% endblock %}
-{% block total_websites %}近8.4百萬{% endblock %}
+{% block methodology_stat_1 %}16.9 M{% endblock %}
+{% block methodology_stat_2 %}82.61 TB{% endblock %}
+{% block total_websites %}近17百萬{% endblock %}
 {% block dataset %}2022年6{% endblock %}
 {% block read_last_years_almanac %}閱讀 {{ year | int - 2 }} Web Almanac{% endblock %}
 

--- a/src/templates/zh-TW/2024/contributors.html
+++ b/src/templates/zh-TW/2024/contributors.html
@@ -1,0 +1,11 @@
+{% extends "base/contributors.html" %}
+
+{% block title %}{{ year }} 貢獻者 | Web Almanac 精粹自 HTTP Archive{% endblock %}
+
+{% block description %}{{ config.contributors.items() | length }} 位團隊成員貢獻 {{ year }} Web Almanac 有分析者、作者、腦力激盪者、設計者、開發者、編輯者、審稿者和翻譯者。{% endblock %}
+
+{% block filter_by_team %}按類組篩選： <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> 的 <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> 貢獻者。{% endblock %}
+{% block filter_by %}篩選{% endblock %}
+
+{% block join_the_team_title%}加入 Web Almanac 團隊{% endblock %}
+{% block join_the_team_text%}加入團隊!{% endblock %}

--- a/src/templates/zh-TW/2024/index.html
+++ b/src/templates/zh-TW/2024/index.html
@@ -1,0 +1,6 @@
+{% extends "base/index.html" %}
+
+{% block title %}{{ year }} Web Almanac{% endblock %}
+{% block description %}Web Almanac 網路年鑑是網路狀態的年度報告，集結網路社群的專業知識共同精萃HTTP Archive的數據與趨勢。{% endblock %}
+
+{% block twitter_image_alt %}{{ year }} Web Almanac{% endblock %}

--- a/src/templates/zh-TW/2024/table_of_contents.html
+++ b/src/templates/zh-TW/2024/table_of_contents.html
@@ -1,0 +1,7 @@
+{% extends "base/table_of_contents.html" %}
+
+{% block title %}目錄 | Web Almanac {{ year }}{% endblock %}
+
+{% block description %}Web Almanac 網路年鑑{{ year }}年列出以下章節：頁面內容、使用者體驗、內容發布、內容傳遞。{% endblock %}
+
+{% block twitter_image_alt %}{{ year }} Web Almanac 網路年鑑的統計方法{% endblock %}

--- a/src/templates/zh-TW/base.html
+++ b/src/templates/zh-TW/base.html
@@ -24,7 +24,7 @@
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}閱讀 {{ year | int - 1 }} Web Almanac{% endblock %}
+{% block read_last_years_almanac %}閱讀 {{ self.previous_year() }} Web Almanac{% endblock %}
 
 {% block http_archive_link %}HTTP Archive 主頁{% endblock %}
 
@@ -123,15 +123,17 @@
 {% block accessibility_statement %}無障礙網頁聲明{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
+{% block previous_year %}{{ year|int - 1 }}{% endblock %}
+
 {% block featured_chapter %}章節精選{% endblock %}
-{% block featured_chapter_last_year %}精選章節<br>從 {{ year|int -1 }} Web Almanac{% endblock %}
+{% block featured_chapter_last_year %}精選章節<br>從 {{ self.previous_year() }} Web Almanac{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}閱讀 <span class="featured-chapter-name">{{ chapter }}</span> 章節{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}閱讀 {{ year|int -1 }} <span class="featured-chapter-name">{{ chapter }}</span> 章節{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}閱讀 {{ self.previous_year() }} <span class="featured-chapter-name">{{ chapter }}</span> 章節{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}

--- a/src/templates/zh-TW/base.html
+++ b/src/templates/zh-TW/base.html
@@ -24,7 +24,7 @@
 </p>
 {% endblock %}
 
-{% block read_last_years_almanac %}閱讀 {{ self.previous_year() }} Web Almanac{% endblock %}
+{% block read_last_years_almanac %}閱讀 {{ previous_year }} Web Almanac{% endblock %}
 
 {% block http_archive_link %}HTTP Archive 主頁{% endblock %}
 
@@ -123,17 +123,15 @@
 {% block accessibility_statement %}無障礙網頁聲明{% endblock %}
 {% block rss_feed %}RSS Feed{% endblock %}
 
-{% block previous_year %}{{ year|int - 1 }}{% endblock %}
-
 {% block featured_chapter %}章節精選{% endblock %}
-{% block featured_chapter_last_year %}精選章節<br>從 {{ self.previous_year() }} Web Almanac{% endblock %}
+{% block featured_chapter_last_year %}精選章節<br>從 {{ previous_year }} Web Almanac{% endblock %}
 
 {# Check if read_chapter already defined in child template as macros can't be overridden #}
 {% if not read_chapter %}
 {% macro read_chapter(chapter) %}閱讀 <span class="featured-chapter-name">{{ chapter }}</span> 章節{% endmacro %}
 {% endif %}
 {% if not read_last_years_chapter %}
-{% macro read_last_years_chapter(chapter) %}閱讀 {{ self.previous_year() }} <span class="featured-chapter-name">{{ chapter }}</span> 章節{% endmacro %}
+{% macro read_last_years_chapter(chapter) %}閱讀 {{ previous_year }} <span class="featured-chapter-name">{{ chapter }}</span> 章節{% endmacro %}
 {% endif %}
 
 {% block contributors_description %}


### PR DESCRIPTION
* Removes methodology for no
* Add 2024 base template files
* Updated link of last chapter to 2022 instead of 2023
* Does not update stats or dates

PS: i have not made 2024 as the default year, so the link will still take to 2022, but if someone visits the URL with `/2024/` path, then this will work.

@tunetheweb I think I still need to update the stats text in base.html and the month/year when the crawler was run?