### PR TITLE
Limit image compression to >10% changes to reduce noise

### DIFF
--- a/.github/workflows/compress-images.yml
+++ b/.github/workflows/compress-images.yml
@@ -53,6 +53,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           compressOnly: ${{ github.event_name != 'pull_request' }}
           jpegProgressive: true
+          minPctChange: '10.0'
       - name: Create Pull Request
         # If it's not a pull request then commit any changes as a new PR
         if: |


### PR DESCRIPTION
We don't need to endlessly recompress images. Let's up the limit to 10%