### PR TITLE
Small markup fix for Ecommerce chapter

### DIFF
--- a/src/content/en/2025/ecommerce.md
+++ b/src/content/en/2025/ecommerce.md
@@ -656,10 +656,10 @@ A site is considered "good" on CWV when it passes all three thresholds.
         <tr>
         <td>Square Online</td>
         <td class="numeric">18,812</td>
-        <td>0%</td>
+        <td class="numeric">0%</td>
         <td class="numeric">39%</td>
-        <td>0%</td>
-        <td>0%</td>
+        <td class="numeric">0%</td>
+        <td class="numeric">0%</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
replaces replaces `</td>>` with `</td>`

Should fix:

<img width="1262" height="728" alt="image" src="https://github.com/user-attachments/assets/2f881252-891b-4348-bd24-e01f32605587" />
