### PR TITLE
Update Nick McCord's LinkedIn handle

### DIFF
--- a/src/config/contributors.json
+++ b/src/config/contributors.json
@@ -3677,7 +3677,7 @@
   "nick-mccord": {
     "avatar_url": "102171522",
     "github": "nick-mccord",
-    "linkedin": "nicholasmccord",
+    "linkedin": "npmccord",
     "name": "Nick McCord",
     "teams": {
       "2025": [


### PR DESCRIPTION
Updates my own entry in `src/config/contributors.json`.

My LinkedIn handle is `npmccord`; the entry currently points at an older profile (`nicholasmccord`), so the contributors page and my 2025 CDN chapter byline both link to the wrong place.

Per CONTRIBUTING ("please add your personal information to the JSON contributors config file"), this touches only the `nick-mccord` entry — one line changed, no other contributor and no chapter content affected.
