### PR TITLE
Force utf8 mode on Windows

### DIFF
--- a/src/tools/scripts/run_and_test_website.bat
+++ b/src/tools/scripts/run_and_test_website.bat
@@ -26,10 +26,10 @@ echo "Building website"
 call npm run generate
 
 echo "Starting website"
-# Can remove -Xutf8 argument after Python 3.15 is everywhere - https://peps.python.org/pep-0686/
+rem # Can remove -Xutf8 argument after Python 3.15 is everywhere - https://peps.python.org/pep-0686/
 start python -Xutf8 main.py
 rem # Sleep for 5 seconds to make sure server is up
-timeout 5 /nobreak
+timeout /t 5 /nobreak
 rem # Use sleep as well in case running in GitBash where above command fails
 sleep 5
 

--- a/src/tools/scripts/run_and_test_website.bat
+++ b/src/tools/scripts/run_and_test_website.bat
@@ -26,9 +26,10 @@ echo "Building website"
 call npm run generate
 
 echo "Starting website"
+# Can remove -Xutf8 argument after Python 3.15 is everywhere - https://peps.python.org/pep-0686/
 start python -Xutf8 main.py
 rem # Sleep for 5 seconds to make sure server is up
-timeout /t 5 /nobreak
+timeout 5 /nobreak
 rem # Use sleep as well in case running in GitBash where above command fails
 sleep 5
 

--- a/src/tools/scripts/run_and_test_website.bat
+++ b/src/tools/scripts/run_and_test_website.bat
@@ -26,7 +26,7 @@ echo "Building website"
 call npm run generate
 
 echo "Starting website"
-start python main.py
+start python -Xutf8 main.py
 rem # Sleep for 5 seconds to make sure server is up
 timeout /t 5 /nobreak
 rem # Use sleep as well in case running in GitBash where above command fails


### PR DESCRIPTION
Python apparently doesn't run in UTF-8 mode on windows by default (but does on linux and MacOS). This is [due to change in Pythong 3.15](https://peps.python.org/pep-0686/) but in the meantime let's force it by default as contributors names (and some text) use UTF-8 characters (e.g. /en/2024/third-parties)