### PR TITLE
Allow accelerometer/gyroscope permissions to avoid errors

### DIFF
--- a/src/server/feature_policy.py
+++ b/src/server/feature_policy.py
@@ -1,8 +1,6 @@
 feature_policy = {
-    "accelerometer": "'none'",
     "camera": "'none'",
     "geolocation": "'none'",
-    "gyroscope": "'none'",
     "magnetometer": "'none'",
     "microphone": "'none'",
     "payment": "'none'",


### PR DESCRIPTION
YouTube embeds use them and errors causing checks to fail.