### PR TITLE
Fix Mastodon links in contributors page

### DIFF
--- a/src/config/contributors.json
+++ b/src/config/contributors.json
@@ -1823,7 +1823,7 @@
         "reviewers"
       ]
     },
-    "mastodon": "@hdv@front-end.social",
+    "mastodon": "https://front-end.social/@hdv",
     "website": "https://hidde.blog/"
   },
   "housseindjirdeh": {

--- a/src/templates/base/contributors.html
+++ b/src/templates/base/contributors.html
@@ -328,7 +328,7 @@
           </a>
           {% endif %}
           {% if contributor.mastodon %}
-          <a href="https://mastodon.com/{{ contributor.mastodon }}" aria-label="{{ onMastodon(contributor.mastodon) }}">
+          <a href="{{ contributor.mastodon|raw }}" aria-label="{{ onMastodon(contributor.mastodon) }}">
             <svg width="22" height="22" role="img">
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#mastodon-logo"></use>
             </svg>

--- a/src/templates/base/contributors.html
+++ b/src/templates/base/contributors.html
@@ -328,7 +328,7 @@
           </a>
           {% endif %}
           {% if contributor.mastodon %}
-          <a href="{{ contributor.mastodon|raw }}" aria-label="{{ onMastodon(contributor.mastodon) }}">
+          <a href="{{ contributor.mastodon }}" aria-label="{{ onMastodon(contributor.mastodon) }}">
             <svg width="22" height="22" role="img">
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#mastodon-logo"></use>
             </svg>


### PR DESCRIPTION
The Mastodon links in the contributors page incorrectly prefixed `https://mastodon.com/` in front of the actual URL of the contributor's profile. This PR fixes links and a single metadata reference in the contributors configuration.