### PR TITLE
Enable German for 2019-2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The Web Almanac is available in the original [English](https://almanac.httparchi
 - [Chinese (Traditional)](https://almanac.httparchive.org/zh-TW/)
 - [Dutch](https://almanac.httparchive.org/nl/)
 - [French](https://almanac.httparchive.org/fr/)
+- [German](https://almanac.httparchive.org/de/)
 - [Hindi](https://almanac.httparchive.org/hi/)
 - [Italian](https://almanac.httparchive.org/it/)
 - [Japanese](https://almanac.httparchive.org/ja/)

--- a/src/config/2019.json
+++ b/src/config/2019.json
@@ -2,7 +2,7 @@
   "settings": [
     {
       "is_live": true,
-      "supported_languages": ["en","es","fr","hi","it","ja","nl","pt","ru","tr","uk","zh-CN","zh-TW"],
+      "supported_languages": ["de","en","es","fr","hi","it","ja","nl","pt","ru","tr","uk","zh-CN","zh-TW"],
       "ebook_languages": ["en","ja"]
     }
   ],

--- a/src/config/2020.json
+++ b/src/config/2020.json
@@ -2,7 +2,7 @@
   "settings": [
     {
       "is_live": true,
-      "supported_languages": ["en","es","fr","hi","it","ja","nl","pt","ru","tr","uk","zh-CN","zh-TW"],
+      "supported_languages": ["de","en","es","fr","hi","it","ja","nl","pt","ru","tr","uk","zh-CN","zh-TW"],
       "ebook_languages": ["en","ja"]
     }
   ],

--- a/src/config/2021.json
+++ b/src/config/2021.json
@@ -2,7 +2,7 @@
   "settings": [
     {
       "is_live": true,
-      "supported_languages": ["en","es","fr","hi","it","ja","nl","pt","ru","tr","uk","zh-CN","zh-TW"],
+      "supported_languages": ["de","en","es","fr","hi","it","ja","nl","pt","ru","tr","uk","zh-CN","zh-TW"],
       "ebook_languages": ["en","ja"]
     }
   ],

--- a/src/config/2022.json
+++ b/src/config/2022.json
@@ -2,7 +2,7 @@
   "settings": [
     {
       "is_live": true,
-      "supported_languages": ["en","es","fr","hi","it","ja","nl","pt","ru","tr","uk","zh-CN","zh-TW"],
+      "supported_languages": ["de","en","es","fr","hi","it","ja","nl","pt","ru","tr","uk","zh-CN","zh-TW"],
       "ebook_languages": ["en","ja"]
     }
   ],

--- a/src/config/2024.json
+++ b/src/config/2024.json
@@ -2,7 +2,7 @@
   "settings": [
     {
       "is_live": true,
-      "supported_languages": ["en","es","fr","hi","it","ja","nl","pt","ru","tr","uk","zh-CN","zh-TW"],
+      "supported_languages": ["de","en","es","fr","hi","it","ja","nl","pt","ru","tr","uk","zh-CN","zh-TW"],
       "ebook_languages": ["en","ja"]
     }
   ],

--- a/src/config/contributors.json
+++ b/src/config/contributors.json
@@ -3428,6 +3428,9 @@
       "teams": {
         "2024": [
           "translators"
+        ],
+        "2025": [
+          "translators"
         ]
       }
   },

--- a/src/templates/de/2019/base.html
+++ b/src/templates/de/2019/base.html
@@ -2,7 +2,7 @@
 
 {% block methodology_stat_1 %}5,8M{% endblock %}
 {% block methodology_stat_2 %}20,9 TB{% endblock %}
-{% block total_websites %}fast 9 Millionen{% endblock %}
+{% block total_websites %}fast 6 Millionen{% endblock %}
 {% block dataset %}Juli 2019{% endblock %}
 
 {% block foreword %}

--- a/src/templates/de/2019/base.html
+++ b/src/templates/de/2019/base.html
@@ -1,0 +1,28 @@
+{% extends "%s/base.html" % lang %}
+
+{% block methodology_stat_1 %}5,8M{% endblock %}
+{% block methodology_stat_2 %}20,9 TB{% endblock %}
+{% block total_websites %}fast 9 Millionen{% endblock %}
+{% block dataset %}Juli 2019{% endblock %}
+
+{% block foreword %}
+{# TODO - Translate this! #}<div lang="en">
+  <p>
+    The open web is an amazingly complex, evolving network of technologies. Entire industries and careers are built on the web and depend on its vibrant ecosystem to succeed. As critical as the web is, understanding how it&#8217;s doing has been surprisingly elusive. Since 2010, the mission of the HTTP Archive project has been to track how the web is built, and it&#8217;s been doing an amazing job of it. However, there has been one gap that has been especially challenging to close: bringing meaning to the data that the HTTP Archive project has been collecting and enabling the community to easily understand how the web is performing. That&#8217;s where the Web Almanac comes in.
+  </p>
+
+  <p>
+    The mission of the Web Almanac is to take the treasure trove of insights that would otherwise be accessible only to intrepid data miners, and package it up in a way that&#8217;s easy to understand. This is made possible with the help of industry experts who can make sense of the data and tell us what it means. Each of the 20 chapters in the Web Almanac focuses on a specific aspect of the web, and each one has been authored and peer reviewed by experts in their field. The strength of the Web Almanac flows directly from the expertise of the people who write it.
+  </p>
+
+  <p>
+    Many of the findings in the Web Almanac are worthy of celebration, but it&#8217;s also an important reminder of the work still required to deliver high-quality user experiences. The data-driven analyses in each chapter are a form of accountability we all share for developing a better web. It&#8217;s not about shaming those that are getting it wrong, but about shining a guiding light on the path of best practices so there is a clear, right way to do things. With the continued help of the web community, we hope to make this an annual tradition, so each year we can track our progress and make course corrections as needed.
+  </p>
+
+  <p>
+    There is so much to learn in this report, so start exploring and share your takeaways with the community so we can collectively advance our understanding of the state of the web.
+  </p>
+
+  <p>— <em><a href="{{ url_for('contributors', year=year, lang=lang, _anchor='rviscomi') }}">Rick Viscomi</a>, Web Almanac Editor-in-Chief</em></p>
+</div>
+{% endblock %}

--- a/src/templates/de/2019/contributors.html
+++ b/src/templates/de/2019/contributors.html
@@ -1,0 +1,11 @@
+{% extends "base/contributors.html" %}
+
+{% block title %}{{ year }} Mitwirkende | The Web Almanac von HTTP Archive{% endblock %}
+
+{% block description %}Die {{ config.contributors.items() | length }} Personen, die als Analysten, Autoren, Designer, Entwickler, Redakteure, Leiter, Reviewer und Übersetzer zum {{ year }} Web Almanac beigetragen haben.{% endblock %}
+
+{% block filter_by_team %}Nach Team filtern: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> von <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> Mitwirkenden.{% endblock %}
+{% block filter_by %}Filtern nach{% endblock %}
+
+{% block join_the_team_title%}Werde Teil des Web Almanac-Teams{% endblock %}
+{% block join_the_team_text%}Tritt dem Team bei!{% endblock %}

--- a/src/templates/de/2019/index.html
+++ b/src/templates/de/2019/index.html
@@ -1,0 +1,6 @@
+{% extends "base/index.html" %}
+
+{% block title %}Der {{ year }} Web Almanac{% endblock %}
+{% block description %}Der Web Almanac ist ein jährlicher Bericht über den aktuellen Stand des Webs, der das Fachwissen der Web-Community mit den Daten und Trends des HTTP Archive verbindet.{% endblock %}
+
+{% block twitter_image_alt %}Der {{ year }} Web Almanac{% endblock %}

--- a/src/templates/de/2019/table_of_contents.html
+++ b/src/templates/de/2019/table_of_contents.html
@@ -1,0 +1,7 @@
+{% extends "base/table_of_contents.html" %}
+
+{% block title %}Inhaltsverzeichnis | Web Almanac {{ year }}{% endblock %}
+
+{% block description %}Inhaltsverzeichnis des Web Almanac {{ year }}, mit allen Abschnitten: Seiteninhalte, Nutzererfahrung, Content-Veröffentlichung, Content-Distribution.{% endblock %}
+
+{% block twitter_image_alt %}Methodik des Web Almanac {{ year }}{% endblock %}

--- a/src/templates/de/2020/base.html
+++ b/src/templates/de/2020/base.html
@@ -1,0 +1,28 @@
+{% extends "%s/base.html" % lang %}
+
+{% block methodology_stat_1 %}7,5M{% endblock %}
+{% block methodology_stat_2 %}31,3 TB{% endblock %}
+{% block total_websites %}über 7,5 Millionen{% endblock %}
+{% block dataset %}August 2020{% endblock %}
+
+{% block foreword %}
+{# TODO - Translate this! #}<div lang="en">
+  <p>
+    2020 has been a year many of us would like to forget. It&#8217;s rare for a community as globalized as ours to be affected by events as far-reaching as the COVID-19 pandemic and protests against racial injustice. These events almost discouraged us from restarting the project this year—with so many people physically and emotionally drained, how could we expect anyone to <em>want</em> to contribute, let alone have the time and energy for it? We proceeded with caution, hoping there was still community interest.
+  </p>
+
+  <p>
+    The purpose of this edition of the Web Almanac is not to forget about 2020, but to memorialize it. For better or worse, this is a chapter in our history. Despite all of the external pressures of this year, <em>over a hundred <a href="./contributors">contributors</a></em> from the web community signed up and volunteered countless hours of their time for a project dedicated to remembering 2020 and the state of the web. Amazingly, we actually managed to <em>expand</em> the scope of this year&#8217;s edition by adding three new chapters and only losing one.
+  </p>
+
+  <p>
+    When I ask contributors what they enjoy most about the project, the answer is almost always about the people. We work together as teams, we support each other, and in only five months time we were able to build the equivalent of a 600 page book! It was an enormous challenge, and while we haven&#8217;t solved the world&#8217;s problems, we&#8217;ve shown what&#8217;s possible when people choose to work together.
+  </p>
+
+  <p>
+    Please enjoy the 2020 Web Almanac, the culmination of our labor of love for the web. And be sure to <a hreflang="en" href="https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/CONTRIBUTING.md">reach out</a> if you&#8217;d like to join the team.
+  </p>
+
+  <p>— <em><a href="{{ url_for('contributors', year=year, lang=lang, _anchor='rviscomi') }}">Rick Viscomi</a>, Web Almanac Editor-in-Chief</em></p>
+</div>
+{% endblock %}

--- a/src/templates/de/2020/contributors.html
+++ b/src/templates/de/2020/contributors.html
@@ -1,0 +1,11 @@
+{% extends "base/contributors.html" %}
+
+{% block title %}{{ year }} Mitwirkende | The Web Almanac von HTTP Archive{% endblock %}
+
+{% block description %}Die {{ config.contributors.items() | length }} Personen, die als Analysten, Autoren, Designer, Entwickler, Redakteure, Leiter, Reviewer und Übersetzer zum {{ year }} Web Almanac beigetragen haben.{% endblock %}
+
+{% block filter_by_team %}Nach Team filtern: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> von <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> Mitwirkenden.{% endblock %}
+{% block filter_by %}Filtern nach{% endblock %}
+
+{% block join_the_team_title%}Werde Teil des Web Almanac-Teams{% endblock %}
+{% block join_the_team_text%}Tritt dem Team bei!{% endblock %}

--- a/src/templates/de/2020/index.html
+++ b/src/templates/de/2020/index.html
@@ -1,0 +1,6 @@
+{% extends "base/index.html" %}
+
+{% block title %}Der {{ year }} Web Almanac{% endblock %}
+{% block description %}Der Web Almanac ist ein jährlicher Bericht über den aktuellen Stand des Webs, der das Fachwissen der Web-Community mit den Daten und Trends des HTTP Archive verbindet.{% endblock %}
+
+{% block twitter_image_alt %}Der {{ year }} Web Almanac{% endblock %}

--- a/src/templates/de/2020/table_of_contents.html
+++ b/src/templates/de/2020/table_of_contents.html
@@ -1,0 +1,7 @@
+{% extends "base/table_of_contents.html" %}
+
+{% block title %}Inhaltsverzeichnis | Web Almanac {{ year }}{% endblock %}
+
+{% block description %}Inhaltsverzeichnis des Web Almanac {{ year }}, mit allen Abschnitten: Seiteninhalte, Nutzererfahrung, Content-Veröffentlichung, Content-Distribution.{% endblock %}
+
+{% block twitter_image_alt %}Methodik des Web Almanac {{ year }}{% endblock %}

--- a/src/templates/de/2021/base.html
+++ b/src/templates/de/2021/base.html
@@ -1,0 +1,24 @@
+{% extends "%s/base.html" % lang %}
+
+{% block methodology_stat_1 %}8,2M{% endblock %}
+{% block methodology_stat_2 %}39,5 TB{% endblock %}
+{% block total_websites %}fast 8,2 Millionen{% endblock %}
+{% block dataset %}Juli 2021{% endblock %}
+
+{% block foreword %}
+{# TODO - Translate this! #}<div lang="en">
+  <p>
+    Three years ago I wondered to myself, <em>plenty of tools can tell me how well-built my website is, but where would I go to see the state of the web as a whole</em>? As sophisticated as the HTTP Archive dataset is, the answers it gives us can only be as useful as the questions we ask it. I’m a web developer, but I’m not an expert in all areas of web development—no one is expected to be! But collectively, we all have our own areas of expertise. Get enough of us together, and we can start to ask the right questions about the state of the web that the HTTP Archive can answer in really meaningful ways. That was the original idea behind the Web Almanac.
+  </p>
+
+  <p>
+    This year we’re back with the third edition, which was made possible by the hard work of more than a hundred amazing people from the web community. I’d like to specifically call out a few people for whom this is their third consecutive year contributing: <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='tunetheweb') }}">Barry Pollard</a>, <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='foxdavidj') }}">David Fox</a>, <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='paulcalvano') }}">Paul Calvano</a>, <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='bkardell') }}">Brian Kardell</a>, <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='dougsillars') }}">Doug Sillars</a>, <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='eeeps') }}">Eric Portis</a>, <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='tomayac') }}">Thomas Steiner</a>, <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='rmarx') }}">Robin Marx</a>, <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='alankent') }}">Alan Kent</a>, and <a href="{{ url_for('contributors', year=year, lang=lang, _anchor='AbbyTsai') }}">Abby Tsai</a>. I owe every contributor an enormous debt of gratitude for volunteering their time to this project, but especially these 10 people who have been a part of it since the beginning.
+  </p>
+
+  <p>
+    The 2021 edition consists of a comprehensive lineup of 24 chapters, including two that we’re excited to cover for the first time: <a href="{{ url_for('chapter', year=year, lang=lang, chapter='structured-data') }}">Structured Data</a> and <a href="{{ url_for('chapter', year=year, lang=lang, chapter='webassembly') }}">WebAssembly</a>. These new chapters help us expand the scope of the Web Almanac, which educates our reader base about a more diverse range of topics and equips even more specialized groups with actionable data. Ultimately, that’s why we do it: we hope that our research can be utilized by the web community as a shared source of truth to meaningfully improve the ecosystem. If you find this resource as valuable as we do, we’d love it if you shared it with other people who are interested in the state of the web. Together, let’s use this data as a forcing function for positive change.
+  </p>
+
+  <p>— <em><a href="{{ url_for('contributors', year=year, lang=lang, _anchor='rviscomi') }}">Rick Viscomi</a>, Web Almanac Editor-in-Chief</em></p>
+</div>
+{% endblock %}

