### PR TITLE
[WIP] Performance 2025 Queries

### DIFF
--- a/sql/2025/performance/bfcache_cachecontrol_nostore.sql
+++ b/sql/2025/performance/bfcache_cachecontrol_nostore.sql
@@ -1,0 +1,29 @@
+CREATE TEMP FUNCTION HAS_NO_STORE_DIRECTIVE(cache_control STRING) RETURNS BOOL AS (
+  REGEXP_CONTAINS(cache_control, r'(?i)\bno-store\b')
+);
+
+WITH requests AS (
+  SELECT
+    client,
+    LOGICAL_OR(HAS_NO_STORE_DIRECTIVE(JSON_VALUE(payload._cacheControl))) AS includes_ccns
+  FROM
+    `httparchive.crawl.requests`
+  WHERE
+    date = '2025-06-01' AND
+    is_main_document
+  GROUP BY
+    client,
+    page
+)
+
+SELECT
+  client,
+  COUNTIF(includes_ccns) AS pages,
+  COUNT(0) AS total,
+  COUNTIF(includes_ccns) / COUNT(0) AS pct
+FROM
+  requests
+GROUP BY
+  client
+ORDER BY
+  client

--- a/sql/2025/performance/bfcache_unload.sql
+++ b/sql/2025/performance/bfcache_unload.sql
@@ -1,0 +1,39 @@
+CREATE TEMPORARY FUNCTION getUnloadHandler(audit STRING)
+RETURNS BOOL LANGUAGE js AS '''
+try {
+  var $ = JSON.parse(audit);
+  return $.details?.items?.some(n => n.value?.toLowerCase() === "unloadhandler");
+} catch (e) {
+  return false;
+}
+''';
+
+WITH lh AS (
+  SELECT
+    client,
+    page,
+    rank,
+    getUnloadHandler(TO_JSON_STRING(lighthouse.audits.deprecations)) AS has_unload
+  FROM
+    `httparchive.crawl.pages`
+  WHERE
+    date = '2025-06-01'
+)
+
+SELECT
+  client,
+  _rank AS rank,
+  COUNTIF(has_unload) AS pages,
+  COUNT(0) AS total,
+  COUNTIF(has_unload) / COUNT(0) AS pct
+FROM
+  lh,
+  UNNEST([1000, 10000, 100000, 1000000, 10000000, 100000000]) AS _rank
+WHERE
+  rank <= _rank
+GROUP BY
+  client,
+  rank
+ORDER BY
+  rank,
+  client

--- a/sql/2025/performance/cls_animations.sql
+++ b/sql/2025/performance/cls_animations.sql
@@ -1,0 +1,27 @@
+WITH lh AS (
+  SELECT
+    client,
+    ARRAY_LENGTH(JSON_QUERY_ARRAY(lighthouse.audits.`non-composited-animations`.details.items)) AS num_animations
+  FROM
+    `httparchive.crawl.pages`
+  WHERE
+    date = '2025-06-01' AND
+    is_root_page
+)
+
+SELECT
+  percentile,
+  client,
+  APPROX_QUANTILES(num_animations, 1000)[OFFSET(percentile * 10)] AS num_animations,
+  COUNTIF(num_animations > 0) AS pages,
+  COUNT(0) AS total,
+  COUNTIF(num_animations > 0) / COUNT(0) AS pct
+FROM
+  lh,
+  UNNEST([10, 25, 50, 75, 90, 100]) AS percentile
+GROUP BY
+  percentile,
+  client
+ORDER BY
+  percentile,
+  client

--- a/sql/2025/performance/cls_unsized_image_height.sql
+++ b/sql/2025/performance/cls_unsized_image_height.sql
@@ -1,0 +1,26 @@
+WITH lh AS (
+  SELECT
+    client,
+    CAST(JSON_VALUE(unsized_image, '$.node.boundingRect.height') AS INT64) AS height
+  FROM
+    `httparchive.crawl.pages`,
+    UNNEST(JSON_QUERY_ARRAY(lighthouse.audits.`unsized-images`.details.items)) AS unsized_image
+  WHERE
+    date = '2025-06-01' AND
+    is_root_page
+)
+
+SELECT
+  percentile,
+  client,
+  APPROX_QUANTILES(height, 1000)[OFFSET(percentile * 10)] AS height,
+  COUNT(0) AS unsized_images
+FROM
+  lh,
+  UNNEST([10, 25, 50, 75, 90, 100]) AS percentile
+GROUP BY
+  percentile,
+  client
+ORDER BY
+  percentile,
+  client

--- a/sql/2025/performance/cls_unsized_images.sql
+++ b/sql/2025/performance/cls_unsized_images.sql
@@ -1,0 +1,27 @@
+WITH lh AS (
+  SELECT
+    client,
+    ARRAY_LENGTH(JSON_QUERY_ARRAY(lighthouse.audits.`unsized-images`.details.items)) AS num_unsized_images
+  FROM
+    `httparchive.crawl.pages`
+  WHERE
+    date = '2025-06-01' AND
+    is_root_page
+)
+
+SELECT
+  percentile,
+  client,
+  APPROX_QUANTILES(num_unsized_images, 1000)[OFFSET(percentile * 10)] AS num_unsized_images,
+  COUNTIF(num_unsized_images > 0) AS pages,
+  COUNT(0) AS total,
+  COUNTIF(num_unsized_images > 0) / COUNT(0) AS pct
+FROM
+  lh,
+  UNNEST([10, 25, 50, 75, 90, 100]) AS percentile
+GROUP BY
+  percentile,
+  client
+ORDER BY
+  percentile,
+  client

