### PR TITLE
fix: correctly link bsky profiles

### DIFF
--- a/src/templates/base/base_chapter.html
+++ b/src/templates/base/base_chapter.html
@@ -276,7 +276,7 @@ window.discussion_url="https://discuss.httparchive.org/t/{{ metadata.get('discus
                   </a>
                   {% endif %}
                   {% if authordata.bluesky %}
-                  <a class="bluesky" href="https://bsky.app/{{ authordata.bluesky }}" aria-labelledby="author-{{ author }}-bluesky">
+                  <a class="bluesky" href="https://bsky.app/profile/{{ authordata.bluesky }}" aria-labelledby="author-{{ author }}-bluesky">
                     <svg width="22" height="22" role="img">
                       <title id="author-{{ author }}-bluesky">{{ onBluesky(authordata.bluesky) }}</title>
                       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#bluesky-logo"></use>

--- a/src/templates/base/base_ebook.html
+++ b/src/templates/base/base_ebook.html
@@ -389,7 +389,7 @@
           {% endif %}
           {% if contributor.bluesky %}
           <div class="contributor-social">
-            <a href="https://bsky.app/{{ contributor.bluesky }}" aria-labelledby="contributors-{{ id }}-bluesky">
+            <a href="https://bsky.app/profile/{{ contributor.bluesky }}" aria-labelledby="contributors-{{ id }}-bluesky">
               <svg role="img">
                 <title id="contributors-{{ id }}-bluesky">{{ onBluesky(contributor.bluesky) }}</title>
                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#bluesky-logo"></use>

--- a/src/templates/base/contributors.html
+++ b/src/templates/base/contributors.html
@@ -335,7 +335,7 @@
           </a>
           {% endif %}
           {% if contributor.bluesky %}
-          <a href="https://bsky.app/{{ contributor.bluesky }}" aria-label="{{ onBluesky(contributor.bluesky) }}">
+          <a href="https://bsky.app/profile/{{ contributor.bluesky }}" aria-label="{{ onBluesky(contributor.bluesky) }}">
             <svg width="22" height="22" role="img">
               <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#bluesky-logo"></use>
             </svg>

--- a/src/templates/base/ebook.ejs.html
+++ b/src/templates/base/ebook.ejs.html
@@ -114,7 +114,7 @@
                                 </a>
                                 {% endif %}
                                 {% if authordata.bluesky %}
-                                <a class="bluesky" href="https://bsky.app/{{ authordata.bluesky }}" aria-labelledby="{{ metadata.get('chapter') }}-author-{{ author }}-bluesky">
+                                <a class="bluesky" href="https://bsky.app/profile/{{ authordata.bluesky }}" aria-labelledby="{{ metadata.get('chapter') }}-author-{{ author }}-bluesky">
                                     <svg aria-hidden="true">
                                         <title id="{{ metadata.get('chapter') }}-author-{{ author }}-bluesky">{{ onBluesky(authordata.bluesky) }}</title>
                                         <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#bluesky-logo"></use>


### PR DESCRIPTION
This PR ensures that bsky profiles are correctly link (`bsky.app/profile/<HANDLE>` instead of `bsky.app/<HANDLE>`)