### PR TITLE
WebAssembly 2025 queries updates for counts and page ranking

### DIFF
--- a/sql/2025/webassembly/counts.sql
+++ b/sql/2025/webassembly/counts.sql
@@ -1,35 +1,35 @@
 # Query for wasm requests' count with distinct wasm origin name
 
 WITH wasmRequests AS (
-SELECT
-client,
-page,
-CASE
-WHEN REGEXP_CONTAINS(url, r'/(hyphenopoly|patterns).*/[a-z-]{2,5}\.wasm')
-THEN '(hyphenopoly dictionary)'
-WHEN ENDS_WITH(url, '.unityweb')
-THEN '(unityweb app)'
-ELSE
-REGEXP_REPLACE(
-REGEXP_EXTRACT(LOWER(url), r'./([^./?])'), -- lowercase & extract filename between last `/` and `.` or `?`
-r'-[0-9a-f]{20,32}$', -- trim trailing hashes to transform `name-0abc43234[...]` to `name`
-''
-)
-END AS name
-FROM
-`httparchive.crawl.requests`
-WHERE
-date = '2025-07-01' AND
-type = 'wasm'
+  SELECT
+    client,
+    page,
+    CASE
+      WHEN REGEXP_CONTAINS(url, r'/(hyphenopoly|patterns).*/[a-z-]{2,5}\.wasm')
+        THEN '(hyphenopoly dictionary)'
+      WHEN ENDS_WITH(url, '.unityweb')
+        THEN '(unityweb app)'
+      ELSE
+        REGEXP_REPLACE(
+          REGEXP_EXTRACT(LOWER(url), r'./([^./?])'), -- lowercase & extract filename between last `/` and `.` or `?`
+          r'-[0-9a-f]{20,32}$', -- trim trailing hashes to transform `name-0abc43234[...]` to `name`
+          ''
+        )
+    END AS name
+  FROM
+    `httparchive.crawl.requests`
+  WHERE
+    date = '2025-07-01' AND
+    type = 'wasm'
 )
 
 SELECT
-client,
-COUNT(0) AS total_wasm,
-COUNT(DISTINCT NET.REG_DOMAIN(page)) AS distinct_origin
+  client,
+  COUNT(0) AS total_wasm,
+  COUNT(DISTINCT NET.REG_DOMAIN(page)) AS distinct_origin
 FROM
-wasmRequests
+  wasmRequests
 GROUP BY
-client
+  client
 ORDER BY
-client
+  client

--- a/sql/2025/webassembly/page_rankings.sql
+++ b/sql/2025/webassembly/page_rankings.sql
@@ -1,21 +1,21 @@
 SELECT
-client,
-rank_grouping,
-CASE
-WHEN rank_grouping = 100000000 THEN 'all'
-ELSE CAST(rank_grouping AS STRING)
-END AS ranking,
-COUNT(DISTINCT page) AS pages
+  client,
+  rank_grouping,
+  CASE
+    WHEN rank_grouping = 100000000 THEN 'all'
+    ELSE CAST(rank_grouping AS STRING)
+  END AS ranking,
+  COUNT(DISTINCT page) AS pages
 FROM
-`httparchive.crawl.requests`,
-UNNEST([1000, 10000, 100000, 1000000, 10000000, 100000000]) AS rank_grouping
+  `httparchive.crawl.requests`,
+  UNNEST([1000, 10000, 100000, 1000000, 10000000, 100000000]) AS rank_grouping
 WHERE
-date = '2025-07-01' AND
-type = 'wasm' AND
-rank <= rank_grouping
+  date = '2025-07-01' AND
+  type = 'wasm' AND
+  rank <= rank_grouping
 GROUP BY
-client,
-rank_grouping
+  client,
+  rank_grouping
 ORDER BY
-client,
-rank_grouping
+  client,
+  rank_grouping


### PR DESCRIPTION
For further progress on https://github.com/HTTPArchive/almanac.httparchive.org/issues/4090 and https://github.com/HTTPArchive/almanac.httparchive.org/issues/4239

Updated query to use DISTINCT NET.REG_DOMAIN(page) for distinct wasm origin names (counts.sql)
Updated query for page rankings, instead of rank; used rank_grouping to make this more distinct and obvious (page_rankings.sql)

All the queries are grouped by clients i.e. desktop and mobile.