--- a/src/templates/de/2021/contributors.html
+++ b/src/templates/de/2021/contributors.html
@@ -1,0 +1,11 @@
+{% extends "base/contributors.html" %}
+
+{% block title %}{{ year }} Mitwirkende | The Web Almanac von HTTP Archive{% endblock %}
+
+{% block description %}Die {{ config.contributors.items() | length }} Personen, die als Analysten, Autoren, Designer, Entwickler, Redakteure, Leiter, Reviewer und Übersetzer zum {{ year }} Web Almanac beigetragen haben.{% endblock %}
+
+{% block filter_by_team %}Nach Team filtern: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> von <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> Mitwirkenden.{% endblock %}
+{% block filter_by %}Filtern nach{% endblock %}
+
+{% block join_the_team_title%}Werde Teil des Web Almanac-Teams{% endblock %}
+{% block join_the_team_text%}Tritt dem Team bei!{% endblock %}

--- a/src/templates/de/2021/index.html
+++ b/src/templates/de/2021/index.html
@@ -1,0 +1,6 @@
+{% extends "base/index.html" %}
+
+{% block title %}Der {{ year }} Web Almanac{% endblock %}
+{% block description %}Der Web Almanac ist ein jährlicher Bericht über den aktuellen Stand des Webs, der das Fachwissen der Web-Community mit den Daten und Trends des HTTP Archive verbindet.{% endblock %}
+
+{% block twitter_image_alt %}Der {{ year }} Web Almanac{% endblock %}

