### PR TITLE
Update cloudbuild to Node 24

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -29,8 +29,8 @@ steps:
         apt-get update -qq
         apt-get install -y python3 python3-venv curl
 
-        # Install Node.js 20
-        curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+        # Install Node.js 24
+        curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
         apt-get install -y nodejs
 
         # Create a venv so pip install/upgrade works cleanly on Ubuntu 24.04.


### PR DESCRIPTION
We tried this once before but [had to roll it back](https://github.com/HTTPArchive/almanac.httparchive.org/commit/fb38949c25535944d68936a392d57ce22341de3d).

Can't remember why?

However, since then [we upgraded the OS](https://github.com/HTTPArchive/almanac.httparchive.org/commit/16f9e2538718c48d67e8690eef952fcb19d0468e) so maybe it works now?