### PR TITLE
Support Python 3.13

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -7,6 +7,6 @@ pytest-cov==5.0.0
 sqlfluff==1.4.5
 
 # sql/util/* dependencies
-pandas==2.2.2
+pandas==2.2.3
 google-cloud-bigquery==3.25.0
 requests==2.32.3

--- a/src/server/helpers.py
+++ b/src/server/helpers.py
@@ -306,7 +306,7 @@ def accentless_sort(value):
 def get_file_date_info(file, type):
     timestamps_config = get_timestamps_config()
     # Default Published and Last Updated to today
-    today = datetime.datetime.utcnow().isoformat(timespec='milliseconds')
+    today = datetime.datetime.now(datetime.UTC).isoformat(timespec='milliseconds')
     if type == "date_published" or type == "date_modified":
         return timestamps_config.get(file, {}).get(type, today)
     else:


### PR DESCRIPTION
Noticed a couple of issues when using Python 3.13:

- pandas 2.2.2 is not compatible
- `datetime.datetime.utcnow` is deprecated and down to be removed.

Both fixes are backwards compatible to Python 3.11 (and we demand 3.12 as minimum anyway).