--- a/sql/2025/performance/font_resource_hints_usage.sql
+++ b/sql/2025/performance/font_resource_hints_usage.sql
@@ -1,0 +1,65 @@
+CREATE TEMPORARY FUNCTION getResourceHints(custom_metrics STRING)
+RETURNS ARRAY<STRUCT<name STRING, href STRING>>
+LANGUAGE js AS '''
+var hints = new Set(['preload', 'prefetch', 'preconnect', 'prerender', 'dns-prefetch']);
+try {
+    var $ = JSON.parse(custom_metrics);
+    var almanac = $.other.almanac;
+    return almanac['link-nodes'].nodes.reduce((results, link) => {
+        var hint = link.rel.toLowerCase();
+        if (!hints.has(hint)) {
+            return results;
+        }
+        results.push({
+            name: hint,
+            href: link.href
+        });
+        return results;
+    }, []);
+} catch (e) {
+    return [];
+}
+''';
+
+WITH resource_hints AS (
+  SELECT DISTINCT
+    client,
+    page,
+    hint.name
+  FROM
+    `httparchive.crawl.pages`
+  LEFT JOIN
+    UNNEST(getResourceHints(TO_JSON_STRING(custom_metrics))) AS hint
+  WHERE
+    date = '2025-06-01' AND
+    is_root_page
+),
+
+font_requests AS (
+  SELECT
+    client,
+    page,
+    type
+  FROM
+    `httparchive.crawl.requests`
+  WHERE
+    date = '2025-06-01' AND
+    type = 'font' AND
+    is_root_page
+)
+
+SELECT
+  client,
+  name,
+  COUNT(DISTINCT page) AS pages,
+  SUM(COUNT(DISTINCT page)) OVER (PARTITION BY client) AS total,
+  COUNT(DISTINCT page) / SUM(COUNT(DISTINCT page)) OVER (PARTITION BY client) AS pct_hints
+FROM
+  resource_hints
+LEFT JOIN
+  font_requests
+USING (client, page)
+GROUP BY
+  client, name, type
+ORDER BY
+  pct_hints DESC;

--- a/sql/2025/performance/font_resource_hints_usage_trends.sql
+++ b/sql/2025/performance/font_resource_hints_usage_trends.sql
@@ -1,0 +1,94 @@
+CREATE TEMPORARY FUNCTION getResourceHints(custom_metrics STRING)
+RETURNS ARRAY<STRUCT<name STRING, href STRING>>
+LANGUAGE js AS '''
+var hints = new Set(['preload', 'prefetch', 'preconnect', 'prerender', 'dns-prefetch']);
+try {
+    var $ = JSON.parse(custom_metrics);
+    var almanac = $.other.almanac;
+    return almanac['link-nodes'].nodes.reduce((results, link) => {
+        var hint = link.rel.toLowerCase();
+        if (!hints.has(hint)) {
+            return results;
+        }
+        results.push({
+            name: hint,
+            href: link.href
+        });
+        return results;
+    }, []);
+} catch (e) {
+    return [];
+}
+''';
+
+WITH resource_hints AS (
+  SELECT DISTINCT
+    client,
+    date,
+    page,
+    hint.name AS name
+  FROM
+    `httparchive.crawl.pages`
+  LEFT JOIN
+    UNNEST(getResourceHints(TO_JSON_STRING(custom_metrics))) AS hint
+  WHERE
+    (date = '2025-06-01' OR date = '2024-06-01' OR date = '2023-06-01') AND
+    is_root_page
+),
+
+font_requests AS (
+  SELECT
+    client,
+    date,
+    page,
+    type
+  FROM
+    `httparchive.crawl.requests`
+  WHERE
+    (date = '2025-06-01' OR date = '2024-06-01' OR date = '2023-06-01') AND
+    type = 'font' AND
+    is_root_page
+),
+
+totals AS (
+  SELECT
+    client,
+    date,
+    COUNT(0) AS total_pages
+  FROM
+    `httparchive.crawl.pages`
+  WHERE
+    (date = '2025-06-01' OR date = '2024-06-01' OR date = '2023-06-01') AND
+    is_root_page
+  GROUP BY
+    client,
+    date
+)
+
+SELECT
+  client,
+  date,
+  name,
+  type,
+  COUNT(DISTINCT page) AS pages,
+  ANY_VALUE(total_pages) AS total,
+  COUNT(DISTINCT page) / ANY_VALUE(total_pages) AS pct
+FROM
+  resource_hints
+LEFT JOIN
+  font_requests
+USING (client, date, page)
+JOIN
+  totals
+USING (client, date)
+GROUP BY
+  client,
+  date,
+  name,
+  type
+HAVING
+  type IS NOT NULL
+ORDER BY
+  client,
+  date,
+  name DESC