--- a/src/templates/de/2021/table_of_contents.html
+++ b/src/templates/de/2021/table_of_contents.html
@@ -1,0 +1,7 @@
+{% extends "base/table_of_contents.html" %}
+
+{% block title %}Inhaltsverzeichnis | Web Almanac {{ year }}{% endblock %}
+
+{% block description %}Inhaltsverzeichnis des Web Almanac {{ year }}, mit allen Abschnitten: Seiteninhalte, Nutzererfahrung, Content-Veröffentlichung, Content-Distribution.{% endblock %}
+
+{% block twitter_image_alt %}Methodik des Web Almanac {{ year }}{% endblock %}

--- a/src/templates/de/2022/base.html
+++ b/src/templates/de/2022/base.html
@@ -1,0 +1,10 @@
+{% extends "%s/base.html" % lang %}
+
+{% block methodology_stat_1 %}8,36M{% endblock %}
+{% block methodology_stat_2 %}43,88 TB{% endblock %}
+{% block total_websites %}fast 8,4 Millionen{% endblock %}
+{% block dataset %}Juni 2022{% endblock %}
+
+{% block foreword %}
+{# TODO #}
+{% endblock %}

--- a/src/templates/de/2022/contributors.html
+++ b/src/templates/de/2022/contributors.html
@@ -1,0 +1,11 @@
+{% extends "base/contributors.html" %}
+
+{% block title %}{{ year }} Mitwirkende | The Web Almanac von HTTP Archive{% endblock %}
+
+{% block description %}Die {{ config.contributors.items() | length }} Personen, die als Analysten, Autoren, Designer, Entwickler, Redakteure, Leiter, Reviewer und Übersetzer zum {{ year }} Web Almanac beigetragen haben.{% endblock %}
+
+{% block filter_by_team %}Nach Team filtern: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> von <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> Mitwirkenden.{% endblock %}
+{% block filter_by %}Filtern nach{% endblock %}
+
+{% block join_the_team_title%}Werde Teil des Web Almanac-Teams{% endblock %}
+{% block join_the_team_text%}Tritt dem Team bei!{% endblock %}

--- a/src/templates/de/2022/index.html
+++ b/src/templates/de/2022/index.html
@@ -1,0 +1,6 @@
+{% extends "base/index.html" %}
+
+{% block title %}Der {{ year }} Web Almanac{% endblock %}
+{% block description %}Der Web Almanac ist ein jährlicher Bericht über den aktuellen Stand des Webs, der das Fachwissen der Web-Community mit den Daten und Trends des HTTP Archive verbindet.{% endblock %}
+
+{% block twitter_image_alt %}Der {{ year }} Web Almanac{% endblock %}

--- a/src/templates/de/2022/table_of_contents.html
+++ b/src/templates/de/2022/table_of_contents.html
@@ -1,0 +1,7 @@
+{% extends "base/table_of_contents.html" %}
+
+{% block title %}Inhaltsverzeichnis | Web Almanac {{ year }}{% endblock %}
+
+{% block description %}Inhaltsverzeichnis des Web Almanac {{ year }}, mit allen Abschnitten: Seiteninhalte, Nutzererfahrung, Content-Veröffentlichung, Content-Distribution.{% endblock %}
+
+{% block twitter_image_alt %}Methodik des Web Almanac {{ year }}{% endblock %}

--- a/src/templates/de/2024/base.html
+++ b/src/templates/de/2024/base.html
@@ -1,0 +1,41 @@
+{% extends "%s/base.html" % lang %}
+
+{% block methodology_stat_1 %}16.9M{% endblock %}
+{% block methodology_stat_2 %}83 TB{% endblock %}
+{% block total_websites %}fast 17 Millionen{% endblock %}
+{% block dataset %}Juni 2024{% endblock %}
+
+{% block foreword %}
+{# TODO - Translate this! #}<div lang="en">
+  <p>
+    It feels as if a lot has changed in the world in just the last two years. Some changes are negative, such as the increase in regional conflicts and the broader tension they raise globally. Some changes are positive though, such as putting the COVID-19 pandemic mostly behind us and important growth in sustainable energy generation.
+  </p>
+
+  <p>
+    In just about every corner of the earth however, it’s likely that the web contributes to your quality of life in some way. Has the web gotten better over the last couple of years? How should we feel about its health?
+  </p>
+
+  <p>
+    The 2024 Web Almanac is here to provide you data to help answer that question. After a hiatus in 2023, a team of passionate researchers have stepped forward this year to investigate important aspects of the modern web using data. Like most technologies, the web grows more complex over time and the Web Almanac help us make sense of things, including a new chapter on Cookies this year.
+  </p>
+
+  <p>
+    This year marks a significant step in evolving the Web Almanac towards a more community-driven project, inspired by the organizational models of academic conferences. Previously maintained by the dedicated HTTP Archive team, the 2024 Almanac introduces a formal organizing committee to foster broader collaboration and inclusivity. Key roles, such as General Chair, Program Committee Chair, and Event Chair, have been established to streamline responsibilities and encourage participation from diverse contributors. This distributed leadership structure is designed to make the Web Almanac more community-driven, which in turn aims to enhance its sustainability by inviting a wider range of voices and perspectives, making the Web Almanac a more collaborative resource for the web community. We hope that this shift towards a community-driven model will strengthen the Web Almanac’s foundation and lead to many future editions.
+  </p>
+
+  <p>
+    It’s been great to experience the motivation and inclusion from the community—spanning young doctoral researchers to senior experts worldwide. We sincerely thank each of our contributors; it is their hard work that makes this open-source project possible.
+  </p>
+
+  <p>
+    As an engine of prosperity, it’s important that we understand what’s working well on the web and where it needs more support. We encourage you to explore, debate, and share the details in the 2024 Web Almanac so it can better serve us all. We are all in this together.
+  </p>
+
+  <p>
+    <em>
+      —<a href="{{ url_for('contributors', year=year, lang=lang, _anchor='nrllh') }}">Nurullah Demir</a>, 2024 Web Almanac General Co-Chair<br>
+      —<a href="{{ url_for('contributors', year=year, lang=lang, _anchor='cqueern') }}">Caleb Queern</a>, 2024 Web Almanac General Co-Chair
+    </em>
+  </p>
+</div>
+{% endblock %}

--- a/src/templates/de/2024/base.html
+++ b/src/templates/de/2024/base.html
@@ -1,6 +1,6 @@
 {% extends "%s/base.html" % lang %}
 
-{% block methodology_stat_1 %}16.9M{% endblock %}
+{% block methodology_stat_1 %}16,9M{% endblock %}
 {% block methodology_stat_2 %}83 TB{% endblock %}
 {% block total_websites %}fast 17 Millionen{% endblock %}
 {% block dataset %}Juni 2024{% endblock %}

--- a/src/templates/de/2024/contributors.html
+++ b/src/templates/de/2024/contributors.html
@@ -1,0 +1,11 @@
+{% extends "base/contributors.html" %}
+
+{% block title %}{{ year }} Mitwirkende | The Web Almanac von HTTP Archive{% endblock %}
+
+{% block description %}Die {{ config.contributors.items() | length }} Personen, die als Analysten, Autoren, Designer, Entwickler, Redakteure, Leiter, Reviewer und Übersetzer zum {{ year }} Web Almanac beigetragen haben.{% endblock %}
+
+{% block filter_by_team %}Nach Team filtern: <span id="filtered-contributors">{{ self.contributors() }}</span><span id="contributors-total-text" class="hidden"> von <span id="contributors-total">{{ config.contributors.items() | length }}</span></span> Mitwirkenden.{% endblock %}
+{% block filter_by %}Filtern nach{% endblock %}
+
+{% block join_the_team_title%}Werde Teil des Web Almanac-Teams{% endblock %}
+{% block join_the_team_text%}Tritt dem Team bei!{% endblock %}

--- a/src/templates/de/2024/index.html
+++ b/src/templates/de/2024/index.html
@@ -1,0 +1,6 @@
+{% extends "base/index.html" %}
+
+{% block title %}Der {{ year }} Web Almanac{% endblock %}
+{% block description %}Der Web Almanac ist ein jährlicher Bericht über den aktuellen Stand des Webs, der das Fachwissen der Web-Community mit den Daten und Trends des HTTP Archive verbindet.{% endblock %}
+
+{% block twitter_image_alt %}Der {{ year }} Web Almanac{% endblock %}

--- a/src/templates/de/2024/table_of_contents.html
+++ b/src/templates/de/2024/table_of_contents.html
@@ -1,0 +1,7 @@
+{% extends "base/table_of_contents.html" %}
+
+{% block title %}Inhaltsverzeichnis | Web Almanac {{ year }}{% endblock %}
+
+{% block description %}Inhaltsverzeichnis des Web Almanac {{ year }}, mit allen Abschnitten: Seiteninhalte, Nutzererfahrung, Content-Veröffentlichung, Content-Distribution.{% endblock %}
+
+{% block twitter_image_alt %}Methodik des Web Almanac {{ year }}{% endblock %}


### PR DESCRIPTION
Part of #1300

Since @mika943 did the hard work in #4498 I've used those to do the base templates for the other years (minus the foreword).