### PR TITLE
Correct paragraph on WebP support in WordPress

### DIFF
--- a/src/content/en/2024/cms.md
+++ b/src/content/en/2024/cms.md
@@ -576,7 +576,7 @@ In 2024, Wix and Duda continue to make the most use of WebP, at ~75% and ~60% ad
 
 Although WebP is now widely supported, we still observe that platforms are underutilizing the format. With the growing support of WebP, it seems all platforms have work to do to reduce the usage of the older JPEG and PNG formats without compromising on image quality.
 
-As of WordPress 6.1, the WebP format conversion is automatic for all WordPress websites. However, the popularity of the format seems to have plateaued compared to the 2022 data. This can be explained by the more holistic approach the core Performance team at WordPress has chosen toward general performance improvements on the platform. Read more in the section [WordPress in 2024](#wordpress-in-2024).
+As of WordPress 5.8, WordPress supports the WebP format and can be set to automatically convert uploaded images to WebP. However, the popularity of the format seems to have plateaued compared to the 2022 data. This can be explained by the more holistic approach the core Performance team at WordPress has chosen toward general performance improvements on the platform. Read more in the section [WordPress in 2024](#wordpress-in-2024).
 
 #### JavaScript
 


### PR DESCRIPTION
Unfortunately WebP "be default"  - which was merged for 6.1 - was later reverted, see https://make.wordpress.org/core/2022/09/11/webp-in-core-for-6-1/ - so while WordPress has the capability to output WebP for uploaded images, this feature is not turned on by default.