--- a/sql/2025/performance/font_usage_mobile.sql
+++ b/sql/2025/performance/font_usage_mobile.sql
@@ -1,0 +1,12 @@
+SELECT
+  COUNTIF(SAFE_CAST(JSON_VALUE(summary.reqFont) AS INT64) > 0) AS freq_fonts,
+  COUNT(0) AS total,
+  COUNTIF(SAFE_CAST(JSON_VALUE(summary.reqFont) AS INT64) > 0) / COUNT(0) AS pct_fonts
+FROM
+  `httparchive.crawl.pages`
+WHERE
+  date = '2025-06-01' AND
+  client = 'mobile' AND
+  is_root_page AND
+  SAFE_CAST(JSON_VALUE(summary.reqFont) AS INT64) IS NOT NULL AND
+  SAFE_CAST(JSON_VALUE(summary.bytesFont) AS INT64) IS NOT NULL

--- a/sql/2025/performance/lcp_host.sql
+++ b/sql/2025/performance/lcp_host.sql
@@ -1,0 +1,28 @@
+WITH lcp AS (
+  SELECT
+    client,
+    page,
+    JSON_VALUE(custom_metrics.performance.lcp_elem_stats.url) AS url
+  FROM
+    `httparchive.crawl.pages`
+  WHERE
+    date = '2025-06-01' AND
+    is_root_page
+)
+
+SELECT
+  client,
+  CASE
+    WHEN NET.HOST(url) = 'data' THEN 'other content'
+    WHEN NET.HOST(url) IS NULL THEN 'other content'
+    WHEN NET.HOST(page) = NET.HOST(url) THEN 'same host'
+    ELSE 'cross host'
+  END AS lcp_same_host,
+  COUNT(0) AS pages,
+  SUM(COUNT(0)) OVER (PARTITION BY client) AS total,
+  COUNT(0) / SUM(COUNT(0)) OVER (PARTITION BY client) AS pct
+FROM
+  lcp
+GROUP BY
+  client,
+  lcp_same_host


### PR DESCRIPTION
## 📝 Description

Working on queries for https://github.com/HTTPArchive/almanac.httparchive.org/issues/4082.

## ✅ Migrated

The following queries have been migrated from 2024 to 2025 using the new `crawl` dataset: https://har.fyi/guides/migrating-to-crawl-dataset/

- bfcache_cachecontrol_nostore.sql
- bfcache_unload.sql
- cls_animations.sql
- cls_unsized_image_height.sql
- cls_unsized_images.sql
- font_resource_hints_usage.sql
- font_resource_hints_usage_trends.sql
- font_usage_mobile.sql
- lcp_host.sql

## 🚧 TODOs

Still working on migrating the following queries from 2024 to 2025:

- [ ] sql/2025/performance/generated_content.sql
- [ ] sql/2025/performance/generated_content_web_vitals.sql
- [ ] sql/2025/performance/inp_long_tasks.sql
- [ ] sql/2025/performance/inp_tbt.sql
- [ ] sql/2025/performance/js_bytes_rank.sql
- [ ] sql/2025/performance/lcp_async_fetchpriority.sql
- [ ] sql/2025/performance/lcp_bytes_distribution.sql
- [ ] sql/2025/performance/lcp_bytes_histogram.sql
- [ ] sql/2025/performance/lcp_element_data.sql
- [ ] sql/2025/performance/lcp_format.sql
- [ ] sql/2025/performance/lcp_host_3p.sql
- [ ] sql/2025/performance/lcp_initiator_type.sql
- [ ] sql/2025/performance/lcp_lazy.sql
- [ ] sql/2025/performance/lcp_lazy_secondary_pages.sql
- [ ] sql/2025/performance/lcp_lazy_technologies.sql
- [ ] sql/2025/performance/lcp_preload_discoverable.sql
- [ ] sql/2025/performance/lcp_resource_load_delay.sql
- [ ] sql/2025/performance/lcp_resource_type.sql
- [ ] sql/2025/performance/lcp_responsive_data.sql
- [ ] sql/2025/performance/lcp_wasted_bytes.sql
- [ ] sql/2025/performance/monthly_cls_lcp.sql
- [ ] sql/2025/performance/render_blocking_resources.sql
- [ ] sql/2025/performance/render_blocking_savings_fcp.sql
- [ ] sql/2025/performance/render_blocking_savings_lcp.sql
- [ ] sql/2025/performance/resource_hints_usage.sql
- [ ] sql/2025/performance/resource_hints_usage_2021.sql
- [ ] sql/2025/performance/rtt_distribution.sql
- [ ] sql/2025/performance/viewport_meta_zoom_disable.sql
- [ ] sql/2025/performance/web_vitals_by_device.sql
- [ ] sql/2025/performance/web_vitals_by_device_secondary_pages.sql
- [ ] sql/2025/performance/web_vitals_by_rank_and_device.sql
- [ ] sql/2025/performance/web_vitals_by_technology.sql