### PR TITLE
Removes call for contributor banner

### DIFF
--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -106,7 +106,7 @@
 
 {% endblock %}
 
-{% block call_for_contributors_link %}https://github.com/HTTPArchive/almanac.httparchive.org/discussions/4062{% endblock %}
+{% block call_for_contributors_link %}{% endblock %}
 
 {% block contributors %}{{ config.contributors.keys() | length }}{% endblock %}
 


### PR DESCRIPTION
As requested by @nrllh , this PR removes the call for contributor link from the top of the page. I have kept the template to render it, and just removed the link which effectively removes the banner. I think this would help us to use the same template logic in later years to show the call for contributor banner again.