### PR TITLE
Figure generation workaround

### DIFF
--- a/src/tools/generate/generate_figure_images.js
+++ b/src/tools/generate/generate_figure_images.js
@@ -7,7 +7,8 @@ const take_single_screenshot = async (graphUrl, filename) => {
 
   const sheets_chart = graphUrl.startsWith('https://docs.google.com/spreadsheets') ? true :  false;
 
-  const chartUrl = sheets_chart ? graphUrl : 'http://localhost:8080/' + graphUrl;
+  // Temporarily replace `&format=interactive` with `&format=image`
+  const chartUrl = sheets_chart ? graphUrl.replaceAll('&format=interactive', '&format=image') : 'http://localhost:8080/' + graphUrl;
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
   await page.setViewport({
@@ -18,7 +19,11 @@ const take_single_screenshot = async (graphUrl, filename) => {
   await page.goto(chartUrl, {
     waitUntil: 'networkidle2',
   });
-  const el = sheets_chart ? await page.$('#embed_chart') : await page.$('main');
+
+
+  // Temporarily handle `&format=image` instead of `&format=interactive`
+  // const el = sheets_chart ? await page.$('#embed_chart') : await page.$('main');
+  const el = sheets_chart ? await page.$('img') : await page.$('main');
   await el.screenshot({ path: filename });
   await browser.close();
 }


### PR DESCRIPTION
Temp workaround for #3803 

This changes the `npm run figure-images` script to use `&format=image` instead of `&format=interactive` to allow authors to generate fallback (low-res) images for their chapters until Sheets fixes the export issue.