### PR TITLE
Update PDF URLs to use the new path

### DIFF
--- a/src/server/routes.py
+++ b/src/server/routes.py
@@ -254,4 +254,4 @@ def redirect_old_hero_images(folder, image):
 # Redirect requests for the pdfs to GitHub
 @app.route("/static/pdfs/<pdf>")
 def redirect_pdfs(pdf):
-    return redirect("https://cdn.httparchive.org/almanac/ebooks/%s" % (pdf)), 301
+    return redirect("https://cdn.httparchive.org/v1/static/almanac/ebooks/%s" % (pdf)), 301

--- a/src/server/tests/routes_test.py
+++ b/src/server/tests/routes_test.py
@@ -203,7 +203,7 @@ def test_render_pdf_redirect(client):
         client,
         "/static/pdfs/web_almanac_2019_en_cover_A5.pdf",
         301,
-        "https://cdn.httparchive.org/almanac/ebooks/web_almanac_2019_en_cover_A5.pdf",
+        "https://cdn.httparchive.org/v1/static/almanac/ebooks/web_almanac_2019_en_cover_A5.pdf",
     )
 
 

--- a/src/templates/base/base.html
+++ b/src/templates/base/base.html
@@ -249,7 +249,7 @@
     {% endif %}
 
     {% if ebook_size_in_mb and ebook_size_in_mb > 0 %}
-    <option value="https://cdn.httparchive.org/almanac/ebooks/web_almanac_{{ year }}_{{ lang }}.pdf" data-event="ebook-click">
+    <option value="https://cdn.httparchive.org/v1/static/almanac/ebooks/web_almanac_{{ year }}_{{ lang }}.pdf" data-event="ebook-click">
       {{ self.ebook_download_short() }}
     </option>
     {% endif %}
@@ -378,7 +378,7 @@
       <a href="{{ url_for('table_of_contents', year=year, lang=lang, _anchor='ebook') }}">{{ self.ebook_title() }}</a>
     </li>
     <li class="nav-dropdown-list-chapter ebook">
-      <a href="https://cdn.httparchive.org/almanac/ebooks/web_almanac_{{ year }}_{{ lang }}.pdf" data-event="ebook-click" data-label="toc-menu">{{ self.ebook_download_short() }}</a>
+      <a href="https://cdn.httparchive.org/v1/static/almanac/ebooks/web_almanac_{{ year }}_{{ lang }}.pdf" data-event="ebook-click" data-label="toc-menu">{{ self.ebook_download_short() }}</a>
     </li>
     {% endif %}
   </ul>

--- a/src/templates/base/table_of_contents.html
+++ b/src/templates/base/table_of_contents.html
@@ -158,7 +158,7 @@
       <h2 id="ebook" class="part-name"><a href="#ebook" class="anchor-link">{{ self.ebook_title() }}</a></h2>
       <div class="chapters">
         <div class="chapter">
-          <a href="https://cdn.httparchive.org/almanac/ebooks/web_almanac_{{ year }}_{{ lang }}.pdf" data-event="ebook-click" data-label="toc-page">{{ self.ebook_download() }}</a><br>
+          <a href="https://cdn.httparchive.org/v1/static/almanac/ebooks/web_almanac_{{ year }}_{{ lang }}.pdf" data-event="ebook-click" data-label="toc-page">{{ self.ebook_download() }}</a><br>
           <small>{{ self.ebook_download_note() }}</small>
         </div>
       </div>


### PR DESCRIPTION
The path has changed after replacing a direct GCS bucket backend with a proxy.

It's strange that the false paths in the tests didn't highlight it in earlier PRs.