### PR TITLE
Ignore some package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/src/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "prettier"
+        update-types: ["version-update:semver-patch"]
   - package-ecosystem: "pip"
     directory: "/src/"
     schedule:

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -14,7 +14,7 @@
         "jsdom": "26.0.0",
         "node-fetch": "3.3.2",
         "node-watch": "0.7.4",
-        "prettier": "^3.5.x",
+        "prettier": "3.5.3",
         "puppeteer": "24.3.1",
         "rainbow-code": "2.1.7",
         "recursive-readdir": "2.2.3",

--- a/src/package.json
+++ b/src/package.json
@@ -40,7 +40,7 @@
     "jsdom": "26.0.0",
     "node-fetch": "3.3.2",
     "node-watch": "0.7.4",
-    "prettier": "^3.5.x",
+    "prettier": "3.5.3",
     "puppeteer": "24.3.1",
     "rainbow-code": "2.1.7",
     "recursive-readdir": "2.2.3",


### PR DESCRIPTION
I've found the proper way to mute updates - with `dependabot.yml`.
Successfully tested with `HTTPArchive/har.fyi`.

So decided to rollback my wildcard in `package.json`.